### PR TITLE
Fix false rate limit detection from agent conversation content (fixes #98)

### DIFF
--- a/src/main/control-plane/token-parser.ts
+++ b/src/main/control-plane/token-parser.ts
@@ -73,9 +73,13 @@ export function parseTokenUsage(output: string): ParsedTokenUsage {
 /**
  * Detect rate limit errors from Claude CLI output (stdout + stderr).
  * Returns null if no rate limit detected.
+ *
+ * IMPORTANT: Only checks error/system lines — NOT conversation content.
+ * The raw log contains everything the inner Claude writes, so matching
+ * patterns like "rate limit" against the full text causes false positives
+ * when the agent discusses rate limiting in its own output.
  */
 export function parseRateLimit(output: string): ParsedRateLimit | null {
-  // Common rate limit patterns from Claude CLI / API
   const rateLimitPatterns = [
     /rate.?limit/i,
     /usage.?limit/i,
@@ -86,16 +90,65 @@ export function parseRateLimit(output: string): ParsedRateLimit | null {
     /capacity.*exceeded/i,
   ];
 
-  const isRateLimited = rateLimitPatterns.some((pattern) => pattern.test(output));
+  // Extract only error-relevant lines, skipping conversation content.
+  // In stream-json, content_block_delta events carry the agent's text output —
+  // these must be excluded to avoid false positives.
+  const errorLines = extractErrorLines(output);
+  if (errorLines.length === 0) return null;
+
+  const errorText = errorLines.join('\n');
+  const isRateLimited = rateLimitPatterns.some((pattern) => pattern.test(errorText));
   if (!isRateLimited) return null;
 
-  // Try to extract reset time
-  const resetAt = parseResetTime(output);
+  const resetAt = parseResetTime(errorText);
 
   return {
     reset_at: resetAt,
-    reason: extractRateLimitReason(output),
+    reason: extractRateLimitReason(errorText),
   };
+}
+
+/**
+ * Extract only error-relevant lines from Claude CLI output.
+ * Skips content_block_delta (agent text), content_block_start,
+ * and other content-carrying events.
+ */
+function extractErrorLines(output: string): string[] {
+  const errorLines: string[] = [];
+  // Content event types whose text should be ignored
+  const contentTypes = new Set([
+    'content_block_delta',
+    'content_block_start',
+    'content_block_stop',
+    'message_start',
+    'message_delta',
+    'message_stop',
+  ]);
+
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    try {
+      const parsed = JSON.parse(trimmed);
+
+      // Skip content events (agent conversation text)
+      const eventType = parsed.type === 'stream_event'
+        ? parsed.event?.type
+        : parsed.type;
+      if (eventType && contentTypes.has(eventType)) continue;
+
+      // Include error objects and result messages (which may contain error info)
+      if (parsed.error || parsed.type === 'error' || parsed.type === 'result') {
+        errorLines.push(trimmed);
+      }
+    } catch {
+      // Non-JSON line (plain text from stderr) — always include
+      errorLines.push(trimmed);
+    }
+  }
+
+  return errorLines;
 }
 
 /**

--- a/tests/unit/token-parser.test.ts
+++ b/tests/unit/token-parser.test.ts
@@ -163,6 +163,42 @@ describe('parseRateLimit', () => {
     expect(parseRateLimit('line 429: some code')).toBeNull();
   });
 
+  it('does not false-positive on rate limit keywords in agent conversation content', () => {
+    // Inner Claude discussing rate limits in its output should NOT trigger detection
+    const streamOutput = [
+      JSON.stringify({ type: 'stream_event', event: { type: 'content_block_delta', delta: { text: 'The rate limit detection needs to be fixed' } } }),
+      JSON.stringify({ type: 'stream_event', event: { type: 'content_block_delta', delta: { text: 'We should handle HTTP 429 errors properly' } } }),
+      JSON.stringify({ type: 'stream_event', event: { type: 'content_block_delta', delta: { text: 'retry after 300 seconds when rate limited' } } }),
+      JSON.stringify({ type: 'result', usage: { input_tokens: 100, output_tokens: 50 }, session_id: 'sess-1' }),
+    ].join('\n');
+    expect(parseRateLimit(streamOutput)).toBeNull();
+  });
+
+  it('does not false-positive on rate limit keywords in message_start events', () => {
+    const output = [
+      JSON.stringify({ type: 'stream_event', event: { type: 'message_start', message: { usage: { input_tokens: 100 } } } }),
+      JSON.stringify({ type: 'stream_event', event: { type: 'message_delta', usage: { output_tokens: 50 } } }),
+      JSON.stringify({ type: 'result', usage: { input_tokens: 100, output_tokens: 50 } }),
+    ].join('\n');
+    expect(parseRateLimit(output)).toBeNull();
+  });
+
+  it('detects rate limit in error-typed JSON lines', () => {
+    const output = [
+      JSON.stringify({ type: 'stream_event', event: { type: 'content_block_delta', delta: { text: 'working...' } } }),
+      JSON.stringify({ type: 'error', error: { message: 'Rate limit exceeded. Retry after 60 seconds' } }),
+    ].join('\n');
+    const result = parseRateLimit(output);
+    expect(result).not.toBeNull();
+    expect(result!.reset_at).toBeTruthy();
+  });
+
+  it('detects rate limit in result-typed JSON with error info', () => {
+    const output = JSON.stringify({ type: 'result', error: { message: 'rate limit exceeded' } });
+    const result = parseRateLimit(output);
+    expect(result).not.toBeNull();
+  });
+
   it('extracts retry-after seconds', () => {
     const result = parseRateLimit('Rate limit hit. Retry after 300 seconds');
     expect(result).not.toBeNull();


### PR DESCRIPTION
## Summary

- **Root cause:** `parseRateLimit()` ran regex patterns (like `/rate.?limit/i`) against the **entire** Claude raw log, which includes all conversation text the inner agent generates. When the agent discussed rate limits (e.g., working on issue #75's token parser), it triggered a false positive that marked all stacks as rate-limited with a bogus reset time (10,000+ minutes).
- **Fix:** Added `extractErrorLines()` that filters the raw log to only error-relevant lines — JSON lines with `type: "error"` or `type: "result"`, plus non-JSON lines (stderr). Skips all content events (`content_block_delta`, `message_start`, etc.) that carry the agent's conversation output.
- Also cleared stale `rate_limit_reset_at` timestamp from the DB for the affected stack.

## Test plan

- [x] All 26 token parser tests pass, including 4 new tests:
  - Agent conversation mentioning "rate limit" does NOT trigger detection
  - Agent conversation mentioning "HTTP 429" does NOT trigger detection  
  - Error-typed JSON with rate limit message IS detected
  - Result-typed JSON with error info IS detected
- [x] All 132 component tests pass
- [ ] Rebuild app, start stacks — no false rate limit banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)