### PR TITLE
Fix blank window in production AppImage (fixes #96)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ squashfs-root/
 .mcp.json
 .sandstorm-ready
 .sandstorm/
+src/renderer/build-version.txt

--- a/electron-vite.config.ts
+++ b/electron-vite.config.ts
@@ -1,15 +1,6 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
-import { execSync } from 'child_process';
-
-const gitCommitHash = (() => {
-  try {
-    return execSync('git rev-parse --short HEAD').toString().trim();
-  } catch {
-    return 'unknown';
-  }
-})();
 
 export default defineConfig({
   main: {
@@ -33,9 +24,6 @@ export default defineConfig({
   renderer: {
     plugins: [react()],
     root: resolve(__dirname, 'src/renderer'),
-    define: {
-      __GIT_COMMIT__: JSON.stringify(gitCommitHash),
-    },
     build: {
       outDir: resolve(__dirname, 'dist/renderer'),
       rollupOptions: {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,10 @@ echo "    Platform: $platform"
 echo "==> Installing dependencies..."
 npm ci
 
+echo "==> Writing build version..."
+git rev-parse --short HEAD > src/renderer/build-version.txt
+echo "    Commit: $(cat src/renderer/build-version.txt)"
+
 echo "==> Building app..."
 npm run build
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { NewStackDialog } from './components/NewStackDialog';
 import { ProjectTabs } from './components/ProjectTabs';
 import { OpenProjectDialog } from './components/OpenProjectDialog';
 import trayIcon from './tray-icon.png';
+import buildVersion from './build-version.txt?raw';
 
 /** Polling interval when Docker is connected (ms) */
 const STACK_POLL_INTERVAL = 3000;
@@ -104,8 +105,8 @@ export default function App() {
           <span className="text-xs font-semibold text-sandstorm-muted tracking-wide uppercase">
             Sandstorm
           </span>
-          <span className="text-[10px] text-sandstorm-muted/50 font-mono" title={`Build: ${__GIT_COMMIT__}`}>
-            {__GIT_COMMIT__}
+          <span className="text-[10px] text-sandstorm-muted/50 font-mono" title={`Build: ${buildVersion.trim()}`}>
+            {buildVersion.trim()}
           </span>
         </div>
       </div>

--- a/src/renderer/assets.d.ts
+++ b/src/renderer/assets.d.ts
@@ -3,4 +3,7 @@ declare module '*.png' {
   export default src;
 }
 
-declare const __GIT_COMMIT__: string;
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `electron-vite` silently drops the `define` config from the renderer, so `__GIT_COMMIT__` (added in PR #93) was never replaced at build time — causing a `ReferenceError` that crashed React on startup, resulting in a blank window.
- **Fix:** Build script now writes `git rev-parse --short HEAD` to a gitignored `src/renderer/build-version.txt`, which `App.tsx` imports via Vite's `?raw` suffix. Simple, no framework quirks.
- Removed broken `define`/`execSync` from `electron-vite.config.ts`

## Test plan

- [x] `npm run build` succeeds, `grep '__GIT_COMMIT__' dist/renderer/assets/index-*.js` returns no matches
- [x] `npm run release` produces a working AppImage
- [x] App component tests pass (`npm test -- tests/unit/components/App.test.tsx`)
- [ ] Launch AppImage — window renders correctly with commit hash in sidebar header

🤖 Generated with [Claude Code](https://claude.com/claude-code)