### PR TITLE
Add account-wide token usage progress bar

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import { StackDetail } from './components/StackDetail';
 import { NewStackDialog } from './components/NewStackDialog';
 import { ProjectTabs } from './components/ProjectTabs';
 import { OpenProjectDialog } from './components/OpenProjectDialog';
+import { AccountUsageBar } from './components/AccountUsageBar';
 import trayIcon from './tray-icon.png';
 import buildVersion from './build-version.txt?raw';
 
@@ -99,7 +100,7 @@ export default function App() {
   return (
     <div className="h-screen flex flex-col bg-sandstorm-bg text-sandstorm-text">
       {/* Title bar — centered on macOS to avoid traffic lights, left-aligned elsewhere */}
-      <div className={`titlebar-drag h-10 bg-sandstorm-surface border-b border-sandstorm-border flex items-center px-4 shrink-0 ${navigator.platform.includes('Mac') ? 'justify-center' : ''}`}>
+      <div className={`titlebar-drag h-10 bg-sandstorm-surface border-b border-sandstorm-border flex items-center px-4 shrink-0 relative ${navigator.platform.includes('Mac') ? 'justify-center' : ''}`}>
         <div className="titlebar-no-drag flex items-center gap-2.5">
           <img src={trayIcon} alt="Sandstorm" className="w-6 h-6" />
           <span className="text-xs font-semibold text-sandstorm-muted tracking-wide uppercase">
@@ -108,6 +109,9 @@ export default function App() {
           <span className="text-[10px] text-sandstorm-muted/50 font-mono" title={`Build: ${buildVersion.trim()}`}>
             {buildVersion.trim()}
           </span>
+        </div>
+        <div className="titlebar-no-drag absolute right-4">
+          <AccountUsageBar />
         </div>
       </div>
 

--- a/src/renderer/components/AccountUsageBar.tsx
+++ b/src/renderer/components/AccountUsageBar.tsx
@@ -1,0 +1,192 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useAppStore } from '../store';
+import { formatTokenCount } from '../utils/format';
+
+const BUDGET_PRESETS = [500_000, 1_000_000, 5_000_000, 10_000_000, 50_000_000];
+
+function getBarColor(percent: number): string {
+  if (percent < 50) return 'bg-emerald-500';
+  if (percent < 75) return 'bg-yellow-500';
+  if (percent < 90) return 'bg-orange-500';
+  return 'bg-red-500';
+}
+
+function getTextColor(percent: number): string {
+  if (percent < 50) return 'text-emerald-400';
+  if (percent < 75) return 'text-yellow-400';
+  if (percent < 90) return 'text-orange-400';
+  return 'text-red-400';
+}
+
+export function AccountUsageBar() {
+  const { globalTokenUsage, tokenBudget, setTokenBudget } = useAppStore();
+  const [showPopover, setShowPopover] = useState(false);
+  const [customBudget, setCustomBudget] = useState('');
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Close popover on outside click
+  useEffect(() => {
+    if (!showPopover) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        popoverRef.current && !popoverRef.current.contains(e.target as Node) &&
+        buttonRef.current && !buttonRef.current.contains(e.target as Node)
+      ) {
+        setShowPopover(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showPopover]);
+
+  const totalTokens = globalTokenUsage?.total_tokens ?? 0;
+  const hasBudget = tokenBudget > 0;
+  const percent = hasBudget ? Math.min((totalTokens / tokenBudget) * 100, 100) : 0;
+
+  const handleSetBudget = (value: number) => {
+    setTokenBudget(value);
+    setShowPopover(false);
+    setCustomBudget('');
+  };
+
+  const handleCustomSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = parseFloat(customBudget);
+    if (!isNaN(parsed) && parsed > 0) {
+      // Support shorthand: "1M", "500k", or raw numbers
+      let value = parsed;
+      const lower = customBudget.toLowerCase().trim();
+      if (lower.endsWith('m')) {
+        value = parseFloat(lower) * 1_000_000;
+      } else if (lower.endsWith('k')) {
+        value = parseFloat(lower) * 1_000;
+      }
+      if (value > 0) {
+        handleSetBudget(Math.round(value));
+      }
+    }
+  };
+
+  // Don't render anything if no usage data yet
+  if (!globalTokenUsage) return null;
+
+  return (
+    <div className="titlebar-no-drag relative flex items-center" data-testid="account-usage-bar">
+      <button
+        ref={buttonRef}
+        onClick={() => setShowPopover(!showPopover)}
+        className="flex items-center gap-2 px-2 py-1 rounded-md hover:bg-sandstorm-surface-hover transition-colors group"
+        title={`Total tokens: ${totalTokens.toLocaleString()}${hasBudget ? ` / ${tokenBudget.toLocaleString()} budget` : ''}\nInput: ${(globalTokenUsage.total_input_tokens ?? 0).toLocaleString()}\nOutput: ${(globalTokenUsage.total_output_tokens ?? 0).toLocaleString()}\nClick to set budget`}
+        data-testid="usage-bar-button"
+      >
+        {/* Token icon */}
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-sandstorm-muted opacity-60 shrink-0">
+          <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+        </svg>
+
+        {hasBudget ? (
+          /* Progress bar mode */
+          <div className="flex items-center gap-1.5">
+            <div className="w-16 h-1.5 bg-sandstorm-border rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${getBarColor(percent)}`}
+                style={{ width: `${percent}%` }}
+                data-testid="usage-progress-fill"
+              />
+            </div>
+            <span className={`text-[10px] tabular-nums font-medium ${getTextColor(percent)}`} data-testid="usage-percent">
+              {Math.round(percent)}%
+            </span>
+          </div>
+        ) : (
+          /* Counter mode (no budget set) */
+          <span className="text-[10px] tabular-nums text-sandstorm-muted group-hover:text-sandstorm-text-secondary transition-colors" data-testid="usage-counter">
+            {formatTokenCount(totalTokens)}
+          </span>
+        )}
+      </button>
+
+      {/* Budget popover */}
+      {showPopover && (
+        <div
+          ref={popoverRef}
+          className="absolute top-full right-0 mt-1 w-56 bg-sandstorm-surface border border-sandstorm-border rounded-lg shadow-xl z-50 p-3"
+          data-testid="budget-popover"
+        >
+          <div className="text-[11px] font-semibold text-sandstorm-text mb-2">Token Budget</div>
+
+          {/* Current usage summary */}
+          <div className="text-[10px] text-sandstorm-muted mb-3 space-y-0.5">
+            <div className="flex justify-between">
+              <span>Total used</span>
+              <span className="text-sandstorm-text-secondary tabular-nums">{formatTokenCount(totalTokens)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Input</span>
+              <span className="tabular-nums">{formatTokenCount(globalTokenUsage.total_input_tokens)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Output</span>
+              <span className="tabular-nums">{formatTokenCount(globalTokenUsage.total_output_tokens)}</span>
+            </div>
+            {hasBudget && (
+              <div className="flex justify-between pt-1 border-t border-sandstorm-border">
+                <span>Budget</span>
+                <span className="text-sandstorm-text-secondary tabular-nums">{formatTokenCount(tokenBudget)}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Preset buttons */}
+          <div className="text-[10px] text-sandstorm-muted mb-1.5">Set budget</div>
+          <div className="flex flex-wrap gap-1 mb-2">
+            {BUDGET_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                onClick={() => handleSetBudget(preset)}
+                className={`px-2 py-0.5 text-[10px] rounded-md border transition-colors ${
+                  tokenBudget === preset
+                    ? 'bg-sandstorm-accent/15 border-sandstorm-accent/30 text-sandstorm-accent'
+                    : 'bg-sandstorm-bg border-sandstorm-border text-sandstorm-muted hover:text-sandstorm-text-secondary hover:border-sandstorm-border-light'
+                }`}
+                data-testid={`budget-preset-${preset}`}
+              >
+                {formatTokenCount(preset)}
+              </button>
+            ))}
+          </div>
+
+          {/* Custom input */}
+          <form onSubmit={handleCustomSubmit} className="flex gap-1">
+            <input
+              type="text"
+              value={customBudget}
+              onChange={(e) => setCustomBudget(e.target.value)}
+              placeholder="e.g. 2M, 500k"
+              className="flex-1 bg-sandstorm-bg border border-sandstorm-border rounded-md px-2 py-1 text-[10px] text-sandstorm-text placeholder:text-sandstorm-muted/50 focus:outline-none focus:border-sandstorm-accent/50"
+              data-testid="custom-budget-input"
+            />
+            <button
+              type="submit"
+              className="px-2 py-1 text-[10px] bg-sandstorm-accent/15 text-sandstorm-accent rounded-md hover:bg-sandstorm-accent/25 transition-colors"
+            >
+              Set
+            </button>
+          </form>
+
+          {/* Clear budget */}
+          {hasBudget && (
+            <button
+              onClick={() => handleSetBudget(0)}
+              className="mt-2 w-full text-[10px] text-sandstorm-muted hover:text-red-400 transition-colors text-center"
+              data-testid="clear-budget"
+            >
+              Clear budget
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -140,6 +140,10 @@ interface AppState {
   globalTokenUsage: GlobalTokenUsage | null;
   rateLimitState: RateLimitState | null;
 
+  // Account usage budget (persisted in localStorage)
+  tokenBudget: number; // 0 means no budget set
+  setTokenBudget: (budget: number) => void;
+
   // Docker connection
   setDockerConnected: (connected: boolean) => void;
 
@@ -267,6 +271,18 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Token usage & rate limits
   globalTokenUsage: null,
   rateLimitState: null,
+
+  // Account usage budget
+  tokenBudget: (() => {
+    try {
+      const saved = localStorage.getItem('sandstorm-token-budget');
+      return saved ? Number(saved) : 0;
+    } catch { return 0; }
+  })(),
+  setTokenBudget: (budget: number) => {
+    localStorage.setItem('sandstorm-token-budget', String(budget));
+    set({ tokenBudget: budget });
+  },
 
   // Project actions
   setProjects: (projects) => set({ projects }),

--- a/tests/unit/components/AccountUsageBar.test.tsx
+++ b/tests/unit/components/AccountUsageBar.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AccountUsageBar } from '../../../src/renderer/components/AccountUsageBar';
+import { useAppStore } from '../../../src/renderer/store';
+import { mockSandstormApi } from './setup';
+
+describe('AccountUsageBar', () => {
+  beforeEach(() => {
+    mockSandstormApi();
+    localStorage.clear();
+    useAppStore.setState({
+      globalTokenUsage: null,
+      tokenBudget: 0,
+    });
+  });
+
+  it('renders nothing when no usage data', () => {
+    const { container } = render(<AccountUsageBar />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders token counter when usage exists but no budget', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 300000,
+        total_output_tokens: 200000,
+        total_tokens: 500000,
+        per_stack: [],
+      },
+    });
+    render(<AccountUsageBar />);
+    expect(screen.getByTestId('usage-counter')).toBeDefined();
+    expect(screen.getByTestId('usage-counter').textContent).toBe('500.0k');
+  });
+
+  it('renders progress bar when budget is set', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 300000,
+        total_output_tokens: 200000,
+        total_tokens: 500000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    expect(screen.getByTestId('usage-progress-fill')).toBeDefined();
+    expect(screen.getByTestId('usage-percent').textContent).toBe('50%');
+  });
+
+  it('caps progress at 100% when over budget', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 800000,
+        total_output_tokens: 700000,
+        total_tokens: 1500000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    expect(screen.getByTestId('usage-percent').textContent).toBe('100%');
+    const fill = screen.getByTestId('usage-progress-fill');
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('opens budget popover on click', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_tokens: 0,
+        per_stack: [],
+      },
+    });
+    render(<AccountUsageBar />);
+    expect(screen.queryByTestId('budget-popover')).toBeNull();
+    fireEvent.click(screen.getByTestId('usage-bar-button'));
+    expect(screen.getByTestId('budget-popover')).toBeDefined();
+  });
+
+  it('sets budget from preset button', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 100000,
+        total_output_tokens: 50000,
+        total_tokens: 150000,
+        per_stack: [],
+      },
+    });
+    render(<AccountUsageBar />);
+    fireEvent.click(screen.getByTestId('usage-bar-button'));
+    fireEvent.click(screen.getByTestId('budget-preset-1000000'));
+
+    // Popover should close
+    expect(screen.queryByTestId('budget-popover')).toBeNull();
+    // Budget should be set
+    expect(useAppStore.getState().tokenBudget).toBe(1000000);
+    // Should now show progress bar
+    expect(screen.getByTestId('usage-progress-fill')).toBeDefined();
+    expect(screen.getByTestId('usage-percent').textContent).toBe('15%');
+  });
+
+  it('sets custom budget with shorthand notation', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_tokens: 0,
+        per_stack: [],
+      },
+    });
+    render(<AccountUsageBar />);
+    fireEvent.click(screen.getByTestId('usage-bar-button'));
+
+    const input = screen.getByTestId('custom-budget-input');
+    fireEvent.change(input, { target: { value: '2M' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(useAppStore.getState().tokenBudget).toBe(2000000);
+  });
+
+  it('clears budget when clear button is clicked', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 100000,
+        total_output_tokens: 50000,
+        total_tokens: 150000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    fireEvent.click(screen.getByTestId('usage-bar-button'));
+    fireEvent.click(screen.getByTestId('clear-budget'));
+
+    expect(useAppStore.getState().tokenBudget).toBe(0);
+    // Should switch back to counter mode
+    expect(screen.getByTestId('usage-counter')).toBeDefined();
+  });
+
+  it('persists budget to localStorage', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_tokens: 0,
+        per_stack: [],
+      },
+    });
+    render(<AccountUsageBar />);
+    fireEvent.click(screen.getByTestId('usage-bar-button'));
+    fireEvent.click(screen.getByTestId('budget-preset-5000000'));
+
+    expect(localStorage.getItem('sandstorm-token-budget')).toBe('5000000');
+  });
+
+  it('shows correct color for high usage (red at 90%+)', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 500000,
+        total_output_tokens: 450000,
+        total_tokens: 950000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    const fill = screen.getByTestId('usage-progress-fill');
+    expect(fill.className).toContain('bg-red-500');
+    const percent = screen.getByTestId('usage-percent');
+    expect(percent.className).toContain('text-red-400');
+  });
+
+  it('shows correct color for medium usage (yellow at 50-74%)', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 300000,
+        total_output_tokens: 300000,
+        total_tokens: 600000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    const fill = screen.getByTestId('usage-progress-fill');
+    expect(fill.className).toContain('bg-yellow-500');
+  });
+
+  it('shows correct color for low usage (green at <50%)', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 100000,
+        total_output_tokens: 100000,
+        total_tokens: 200000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    const fill = screen.getByTestId('usage-progress-fill');
+    expect(fill.className).toContain('bg-emerald-500');
+  });
+
+  it('displays usage breakdown in popover', () => {
+    useAppStore.setState({
+      globalTokenUsage: {
+        total_input_tokens: 300000,
+        total_output_tokens: 200000,
+        total_tokens: 500000,
+        per_stack: [],
+      },
+      tokenBudget: 1000000,
+    });
+    render(<AccountUsageBar />);
+    fireEvent.click(screen.getByTestId('usage-bar-button'));
+
+    const popover = screen.getByTestId('budget-popover');
+    expect(popover.textContent).toContain('500.0k');
+    expect(popover.textContent).toContain('300.0k');
+    expect(popover.textContent).toContain('200.0k');
+    expect(popover.textContent).toContain('1.00M'); // budget
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an `AccountUsageBar` component in the title bar (upper right) showing overall account token usage as a progress bar
- Users can set a token budget (persisted in localStorage) to monitor consumption as they work
- Progress bar visually indicates usage relative to budget, similar to the Claude `/usage` bar

Fixes #81

## Test plan
- [ ] Verify AccountUsageBar renders in the title bar
- [ ] Set a token budget and confirm progress bar updates
- [ ] Confirm budget persists across app restarts (localStorage)
- [ ] Run `npm test` — all tests pass including new AccountUsageBar tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)