### PR TITLE
Fix stack workflow: branch from main, no commits until PR

### DIFF
--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -315,11 +315,11 @@ case "$COMMAND" in
       esac
     done
 
-    # Default to main if no branch specified
+    # Default to stack ID as branch name if no branch specified
     if [ -n "$BRANCH" ]; then
       export GIT_BRANCH="$BRANCH"
     else
-      export GIT_BRANCH="main"
+      export GIT_BRANCH="$STACK_ID"
     fi
 
     echo "Starting Sandstorm stack ${STACK_ID} (${COMPOSE_PROJECT})..."
@@ -558,7 +558,7 @@ case "$COMMAND" in
 
   # -----------------------------------------------------------------
   diff)
-    docker exec -u claude -w /app "$CONTAINER_NAME" git diff
+    docker exec -u claude -w /app "$CONTAINER_NAME" bash -c 'git status --short && echo "---" && git diff'
     ;;
 
   # -----------------------------------------------------------------
@@ -601,6 +601,7 @@ case "$COMMAND" in
       -u claude \
       -w /app \
       -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+      -e GH_TOKEN="$GITHUB_TOKEN" \
       -e GIT_AUTHOR_NAME="$GIT_AUTHOR_NAME" \
       -e GIT_AUTHOR_EMAIL="$GIT_AUTHOR_EMAIL" \
       -e GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME" \
@@ -613,67 +614,22 @@ case "$COMMAND" in
         done
         git add -A
         git diff --cached --quiet || git commit -m "'"${COMMIT_MSG}"'"
-        git push origin "'"${CURRENT_BRANCH}"'"
+        git push -u origin "'"${CURRENT_BRANCH}"'"
+        # Create PR back to main
+        if git log origin/main.."'"${CURRENT_BRANCH}"'" --oneline | head -1 | grep -q .; then
+          gh pr create \
+            --title "'"${COMMIT_MSG}"'" \
+            --body "Changes from Sandstorm stack '"${STACK_ID}"'" \
+            --base main \
+            --head "'"${CURRENT_BRANCH}"'" 2>/dev/null || echo "PR already exists or could not be created"
+        fi
         git remote set-url origin "https://github.com/'"${GIT_REPO}"'.git"
       '
 
-    registry_write "$STACK_ID" "" "$CURRENT_BRANCH" "" "pushed" ""
+    registry_write "$STACK_ID" "" "$CURRENT_BRANCH" "" "pr-created" ""
 
     echo ""
-    echo "Done! Changes pushed to ${CURRENT_BRANCH}."
-    ;;
-
-  # -----------------------------------------------------------------
-  publish)
-    FORCE=false
-    for arg in "$@"; do
-      [ "$arg" = "--force" ] && FORCE=true
-    done
-    BRANCH="${3}"
-    COMMIT_MSG="${4:-"Changes from Sandstorm stack ${STACK_ID}"}"
-
-    if [ -z "$BRANCH" ]; then
-      echo "Error: Branch name required."
-      echo "Usage: sandstorm publish <id> <branch_name> [\"commit message\"]"
-      exit 1
-    fi
-
-    check_ticket_match "$BRANCH" "$FORCE"
-    resolve_github_token
-
-    echo "Publishing from stack ${STACK_ID}..."
-    echo "  Branch: ${BRANCH}"
-
-    PROTECTED_FILES="${PROTECTED_FILES:-CLAUDE.md}"
-
-    echo ""
-    echo "Committing and pushing..."
-    docker exec \
-      -u claude \
-      -w /app \
-      -e GITHUB_TOKEN="$GITHUB_TOKEN" \
-      -e GH_TOKEN="$GITHUB_TOKEN" \
-      -e GIT_AUTHOR_NAME="$GIT_AUTHOR_NAME" \
-      -e GIT_AUTHOR_EMAIL="$GIT_AUTHOR_EMAIL" \
-      -e GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME" \
-      -e GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL" \
-      "$CONTAINER_NAME" bash -c '
-        set -e
-        git remote set-url origin "https://${GITHUB_TOKEN}@github.com/'"${GIT_REPO}"'.git"
-        git checkout -b "'"${BRANCH}"'"
-        for f in '"${PROTECTED_FILES}"'; do
-          git checkout -- "$f" 2>/dev/null || true
-        done
-        git add -A
-        git commit -m "'"${COMMIT_MSG}"'"
-        git push -u origin "'"${BRANCH}"'"
-        git remote set-url origin "https://github.com/'"${GIT_REPO}"'.git"
-      '
-
-    registry_write "$STACK_ID" "" "$BRANCH" "" "published" ""
-
-    echo ""
-    echo "Done! Branch ${BRANCH} pushed."
+    echo "Done! Changes pushed to ${CURRENT_BRANCH} and PR created."
     ;;
 
   # -----------------------------------------------------------------
