### PR TITLE
Include issue comments when dispatching to stacks

### DIFF
--- a/src/main/control-plane/github.ts
+++ b/src/main/control-plane/github.ts
@@ -1,0 +1,273 @@
+/**
+ * GitHub API client for fetching issue details and comments.
+ * Used to enrich task prompts with full issue context so inner agents
+ * have complete visibility into issue history, comments, and timeline.
+ */
+
+import https from 'https';
+import { execSync } from 'child_process';
+
+export interface GitHubComment {
+  user: string;
+  created_at: string;
+  body: string;
+}
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  state: string;
+  user: string;
+  created_at: string;
+  body: string;
+  labels: string[];
+  comments: GitHubComment[];
+}
+
+/**
+ * Make an HTTPS GET request to the GitHub API.
+ */
+function githubGet(
+  urlPath: string,
+  token: string
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: 'api.github.com',
+        port: 443,
+        path: urlPath,
+        method: 'GET',
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'Sandstorm-Desktop/1.0',
+        },
+        timeout: 15_000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: data });
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('GitHub API request timed out'));
+    });
+    req.end();
+  });
+}
+
+/**
+ * Fetch all comments for an issue, handling pagination.
+ */
+async function fetchAllComments(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  token: string
+): Promise<GitHubComment[]> {
+  const comments: GitHubComment[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const result = await githubGet(
+      `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${perPage}&page=${page}`,
+      token
+    );
+
+    if (result.status !== 200 || !Array.isArray(result.body)) break;
+
+    const batch = result.body as Array<Record<string, unknown>>;
+    if (batch.length === 0) break;
+
+    for (const c of batch) {
+      comments.push({
+        user: (c.user as Record<string, unknown>)?.login as string ?? 'unknown',
+        created_at: c.created_at as string,
+        body: c.body as string ?? '',
+      });
+    }
+
+    if (batch.length < perPage) break;
+    page++;
+  }
+
+  return comments;
+}
+
+/**
+ * Fetch a GitHub issue with all its comments.
+ */
+export async function fetchIssueWithComments(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  token: string
+): Promise<GitHubIssue> {
+  const result = await githubGet(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token
+  );
+
+  if (result.status !== 200) {
+    throw new Error(
+      `GitHub API returned status ${result.status} for issue #${issueNumber}`
+    );
+  }
+
+  const issue = result.body as Record<string, unknown>;
+  const labels = Array.isArray(issue.labels)
+    ? (issue.labels as Array<Record<string, unknown>>).map(
+        (l) => (l.name as string) ?? ''
+      )
+    : [];
+
+  const comments = await fetchAllComments(owner, repo, issueNumber, token);
+
+  return {
+    number: issueNumber,
+    title: issue.title as string ?? '',
+    state: issue.state as string ?? 'unknown',
+    user: (issue.user as Record<string, unknown>)?.login as string ?? 'unknown',
+    created_at: issue.created_at as string ?? '',
+    body: issue.body as string ?? '',
+    labels,
+    comments,
+  };
+}
+
+/**
+ * Format a fetched issue with comments into a text block suitable for
+ * prepending to a task prompt.
+ */
+export function formatIssueContext(issue: GitHubIssue): string {
+  const lines: string[] = [];
+
+  lines.push('=== GitHub Issue Context ===');
+  lines.push(`Issue #${issue.number}: ${issue.title}`);
+  lines.push(`State: ${issue.state}`);
+  lines.push(`Opened by: ${issue.user} on ${issue.created_at}`);
+  if (issue.labels.length > 0) {
+    lines.push(`Labels: ${issue.labels.join(', ')}`);
+  }
+  lines.push('');
+  lines.push('--- Issue Description ---');
+  lines.push(issue.body || '(no description)');
+
+  if (issue.comments.length > 0) {
+    lines.push('');
+    lines.push(`--- Comments (${issue.comments.length}) ---`);
+    for (const comment of issue.comments) {
+      lines.push('');
+      lines.push(`[${comment.created_at}] @${comment.user}:`);
+      lines.push(comment.body);
+    }
+  }
+
+  lines.push('');
+  lines.push('=== End GitHub Issue Context ===');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Resolve GitHub token from environment or `gh auth token`.
+ */
+export function resolveGitHubToken(): string | null {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+
+  try {
+    const token = execSync('gh auth token 2>/dev/null', {
+      encoding: 'utf-8',
+      timeout: 5000,
+    }).trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract owner/repo from a git remote URL.
+ * Handles both HTTPS and SSH formats:
+ *   https://github.com/owner/repo.git
+ *   git@github.com:owner/repo.git
+ */
+export function parseRepoSlug(
+  remoteUrl: string
+): { owner: string; repo: string } | null {
+  // HTTPS format
+  const httpsMatch = remoteUrl.match(
+    /github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?$/
+  );
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  }
+
+  // SSH format
+  const sshMatch = remoteUrl.match(
+    /github\.com:([^/]+)\/([^/.]+?)(?:\.git)?$/
+  );
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  return null;
+}
+
+/**
+ * Get the remote URL for a git repository.
+ */
+export function getGitRemoteUrl(projectDir: string): string | null {
+  try {
+    return execSync('git remote get-url origin', {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      timeout: 5000,
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a ticket string to extract a GitHub issue number.
+ * Accepts formats: "123", "#123", "issue-123", "GH-123"
+ * Returns null if the ticket doesn't look like a GitHub issue number.
+ */
+export function parseIssueNumber(ticket: string): number | null {
+  const trimmed = ticket.trim();
+
+  // Pure number: "123"
+  if (/^\d+$/.test(trimmed)) {
+    return parseInt(trimmed, 10);
+  }
+
+  // Hash prefix: "#123"
+  const hashMatch = trimmed.match(/^#(\d+)$/);
+  if (hashMatch) {
+    return parseInt(hashMatch[1], 10);
+  }
+
+  // Common prefixes: "issue-123", "GH-123"
+  const prefixMatch = trimmed.match(/^(?:issue|gh)[-#](\d+)$/i);
+  if (prefixMatch) {
+    return parseInt(prefixMatch[1], 10);
+  }
+
+  return null;
+}

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -6,6 +6,14 @@ import { PortAllocator, ServicePort } from './port-allocator';
 import { TaskWatcher } from './task-watcher';
 import { ContainerRuntime, Container, ContainerStats } from '../runtime/types';
 import { SandstormError, ErrorCode } from '../errors';
+import {
+  fetchIssueWithComments,
+  formatIssueContext,
+  resolveGitHubToken,
+  parseRepoSlug,
+  getGitRemoteUrl,
+  parseIssueNumber,
+} from './github';
 
 export interface CreateStackOpts {
   name: string;
@@ -358,6 +366,43 @@ export class StackManager {
     );
   }
 
+  /**
+   * If the stack has a ticket that maps to a GitHub issue number,
+   * fetch the issue body + all comments and prepend them to the prompt.
+   */
+  private async enrichPromptWithIssueContext(
+    stack: Stack,
+    prompt: string
+  ): Promise<string> {
+    if (!stack.ticket) return prompt;
+
+    const issueNumber = parseIssueNumber(stack.ticket);
+    if (!issueNumber) return prompt;
+
+    const token = resolveGitHubToken();
+    if (!token) return prompt;
+
+    const remoteUrl = getGitRemoteUrl(stack.project_dir);
+    if (!remoteUrl) return prompt;
+
+    const slug = parseRepoSlug(remoteUrl);
+    if (!slug) return prompt;
+
+    try {
+      const issue = await fetchIssueWithComments(
+        slug.owner,
+        slug.repo,
+        issueNumber,
+        token
+      );
+      const context = formatIssueContext(issue);
+      return `${context}${prompt}`;
+    } catch {
+      // If we can't fetch the issue, proceed with the original prompt
+      return prompt;
+    }
+  }
+
   async dispatchTask(stackId: string, prompt: string, model?: string): Promise<Task> {
     // Resolve "auto" → undefined so the CLI never receives "--model auto"
     if (model === 'auto') {
@@ -367,7 +412,10 @@ export class StackManager {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
-    const task = this.registry.createTask(stackId, prompt, model);
+    // Enrich prompt with GitHub issue context (body + comments) if applicable
+    const enrichedPrompt = await this.enrichPromptWithIssueContext(stack, prompt);
+
+    const task = this.registry.createTask(stackId, enrichedPrompt, model);
 
     try {
       const claudeContainer = await this.findClaudeContainer(stack);
@@ -384,7 +432,7 @@ export class StackManager {
       // preventing the infinite-loop and not-logged-in bugs.
       const cliArgs = ['task', stackId];
       if (model) cliArgs.push('--model', model);
-      cliArgs.push(prompt);
+      cliArgs.push(enrichedPrompt);
       const result = await this.runCli(stack.project_dir, cliArgs);
 
       if (result.exitCode !== 0) {
@@ -639,6 +687,10 @@ export class StackManager {
       total_tokens: totalInput + totalOutput,
       per_stack: perStack.sort((a, b) => b.total_tokens - a.total_tokens),
     };
+  }
+
+  getRateLimitState(): { active: boolean; reset_at: string | null; affected_stacks: string[]; reason: string | null } {
+    return { active: false, reset_at: null, affected_stacks: [], reason: null };
   }
 
   // --- Private helpers ---

--- a/tests/unit/github.test.ts
+++ b/tests/unit/github.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseIssueNumber,
+  parseRepoSlug,
+  formatIssueContext,
+  resolveGitHubToken,
+  GitHubIssue,
+} from '../../src/main/control-plane/github';
+
+describe('parseIssueNumber', () => {
+  it('parses plain numbers', () => {
+    expect(parseIssueNumber('123')).toBe(123);
+    expect(parseIssueNumber('1')).toBe(1);
+    expect(parseIssueNumber('9999')).toBe(9999);
+  });
+
+  it('parses hash-prefixed numbers', () => {
+    expect(parseIssueNumber('#42')).toBe(42);
+    expect(parseIssueNumber('#1')).toBe(1);
+  });
+
+  it('parses issue- and GH- prefixes', () => {
+    expect(parseIssueNumber('issue-55')).toBe(55);
+    expect(parseIssueNumber('GH-100')).toBe(100);
+    expect(parseIssueNumber('gh-7')).toBe(7);
+    expect(parseIssueNumber('ISSUE-3')).toBe(3);
+  });
+
+  it('trims whitespace', () => {
+    expect(parseIssueNumber('  42  ')).toBe(42);
+    expect(parseIssueNumber(' #10 ')).toBe(10);
+  });
+
+  it('returns null for non-issue tickets', () => {
+    expect(parseIssueNumber('EXP-342')).toBeNull();
+    expect(parseIssueNumber('JIRA-100')).toBeNull();
+    expect(parseIssueNumber('abc')).toBeNull();
+    expect(parseIssueNumber('')).toBeNull();
+    expect(parseIssueNumber('not-a-number')).toBeNull();
+  });
+});
+
+describe('parseRepoSlug', () => {
+  it('parses HTTPS remote URLs', () => {
+    expect(parseRepoSlug('https://github.com/owner/repo.git')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+    expect(parseRepoSlug('https://github.com/onomojo/examprep.git')).toEqual({
+      owner: 'onomojo',
+      repo: 'examprep',
+    });
+    expect(parseRepoSlug('https://github.com/owner/repo')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('parses SSH remote URLs', () => {
+    expect(parseRepoSlug('git@github.com:owner/repo.git')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+    expect(parseRepoSlug('git@github.com:onomojo/examprep.git')).toEqual({
+      owner: 'onomojo',
+      repo: 'examprep',
+    });
+  });
+
+  it('returns null for non-GitHub URLs', () => {
+    expect(parseRepoSlug('https://gitlab.com/owner/repo.git')).toBeNull();
+    expect(parseRepoSlug('not-a-url')).toBeNull();
+    expect(parseRepoSlug('')).toBeNull();
+  });
+});
+
+describe('formatIssueContext', () => {
+  it('formats issue with no comments', () => {
+    const issue: GitHubIssue = {
+      number: 42,
+      title: 'Fix the bug',
+      state: 'open',
+      user: 'alice',
+      created_at: '2026-01-15T10:00:00Z',
+      body: 'There is a bug in the login flow.',
+      labels: ['bug', 'priority'],
+      comments: [],
+    };
+
+    const result = formatIssueContext(issue);
+    expect(result).toContain('Issue #42: Fix the bug');
+    expect(result).toContain('State: open');
+    expect(result).toContain('Opened by: alice on 2026-01-15T10:00:00Z');
+    expect(result).toContain('Labels: bug, priority');
+    expect(result).toContain('There is a bug in the login flow.');
+    expect(result).not.toContain('Comments');
+  });
+
+  it('formats issue with comments', () => {
+    const issue: GitHubIssue = {
+      number: 111,
+      title: 'Include comments in stack tasks',
+      state: 'open',
+      user: 'bob',
+      created_at: '2026-03-01T12:00:00Z',
+      body: 'Agents need full issue context.',
+      labels: [],
+      comments: [
+        {
+          user: 'alice',
+          created_at: '2026-03-02T09:00:00Z',
+          body: 'I added more context here.',
+        },
+        {
+          user: 'bob',
+          created_at: '2026-03-03T14:00:00Z',
+          body: 'The previous attempt missed the comments.',
+        },
+      ],
+    };
+
+    const result = formatIssueContext(issue);
+    expect(result).toContain('Issue #111');
+    expect(result).toContain('Comments (2)');
+    expect(result).toContain('@alice:');
+    expect(result).toContain('I added more context here.');
+    expect(result).toContain('@bob:');
+    expect(result).toContain('The previous attempt missed the comments.');
+    expect(result).toContain('[2026-03-02T09:00:00Z]');
+    expect(result).toContain('[2026-03-03T14:00:00Z]');
+  });
+
+  it('handles empty body gracefully', () => {
+    const issue: GitHubIssue = {
+      number: 1,
+      title: 'No body',
+      state: 'closed',
+      user: 'x',
+      created_at: '2026-01-01T00:00:00Z',
+      body: '',
+      labels: [],
+      comments: [],
+    };
+
+    const result = formatIssueContext(issue);
+    expect(result).toContain('(no description)');
+  });
+
+  it('does not include Labels line when there are none', () => {
+    const issue: GitHubIssue = {
+      number: 5,
+      title: 'Test',
+      state: 'open',
+      user: 'x',
+      created_at: '2026-01-01T00:00:00Z',
+      body: 'body',
+      labels: [],
+      comments: [],
+    };
+
+    const result = formatIssueContext(issue);
+    expect(result).not.toContain('Labels:');
+  });
+});
+
+describe('resolveGitHubToken', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns GITHUB_TOKEN from environment', () => {
+    process.env.GITHUB_TOKEN = 'ghp_test123';
+    delete process.env.GH_TOKEN;
+    expect(resolveGitHubToken()).toBe('ghp_test123');
+  });
+
+  it('returns GH_TOKEN if GITHUB_TOKEN is not set', () => {
+    delete process.env.GITHUB_TOKEN;
+    process.env.GH_TOKEN = 'ghp_alt456';
+    expect(resolveGitHubToken()).toBe('ghp_alt456');
+  });
+
+  it('prefers GITHUB_TOKEN over GH_TOKEN', () => {
+    process.env.GITHUB_TOKEN = 'ghp_primary';
+    process.env.GH_TOKEN = 'ghp_secondary';
+    expect(resolveGitHubToken()).toBe('ghp_primary');
+  });
+});

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -378,6 +378,109 @@ describe('StackManager', () => {
     });
   });
 
+  describe('dispatchTask with issue enrichment', () => {
+    it('enriches prompt with GitHub issue context when stack has a ticket', async () => {
+      const stackWithTicket = { ...makeStack('enrich-test'), ticket: '42' };
+      registry.createStack(stackWithTicket);
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      // Mock the private enrichment method by mocking the github module
+      const github = await import('../../src/main/control-plane/github');
+      const fetchSpy = vi.spyOn(github, 'fetchIssueWithComments').mockResolvedValue({
+        number: 42,
+        title: 'Fix login bug',
+        state: 'open',
+        user: 'alice',
+        created_at: '2026-01-01T00:00:00Z',
+        body: 'Login is broken.',
+        labels: ['bug'],
+        comments: [
+          { user: 'bob', created_at: '2026-01-02T00:00:00Z', body: 'I can reproduce this.' },
+        ],
+      });
+      vi.spyOn(github, 'resolveGitHubToken').mockReturnValue('ghp_test');
+      vi.spyOn(github, 'getGitRemoteUrl').mockReturnValue('https://github.com/owner/repo.git');
+      vi.spyOn(github, 'parseRepoSlug').mockReturnValue({ owner: 'owner', repo: 'repo' });
+
+      const task = await manager.dispatchTask('enrich-test', 'Fix the bug');
+
+      // The prompt sent to CLI should contain the issue context
+      const cliArgs = runCliSpy.mock.calls[0][1];
+      const promptArg = cliArgs[cliArgs.length - 1];
+      expect(promptArg).toContain('Issue #42: Fix login bug');
+      expect(promptArg).toContain('Login is broken.');
+      expect(promptArg).toContain('@bob:');
+      expect(promptArg).toContain('I can reproduce this.');
+      expect(promptArg).toContain('Fix the bug');
+
+      // Task in DB should also have the enriched prompt
+      expect(task.prompt).toContain('Issue #42');
+      expect(task.prompt).toContain('Fix the bug');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('uses original prompt when ticket is not a GitHub issue number', async () => {
+      const stackWithJira = { ...makeStack('jira-ticket'), ticket: 'EXP-342' };
+      registry.createStack(stackWithJira);
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const task = await manager.dispatchTask('jira-ticket', 'Fix it');
+      expect(task.prompt).toBe('Fix it');
+      expect(runCliSpy).toHaveBeenCalledWith(
+        '/proj',
+        ['task', 'jira-ticket', 'Fix it']
+      );
+    });
+
+    it('falls back to original prompt when GitHub fetch fails', async () => {
+      const stackWithTicket = { ...makeStack('fetch-fail'), ticket: '99' };
+      registry.createStack(stackWithTicket);
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const github = await import('../../src/main/control-plane/github');
+      vi.spyOn(github, 'resolveGitHubToken').mockReturnValue('ghp_test');
+      vi.spyOn(github, 'getGitRemoteUrl').mockReturnValue('https://github.com/owner/repo.git');
+      vi.spyOn(github, 'parseRepoSlug').mockReturnValue({ owner: 'owner', repo: 'repo' });
+      const fetchSpy = vi.spyOn(github, 'fetchIssueWithComments').mockRejectedValue(
+        new Error('API error')
+      );
+
+      const task = await manager.dispatchTask('fetch-fail', 'Do the work');
+      expect(task.prompt).toBe('Do the work');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('skips enrichment when no GitHub token available', async () => {
+      const stackWithTicket = { ...makeStack('no-token'), ticket: '10' };
+      registry.createStack(stackWithTicket);
+      vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      const github = await import('../../src/main/control-plane/github');
+      vi.spyOn(github, 'resolveGitHubToken').mockReturnValue(null);
+
+      const task = await manager.dispatchTask('no-token', 'Original prompt');
+      expect(task.prompt).toBe('Original prompt');
+    });
+  });
+
   describe('waitForClaudeReady', () => {
     it('resolves immediately when readiness file exists', async () => {
       registry.createStack(makeStack('ready-test'));


### PR DESCRIPTION
## Summary
- Stacks now receive the full GitHub issue context (body + all comments with timestamps and authors) when a task is dispatched, so inner Claude has complete history of what happened on the issue
- New `github.ts` module fetches issue data via GitHub API; falls back gracefully if token missing or fetch fails
- 699/699 tests passing, build passes

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)