### PR TITLE
Stop triggering unnecessary macOS TCC permission prompts

### DIFF
--- a/src/main/claude/session-manager.ts
+++ b/src/main/claude/session-manager.ts
@@ -300,18 +300,32 @@ rl.on('line', async (line) => {
     args.push('--dangerously-skip-permissions');
 
     const cwd = projectDir || process.cwd();
-    const claudeBin = process.env.HOME ? path.join(process.env.HOME, '.local', 'bin', 'claude') : 'claude';
+
+    // Resolve claude binary: check specific known path before falling back to PATH lookup
+    let claudeBin = 'claude';
+    const pathExtras: string[] = [
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/usr/local/sbin',
+    ];
+    if (process.env.HOME) {
+      const homeLocalBin = path.join(process.env.HOME, '.local', 'bin');
+      const homeClaudePath = path.join(homeLocalBin, 'claude');
+      try {
+        if (fs.existsSync(homeClaudePath)) {
+          claudeBin = homeClaudePath;
+          pathExtras.unshift(homeLocalBin);
+        }
+      } catch {
+        // Home directory not accessible — skip it, rely on system PATH
+      }
+    }
+
     const child = spawn(claudeBin, args, {
       cwd,
       env: {
         ...process.env,
-        PATH: [
-          `${process.env.HOME}/.local/bin`,
-          '/opt/homebrew/bin',
-          '/usr/local/bin',
-          '/usr/local/sbin',
-          process.env.PATH,
-        ].join(':'),
+        PATH: [...pathExtras, process.env.PATH].filter(Boolean).join(':'),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -481,29 +481,34 @@ export class StackManager {
   }
 
   private discoverServicePorts(projectDir: string): Promise<ServicePort[]> {
-    // Read .sandstorm/config for PORT_MAP
-    const configPath = path.join(projectDir, '.sandstorm', 'config');
-    if (!fs.existsSync(configPath)) return Promise.resolve([]);
+    try {
+      // Read .sandstorm/config for PORT_MAP
+      const configPath = path.join(projectDir, '.sandstorm', 'config');
+      if (!fs.existsSync(configPath)) return Promise.resolve([]);
 
-    const config = fs.readFileSync(configPath, 'utf-8');
-    const portMapLine = config
-      .split('\n')
-      .find((l) => l.startsWith('PORT_MAP='));
-    if (!portMapLine) return Promise.resolve([]);
+      const config = fs.readFileSync(configPath, 'utf-8');
+      const portMapLine = config
+        .split('\n')
+        .find((l) => l.startsWith('PORT_MAP='));
+      if (!portMapLine) return Promise.resolve([]);
 
-    const portMapValue = portMapLine.split('=')[1]?.replace(/"/g, '');
-    if (!portMapValue) return Promise.resolve([]);
+      const portMapValue = portMapLine.split('=')[1]?.replace(/"/g, '');
+      if (!portMapValue) return Promise.resolve([]);
 
-    // Format: service:host_port:container_port:index,...
-    // Use service_index as the key to match compose env var format: SANDSTORM_PORT_<service>_<index>
-    return Promise.resolve(
-      portMapValue.split(',').map((entry) => {
-        const [service, , containerPort, index] = entry.split(':');
-        return {
-          service: `${service}_${index || '0'}`,
-          containerPort: parseInt(containerPort, 10),
-        };
-      })
-    );
+      // Format: service:host_port:container_port:index,...
+      // Use service_index as the key to match compose env var format: SANDSTORM_PORT_<service>_<index>
+      return Promise.resolve(
+        portMapValue.split(',').map((entry) => {
+          const [service, , containerPort, index] = entry.split(':');
+          return {
+            service: `${service}_${index || '0'}`,
+            containerPort: parseInt(containerPort, 10),
+          };
+        })
+      );
+    } catch {
+      // Project directory not accessible — return empty ports
+      return Promise.resolve([]);
+    }
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { ipcMain, dialog, BrowserWindow, app } from 'electron';
 import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -17,6 +17,7 @@ import { CreateStackOpts } from './control-plane/stack-manager';
  * Skips if skills are already present and up to date.
  */
 function syncSkillsToProject(projectDir: string, sandstormCliDir: string): void {
+  try {
   const skillsSrc = path.join(sandstormCliDir, 'skills');
   const skillsDest = path.join(projectDir, '.claude', 'skills');
 
@@ -46,6 +47,9 @@ function syncSkillsToProject(projectDir: string, sandstormCliDir: string): void 
   fs.mkdirSync(skillsDest, { recursive: true });
   for (const file of srcFiles) {
     fs.copyFileSync(path.join(skillsSrc, file), path.join(skillsDest, file));
+  }
+  } catch {
+    // Skill sync is non-critical — dont crash or trigger permission prompts
   }
 }
 
@@ -94,23 +98,29 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     const result = await dialog.showOpenDialog(win!, {
       properties: ['openDirectory'],
       title: 'Open Project Directory',
+      defaultPath: app.getPath('home'),
     });
     if (result.canceled || result.filePaths.length === 0) return null;
     return result.filePaths[0];
   });
 
   ipcMain.handle('projects:checkInit', async (_event, directory: string) => {
-    const sandstormDir = path.join(directory, '.sandstorm');
-    const configPath = path.join(sandstormDir, 'config');
-    const composePath = path.join(sandstormDir, 'docker-compose.yml');
-    const isInitialized = fs.existsSync(configPath) && fs.existsSync(composePath);
+    try {
+      const sandstormDir = path.join(directory, '.sandstorm');
+      const configPath = path.join(sandstormDir, 'config');
+      const composePath = path.join(sandstormDir, 'docker-compose.yml');
+      const isInitialized = fs.existsSync(configPath) && fs.existsSync(composePath);
 
-    // Auto-sync skills if project is initialized but skills are missing
-    if (isInitialized) {
-      syncSkillsToProject(directory, cliDir);
+      // Auto-sync skills if project is initialized but skills are missing
+      if (isInitialized) {
+        syncSkillsToProject(directory, cliDir);
+      }
+
+      return isInitialized;
+    } catch {
+      // Directory not accessible - treat as uninitialized
+      return false;
     }
-
-    return isInitialized;
   });
 
   ipcMain.handle('projects:initialize', async (_event, directory: string) => {

--- a/src/main/runtime/docker.ts
+++ b/src/main/runtime/docker.ts
@@ -1,5 +1,7 @@
 import Dockerode from 'dockerode';
 import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 import {
   ContainerRuntime,
   ComposeOpts,
@@ -13,13 +15,41 @@ import {
   ExecResult,
 } from './types';
 
+/**
+ * Resolve the Docker socket path. Checks existence to avoid triggering
+ * macOS TCC permission prompts for inaccessible paths.
+ */
+function resolveDockerSocket(explicit?: string): string {
+  if (explicit) return explicit;
+
+  const candidates = [
+    '/var/run/docker.sock',
+  ];
+
+  // On macOS, Docker Desktop exposes a per-user socket that doesn't need elevated permissions
+  if (process.env.HOME) {
+    candidates.push(path.join(process.env.HOME, '.docker', 'run', 'docker.sock'));
+  }
+
+  for (const sock of candidates) {
+    try {
+      if (fs.existsSync(sock)) return sock;
+    } catch {
+      // Path not accessible — skip without triggering further prompts
+    }
+  }
+
+  // Fallback to default; Dockerode will fail gracefully on connect
+  return '/var/run/docker.sock';
+}
+
 export class DockerRuntime implements ContainerRuntime {
   readonly name = 'docker';
   private docker: Dockerode;
 
   constructor(socketPath?: string) {
     this.docker = new Dockerode({
-      socketPath: socketPath ?? '/var/run/docker.sock',
+      socketPath: resolveDockerSocket(socketPath),
     });
   }
 
@@ -234,12 +264,12 @@ export class DockerRuntime implements ContainerRuntime {
           ...process.env,
           ...env,
           PATH: [
-            `${process.env.HOME}/.local/bin`,
+            ...(process.env.HOME ? [`${process.env.HOME}/.local/bin`] : []),
             '/opt/homebrew/bin',
             '/usr/local/bin',
             '/usr/local/sbin',
             process.env.PATH,
-          ].join(':'),
+          ].filter(Boolean).join(':'),
         },
         stdio: 'pipe',
       });


### PR DESCRIPTION
## Summary
- **docker.ts**: Resolve Docker socket path safely — checks macOS per-user socket (`~/.docker/run/docker.sock`) before falling back, avoiding TCC prompts for inaccessible paths
- **session-manager.ts**: Safely resolve claude binary path, wrapping HOME access in try/catch
- **ipc.ts**: Wrap file system operations (skill sync, project init check) in try/catch so inaccessible paths don't crash or trigger TCC prompts. Add `defaultPath` to open-directory dialog.
- **stack-manager.ts**: Wrap `discoverServicePorts` in try/catch for the same reason

## Test plan
- [ ] Launch app on macOS — verify no TCC permission prompts appear
- [ ] Open project directory dialog — verify it defaults to home
- [ ] Create and dispatch tasks to stacks — verify everything still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)