@@ -719,9 +675,8 @@ case "$COMMAND" in
     echo "  task-status <id>                       Check task status"
     echo "  task-output <id> [lines]               Show task output"
     echo ""
-    echo "  diff <id>                              Show git diff"
-    echo "  push <id> [\"msg\"] [--force]            Commit and push"
-    echo "  publish <id> <branch> [\"msg\"] [--force] Create branch and push"
+    echo "  diff <id>                              Show git diff and untracked files"
+    echo "  push <id> [\"msg\"] [--force]            Commit, push, and create PR"
     echo "  status                                 Dashboard of all stacks"
     echo "  logs <id> [service]                    Tail container logs (default: claude)"
     ;;

--- a/sandstorm-cli/skills/sandstorm-create-stack.md
+++ b/sandstorm-cli/skills/sandstorm-create-stack.md
@@ -18,14 +18,14 @@ sandstorm up <stack_id> [--ticket TICKET] [--branch BRANCH]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `<stack_id>` | Yes | Alphanumeric identifier (e.g., `1`, `2`, `fix-auth-bug`) |
+| `<stack_id>` | Yes | Descriptive identifier — becomes the branch name (e.g., `fix-auth-bug`, `add-search`) |
 | `--ticket TICKET` | No | Associated ticket ID (e.g., `PROJ-123`) |
