### PR TITLE
Update sandstorm skill to pass issue body verbatim as task (fixes #48)

### DIFF
--- a/.claude/skills/sandstorm/SKILL.md
+++ b/.claude/skills/sandstorm/SKILL.md
@@ -28,13 +28,14 @@ Sandstorm manages isolated Docker agent stacks. Each stack is a full clone of th
 - **NEVER set `branch` to `main`.** Omit the `branch` parameter — it defaults to the stack name, which becomes a feature branch. Setting `branch: "main"` causes pushes to go directly to main, bypassing code review. This has caused loss of work.
 - **NEVER tear down stacks unless the user explicitly asks.** No inference, no cleanup, no "let me tear this down first." The ONLY valid trigger is the user directly requesting teardown.
 - **Always create PRs after pushing.** Use `gh pr create` to open a pull request from the feature branch.
+- **NEVER rewrite, summarize, or embellish GitHub issue text when dispatching.** Pass the issue body verbatim. See the "Verbatim Issue Dispatch" section below.
 
 ## Workflows
 
 ### Typical flow: ticket to PR
 
 1. `create_stack` — name, projectDir, ticket (do NOT pass branch — it defaults to the stack name)
-2. `dispatch_task` — goal-oriented prompt describing the work
+2. `dispatch_task` — pass the **verbatim issue body** as the task prompt (see Verbatim Issue Dispatch below)
 3. `get_task_status` — check when done
 4. `get_diff` — review changes
 5. `push_stack` — commit and push to the feature branch
@@ -42,14 +43,35 @@ Sandstorm manages isolated Docker agent stacks. Each stack is a full clone of th
 
 Do NOT tear down stacks — only the user decides when to tear down.
 
-### Create stack and dispatch work
+### Verbatim Issue Dispatch
 
-```
+When the user says "start issue #N", "spin up a stack for issue #N", or any variation:
+
+1. **Fetch the full issue body:** `gh issue view <N> --json body,title -q '.body'`
+2. **Pass the issue body verbatim** as the `task` parameter to `create_stack` or `dispatch_task`
+3. **Do NOT summarize, rewrite, add implementation details, or "improve" the issue text**
+4. **Never add file paths, class names, or implementation steps that aren't in the issue**
+
+**If the user gives verbal instructions that differ from the issue**, update the issue first with `gh issue edit <N>`, then fetch and dispatch the updated body. The issue is the single source of truth.
+
+**Why this matters:**
+- The inner Claude has full repo context — it can figure out implementation details itself
+- The inner Claude reads CLAUDE.md, understands the codebase, and makes appropriate decisions
+- Adding implementation specifics from the outer Claude constrains the inner Claude and can steer it wrong
+- Summarizing loses important details and nuance from the original issue
+
+### Create stack and dispatch work (for a GitHub issue)
+
+```bash
+# 1. Fetch the issue body verbatim
+ISSUE_BODY=$(gh issue view 28 --json body -q '.body')
+
+# 2. Create stack with the unmodified issue body as the task
 mcp__sandstorm-tools__create_stack({
   name: "issue-28-fix-auth-bug",
   projectDir: "/path/to/project",
   ticket: "28",
-  task: "Fix the auth token expiry bug. Users should see a clear error and be redirected to login."
+  task: <ISSUE_BODY — the full, unmodified issue text>
 })
 ```
 
@@ -86,7 +108,7 @@ gh pr create --title "Fix auth token expiry" --body "Fixes #28"
 | `branch` | No | Git branch name (defaults to stack name). **NEVER set to `main`.** |
 | `description` | No | Short description of the work |
 | `runtime` | No | `docker` (default) or `podman` |
-| `task` | No | Task to dispatch immediately after creation |
+| `task` | No | Task to dispatch immediately after creation. **When working on a GitHub issue, this MUST be the verbatim issue body — never a summary or rewrite.** |
 
 The stack builds in the background. Use `get_task_status` or `list_stacks` to check when it's ready.
 
@@ -95,13 +117,17 @@ The stack builds in the background. Use `get_task_status` or `list_stacks` to ch
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `stackId` | Yes | Target stack ID |
-| `prompt` | Yes | Task description for inner Claude |
+| `prompt` | Yes | Task description for inner Claude. **When working on a GitHub issue, this MUST be the verbatim issue body.** |
 
 **Write goal-oriented prompts.** Describe WHAT to achieve, not HOW. The inner Claude has the full repo context.
 
-**Good:** "Fix the auth bug where JWT tokens expire silently. User should see an error and be redirected to login. Run the auth test suite."
+**When dispatching for a GitHub issue:** Pass the issue body verbatim. Do not summarize, rewrite, or add implementation details.
 
-**Bad:** "Open src/auth.ts, find line 42, change the catch block..."
+**For follow-up tasks** (not initial issue dispatch): goal-oriented prompts are fine.
+
+**Good follow-up:** "Looks good but add limit/offset params to the list endpoint"
+
+**Bad initial dispatch:** Rewriting "Fix auth bug" into "Open src/auth.ts, find line 42, change the catch block..."
 
 ### `get_task_status`
 
@@ -142,7 +168,7 @@ Stops containers, removes workspace, archives stack to history. **This is irreve
 - **No polling loops.** Run `get_task_status` as a one-shot check when the user asks. Never write sleep/poll loops.
 - **Review before pushing.** Always `get_diff` before `push_stack`.
 - **Check before teardown.** Always `get_diff` before `teardown_stack` to avoid losing work.
-- **Goal-oriented prompts.** Tell inner Claude what to achieve, not which lines to edit.
+- **Verbatim issue dispatch.** When dispatching work for a GitHub issue, pass the issue body verbatim as the task prompt. Never summarize, rewrite, add file paths, class names, or implementation steps that aren't in the issue. If the user's instructions differ from the issue, update the issue first, then dispatch.
 - **Stacks appear in the UI.** Because MCP tools go through the Electron control plane, every stack you create will be visible in the Sandstorm Desktop UI.
 - **NEVER use `main` as the branch.** Omit the branch parameter so stacks always work on feature branches.
 - **NEVER tear down stacks** unless the user explicitly requests it. No automatic cleanup.


### PR DESCRIPTION
Changes from Sandstorm stack issue-48-verbatim-issue-dispatch