### PR TITLE
Add re-authentication modal for 401 errors

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -544,6 +544,12 @@ rl.on('line', async (line) => {
       const text = data.toString();
       stderrBuffer += text;
       this.log(`stderr [tab=${tabId}]: ${text.trimEnd()}`);
+
+      // Detect auth errors early from stderr so the modal appears promptly
+      if (this.isAuthError(text)) {
+        this.log(`Auth error detected in stderr for tab=${tabId}, emitting auth:required`);
+        send('auth:required', text.trim());
+      }
     });
 
     child.on('close', (code) => {
@@ -569,6 +575,13 @@ rl.on('line', async (line) => {
         const errorMsg = stderrBuffer.trim()
           || `Claude exited with code ${code}`;
         this.log(`Sending error for tab=${tabId}: ${errorMsg}`);
+
+        // Detect 401/auth errors and emit auth:required so the UI can show a reauth modal
+        if (this.isAuthError(errorMsg) || this.isAuthError(fullResponse)) {
+          this.log(`Auth error detected for tab=${tabId}, emitting auth:required`);
+          send('auth:required', errorMsg);
+        }
+
         send(`agent:error:${tabId}`, errorMsg);
       } else {
         if (session && fullResponse) {
@@ -601,6 +614,25 @@ rl.on('line', async (line) => {
       this.log(`Spawn error for tab=${tabId}: ${err.message}`);
       send(`agent:error:${tabId}`, err.message);
     });
+  }
+
+  /**
+   * Detect 401/authentication errors from Claude CLI output.
+   */
+  private isAuthError(output: string): boolean {
+    if (!output) return false;
+    const patterns = [
+      /\b401\b/,
+      /unauthorized/i,
+      /authentication.*(required|failed|expired|invalid)/i,
+      /token.*(expired|invalid|revoked)/i,
+      /not\s+authenticated/i,
+      /login\s+required/i,
+      /session\s+expired/i,
+      /invalid.*credentials/i,
+      /re-?authenticate/i,
+    ];
+    return patterns.some((p) => p.test(output));
   }
 
   private extractText(parsed: Record<string, unknown>): string | null {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { NewStackDialog } from './components/NewStackDialog';
 import { ProjectTabs } from './components/ProjectTabs';
 import { OpenProjectDialog } from './components/OpenProjectDialog';
 import { AccountUsageBar } from './components/AccountUsageBar';
+import { ReauthModal } from './components/ReauthModal';
 import trayIcon from './tray-icon.png';
 import buildVersion from './build-version.txt?raw';
 
@@ -21,6 +22,8 @@ export default function App() {
     selectedStackId,
     showNewStackDialog,
     showOpenProjectDialog,
+    showReauthModal,
+    setShowReauthModal,
     dockerConnected,
     refreshStacks,
     refreshProjects,
@@ -48,11 +51,17 @@ export default function App() {
       setDockerConnected(false);
     });
 
+    // Listen for auth:required events (401 from Claude CLI)
+    const unsubAuthRequired = window.sandstorm.on('auth:required', () => {
+      setShowReauthModal(true);
+    });
+
     return () => {
       unsubConnected();
       unsubDisconnected();
+      unsubAuthRequired();
     };
-  }, [setDockerConnected, refreshStacks, refreshMetrics]);
+  }, [setDockerConnected, setShowReauthModal, refreshStacks, refreshMetrics]);
 
   useEffect(() => {
     refreshProjects();
@@ -154,6 +163,7 @@ export default function App() {
       {/* Dialogs */}
       {showNewStackDialog && <NewStackDialog />}
       {showOpenProjectDialog && <OpenProjectDialog />}
+      {showReauthModal && <ReauthModal onClose={() => setShowReauthModal(false)} />}
     </div>
   );
 }

--- a/src/renderer/components/ReauthModal.tsx
+++ b/src/renderer/components/ReauthModal.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface ReauthModalProps {
+  onClose: () => void;
+}
+
+export function ReauthModal({ onClose }: ReauthModalProps) {
+  const [loginInProgress, setLoginInProgress] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [urlOpened, setUrlOpened] = useState(false);
+
+  useEffect(() => {
+    const unsubUrl = window.sandstorm.on('auth:url-opened', () => {
+      setUrlOpened(true);
+    });
+    const unsubCompleted = window.sandstorm.on('auth:completed', (success: unknown) => {
+      setLoginInProgress(false);
+      if (success) {
+        onClose();
+      } else {
+        setError('Authentication failed. Please try again.');
+        setUrlOpened(false);
+      }
+    });
+    return () => {
+      unsubUrl();
+      unsubCompleted();
+    };
+  }, [onClose]);
+
+  const handleReauthenticate = useCallback(async () => {
+    setLoginInProgress(true);
+    setError(null);
+    setUrlOpened(false);
+    try {
+      const result = await window.sandstorm.auth.login();
+      if (!result.success) {
+        setLoginInProgress(false);
+        setError(result.error || 'Authentication failed. Please try again.');
+        setUrlOpened(false);
+      }
+      // Success is handled by auth:completed event
+    } catch {
+      setLoginInProgress(false);
+      setError('Failed to start authentication. Is Claude Code installed?');
+      setUrlOpened(false);
+    }
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !loginInProgress) onClose();
+      }}
+    >
+      <div className="bg-sandstorm-surface rounded-xl w-[440px] shadow-dialog animate-slide-up border border-sandstorm-border">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-sandstorm-border">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-lg bg-amber-500/15 flex items-center justify-center">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-amber-400">
+                <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </div>
+            <h2 className="text-sm font-semibold text-sandstorm-text">Authentication Required</h2>
+          </div>
+          {!loginInProgress && (
+            <button
+              onClick={onClose}
+              className="text-sandstorm-muted hover:text-sandstorm-text transition-colors"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          <p className="text-sm text-sandstorm-text-secondary leading-relaxed">
+            Your Claude Code session has expired or is unauthorized. Click the button below to
+            re-authenticate. This will open your browser where you can sign in.
+          </p>
+
+          {urlOpened && loginInProgress && (
+            <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg bg-sandstorm-accent/10 border border-sandstorm-accent/20 text-sm text-sandstorm-accent">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 animate-pulse">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 6v6l4 2" />
+              </svg>
+              Browser opened. Complete sign-in there, then return here.
+            </div>
+          )}
+
+          {error && (
+            <div className="px-3 py-2.5 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-400">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-sandstorm-border">
+          {!loginInProgress && (
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-sandstorm-text-secondary hover:text-sandstorm-text transition-colors"
+            >
+              Dismiss
+            </button>
+          )}
+          <button
+            onClick={handleReauthenticate}
+            disabled={loginInProgress}
+            className="px-4 py-2 text-sm font-medium rounded-lg transition-all
+              bg-amber-500 hover:bg-amber-400 text-black
+              disabled:opacity-60 disabled:cursor-wait
+              flex items-center gap-2"
+          >
+            {loginInProgress ? (
+              <>
+                <span className="w-3 h-3 border-2 border-black/30 border-t-black rounded-full animate-spin" />
+                {urlOpened ? 'Waiting for sign-in...' : 'Opening browser...'}
+              </>
+            ) : (
+              <>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M15 3h4a2 2 0 012 2v14a2 2 0 01-2 2h-4" />
+                  <polyline points="10 17 15 12 10 7" />
+                  <line x1="15" y1="12" x2="3" y2="12" />
+                </svg>
+                Re-authenticate
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -142,6 +142,10 @@ interface AppState {
   globalTokenUsage: GlobalTokenUsage | null;
   rateLimitState: RateLimitState | null;
 
+  // Auth reauth modal
+  showReauthModal: boolean;
+  setShowReauthModal: (show: boolean) => void;
+
   // Account usage budget (persisted in localStorage)
   tokenBudget: number; // 0 means no budget set
   setTokenBudget: (budget: number) => void;
@@ -269,6 +273,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   showNewStackDialog: false,
   loading: false,
   error: null,
+
+  // Auth reauth modal
+  showReauthModal: false,
+  setShowReauthModal: (show) => set({ showReauthModal: show }),
 
   // Token usage & rate limits
   globalTokenUsage: null,

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -294,6 +294,67 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
     }, 5000);
   });
 
+  describe('auth error detection (401 reauth)', () => {
+    it('emits auth:required when stderr contains 401', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('HTTP 401 Unauthorized'));
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBe(1);
+    });
+
+    it('emits auth:required when stderr contains "unauthorized"', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('Error: Unauthorized access'));
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBe(1);
+    });
+
+    it('emits auth:required when stderr contains "token expired"', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('Your authentication token expired'));
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBe(1);
+    });
+
+    it('emits auth:required when stderr contains "not authenticated"', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('Error: not authenticated'));
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBe(1);
+    });
+
+    it('emits auth:required on exit when error output contains auth failure', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('authentication required'));
+      proc.exitCode = 1;
+      proc.emit('close', 1);
+      // Should have auth:required from both stderr streaming and on-close detection
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not emit auth:required for non-auth errors', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('Error: network timeout'));
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBe(0);
+    });
+
+    it('does not emit auth:required for rate limit errors', () => {
+      backend.sendMessage('tab1', 'hello', '/tmp');
+      const proc = getLastProcess();
+      proc.stderr.emit('data', Buffer.from('Error: rate limit exceeded, too many requests'));
+      const authRequired = findMessages('auth:required');
+      expect(authRequired.length).toBe(0);
+    });
+  });
+
   describe('syncCredentials', () => {
     it('handles empty stacks list without error', async () => {
       await expect(backend.syncCredentials([])).resolves.toBeUndefined();

--- a/tests/unit/components/App.test.tsx
+++ b/tests/unit/components/App.test.tsx
@@ -28,6 +28,13 @@ vi.mock('../../../src/renderer/components/ProjectTabs', () => ({
 vi.mock('../../../src/renderer/components/OpenProjectDialog', () => ({
   OpenProjectDialog: () => <div data-testid="open-project-dialog" />,
 }));
+vi.mock('../../../src/renderer/components/ReauthModal', () => ({
+  ReauthModal: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="reauth-modal">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
 vi.mock('../../../src/renderer/tray-icon.png', () => ({ default: 'tray-icon.png' }));
 
 describe('App', () => {
@@ -44,6 +51,7 @@ describe('App', () => {
       selectedStackId: null,
       showNewStackDialog: false,
       showOpenProjectDialog: false,
+      showReauthModal: false,
       dockerConnected: true,
       error: null,
     });

--- a/tests/unit/components/ReauthModal.test.tsx
+++ b/tests/unit/components/ReauthModal.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ReauthModal } from '../../../src/renderer/components/ReauthModal';
+import { mockSandstormApi } from './setup';
+
+describe('ReauthModal', () => {
+  let api: ReturnType<typeof mockSandstormApi>;
+  let onClose: ReturnType<typeof vi.fn>;
+  // Track event listeners registered via window.sandstorm.on
+  let eventListeners: Record<string, (...args: unknown[]) => void>;
+
+  beforeEach(() => {
+    eventListeners = {};
+    api = mockSandstormApi();
+    // Capture event listeners so we can trigger them in tests
+    api.on.mockImplementation((channel: string, callback: (...args: unknown[]) => void) => {
+      eventListeners[channel] = callback;
+      return () => { delete eventListeners[channel]; };
+    });
+    onClose = vi.fn();
+  });
+
+  it('renders the modal with authentication required message', () => {
+    render(<ReauthModal onClose={onClose} />);
+    expect(screen.getByText('Authentication Required')).toBeDefined();
+    expect(screen.getByText(/session has expired or is unauthorized/)).toBeDefined();
+    expect(screen.getByText('Re-authenticate')).toBeDefined();
+  });
+
+  it('calls auth.login when Re-authenticate button is clicked', async () => {
+    render(<ReauthModal onClose={onClose} />);
+    const button = screen.getByText('Re-authenticate');
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(api.auth.login).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows loading state while authenticating', async () => {
+    // Make login hang (never resolve)
+    api.auth.login.mockReturnValue(new Promise(() => {}));
+    render(<ReauthModal onClose={onClose} />);
+    fireEvent.click(screen.getByText('Re-authenticate'));
+    await waitFor(() => {
+      expect(screen.getByText('Opening browser...')).toBeDefined();
+    });
+  });
+
+  it('shows browser opened message when auth:url-opened fires', async () => {
+    api.auth.login.mockReturnValue(new Promise(() => {}));
+    render(<ReauthModal onClose={onClose} />);
+    fireEvent.click(screen.getByText('Re-authenticate'));
+
+    // Simulate the auth:url-opened event
+    await waitFor(() => {
+      expect(eventListeners['auth:url-opened']).toBeDefined();
+    });
+    eventListeners['auth:url-opened']();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Complete sign-in there/)).toBeDefined();
+      expect(screen.getByText('Waiting for sign-in...')).toBeDefined();
+    });
+  });
+
+  it('calls onClose when auth:completed fires with success', async () => {
+    api.auth.login.mockReturnValue(new Promise(() => {}));
+    render(<ReauthModal onClose={onClose} />);
+    fireEvent.click(screen.getByText('Re-authenticate'));
+
+    await waitFor(() => {
+      expect(eventListeners['auth:completed']).toBeDefined();
+    });
+    eventListeners['auth:completed'](true);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows error when auth:completed fires with failure', async () => {
+    api.auth.login.mockReturnValue(new Promise(() => {}));
+    render(<ReauthModal onClose={onClose} />);
+    fireEvent.click(screen.getByText('Re-authenticate'));
+
+    await waitFor(() => {
+      expect(eventListeners['auth:completed']).toBeDefined();
+    });
+    eventListeners['auth:completed'](false);
+
+    await waitFor(() => {
+      expect(screen.getByText('Authentication failed. Please try again.')).toBeDefined();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows error when login returns failure', async () => {
+    api.auth.login.mockResolvedValue({ success: false, error: 'Token revoked' });
+    render(<ReauthModal onClose={onClose} />);
+    fireEvent.click(screen.getByText('Re-authenticate'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Token revoked')).toBeDefined();
+    });
+  });
+
+  it('calls onClose when Dismiss button is clicked', () => {
+    render(<ReauthModal onClose={onClose} />);
+    fireEvent.click(screen.getByText('Dismiss'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when clicking the backdrop', () => {
+    render(<ReauthModal onClose={onClose} />);
+    // The backdrop is the outermost div with the fixed class
+    const backdrop = screen.getByText('Authentication Required').closest('.fixed');
+    if (backdrop) {
+      fireEvent.click(backdrop);
+    }
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when clicking the X button', () => {
+    render(<ReauthModal onClose={onClose} />);
+    // The X button is in the header next to the title
+    const header = screen.getByText('Authentication Required').closest('div');
+    const closeButton = header?.parentElement?.querySelector('button');
+    if (closeButton) {
+      fireEvent.click(closeButton);
+    }
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers auth:url-opened and auth:completed listeners', () => {
+    render(<ReauthModal onClose={onClose} />);
+    expect(api.on).toHaveBeenCalledWith('auth:url-opened', expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith('auth:completed', expect.any(Function));
+  });
+});

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -63,6 +63,20 @@ export function mockSandstormApi() {
       reset: vi.fn().mockResolvedValue(undefined),
       history: vi.fn().mockResolvedValue({ messages: [], processing: false }),
     },
+    auth: {
+      status: vi.fn().mockResolvedValue({ loggedIn: true, expired: false }),
+      login: vi.fn().mockResolvedValue({ success: true }),
+    },
+    context: {
+      get: vi.fn().mockResolvedValue({ instructions: '', skills: [], settings: '' }),
+      saveInstructions: vi.fn().mockResolvedValue(undefined),
+      listSkills: vi.fn().mockResolvedValue([]),
+      getSkill: vi.fn().mockResolvedValue(''),
+      saveSkill: vi.fn().mockResolvedValue(undefined),
+      deleteSkill: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn().mockResolvedValue(''),
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    },
     on: vi.fn().mockReturnValue(() => {}),
   };
 


### PR DESCRIPTION
## Summary
- Added `ReauthModal` component that shows when Claude CLI returns a 401/auth error
- `ClaudeBackend` detects auth errors in stderr and on process exit, emits `auth:required` event
- App listens for `auth:required` and shows modal with re-authenticate button
- Added `isAuthError()` method with patterns for 401, unauthorized, token expired, session expired, etc.

Fixes #50

## Test plan
- [ ] Run `npm test` — all claude-backend and App tests pass
- [ ] Trigger a 401 from Claude CLI — verify reauth modal appears
- [ ] Click re-authenticate button — verify it triggers the login flow
- [ ] Verify non-auth errors (rate limits, timeouts) do NOT trigger the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)