### PR TITLE
Display loop iteration counts in task history

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -417,6 +417,10 @@ while true; do
     rm -f /tmp/claude-review-task.log
     rm -f /tmp/claude-verify.log
 
+    # Write loop iteration counts for the task watcher to read
+    echo "${TOTAL_REVIEW_ITERATIONS}" > /tmp/claude-task.review-iterations
+    echo "${TOTAL_VERIFY_RETRIES}" > /tmp/claude-task.verify-retries
+
     if [ $TASK_DONE -eq 1 ]; then
       echo 0 > /tmp/claude-task.exit
       echo "completed" > /tmp/claude-task.status

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -45,6 +45,8 @@ export interface Task {
   session_id: string | null;
   input_tokens: number;
   output_tokens: number;
+  review_iterations: number;
+  verify_retries: number;
   started_at: string;
   finished_at: string | null;
 }
@@ -257,8 +259,15 @@ export class Registry {
       this.setSchemaVersion(4);
     }
 
+    if (currentVersion < 5) {
+      // Add loop iteration tracking columns to tasks
+      try { this.db.exec('ALTER TABLE tasks ADD COLUMN review_iterations INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
+      try { this.db.exec('ALTER TABLE tasks ADD COLUMN verify_retries INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
+      this.setSchemaVersion(5);
+    }
+
     // Future migrations go here:
-    // if (currentVersion < 5) { ... this.setSchemaVersion(5); }
+    // if (currentVersion < 6) { ... this.setSchemaVersion(6); }
   }
 
   // --- Projects ---
@@ -401,6 +410,12 @@ export class Registry {
 
   setTaskSessionId(taskId: number, sessionId: string): void {
     this.db.prepare('UPDATE tasks SET session_id = ? WHERE id = ?').run(sessionId, taskId);
+  }
+
+  setTaskIterations(taskId: number, reviewIterations: number, verifyRetries: number): void {
+    this.db.prepare(
+      'UPDATE tasks SET review_iterations = ?, verify_retries = ? WHERE id = ?'
+    ).run(reviewIterations, verifyRetries, taskId);
   }
 
   getStackTokenUsage(stackId: string): TokenUsage {

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -111,9 +111,10 @@ export class TaskWatcher extends EventEmitter {
       }
     }
 
-    // Read token usage and session ID from task log (async, best-effort)
+    // Read token usage, session ID, and loop iterations from task log (async, best-effort)
     if (containerId) {
       this.readTaskTokens(task.id, stackId, containerId).catch(() => {});
+      this.readTaskIterations(task.id, containerId).catch(() => {});
     }
 
     const updatedTask = {
@@ -183,6 +184,41 @@ export class TaskWatcher extends EventEmitter {
       } catch {
         // stderr file may not exist
       }
+    }
+  }
+
+  /**
+   * Read loop iteration counts from files written by task-runner.sh.
+   */
+  private async readTaskIterations(
+    taskId: number,
+    containerId: string
+  ): Promise<void> {
+    let reviewIterations = 0;
+    let verifyRetries = 0;
+
+    try {
+      const result = await this.runtime.exec(containerId, [
+        'cat', '/tmp/claude-task.review-iterations',
+      ]);
+      const parsed = parseInt(result.stdout.trim(), 10);
+      if (!isNaN(parsed)) reviewIterations = parsed;
+    } catch {
+      // File may not exist (single-pass task)
+    }
+
+    try {
+      const result = await this.runtime.exec(containerId, [
+        'cat', '/tmp/claude-task.verify-retries',
+      ]);
+      const parsed = parseInt(result.stdout.trim(), 10);
+      if (!isNaN(parsed)) verifyRetries = parsed;
+    } catch {
+      // File may not exist (single-pass task)
+    }
+
+    if (reviewIterations > 0 || verifyRetries > 0) {
+      this.registry.setTaskIterations(taskId, reviewIterations, verifyRetries);
     }
   }
 

--- a/src/renderer/components/StackDetail.tsx
+++ b/src/renderer/components/StackDetail.tsx
@@ -323,6 +323,11 @@ export function StackDetail({
                           {task.model}
                         </span>
                       )}
+                      {task.status !== 'running' && (task.review_iterations > 0 || task.verify_retries > 0) && (
+                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-sandstorm-bg border border-sandstorm-border text-sandstorm-muted tabular-nums" title="Review iterations / Verify retries">
+                          {task.review_iterations} review{task.review_iterations !== 1 ? 's' : ''}, {task.verify_retries} retr{task.verify_retries !== 1 ? 'ies' : 'y'}
+                        </span>
+                      )}
                       <span className="text-sandstorm-muted text-[10px] ml-auto tabular-nums">
                         {new Date(task.started_at).toLocaleString()}
                       </span>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -46,6 +46,8 @@ export interface Task {
   session_id: string | null;
   input_tokens: number;
   output_tokens: number;
+  review_iterations: number;
+  verify_retries: number;
   started_at: string;
   finished_at: string | null;
 }

--- a/tests/unit/components/StackDetail.test.tsx
+++ b/tests/unit/components/StackDetail.test.tsx
@@ -147,6 +147,79 @@ describe('StackDetail', () => {
     });
   });
 
+  it('shows loop iteration counts for completed tasks in History tab', async () => {
+    api.tasks.list.mockResolvedValue([
+      {
+        id: 1,
+        stack_id: 'detail-stack',
+        prompt: 'Add feature',
+        model: null,
+        status: 'completed',
+        exit_code: 0,
+        review_iterations: 3,
+        verify_retries: 1,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+      },
+    ]);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('3 reviews, 1 retry')).toBeDefined();
+    });
+  });
+
+  it('does not show loop iterations when both are zero', async () => {
+    api.tasks.list.mockResolvedValue([
+      {
+        id: 1,
+        stack_id: 'detail-stack',
+        prompt: 'Simple task',
+        model: null,
+        status: 'completed',
+        exit_code: 0,
+        review_iterations: 0,
+        verify_retries: 0,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+      },
+    ]);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Simple task')).toBeDefined();
+    });
+    expect(screen.queryByText(/review/)).toBeNull();
+  });
+
+  it('pluralizes loop iteration labels correctly', async () => {
+    api.tasks.list.mockResolvedValue([
+      {
+        id: 1,
+        stack_id: 'detail-stack',
+        prompt: 'Single iteration task',
+        model: null,
+        status: 'completed',
+        exit_code: 0,
+        review_iterations: 1,
+        verify_retries: 0,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+      },
+    ]);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+    fireEvent.click(screen.getByText('History'));
+
+    await waitFor(() => {
+      expect(screen.getByText('1 review, 0 retries')).toBeDefined();
+    });
+  });
+
   it('shows task history in the History tab', async () => {
     api.tasks.list.mockResolvedValue([
       {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -730,6 +730,33 @@ describe('Registry', () => {
       const task = registry.createTask('token-stack', 'test', 'sonnet');
       expect(task.model).toBe('sonnet');
     });
+
+    it('new tasks have zero loop iteration counts', () => {
+      const task = registry.createTask('token-stack', 'test');
+      expect(task.review_iterations).toBe(0);
+      expect(task.verify_retries).toBe(0);
+    });
+
+    it('setTaskIterations stores review iterations and verify retries', () => {
+      const task = registry.createTask('token-stack', 'test');
+      registry.setTaskIterations(task.id, 3, 1);
+
+      const tasks = registry.getTasksForStack('token-stack');
+      const updated = tasks.find(t => t.id === task.id)!;
+      expect(updated.review_iterations).toBe(3);
+      expect(updated.verify_retries).toBe(1);
+    });
+
+    it('setTaskIterations overwrites previous values', () => {
+      const task = registry.createTask('token-stack', 'test');
+      registry.setTaskIterations(task.id, 2, 1);
+      registry.setTaskIterations(task.id, 5, 3);
+
+      const tasks = registry.getTasksForStack('token-stack');
+      const updated = tasks.find(t => t.id === task.id)!;
+      expect(updated.review_iterations).toBe(5);
+      expect(updated.verify_retries).toBe(3);
+    });
   });
 
   // ===========================================

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -231,6 +231,14 @@ describe('task-runner.sh dual-loop workflow', () => {
       expect(taskRunner).toContain('Review iterations: $TOTAL_REVIEW_ITERATIONS')
       expect(taskRunner).toContain('Verify retries: $TOTAL_VERIFY_RETRIES')
     })
+
+    it('writes review iteration count to file for task watcher', () => {
+      expect(taskRunner).toContain('> /tmp/claude-task.review-iterations')
+    })
+
+    it('writes verify retry count to file for task watcher', () => {
+      expect(taskRunner).toContain('> /tmp/claude-task.verify-retries')
+    })
   })
 
   // ── Single-pass tasks ────────────────────────────────────────────────

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -796,6 +796,72 @@ describe('TaskWatcher', () => {
     watcher.unwatchAll();
   });
 
+  // --- Loop iteration reading ---
+
+  it('reads loop iteration counts from container on task completion', async () => {
+    const runtime = createSequencedRuntime(['running', 'completed'], '0');
+    const origExec = (runtime.exec as ReturnType<typeof vi.fn>).getMockImplementation()!;
+    (runtime.exec as ReturnType<typeof vi.fn>).mockImplementation(
+      async (id: string, cmd: string[]) => {
+        if (cmd.includes('/tmp/claude-task.review-iterations')) {
+          return { exitCode: 0, stdout: '3', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-task.verify-retries')) {
+          return { exitCode: 0, stdout: '1', stderr: '' };
+        }
+        return origExec(id, cmd);
+      }
+    );
+
+    const watcher = new TaskWatcher(registry, runtime, { pollInterval: 50 });
+    registry.createTask('watch-stack', 'loop iteration task');
+
+    await new Promise<void>((resolve) => {
+      watcher.on('task:completed', () => resolve());
+      watcher.watch('watch-stack', 'container-123');
+    });
+
+    // Give async iteration reading time to complete
+    await new Promise((r) => setTimeout(r, 200));
+
+    const tasks = registry.getTasksForStack('watch-stack');
+    const task = tasks.find((t) => t.prompt === 'loop iteration task');
+    expect(task!.review_iterations).toBe(3);
+    expect(task!.verify_retries).toBe(1);
+
+    watcher.unwatchAll();
+  });
+
+  it('handles missing iteration files gracefully (single-pass task)', async () => {
+    const runtime = createSequencedRuntime(['running', 'completed'], '0');
+    const origExec = (runtime.exec as ReturnType<typeof vi.fn>).getMockImplementation()!;
+    (runtime.exec as ReturnType<typeof vi.fn>).mockImplementation(
+      async (id: string, cmd: string[]) => {
+        if (cmd.includes('/tmp/claude-task.review-iterations') || cmd.includes('/tmp/claude-task.verify-retries')) {
+          throw new Error('No such file');
+        }
+        return origExec(id, cmd);
+      }
+    );
+
+    const watcher = new TaskWatcher(registry, runtime, { pollInterval: 50 });
+    registry.createTask('watch-stack', 'single-pass task');
+
+    await new Promise<void>((resolve) => {
+      watcher.on('task:completed', () => resolve());
+      watcher.watch('watch-stack', 'container-123');
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const tasks = registry.getTasksForStack('watch-stack');
+    const task = tasks.find((t) => t.prompt === 'single-pass task');
+    expect(task!.review_iterations).toBe(0);
+    expect(task!.verify_retries).toBe(0);
+
+    watcher.unwatchAll();
+  });
+
   // --- Stale poll safety net ---
 
   it('accepts stale status after MAX_STALE_POLLS without seeing running', async () => {


### PR DESCRIPTION
## Summary
- Task runner now writes review iteration and verify retry counts to files (`/tmp/claude-task.review-iterations`, `/tmp/claude-task.verify-retries`)
- Task watcher reads these counts on task completion and stores them in the database (schema migration v5)
- StackDetail History tab shows iteration badges (e.g., "3 reviews, 1 retry") for completed tasks
- Hidden when both counts are zero (single-pass tasks)

Fixes #69

## Test plan
- [ ] Run a task that triggers review loops — verify counts display in History tab
- [ ] Run a single-pass task — verify no iteration badge appears
- [ ] Check pluralization: "1 review" vs "2 reviews", "1 retry" vs "2 retries"
- [ ] Run `npm test` — all tests pass including new registry, task-watcher, and StackDetail tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)