-| `--branch BRANCH` | No | Git branch to checkout (creates if doesn't exist) |
+| `--branch BRANCH` | No | Override the default branch (defaults to stack ID) |
 
 ## What it does
 
 1. Clones the project repo to `.sandstorm/workspaces/<stack_id>/`
-2. Checks out the specified branch (if provided)
+2. Creates/checks out a branch named after the stack ID (or `--branch` if specified)
 3. Copies `.env*` files from host to workspace
 4. Remaps ports: `new_port = original_port + (stack_id_num * PORT_OFFSET)`
 5. Runs `docker compose up -d --build`
@@ -33,20 +33,23 @@ sandstorm up <stack_id> [--ticket TICKET] [--branch BRANCH]
 
 ## Usage patterns
 
-**Simple numbered stack:**
+**Stack with descriptive name (recommended):**
 ```bash
-sandstorm up 1
+sandstorm up fix-auth-bug --ticket PROJ-123
+```
+This creates the stack on branch `fix-auth-bug`.
+
+**Stack with explicit branch override:**
+```bash
+sandstorm up fix-auth --ticket PROJ-123 --branch feature/auth-fix
 ```
 
-**Stack with ticket and branch:**
-```bash
-sandstorm up 1 --ticket PROJ-123 --branch feature/auth-fix
-```
+## Critical: Branching behavior
 
-**Named stack:**
-```bash
-sandstorm up fix-auth --ticket PROJ-123 --branch fix/auth-bug
-```
+- **Stack ID = branch name** by default. Choose descriptive stack IDs since they become the branch name.
+- Stacks **never** default to `main`. Every stack works on its own branch.
+- Inner Claude makes changes but does **not** commit. The outer orchestrator reviews via `sandstorm diff` and pushes via `sandstorm push`.
+- Use `--branch` only when you need a specific branch name different from the stack ID.
 
 ## Important notes
 

--- a/sandstorm-cli/skills/sandstorm-dispatch-task.md
+++ b/sandstorm-cli/skills/sandstorm-dispatch-task.md
@@ -6,7 +6,7 @@ trigger: when the user wants to send a task to a stack, dispatch work, run a tas
 
 # Sandstorm Dispatch Task
 
-Send a task prompt to the inner Claude agent in a stack.
+Send a task prompt to the inner Claude agent in a stack. Inner Claude makes code changes but does NOT commit — the outer orchestrator reviews via `sandstorm diff` and pushes via `sandstorm push`.
 
 ## Command
 
@@ -36,6 +36,7 @@ sandstorm task <stack_id> --sync "prompt text"
 1. **Always use async mode** (no `--sync`). Never block the conversation waiting for a task.
 2. **Never write sleep/poll loops.** Check status with `sandstorm task-status <id>` only when needed.
 3. **Write clear, goal-oriented prompts.** Describe WHAT, not HOW. The inner Claude has the full repo.
+4. **Inner Claude should NOT commit.** It only makes file changes. The outer orchestrator handles git operations.
 
 ## Writing good task prompts
 
@@ -68,7 +69,6 @@ sandstorm diff <stack_id>            # See what changed
 3. Inner Claude works autonomously with `--dangerously-skip-permissions`
 4. Output streams to `/tmp/claude-task.log`
 5. Status file updated to "completed" or "failed"
-6. Registry updated with final branch info
 
 ## Common patterns
 

--- a/sandstorm-cli/skills/sandstorm-push.md
+++ b/sandstorm-cli/skills/sandstorm-push.md
@@ -1,23 +1,17 @@
 ---
 name: sandstorm-push
-description: Commit and push code changes from a Sandstorm stack to the remote git repository.
-trigger: when the user wants to push changes, commit and push, save work from a stack, or publish changes to github
+description: Commit, push, and create a PR from a Sandstorm stack to the remote git repository.
+trigger: when the user wants to push changes, commit and push, save work from a stack, create a PR, or publish changes to github
 ---
 
-# Sandstorm Push / Publish
+# Sandstorm Push
 
-Commit and push changes from a stack workspace to the remote repository.
+Commit all uncommitted changes, push the branch, and create a PR back to main.
 
-## Commands
+## Command
 
-### Push (existing branch)
 ```bash
 sandstorm push <stack_id> ["commit message"] [--force]
-```
-
-### Publish (new branch)
-```bash
-sandstorm publish <stack_id> <branch_name> ["commit message"] [--force]
 ```
 
 ## Arguments
@@ -26,13 +20,7 @@ sandstorm publish <stack_id> <branch_name> ["commit message"] [--force]
 |----------|----------|-------------|
 | `<stack_id>` | Yes | Stack to push from |
 | `"commit message"` | No | Custom message (default: "Changes from Sandstorm stack <id>") |
-| `--force` | No | Override ticket safety checks |
-| `<branch_name>` | Yes (publish only) | New branch name to create |
-
-## When to use which
-
-- **`push`** — Stack is already on the right branch (e.g., created with `--branch`)
-- **`publish`** — Work was done on main/default branch and needs a feature branch
+| `--force` | No | Override ticket safety checks and branch drift warnings |
 
 ## Prerequisites
 
@@ -41,19 +29,14 @@ sandstorm publish <stack_id> <branch_name> ["commit message"] [--force]
 
 ## Usage patterns
 
-**Push to current branch:**
+**Push and create PR:**
 ```bash
-sandstorm push 1 "Fix authentication token expiry"
+sandstorm push fix-auth-bug "Fix authentication token expiry"
 ```
 
-**Create new branch and push:**
+**Force push (skip safety checks):**
 ```bash
-sandstorm publish 1 feature/auth-fix "Fix authentication token expiry"
-```
-
-**Force push (skip ticket check):**
-```bash
-sandstorm push 1 "Emergency fix" --force
+sandstorm push fix-auth-bug "Emergency fix" --force
 ```
 
 ## Before pushing
@@ -69,9 +52,10 @@ sandstorm diff <stack_id>
 2. Protected files (e.g., `CLAUDE.md`) are restored from git
 3. All changes are staged (`git add -A`)
 4. Commit is created with the message
-5. Changes are pushed to remote
-6. Token is removed from remote URL
-7. Registry status updated to "pushed" / "published"
+5. Branch is pushed to remote
+6. A PR is created back to `main` (via `gh pr create`)
+7. Token is removed from remote URL
+8. Registry status updated to "pr-created"
 
 ## Ticket safety
 
@@ -86,3 +70,4 @@ If `TICKET_PREFIX` is configured in `.sandstorm/config`:
 | "GITHUB_TOKEN not set" | No git credentials | Set `GITHUB_TOKEN` or run `gh auth login` |
 | "Ticket mismatch" | Branch doesn't match registered ticket | Use `--force` or fix the branch name |
 | "Nothing to commit" | No changes in workspace | Check `sandstorm diff <id>` |
+| "PR already exists" | A PR for this branch already exists | This is informational — the push still succeeded |

--- a/sandstorm-cli/skills/sandstorm-status.md
+++ b/sandstorm-cli/skills/sandstorm-status.md
@@ -32,7 +32,7 @@ Shows the last N lines of task output (default: 50).
 ```bash
 sandstorm diff <stack_id>
 ```
-Shows all uncommitted changes in the stack's workspace.
+Shows untracked/modified file summary and all uncommitted changes in the stack's workspace. This is the primary review mechanism — inner Claude does not commit, so all changes appear here.
 
 ### Container logs
 ```bash
@@ -50,6 +50,7 @@ Tails Docker logs for a service (default: `claude`).
 | RUNNING | Task is currently executing |
 | COMPLETED | Last task finished successfully |
 | FAILED | Last task failed |
+| PR-CREATED | Changes pushed and PR created |
 | DOWN | Containers not running |
 
 ## Common monitoring patterns
@@ -68,7 +69,7 @@ sandstorm task-output 1
 **Review completed work:**
 ```bash
 sandstorm task-status 1    # Confirm completed
-sandstorm diff 1           # Review changes
+sandstorm diff 1           # Review uncommitted changes (this is the intended review mechanism)
 sandstorm task-output 1    # See what Claude did
 ```
 
@@ -84,3 +85,4 @@ sandstorm logs 1           # Check container logs
 - **Never poll in a loop.** Run status checks as one-shot commands.
 - **Always use `sandstorm` commands** for monitoring — don't bypass with raw `docker` commands.
 - Task output is stored in `/tmp/claude-task.log` inside the container.
+- `sandstorm diff` shows uncommitted changes because inner Claude does not commit. This is by design — it lets you review everything before pushing.

--- a/sandstorm-cli/skills/sandstorm-teardown.md
+++ b/sandstorm-cli/skills/sandstorm-teardown.md
@@ -36,9 +36,8 @@ sandstorm diff <stack_id>
 If there are changes worth keeping:
 ```bash
 sandstorm push <stack_id> "Save work before teardown"
-# or
-sandstorm publish <stack_id> feature/my-branch "Save work"
 ```
+This will commit, push the branch, and create a PR back to main.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Stacks now always create a task-specific branch (defaults to stack ID) instead of working on main
- Inner Claude is instructed to never commit — changes stay uncommitted for review via `sandstorm diff`
- `push` command now commits + pushes + creates a PR to main in one step
- Removed `publish` command (no longer needed since stacks always start on a branch)
- Updated all skill files to reflect the new workflow

## Test plan
- [ ] Create a new stack without `--branch` — verify it creates a branch named after the stack ID
- [ ] Dispatch a task — verify inner Claude leaves changes uncommitted
- [ ] Run `sandstorm diff` — verify it shows the uncommitted changes
- [ ] Run `sandstorm push` — verify it commits, pushes, and creates a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)