### PR TITLE
Add ability to close project from GUI (fixes #19)

### DIFF
--- a/src/renderer/components/ProjectTabs.tsx
+++ b/src/renderer/components/ProjectTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAppStore } from '../store';
 
 export function ProjectTabs() {
@@ -9,6 +9,22 @@ export function ProjectTabs() {
     setShowOpenProjectDialog,
     removeProject,
   } = useAppStore();
+
+  const [confirmingCloseId, setConfirmingCloseId] = useState<number | null>(null);
+
+  const handleClose = (e: React.MouseEvent, projectId: number) => {
+    e.stopPropagation();
+    setConfirmingCloseId(projectId);
+  };
+
+  const confirmClose = async (projectId: number) => {
+    setConfirmingCloseId(null);
+    await removeProject(projectId);
+  };
+
+  const cancelClose = () => {
+    setConfirmingCloseId(null);
+  };
 
   return (
     <div className="titlebar-no-drag flex items-center bg-sandstorm-surface border-b border-sandstorm-border shrink-0 overflow-x-auto">
@@ -31,24 +47,29 @@ export function ProjectTabs() {
 
       {/* Project tabs */}
       {projects.map((project) => (
-        <button
-          key={project.id}
-          onClick={() => setActiveProjectId(project.id)}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            if (confirm(`Remove project "${project.name}" from tabs?`)) {
-              removeProject(project.id);
-            }
-          }}
-          className={`group shrink-0 px-4 py-2 text-xs font-medium transition-colors border-b-2 ${
-            activeProjectId === project.id
-              ? 'border-sandstorm-accent text-sandstorm-accent'
-              : 'border-transparent text-sandstorm-muted hover:text-sandstorm-text-secondary'
-          }`}
-          title={project.directory}
-        >
-          {project.name}
-        </button>
+        <div key={project.id} className="group relative shrink-0">
+          <button
+            onClick={() => setActiveProjectId(project.id)}
+            className={`shrink-0 pl-4 pr-7 py-2 text-xs font-medium transition-colors border-b-2 ${
+              activeProjectId === project.id
+                ? 'border-sandstorm-accent text-sandstorm-accent'
+                : 'border-transparent text-sandstorm-muted hover:text-sandstorm-text-secondary'
+            }`}
+            title={project.directory}
+          >
+            {project.name}
+          </button>
+          <button
+            onClick={(e) => handleClose(e, project.id)}
+            className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:!opacity-100 hover:bg-sandstorm-border text-sandstorm-muted hover:text-sandstorm-text-secondary transition-opacity"
+            aria-label={`Close ${project.name}`}
+            title={`Close ${project.name}`}
+          >
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
       ))}
 
       {/* Add project button */}
@@ -61,6 +82,34 @@ export function ProjectTabs() {
           <path d="M12 5v14M5 12h14"/>
         </svg>
       </button>
+
+      {/* Close confirmation dialog */}
+      {confirmingCloseId !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={cancelClose}>
+          <div className="bg-sandstorm-surface border border-sandstorm-border rounded-lg p-4 shadow-lg max-w-sm" onClick={(e) => e.stopPropagation()}>
+            <p className="text-sm text-sandstorm-text-primary mb-1">
+              Close project &quot;{projects.find((p) => p.id === confirmingCloseId)?.name}&quot;?
+            </p>
+            <p className="text-xs text-sandstorm-muted mb-4">
+              This won&apos;t affect running stacks.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={cancelClose}
+                className="px-3 py-1.5 text-xs rounded bg-sandstorm-border text-sandstorm-text-secondary hover:bg-sandstorm-border/80"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => confirmClose(confirmingCloseId)}
+                className="px-3 py-1.5 text-xs rounded bg-sandstorm-accent text-white hover:bg-sandstorm-accent/80"
+              >
+                Close Project
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/tests/unit/components/ProjectTabs.test.tsx
+++ b/tests/unit/components/ProjectTabs.test.tsx
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ProjectTabs } from '../../../src/renderer/components/ProjectTabs';
 import { useAppStore } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
@@ -62,5 +62,109 @@ describe('ProjectTabs', () => {
     const addBtn = screen.getByTitle('Open project');
     fireEvent.click(addBtn);
     expect(useAppStore.getState().showOpenProjectDialog).toBe(true);
+  });
+
+  it('shows close button for each project tab', () => {
+    useAppStore.setState({
+      projects: [
+        { id: 1, name: 'project-a', directory: '/a', added_at: '' },
+        { id: 2, name: 'project-b', directory: '/b', added_at: '' },
+      ],
+    });
+
+    render(<ProjectTabs />);
+    expect(screen.getByLabelText('Close project-a')).toBeDefined();
+    expect(screen.getByLabelText('Close project-b')).toBeDefined();
+  });
+
+  it('shows confirmation dialog when close button is clicked', () => {
+    useAppStore.setState({
+      projects: [{ id: 1, name: 'my-project', directory: '/proj', added_at: '' }],
+    });
+
+    render(<ProjectTabs />);
+    fireEvent.click(screen.getByLabelText('Close my-project'));
+
+    expect(screen.getByText(/Close project "my-project"\?/)).toBeDefined();
+    expect(screen.getByText(/won't affect running stacks/)).toBeDefined();
+    expect(screen.getByText('Cancel')).toBeDefined();
+    expect(screen.getByText('Close Project')).toBeDefined();
+  });
+
+  it('dismisses confirmation dialog when Cancel is clicked', () => {
+    useAppStore.setState({
+      projects: [{ id: 1, name: 'my-project', directory: '/proj', added_at: '' }],
+    });
+
+    render(<ProjectTabs />);
+    fireEvent.click(screen.getByLabelText('Close my-project'));
+    expect(screen.getByText(/Close project "my-project"\?/)).toBeDefined();
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByText(/Close project "my-project"\?/)).toBeNull();
+  });
+
+  it('removes project and switches to All tab when confirming close of active project', async () => {
+    const api = mockSandstormApi();
+    api.projects.list.mockResolvedValue([]);
+    api.projects.remove.mockResolvedValue(undefined);
+
+    useAppStore.setState({
+      projects: [{ id: 1, name: 'my-project', directory: '/proj', added_at: '' }],
+      activeProjectId: 1,
+    });
+
+    render(<ProjectTabs />);
+    fireEvent.click(screen.getByLabelText('Close my-project'));
+    fireEvent.click(screen.getByText('Close Project'));
+
+    await waitFor(() => {
+      expect(api.projects.remove).toHaveBeenCalledWith(1);
+    });
+    await waitFor(() => {
+      expect(useAppStore.getState().activeProjectId).toBeNull();
+    });
+  });
+
+  it('removes project without changing active tab when closing non-active project', async () => {
+    const api = mockSandstormApi();
+    api.projects.list.mockResolvedValue([
+      { id: 1, name: 'project-a', directory: '/a', added_at: '' },
+    ]);
+    api.projects.remove.mockResolvedValue(undefined);
+
+    useAppStore.setState({
+      projects: [
+        { id: 1, name: 'project-a', directory: '/a', added_at: '' },
+        { id: 2, name: 'project-b', directory: '/b', added_at: '' },
+      ],
+      activeProjectId: 1,
+    });
+
+    render(<ProjectTabs />);
+    fireEvent.click(screen.getByLabelText('Close project-b'));
+    fireEvent.click(screen.getByText('Close Project'));
+
+    await waitFor(() => {
+      expect(api.projects.remove).toHaveBeenCalledWith(2);
+    });
+    await waitFor(() => {
+      expect(useAppStore.getState().activeProjectId).toBe(1);
+    });
+  });
+
+  it('dismisses confirmation dialog when clicking overlay backdrop', () => {
+    useAppStore.setState({
+      projects: [{ id: 1, name: 'my-project', directory: '/proj', added_at: '' }],
+    });
+
+    render(<ProjectTabs />);
+    fireEvent.click(screen.getByLabelText('Close my-project'));
+    expect(screen.getByText(/Close project "my-project"\?/)).toBeDefined();
+
+    // Click the backdrop overlay (the fixed div)
+    const backdrop = screen.getByText(/Close project "my-project"\?/).closest('.bg-sandstorm-surface')!.parentElement!;
+    fireEvent.click(backdrop);
+    expect(screen.queryByText(/Close project "my-project"\?/)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds an X close button on each project tab (visible on hover, like browser tabs)
- Shows a confirmation dialog: "Close project X? This won't affect running stacks."
- Closing a project removes it from the GUI only — no stacks are stopped or torn down
- If the closed project was the active tab, switches to the "All" tab
- Removes the old right-click context menu for project removal

## Changes

- `src/renderer/components/ProjectTabs.tsx` — Added close button with hover visibility, inline confirmation dialog with Cancel/Close Project actions
- `tests/unit/components/ProjectTabs.test.tsx` — 6 new tests covering: close button visibility, confirmation dialog display, cancel behavior, active project close (switches to All), non-active project close (preserves tab), backdrop dismiss

## Test plan

- [ ] Hover over a project tab — X button appears
- [ ] Click X — confirmation dialog shows with correct project name
- [ ] Click Cancel — dialog dismisses, nothing changes
- [ ] Click Close Project on active project — project removed, switches to All tab
- [ ] Click Close Project on non-active project — project removed, active tab unchanged
- [ ] Verify running stacks for the project are NOT affected

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)