### PR TITLE
Update CLAUDE.md, verify skill, and add grab-ticket skill

- Rewrite CLAUDE.md: remove better-sqlite3 references, fix dist/ paths,
  add issue tracking section, add development workflow section
- Fix verify.md: remove electron-rebuild step (sql.js is WASM, no native
  rebuild needed), renumber remaining steps
- Add grab-ticket.md skill: fetch GitHub issue, create stack, dispatch work

### DIFF
--- a/.claude/skills/grab-ticket.md
+++ b/.claude/skills/grab-ticket.md
@@ -1,0 +1,51 @@
+---
+name: grab-ticket
+description: Fetch a GitHub issue by number, read it, create a stack, and dispatch the work.
+trigger: when the user says to grab a ticket, start an issue, work on issue #N, or pick up a ticket
+user_invocable: true
+---
+
+# Grab Ticket
+
+Fetch a GitHub issue, spin up a Sandstorm stack for it, and dispatch the task.
+
+## Step 1: Fetch the issue
+
+```bash
+gh issue view <NUMBER> -R onomojo/sandstorm-desktop
+```
+
+Read the issue title, body, labels, and any comments. Understand what needs to be done.
+
+## Step 2: Derive a stack ID
+
+Turn the issue title into a short kebab-case identifier suitable for a branch name. Examples:
+- "Fix auth token refresh" → `fix-auth-token-refresh`
+- "Add dark mode toggle" → `add-dark-mode-toggle`
+
+## Step 3: Create the stack
+
+Use the sandstorm-create-stack skill:
+
+```bash
+sandstorm up <stack_id> --ticket <NUMBER>
+```
+
+Wait for the stack to be ready (`sandstorm status`).
+
+## Step 4: Dispatch the task
+
+Use the sandstorm-dispatch-task skill to send the issue description as the task prompt. Include key details from the issue body so the inner Claude has full context.
+
+## Step 5: Confirm
+
+Report back to the user:
+- Issue number and title
+- Stack ID created
+- Task dispatched
+
+## Notes
+
+- If the user says "grab tickets #1 through #5", repeat steps 1-4 for each issue in parallel (one stack per issue).
+- If the issue lacks enough detail to dispatch, ask the user for clarification before dispatching.
+- Always fetch the issue fresh — don't rely on cached or remembered issue content.

--- a/.claude/skills/verify.md
+++ b/.claude/skills/verify.md
@@ -50,34 +50,22 @@ npm run build
 
 Must complete without errors. If it fails, fix and restart from Step 1.
 
-## Step 4: Rebuild native modules for Electron
+## Step 4: Package
 
 ```bash
-npx electron-rebuild
+npm run package
 ```
 
-This recompiles native addons (better-sqlite3) against Electron's Node ABI. If `cpu-features` fails to build (g++ too old for `-std=gnu++20`), that's OK — it's optional. But **better-sqlite3 MUST succeed**.
+Must produce files in `release/`. No native module rebuild is needed — sql.js is WASM-based.
 
-**WHY THIS MATTERS:** The container runs Node 22 (NODE_MODULE_VERSION 127). Electron uses its own Node (MODULE_VERSION 130). If you skip this step or let `npm run package` do it wrong, the packaged app will crash with `NODE_MODULE_VERSION` mismatch on the user's machine.
-
-## Step 5: Package
-
-```bash
-npm run package -- --config.npmRebuild=false
-```
-
-We pass `--config.npmRebuild=false` because we already rebuilt in Step 4. If electron-builder tries to rebuild again, it may undo our work or fail on optional deps.
-
-Must produce files in `release/`.
-
-## Step 6: Run
+## Step 5: Run
 
 ```bash
 ./release/"Sandstorm Desktop-0.1.0.AppImage" --no-sandbox 2>&1 | head -30
 ```
 
-The app MUST launch without crashing. If it crashes with NODE_MODULE_VERSION errors, go back to Step 4 — the native module rebuild failed or was skipped. If it crashes for other reasons, read the error, fix, and go back to Step 1.
+The app MUST launch without crashing. If it crashes, read the error, fix, and go back to Step 1.
 
-## Step 7: Visual verification
+## Step 6: Visual verification
 
 If you changed any UI code, use the Chrome DevTools MCP to take a screenshot of the running app and verify it looks correct. No black text on dark backgrounds. No broken layouts.


### PR DESCRIPTION
Changes from Sandstorm stack fix-claude-md-and-skills