### PR TITLE
Add per-project custom context UI

### DIFF
--- a/src/main/custom-context.ts
+++ b/src/main/custom-context.ts
@@ -1,0 +1,112 @@
+import fs from 'fs';
+import path from 'path';
+
+/** Directory within the project where custom context is stored. */
+const CONTEXT_DIR = '.sandstorm/context';
+const SKILLS_DIR = 'skills';
+const INSTRUCTIONS_FILE = 'instructions.md';
+const SETTINGS_FILE = 'settings.json';
+
+export interface CustomContext {
+  instructions: string;
+  skills: string[];
+  settings: string;
+}
+
+function contextDir(projectDir: string): string {
+  return path.join(projectDir, CONTEXT_DIR);
+}
+
+function ensureContextDir(projectDir: string): string {
+  const dir = contextDir(projectDir);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function ensureSkillsDir(projectDir: string): string {
+  const dir = path.join(contextDir(projectDir), SKILLS_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Ensure .sandstorm/context/ is gitignored.
+ * Adds it to .sandstorm/.gitignore if not already present.
+ */
+export function ensureGitignored(projectDir: string): void {
+  const sandstormDir = path.join(projectDir, '.sandstorm');
+  if (!fs.existsSync(sandstormDir)) return;
+
+  const gitignorePath = path.join(sandstormDir, '.gitignore');
+  const entry = 'context/';
+
+  if (fs.existsSync(gitignorePath)) {
+    const content = fs.readFileSync(gitignorePath, 'utf-8');
+    if (content.split('\n').some((line) => line.trim() === entry)) return;
+    fs.appendFileSync(gitignorePath, `\n${entry}\n`);
+  } else {
+    fs.writeFileSync(gitignorePath, `# Sandstorm local files (not committed)\n${entry}\n`);
+  }
+}
+
+/** Get all custom context for a project. */
+export function getCustomContext(projectDir: string): CustomContext {
+  return {
+    instructions: getInstructions(projectDir),
+    skills: listCustomSkills(projectDir),
+    settings: getCustomSettings(projectDir),
+  };
+}
+
+function getInstructions(projectDir: string): string {
+  const filePath = path.join(contextDir(projectDir), INSTRUCTIONS_FILE);
+  if (!fs.existsSync(filePath)) return '';
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+export function saveCustomInstructions(projectDir: string, content: string): void {
+  ensureContextDir(projectDir);
+  ensureGitignored(projectDir);
+  const filePath = path.join(contextDir(projectDir), INSTRUCTIONS_FILE);
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+export function listCustomSkills(projectDir: string): string[] {
+  const dir = path.join(contextDir(projectDir), SKILLS_DIR);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, ''));
+}
+
+export function getCustomSkill(projectDir: string, name: string): string {
+  const filePath = path.join(contextDir(projectDir), SKILLS_DIR, `${name}.md`);
+  if (!fs.existsSync(filePath)) return '';
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+export function saveCustomSkill(projectDir: string, name: string, content: string): void {
+  ensureSkillsDir(projectDir);
+  ensureGitignored(projectDir);
+  const filePath = path.join(contextDir(projectDir), SKILLS_DIR, `${name}.md`);
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+export function deleteCustomSkill(projectDir: string, name: string): void {
+  const filePath = path.join(contextDir(projectDir), SKILLS_DIR, `${name}.md`);
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+}
+
+export function getCustomSettings(projectDir: string): string {
+  const filePath = path.join(contextDir(projectDir), SETTINGS_FILE);
+  if (!fs.existsSync(filePath)) return '';
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+export function saveCustomSettings(projectDir: string, content: string): void {
+  ensureContextDir(projectDir);
+  ensureGitignored(projectDir);
+  const filePath = path.join(contextDir(projectDir), SETTINGS_FILE);
+  fs.writeFileSync(filePath, content, 'utf-8');
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,6 +11,16 @@ import {
   claudeSessionManager,
 } from './index';
 import { CreateStackOpts } from './control-plane/stack-manager';
+import {
+  getCustomContext,
+  saveCustomInstructions,
+  listCustomSkills,
+  getCustomSkill,
+  saveCustomSkill,
+  deleteCustomSkill,
+  getCustomSettings,
+  saveCustomSettings,
+} from './custom-context';
 
 /**
  * Copy bundled sandstorm skill files into a project's .claude/skills/ directory.
@@ -228,6 +238,55 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   ipcMain.handle('stats:task-metrics', async (_event, stackId: string) => {
     return stackManager.getStackTaskMetrics(stackId);
   });
+
+  // --- Custom Context ---
+
+  ipcMain.handle('context:get', async (_event, projectDir: string) => {
+    return getCustomContext(projectDir);
+  });
+
+  ipcMain.handle(
+    'context:saveInstructions',
+    async (_event, projectDir: string, content: string) => {
+      saveCustomInstructions(projectDir, content);
+    }
+  );
+
+  ipcMain.handle('context:listSkills', async (_event, projectDir: string) => {
+    return listCustomSkills(projectDir);
+  });
+
+  ipcMain.handle(
+    'context:getSkill',
+    async (_event, projectDir: string, name: string) => {
+      return getCustomSkill(projectDir, name);
+    }
+  );
+
+  ipcMain.handle(
+    'context:saveSkill',
+    async (_event, projectDir: string, name: string, content: string) => {
+      saveCustomSkill(projectDir, name, content);
+    }
+  );
+
+  ipcMain.handle(
+    'context:deleteSkill',
+    async (_event, projectDir: string, name: string) => {
+      deleteCustomSkill(projectDir, name);
+    }
+  );
+
+  ipcMain.handle('context:getSettings', async (_event, projectDir: string) => {
+    return getCustomSettings(projectDir);
+  });
+
+  ipcMain.handle(
+    'context:saveSettings',
+    async (_event, projectDir: string, content: string) => {
+      saveCustomSettings(projectDir, content);
+    }
+  );
 
   // --- Runtime ---
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,16 @@ export interface SandstormAPI {
     reset: (tabId: string) => Promise<void>;
     history: (tabId: string) => Promise<{ messages: Array<{ role: string; content: string }>; processing: boolean }>;
   };
+  context: {
+    get: (projectDir: string) => Promise<{ instructions: string; skills: string[]; settings: string }>;
+    saveInstructions: (projectDir: string, content: string) => Promise<void>;
+    listSkills: (projectDir: string) => Promise<string[]>;
+    getSkill: (projectDir: string, name: string) => Promise<string>;
+    saveSkill: (projectDir: string, name: string, content: string) => Promise<void>;
+    deleteSkill: (projectDir: string, name: string) => Promise<void>;
+    getSettings: (projectDir: string) => Promise<string>;
+    saveSettings: (projectDir: string, content: string) => Promise<void>;
+  };
   on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
 }
 
@@ -102,6 +112,23 @@ const api: SandstormAPI = {
     cancel: (tabId) => ipcRenderer.invoke('claude:cancel', tabId),
     reset: (tabId) => ipcRenderer.invoke('claude:reset', tabId),
     history: (tabId) => ipcRenderer.invoke('claude:history', tabId),
+  },
+  context: {
+    get: (projectDir) => ipcRenderer.invoke('context:get', projectDir),
+    saveInstructions: (projectDir, content) =>
+      ipcRenderer.invoke('context:saveInstructions', projectDir, content),
+    listSkills: (projectDir) =>
+      ipcRenderer.invoke('context:listSkills', projectDir),
+    getSkill: (projectDir, name) =>
+      ipcRenderer.invoke('context:getSkill', projectDir, name),
+    saveSkill: (projectDir, name, content) =>
+      ipcRenderer.invoke('context:saveSkill', projectDir, name, content),
+    deleteSkill: (projectDir, name) =>
+      ipcRenderer.invoke('context:deleteSkill', projectDir, name),
+    getSettings: (projectDir) =>
+      ipcRenderer.invoke('context:getSettings', projectDir),
+    saveSettings: (projectDir, content) =>
+      ipcRenderer.invoke('context:saveSettings', projectDir, content),
   },
   on: (channel, callback) => {
     const handler = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>

--- a/src/renderer/components/Dashboard.tsx
+++ b/src/renderer/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { StackCard } from './StackCard';
 import { StackTableRow } from './StackTableRow';
 import { UninitializedProject } from './UninitializedProject';
 import { ClaudeSession } from './ClaudeSession';
+import { ProjectContext } from './ProjectContext';
 
 type DashboardTab = 'active' | 'history';
 
@@ -116,6 +117,7 @@ export function Dashboard() {
 
   const [dashboardTab, setDashboardTab] = useState<DashboardTab>('active');
   const [projectInitialized, setProjectInitialized] = useState<boolean | null>(null);
+  const [showContext, setShowContext] = useState(false);
   const [viewMode, _setViewMode] = useState<'cards' | 'table'>(() => {
     const saved = localStorage.getItem('sandstorm-view-mode');
     return saved === 'table' ? 'table' : 'cards';
@@ -208,16 +210,32 @@ export function Dashboard() {
           <h1 className="text-lg font-semibold text-sandstorm-text tracking-tight">{title}</h1>
           <p className="text-xs text-sandstorm-muted mt-0.5">{subtitle}</p>
         </div>
-        <button
-          onClick={() => setShowNewStackDialog(true)}
-          className="flex items-center gap-1.5 px-4 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white rounded-lg transition-all text-sm font-medium shadow-glow hover:shadow-lg active:scale-[0.98]"
-          data-testid="new-stack-btn"
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-            <path d="M12 5v14M5 12h14"/>
-          </svg>
-          New Stack
-        </button>
+        <div className="flex items-center gap-2">
+          {project && (
+            <button
+              onClick={() => setShowContext(true)}
+              className="flex items-center gap-1.5 px-3 py-2 bg-sandstorm-surface-hover hover:bg-sandstorm-border text-sandstorm-text-secondary rounded-lg transition-all text-sm font-medium active:scale-[0.98]"
+              data-testid="context-btn"
+              title="Custom context for this project"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+              </svg>
+              Context
+            </button>
+          )}
+          <button
+            onClick={() => setShowNewStackDialog(true)}
+            className="flex items-center gap-1.5 px-4 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white rounded-lg transition-all text-sm font-medium shadow-glow hover:shadow-lg active:scale-[0.98]"
+            data-testid="new-stack-btn"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M12 5v14M5 12h14"/>
+            </svg>
+            New Stack
+          </button>
+        </div>
       </div>
 
       {/* Two-column layout: Claude chat (left) + Stacks (right) */}
@@ -391,6 +409,14 @@ export function Dashboard() {
           </div>
         </div>
       </div>
+
+      {/* Custom context dialog */}
+      {showContext && project && (
+        <ProjectContext
+          projectDir={project.directory}
+          onClose={() => setShowContext(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/components/ProjectContext.tsx
+++ b/src/renderer/components/ProjectContext.tsx
@@ -1,0 +1,300 @@
+import React, { useEffect, useState, useCallback } from 'react';
+
+interface ProjectContextProps {
+  projectDir: string;
+  onClose: () => void;
+}
+
+type Tab = 'instructions' | 'skills' | 'settings';
+
+export function ProjectContext({ projectDir, onClose }: ProjectContextProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('instructions');
+  const [instructions, setInstructions] = useState('');
+  const [skills, setSkills] = useState<string[]>([]);
+  const [settings, setSettings] = useState('');
+  const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
+  const [skillContent, setSkillContent] = useState('');
+  const [newSkillName, setNewSkillName] = useState('');
+  const [showNewSkill, setShowNewSkill] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const loadContext = useCallback(async () => {
+    const ctx = await window.sandstorm.context.get(projectDir);
+    setInstructions(ctx.instructions);
+    setSkills(ctx.skills);
+    setSettings(ctx.settings);
+    setDirty(false);
+  }, [projectDir]);
+
+  useEffect(() => {
+    loadContext();
+  }, [loadContext]);
+
+  const loadSkill = useCallback(
+    async (name: string) => {
+      const content = await window.sandstorm.context.getSkill(projectDir, name);
+      setSelectedSkill(name);
+      setSkillContent(content);
+      setDirty(false);
+    },
+    [projectDir]
+  );
+
+  const saveInstructions = async () => {
+    setSaving(true);
+    await window.sandstorm.context.saveInstructions(projectDir, instructions);
+    setSaving(false);
+    setDirty(false);
+  };
+
+  const saveSettings = async () => {
+    setSaving(true);
+    await window.sandstorm.context.saveSettings(projectDir, settings);
+    setSaving(false);
+    setDirty(false);
+  };
+
+  const saveSkill = async () => {
+    if (!selectedSkill) return;
+    setSaving(true);
+    await window.sandstorm.context.saveSkill(projectDir, selectedSkill, skillContent);
+    setSaving(false);
+    setDirty(false);
+  };
+
+  const createSkill = async () => {
+    const name = newSkillName.trim().replace(/\.md$/, '').replace(/[^a-zA-Z0-9_-]/g, '-');
+    if (!name) return;
+    await window.sandstorm.context.saveSkill(projectDir, name, `# ${name}\n\nDescribe this skill...\n`);
+    setNewSkillName('');
+    setShowNewSkill(false);
+    await loadContext();
+    await loadSkill(name);
+  };
+
+  const deleteSkill = async (name: string) => {
+    await window.sandstorm.context.deleteSkill(projectDir, name);
+    if (selectedSkill === name) {
+      setSelectedSkill(null);
+      setSkillContent('');
+    }
+    await loadContext();
+  };
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'instructions', label: 'Instructions' },
+    { id: 'skills', label: 'Skills' },
+    { id: 'settings', label: 'Settings' },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl shadow-2xl w-[700px] max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-sandstorm-border shrink-0">
+          <div>
+            <h2 className="text-sm font-semibold text-sandstorm-text">Custom Context</h2>
+            <p className="text-xs text-sandstorm-muted mt-0.5">
+              Personal overrides for this project (not committed to git)
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-sandstorm-muted hover:text-sandstorm-text transition-colors p-1"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-0 border-b border-sandstorm-border shrink-0">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => {
+                setActiveTab(tab.id);
+                setDirty(false);
+              }}
+              className={`px-4 py-2.5 text-xs font-medium transition-colors relative ${
+                activeTab === tab.id
+                  ? 'text-sandstorm-accent'
+                  : 'text-sandstorm-muted hover:text-sandstorm-text'
+              }`}
+            >
+              {tab.label}
+              {tab.id === 'skills' && skills.length > 0 && (
+                <span className="ml-1.5 text-[10px] bg-sandstorm-accent/15 text-sandstorm-accent px-1.5 py-0.5 rounded-full">
+                  {skills.length}
+                </span>
+              )}
+              {activeTab === tab.id && (
+                <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-sandstorm-accent" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {activeTab === 'instructions' && (
+            <div className="p-5 flex flex-col h-full">
+              <p className="text-xs text-sandstorm-muted mb-3">
+                Custom instructions injected as a personal CLAUDE.md overlay for inner Claude agents.
+                These are additive to the project&apos;s .claude/ settings.
+              </p>
+              <textarea
+                value={instructions}
+                onChange={(e) => {
+                  setInstructions(e.target.value);
+                  setDirty(true);
+                }}
+                placeholder={'# My Custom Instructions\n\nAdd rules, preferences, or context here...\n\nExample:\n- Always run tests before committing\n- Use TDD approach\n- Focus on performance'}
+                className="flex-1 min-h-[280px] w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg p-3 text-sm text-sandstorm-text font-mono resize-none focus:outline-none focus:border-sandstorm-accent/50 placeholder:text-sandstorm-muted/50"
+              />
+              <div className="flex justify-end mt-3">
+                <button
+                  onClick={saveInstructions}
+                  disabled={saving || !dirty}
+                  className="px-4 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-lg text-xs font-medium transition-all"
+                >
+                  {saving ? 'Saving...' : 'Save Instructions'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'skills' && (
+            <div className="flex h-full min-h-[350px]">
+              {/* Skill list sidebar */}
+              <div className="w-48 border-r border-sandstorm-border flex flex-col shrink-0">
+                <div className="p-3 flex items-center justify-between border-b border-sandstorm-border">
+                  <span className="text-xs font-medium text-sandstorm-muted">Skills</span>
+                  <button
+                    onClick={() => setShowNewSkill(true)}
+                    className="text-sandstorm-accent hover:text-sandstorm-accent-hover transition-colors"
+                    title="Add skill"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                      <path d="M12 5v14M5 12h14" />
+                    </svg>
+                  </button>
+                </div>
+                {showNewSkill && (
+                  <div className="p-2 border-b border-sandstorm-border">
+                    <input
+                      value={newSkillName}
+                      onChange={(e) => setNewSkillName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') createSkill();
+                        if (e.key === 'Escape') {
+                          setShowNewSkill(false);
+                          setNewSkillName('');
+                        }
+                      }}
+                      placeholder="skill-name"
+                      autoFocus
+                      className="w-full bg-sandstorm-bg border border-sandstorm-border rounded px-2 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:border-sandstorm-accent/50"
+                    />
+                  </div>
+                )}
+                <div className="flex-1 overflow-y-auto">
+                  {skills.length === 0 && !showNewSkill && (
+                    <p className="text-xs text-sandstorm-muted p-3">No custom skills</p>
+                  )}
+                  {skills.map((name) => (
+                    <div
+                      key={name}
+                      className={`flex items-center justify-between px-3 py-2 text-xs cursor-pointer group ${
+                        selectedSkill === name
+                          ? 'bg-sandstorm-accent/10 text-sandstorm-accent'
+                          : 'text-sandstorm-text-secondary hover:bg-sandstorm-surface-hover'
+                      }`}
+                      onClick={() => loadSkill(name)}
+                    >
+                      <span className="truncate">{name}</span>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteSkill(name);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 text-sandstorm-muted hover:text-red-400 transition-all"
+                        title="Delete skill"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                          <path d="M18 6L6 18M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Skill editor */}
+              <div className="flex-1 flex flex-col p-4">
+                {selectedSkill ? (
+                  <>
+                    <div className="flex items-center justify-between mb-3">
+                      <span className="text-xs font-medium text-sandstorm-text font-mono">
+                        {selectedSkill}.md
+                      </span>
+                    </div>
+                    <textarea
+                      value={skillContent}
+                      onChange={(e) => {
+                        setSkillContent(e.target.value);
+                        setDirty(true);
+                      }}
+                      className="flex-1 min-h-[250px] w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg p-3 text-sm text-sandstorm-text font-mono resize-none focus:outline-none focus:border-sandstorm-accent/50"
+                    />
+                    <div className="flex justify-end mt-3">
+                      <button
+                        onClick={saveSkill}
+                        disabled={saving || !dirty}
+                        className="px-4 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-lg text-xs font-medium transition-all"
+                      >
+                        {saving ? 'Saving...' : 'Save Skill'}
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex-1 flex items-center justify-center text-sandstorm-muted text-xs">
+                    Select a skill or create a new one
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'settings' && (
+            <div className="p-5 flex flex-col h-full">
+              <p className="text-xs text-sandstorm-muted mb-3">
+                Custom settings.json overrides for the inner Claude agent. Must be valid JSON.
+              </p>
+              <textarea
+                value={settings}
+                onChange={(e) => {
+                  setSettings(e.target.value);
+                  setDirty(true);
+                }}
+                placeholder='{"permissions": {"allow": ["Bash(npm test)", "Read"]}, "env": {"DEBUG": "true"}}'
+                className="flex-1 min-h-[280px] w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg p-3 text-sm text-sandstorm-text font-mono resize-none focus:outline-none focus:border-sandstorm-accent/50 placeholder:text-sandstorm-muted/50"
+              />
+              <div className="flex justify-end mt-3">
+                <button
+                  onClick={saveSettings}
+                  disabled={saving || !dirty}
+                  className="px-4 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-lg text-xs font-medium transition-all"
+                >
+                  {saving ? 'Saving...' : 'Save Settings'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -177,6 +177,16 @@ declare global {
         reset: (tabId: string) => Promise<void>;
         history: (tabId: string) => Promise<{ messages: Array<{ role: string; content: string }>; processing: boolean }>;
       };
+      context: {
+        get: (projectDir: string) => Promise<{ instructions: string; skills: string[]; settings: string }>;
+        saveInstructions: (projectDir: string, content: string) => Promise<void>;
+        listSkills: (projectDir: string) => Promise<string[]>;
+        getSkill: (projectDir: string, name: string) => Promise<string>;
+        saveSkill: (projectDir: string, name: string, content: string) => Promise<void>;
+        deleteSkill: (projectDir: string, name: string) => Promise<void>;
+        getSettings: (projectDir: string) => Promise<string>;
+        saveSettings: (projectDir: string, content: string) => Promise<void>;
+      };
       on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
     };
   }


### PR DESCRIPTION
## Summary
- Adds a **Context** button in the Dashboard header (visible when a project tab is selected)
- Opens a modal with 3 tabs: **Instructions**, **Skills**, **Settings**
- Personal overrides stored in `.sandstorm/context/` (auto-gitignored, not committed)
- Files get injected into inner Claude agents via the existing entrypoint mount
- New `custom-context.ts` module handles file-based CRUD for all context types
- Full IPC + preload + store type wiring

## How it works
- **Instructions**: Custom CLAUDE.md overlay appended to inner Claude's user-level instructions
- **Skills**: Personal skill files (`.md`) managed in a sidebar with create/edit/delete
- **Settings**: JSON overrides for inner Claude agent settings

## Test plan
- [x] `npm test` — 198 tests pass
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm run build` — builds successfully
- [ ] Visual: open a project tab, click Context, verify modal renders
- [ ] Save instructions, verify file appears in `.sandstorm/context/instructions.md`
- [ ] Verify `.sandstorm/.gitignore` gets `context/` entry auto-added
- [ ] Create/edit/delete a skill, verify files in `.sandstorm/context/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)