### PR TITLE
Fix stack status stuck on running after second dispatched task (fixes #18)

### DIFF
--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -11,10 +11,21 @@ export interface TaskEvents {
 
 /** Max consecutive exec failures before marking a task as failed */
 const MAX_CONSECUTIVE_ERRORS = 30;
+/** Max consecutive polls that return a stale terminal status (completed/failed)
+ *  before we accept it as valid even without seeing "running" first.
+ *  Acts as a safety net if the task runner crashes before writing "running". */
+const MAX_STALE_POLLS = 30;
 
 export class TaskWatcher extends EventEmitter {
   private watchers = new Map<string, NodeJS.Timeout>();
   private errorCounts = new Map<string, number>();
+  /** Tracks whether we've seen "running" status for the current watch cycle.
+   *  Prevents stale "completed" from a prior task from triggering false completion.
+   *  Assumes the task runner always writes "running" before completion and that
+   *  at least one poll lands while the task is in "running" state (safe because
+   *  Claude tasks take many seconds and the default poll interval is 2 s). */
+  private seenRunning = new Map<string, boolean>();
+  private stalePollCounts = new Map<string, number>();
   private pollInterval: number;
   private onStatusChange?: () => void;
 
@@ -40,6 +51,8 @@ export class TaskWatcher extends EventEmitter {
     }
 
     this.errorCounts.set(stackId, 0);
+    this.seenRunning.set(stackId, false);
+    this.stalePollCounts.set(stackId, 0);
 
     const interval = setInterval(async () => {
       await this.checkTaskStatus(stackId, containerId);
@@ -55,6 +68,8 @@ export class TaskWatcher extends EventEmitter {
       this.watchers.delete(stackId);
     }
     this.errorCounts.delete(stackId);
+    this.seenRunning.delete(stackId);
+    this.stalePollCounts.delete(stackId);
   }
 
   unwatchAll(): void {
@@ -101,7 +116,24 @@ export class TaskWatcher extends EventEmitter {
       ]);
       const status = result.stdout.trim();
 
+      if (status === 'running') {
+        this.seenRunning.set(stackId, true);
+        this.errorCounts.set(stackId, 0);
+        return;
+      }
+
       if (status === 'completed' || status === 'failed') {
+        // Ignore stale completion from a prior task — we must see "running"
+        // at least once before treating completion as valid.
+        // Safety net: if we never see "running" (e.g. task runner crashed),
+        // accept the status after MAX_STALE_POLLS to avoid polling forever.
+        if (!this.seenRunning.get(stackId)) {
+          const staleCount = (this.stalePollCounts.get(stackId) ?? 0) + 1;
+          this.stalePollCounts.set(stackId, staleCount);
+          if (staleCount < MAX_STALE_POLLS) {
+            return;
+          }
+        }
         let exitCode: number;
         try {
           const exitResult = await this.runtime.exec(containerId, [

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -31,6 +31,39 @@ function createMockRuntime(
   };
 }
 
+/**
+ * Create a mock runtime that transitions through status phases.
+ * Returns `statuses[callIndex]` for each successive read of the status file,
+ * staying on the last entry once exhausted.
+ */
+function createSequencedRuntime(
+  statuses: string[],
+  exitCode: string = '0'
+): ContainerRuntime {
+  let callIndex = 0;
+  return {
+    name: 'mock',
+    composeUp: vi.fn(),
+    composeDown: vi.fn(),
+    listContainers: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn(),
+    logs: vi.fn(),
+    exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+      if (cmd.includes('/tmp/claude-task.status')) {
+        const idx = Math.min(callIndex, statuses.length - 1);
+        callIndex++;
+        return { exitCode: 0, stdout: statuses[idx], stderr: '' };
+      }
+      if (cmd.includes('/tmp/claude-task.exit')) {
+        return { exitCode: 0, stdout: exitCode, stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
 describe('TaskWatcher', () => {
   let registry: Registry;
   let dbPath: string;
@@ -63,7 +96,8 @@ describe('TaskWatcher', () => {
   });
 
   it('emits task:completed when task finishes successfully', async () => {
-    const runtime = createMockRuntime('completed', '0');
+    // Status transitions: running → completed
+    const runtime = createSequencedRuntime(['running', 'completed'], '0');
     const watcher = new TaskWatcher(registry, runtime, {
       pollInterval: 50,
     });
@@ -85,7 +119,8 @@ describe('TaskWatcher', () => {
   });
 
   it('emits task:failed when task exits with error', async () => {
-    const runtime = createMockRuntime('failed', '1');
+    // Status transitions: running → failed
+    const runtime = createSequencedRuntime(['running', 'failed'], '1');
     const watcher = new TaskWatcher(registry, runtime, {
       pollInterval: 50,
     });
@@ -107,7 +142,8 @@ describe('TaskWatcher', () => {
   });
 
   it('stops watching after task completes', async () => {
-    const runtime = createMockRuntime('completed', '0');
+    // Status transitions: running → completed
+    const runtime = createSequencedRuntime(['running', 'completed'], '0');
     const watcher = new TaskWatcher(registry, runtime, {
       pollInterval: 50,
     });
@@ -140,5 +176,83 @@ describe('TaskWatcher', () => {
     watcher.unwatchAll();
 
     // No error thrown — clean shutdown
+  });
+
+  it('ignores stale completed status from prior task (regression #18)', async () => {
+    // Simulate the bug scenario:
+    // 1. First task completes → status file says "completed"
+    // 2. Second task dispatched → watcher starts, status file still says "completed"
+    // 3. Task runner eventually overwrites with "running", then "completed"
+    //
+    // Without the fix, the watcher would immediately mark the second task as
+    // completed because it reads the stale "completed" from the first task.
+
+    // Phase 1: Complete the first task normally (running → completed)
+    const runtime1 = createSequencedRuntime(['running', 'completed'], '0');
+    const watcher = new TaskWatcher(registry, runtime1, { pollInterval: 50 });
+
+    registry.createTask('watch-stack', 'first task');
+
+    await new Promise<void>((resolve) => {
+      watcher.on('task:completed', () => resolve());
+      watcher.watch('watch-stack', 'container-123');
+    });
+
+    // Verify first task completed
+    const stack1 = registry.getStack('watch-stack');
+    expect(stack1!.status).toBe('completed');
+
+    // Phase 2: Dispatch second task — status file still has "completed" from task 1
+    // Simulate: stale "completed" → then task runner resets to "running" → then "completed"
+    const runtime2 = createSequencedRuntime(
+      ['completed', 'completed', 'running', 'running', 'completed'],
+      '0'
+    );
+    const watcher2 = new TaskWatcher(registry, runtime2, { pollInterval: 50 });
+
+    const task2 = registry.createTask('watch-stack', 'second task');
+
+    // The watcher should NOT immediately complete — it must wait for "running" first
+    let completedTaskId: number | null = null;
+    const task2Completed = new Promise<void>((resolve) => {
+      watcher2.on('task:completed', ({ task }) => {
+        completedTaskId = task.id;
+        resolve();
+      });
+    });
+
+    watcher2.watch('watch-stack', 'container-123');
+
+    await task2Completed;
+
+    // Must be the second task that completed, not the first
+    expect(completedTaskId).toBe(task2.id);
+
+    // Stack should be completed
+    const stack2 = registry.getStack('watch-stack');
+    expect(stack2!.status).toBe('completed');
+
+    watcher2.unwatchAll();
+  });
+
+  it('detects completion for first task without needing prior running (fresh dispatch)', async () => {
+    // For the very first task on a stack, the status file doesn't exist yet.
+    // The task runner writes "running" first, then "completed".
+    // This should work normally.
+    const runtime = createSequencedRuntime(['running', 'completed'], '0');
+    const watcher = new TaskWatcher(registry, runtime, { pollInterval: 50 });
+
+    registry.createTask('watch-stack', 'fresh task');
+
+    const completed = new Promise<void>((resolve) => {
+      watcher.on('task:completed', ({ task }) => {
+        expect(task.exit_code).toBe(0);
+        resolve();
+      });
+    });
+
+    watcher.watch('watch-stack', 'container-123');
+    await completed;
+    watcher.unwatchAll();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes race condition where the task watcher would read a stale "completed" status from a prior task and immediately mark the new task as done
- Task watcher now tracks whether it has seen "running" status before accepting "completed/failed" as valid
- Safety net: after MAX_STALE_POLLS (30) consecutive stale reads, accepts the status anyway to avoid polling forever

## Changes

- `src/main/control-plane/task-watcher.ts` — Added `seenRunning` and `stalePollCounts` tracking per stack. Watcher ignores terminal statuses until "running" is observed first.
- `tests/unit/task-watcher.test.ts` — Added regression test for the exact bug scenario (second dispatch with stale status), plus sequenced runtime helper for multi-phase status transitions

## Test plan

- [ ] Create a stack, dispatch initial task — completes normally
- [ ] Dispatch a second task to the same stack — verify status transitions to "running" then "completed"
- [ ] Verify `list_stacks` no longer shows stuck "running" after second task completes

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)