### PR TITLE
Fix token parsing pipeline and improve inner Claude output formatting (fixes #75)

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -21,29 +21,44 @@ while true; do
 
     # Stream claude output in real-time using --output-format stream-json.
     # With --include-partial-messages, we get raw API streaming events
-    # (content_block_delta) that arrive token-by-token. We extract the
-    # text deltas with jq for human-readable real-time output in docker logs.
+    # (content_block_delta) that arrive token-by-token.
+    #
+    # Pipeline:
+    #   claude → tee raw JSON (for token parser) → jq (human-readable) → tee task log (for UI)
+    #
+    # The raw JSON log preserves all stream events including token usage in
+    # "result" and "message_delta" events. The jq filter produces clean,
+    # scannable output for the UI.
     #
     # Prompt is piped via stdin (-p -) to avoid shell quoting issues with
     # special characters (backticks, $, quotes, etc.) in prompts.
     cat /tmp/claude-task-prompt.txt \
       | claude --dangerously-skip-permissions --verbose --output-format stream-json \
           --include-partial-messages --print -p - 2>&1 \
+      | stdbuf -o0 tee /tmp/claude-raw.log \
       | jq -rj --unbuffered '
           if .type == "stream_event" then
             if .event.type == "content_block_delta" and .event.delta.type == "text_delta" then
               .event.delta.text
-            elif .event.type == "content_block_delta" and .event.delta.type == "input_json_delta" then
-              empty
             elif .event.type == "content_block_start" and .event.content_block.type == "tool_use" then
-              "\n[" + .event.content_block.name + "] "
+              "\n── \(.event.content_block.name) ──\n"
+            elif .event.type == "content_block_start" and .event.content_block.type == "text" then
+              ""
             else
               empty
             end
           elif .type == "assistant" then
             (.message.content[]? |
               if .type == "tool_use" then
-                "\n[" + .name + ": " + (.input | if .command then .command elif .file_path then .file_path elif .pattern then .pattern elif .prompt then (.prompt | split("\n")[0][:80]) else (tostring[:100]) end) + "]\n"
+                "\n── \(.name) ──\n" +
+                (.input |
+                  if .command then "  $ \(.command)\n"
+                  elif .file_path then "  \(.file_path)\n"
+                  elif .pattern then "  \(.pattern)\n"
+                  elif .prompt then "  \(.prompt | split("\n")[0][:100])\n"
+                  else "  \(tostring[:120])\n"
+                  end
+                )
               elif .type == "text" then
                 .text
               else
@@ -53,7 +68,7 @@ while true; do
           elif .type == "result" then
             "\n" + (.result // "") + "\n"
           elif .type == "error" then
-            "\nERROR: " + (.error.message // "unknown error") + "\n"
+            "\n❌ ERROR: " + (.error.message // "unknown error") + "\n"
           else
             empty
           end

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -143,7 +143,7 @@ export class TaskWatcher extends EventEmitter {
 
     try {
       const result = await this.runtime.exec(containerId, [
-        'cat', '/tmp/claude-task.log',
+        'cat', '/tmp/claude-raw.log',
       ]);
       const output = result.stdout;
 

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -352,6 +352,51 @@ describe('TaskWatcher', () => {
     watcher.unwatchAll();
   });
 
+  // --- Token parsing from raw log ---
+
+  it('reads token usage from claude-raw.log (not claude-task.log)', async () => {
+    const rawJsonOutput = [
+      '{"type":"content_block_delta","delta":{"text":"Hello"}}',
+      '{"type":"result","usage":{"input_tokens":1500,"output_tokens":800},"session_id":"sess-abc"}',
+    ].join('\n');
+
+    const runtime = createSequencedRuntime(['running', 'completed'], '0');
+    // Override exec to return raw JSON for claude-raw.log
+    const origExec = runtime.exec as ReturnType<typeof vi.fn>;
+    const execImpl = origExec.getMockImplementation()!;
+    (runtime.exec as ReturnType<typeof vi.fn>).mockImplementation(
+      async (id: string, cmd: string[]) => {
+        if (cmd.includes('/tmp/claude-raw.log')) {
+          return { exitCode: 0, stdout: rawJsonOutput, stderr: '' };
+        }
+        return execImpl(id, cmd);
+      }
+    );
+
+    const watcher = new TaskWatcher(registry, runtime, { pollInterval: 50 });
+    registry.createTask('watch-stack', 'token test task');
+
+    await new Promise<void>((resolve) => {
+      watcher.on('task:completed', () => resolve());
+      watcher.watch('watch-stack', 'container-123');
+    });
+
+    // Verify exec was called with claude-raw.log
+    const execCalls = (runtime.exec as ReturnType<typeof vi.fn>).mock.calls;
+    const rawLogCalls = execCalls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && call[1].includes('/tmp/claude-raw.log')
+    );
+    expect(rawLogCalls.length).toBeGreaterThan(0);
+
+    // Verify token data was stored
+    const tasks = registry.getTasksForStack('watch-stack');
+    const task = tasks.find((t) => t.prompt === 'token test task');
+    expect(task!.input_tokens).toBe(1500);
+    expect(task!.output_tokens).toBe(800);
+
+    watcher.unwatchAll();
+  });
+
   // --- Exponential backoff tests ---
 
   it('applies exponential backoff on exec failures', async () => {


### PR DESCRIPTION
## Summary

- **Split task-runner pipeline** to capture raw stream-json before the jq filter — token usage data (in `result` and `message_delta` events) was being stripped by jq, so all token counts stayed at 0
- **Updated task-watcher** to read from `/tmp/claude-raw.log` (raw JSON) instead of `/tmp/claude-task.log` (human-readable text)
- **Improved jq filter formatting** — tool calls show with `── ToolName ──` separators, inputs get contextual prefixes (`$` for commands, paths for files), errors get visual prefix

### Pipeline before/after

```
Before: claude → jq (strips JSON) → tee claude-task.log
                                          ↑ token parser reads here (gets no JSON = 0 tokens)

After:  claude → tee claude-raw.log → jq (readable text) → tee claude-task.log
                      ↑ token parser reads here (gets full JSON with token counts)
```

## Test plan

- [ ] Verify token usage displays in Dashboard, StackCard, StackDetail, StackTableRow after dispatching a task
- [ ] Verify inner Claude output in UI is readable with clean tool call formatting
- [ ] Verify rate limit detection from log parsing works
- [ ] Run `npm test` — all tests pass including new `claude-raw.log` token parsing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)