### PR TITLE
Add /verify skill and simplify CLAUDE.md verification loop

### DIFF
--- a/.claude/evals/verify.yml
+++ b/.claude/evals/verify.yml
@@ -1,0 +1,37 @@
+name: verify
+description: Test that Claude uses the verify skill correctly
+test_cases:
+  - name: basic_verify
+    prompt: "verify the build"
+    expected:
+      - skill: verify
+      - command_contains: "npm test"
+      - command_contains: "npx tsc --noEmit"
+      - command_contains: "npm run build"
+    tags: [verify, build, test]
+
+  - name: verify_after_ui_change
+    prompt: "I just changed the UI, verify it works"
+    expected:
+      - skill: verify
+      - command_contains: "npm test"
+      - command_contains: "npm run build"
+      - command_contains: "take_screenshot"
+    tags: [verify, build, ui]
+
+  - name: package_request
+    prompt: "package the app"
+    expected:
+      - skill: verify
+      - command_contains: "npm run package"
+      - command_contains: "--config.npmRebuild=false"
+    tags: [verify, package]
+
+  - name: test_and_build
+    prompt: "run the tests and make sure everything builds"
+    expected:
+      - skill: verify
+      - command_contains: "npm test"
+      - command_contains: "npm run build"
+      - command_contains: "npx electron-rebuild"
+    tags: [verify, test, build]

--- a/.claude/skills/verify.md
+++ b/.claude/skills/verify.md
@@ -1,0 +1,83 @@
+---
+name: verify
+description: Run the full build verification loop. Sandstorm-aware — runs commands in the app service container when inside a stack.
+trigger: when the user asks to verify, build, package, test, or run the verification loop
+user_invocable: true
+---
+
+# Full Build Verification Loop
+
+Run all verification steps in order. If ANY step fails, fix the issue and restart from Step 1. Do not report success without completing all steps.
+
+## Environment Detection
+
+First, detect whether you are inside a Sandstorm stack:
+
+```bash
+echo "${SANDSTORM_STACK_ID:-not-set}"
+```
+
+- **Inside a Sandstorm stack** (`SANDSTORM_STACK_ID` is set): Run ALL build/test commands via `docker exec` on the app service container. Edit code directly in `/app`, but execute commands in the container where node_modules and native tooling live.
+
+  Command pattern:
+  ```bash
+  docker exec ${SANDSTORM_STACK_ID}-app-1 bash -c '<command>'
+  ```
+
+- **Outside a stack** (`SANDSTORM_STACK_ID` is `not-set`): Run commands directly in the current shell.
+
+## Step 1: Tests
+
+```bash
+npm test
+```
+
+ALL tests must pass. If any fail, fix the code and rerun from Step 1.
+
+## Step 2: TypeScript
+
+```bash
+npx tsc --noEmit
+```
+
+Zero type errors. If any exist, fix and rerun from Step 1.
+
+## Step 3: Build
+
+```bash
+npm run build
+```
+
+Must complete without errors. If it fails, fix and restart from Step 1.
+
+## Step 4: Rebuild native modules for Electron
+
+```bash
+npx electron-rebuild
+```
+
+This recompiles native addons (better-sqlite3) against Electron's Node ABI. If `cpu-features` fails to build (g++ too old for `-std=gnu++20`), that's OK — it's optional. But **better-sqlite3 MUST succeed**.
+
+**WHY THIS MATTERS:** The container runs Node 22 (NODE_MODULE_VERSION 127). Electron uses its own Node (MODULE_VERSION 130). If you skip this step or let `npm run package` do it wrong, the packaged app will crash with `NODE_MODULE_VERSION` mismatch on the user's machine.
+
+## Step 5: Package
+
+```bash
+npm run package -- --config.npmRebuild=false
+```
+
+We pass `--config.npmRebuild=false` because we already rebuilt in Step 4. If electron-builder tries to rebuild again, it may undo our work or fail on optional deps.
+
+Must produce files in `release/`.
+
+## Step 6: Run
+
+```bash
+./release/"Sandstorm Desktop-0.1.0.AppImage" --no-sandbox 2>&1 | head -30
+```
+
+The app MUST launch without crashing. If it crashes with NODE_MODULE_VERSION errors, go back to Step 4 — the native module rebuild failed or was skipped. If it crashes for other reasons, read the error, fix, and go back to Step 1.
+
+## Step 7: Visual verification
+
+If you changed any UI code, use the Chrome DevTools MCP to take a screenshot of the running app and verify it looks correct. No black text on dark backgrounds. No broken layouts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,54 +4,7 @@ This is an Electron desktop app (React + Tailwind + TypeScript). It packages int
 
 ## Mandatory verification loop
 
-Every task MUST end with a successful verification loop. Do not report a task as complete unless ALL steps pass:
-
-### Step 1: Tests
-```bash
-npm test
-```
-ALL tests must pass. If any fail, fix the code and rerun.
-
-### Step 2: TypeScript
-```bash
-npx tsc --noEmit
-```
-Zero type errors. If any exist, fix and rerun.
-
-### Step 3: Build
-```bash
-npm run build
-```
-Must complete without errors. If it fails, fix and rebuild.
-
-### Step 4: Rebuild native modules for Electron
-```bash
-npx electron-rebuild
-```
-This recompiles native addons (better-sqlite3) against Electron's Node ABI. If `cpu-features` fails to build (g++ too old for `-std=gnu++20`), that's OK — it's optional. But better-sqlite3 MUST succeed.
-
-**WHY THIS MATTERS:** The container runs Node 22 (NODE_MODULE_VERSION 127). Electron uses its own Node (MODULE_VERSION 130). If you skip this step or let `npm run package` do it wrong, the packaged app will crash with `NODE_MODULE_VERSION` mismatch on the user's machine.
-
-### Step 5: Package
-```bash
-npm run package -- --config.npmRebuild=false
-```
-We pass `--config.npmRebuild=false` here because we already rebuilt in Step 4. If electron-builder tries to rebuild again, it may undo our work or fail on optional deps.
-
-Must produce files in `release/`.
-
-### Step 6: Run
-```bash
-./release/"Sandstorm Desktop-0.1.0.AppImage" --no-sandbox 2>&1 | head -30
-```
-The app MUST launch without crashing. If it crashes with NODE_MODULE_VERSION errors, go back to Step 4 — the native module rebuild failed or was skipped. If it crashes for other reasons, read the error, fix, and go back to Step 3.
-
-### Step 7: Visual verification
-If you changed any UI code, use the Chrome DevTools MCP to take a screenshot of the running app and verify it looks correct. No black text on dark backgrounds. No broken layouts.
-
-## The loop
-
-If ANY step fails, fix the issue and restart from Step 1. Do not skip steps. Do not report success without completing all 6 steps.
+Every task MUST end with a successful /verify. This runs all build verification steps (tests, types, build, electron-rebuild, package, run). Do not report a task as complete unless /verify passes.
 
 ## Product vision
 


### PR DESCRIPTION
## Summary
- Add `/verify` skill (`.claude/skills/verify.md`) with full 7-step build verification loop
- Skill is Sandstorm-aware: detects if running inside a stack and routes commands through `docker exec` on the app service container
- Simplify `CLAUDE.md` — replace verbose 47-line verification section with one-liner referencing `/verify`
- Add eval (`verify.yml`) with 4 test cases covering basic verify, UI changes, packaging, and test+build scenarios

## Test plan
- [ ] Run `/verify` outside a stack — verify all 7 steps execute directly
- [ ] Run `/verify` inside a stack — verify commands route through `docker exec`
- [ ] Check that CLAUDE.md still references the verification requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)