### PR TITLE
Include issue comments when dispatching tasks to stacks

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -27,6 +27,7 @@ export const tools: ToolDefinition[] = [
         description: { type: 'string', description: 'Short description of the work' },
         runtime: { type: 'string', enum: ['docker', 'podman'], description: 'Container runtime' },
         task: { type: 'string', description: 'Task to dispatch immediately after creation' },
+        issueUrl: { type: 'string', description: 'GitHub issue URL (e.g., https://github.com/owner/repo/issues/123). If provided, the full issue body and all comments will be fetched and included in the task context.' },
         model: {
           type: 'string',
           enum: ['auto', 'sonnet', 'opus'],
@@ -52,6 +53,7 @@ export const tools: ToolDefinition[] = [
       properties: {
         stackId: { type: 'string', description: 'Stack ID to dispatch to' },
         prompt: { type: 'string', description: 'Task description for inner Claude' },
+        issueUrl: { type: 'string', description: 'GitHub issue URL (e.g., https://github.com/owner/repo/issues/123). If provided, the full issue body and all comments will be fetched and included in the task context.' },
         model: {
           type: 'string',
           enum: ['auto', 'sonnet', 'opus'],
@@ -172,6 +174,7 @@ export async function handleToolCall(
         runtime: (input.runtime as 'docker' | 'podman') ?? 'docker',
         task: input.task as string | undefined,
         model: input.model as string | undefined,
+        issueUrl: input.issueUrl as string | undefined,
       });
 
     case 'list_stacks':
@@ -181,7 +184,8 @@ export async function handleToolCall(
       return stackManager.dispatchTask(
         input.stackId as string,
         input.prompt as string,
-        input.model as string | undefined
+        input.model as string | undefined,
+        input.issueUrl as string | undefined
       );
 
     case 'get_diff':

--- a/src/main/control-plane/github-issue.ts
+++ b/src/main/control-plane/github-issue.ts
@@ -1,0 +1,122 @@
+import { execFile } from 'child_process';
+
+export interface GitHubComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface GitHubIssue {
+  title: string;
+  body: string;
+  state: string;
+  author: string;
+  createdAt: string;
+  labels: string[];
+  comments: GitHubComment[];
+}
+
+/**
+ * Parse a GitHub issue URL into owner, repo, and issue number.
+ * Supports formats like:
+ *   https://github.com/owner/repo/issues/123
+ *   github.com/owner/repo/issues/123
+ */
+export function parseIssueUrl(url: string): { owner: string; repo: string; number: number } | null {
+  const match = url.match(/(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}
+
+/**
+ * Fetch a GitHub issue with all comments using the `gh` CLI.
+ * Returns null if `gh` is unavailable or the fetch fails.
+ */
+export async function fetchGitHubIssue(
+  owner: string,
+  repo: string,
+  issueNumber: number
+): Promise<GitHubIssue | null> {
+  try {
+    const json = await new Promise<string>((resolve, reject) => {
+      execFile(
+        'gh',
+        [
+          'issue', 'view', String(issueNumber),
+          '--repo', `${owner}/${repo}`,
+          '--json', 'title,body,state,author,comments,labels,createdAt',
+        ],
+        { timeout: 30000 },
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+          } else {
+            resolve(stdout);
+          }
+        }
+      );
+    });
+
+    const data = JSON.parse(json);
+
+    return {
+      title: data.title ?? '',
+      body: data.body ?? '',
+      state: data.state ?? '',
+      author: data.author?.login ?? 'unknown',
+      createdAt: data.createdAt ?? '',
+      labels: (data.labels ?? []).map((l: { name: string }) => l.name),
+      comments: (data.comments ?? []).map((c: { author: { login: string }; body: string; createdAt: string }) => ({
+        author: c.author?.login ?? 'unknown',
+        body: c.body ?? '',
+        createdAt: c.createdAt ?? '',
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a GitHub issue (with comments) into a prompt-friendly string.
+ */
+export function formatIssueForPrompt(issue: GitHubIssue): string {
+  const parts: string[] = [];
+
+  parts.push(`## GitHub Issue: ${issue.title}`);
+  parts.push(`**State:** ${issue.state} | **Author:** @${issue.author} | **Created:** ${issue.createdAt}`);
+
+  if (issue.labels.length > 0) {
+    parts.push(`**Labels:** ${issue.labels.join(', ')}`);
+  }
+
+  parts.push('');
+  parts.push('### Description');
+  parts.push(issue.body || '(no description)');
+
+  if (issue.comments.length > 0) {
+    parts.push('');
+    parts.push(`### Comments (${issue.comments.length})`);
+    for (const comment of issue.comments) {
+      parts.push('');
+      parts.push(`**@${comment.author}** on ${comment.createdAt}:`);
+      parts.push(comment.body);
+    }
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Given a GitHub issue URL, fetch the issue and return a formatted prompt context string.
+ * Returns null if the URL is not a valid GitHub issue URL or the fetch fails.
+ */
+export async function fetchIssueContext(issueUrl: string): Promise<string | null> {
+  const parsed = parseIssueUrl(issueUrl);
+  if (!parsed) return null;
+
+  const issue = await fetchGitHubIssue(parsed.owner, parsed.repo, parsed.number);
+  if (!issue) return null;
+
+  return formatIssueForPrompt(issue);
+}

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -6,6 +6,7 @@ import { PortAllocator, ServicePort } from './port-allocator';
 import { TaskWatcher } from './task-watcher';
 import { ContainerRuntime, Container, ContainerStats } from '../runtime/types';
 import { SandstormError, ErrorCode } from '../errors';
+import { fetchIssueContext } from './github-issue';
 
 export interface CreateStackOpts {
   name: string;
@@ -16,6 +17,7 @@ export interface CreateStackOpts {
   runtime: 'docker' | 'podman';
   task?: string;
   model?: string;
+  issueUrl?: string;
 }
 
 export interface StackWithServices extends Stack {
@@ -218,12 +220,12 @@ export class StackManager {
       // If a task was provided, dispatch it (with one retry on failure)
       if (opts.task) {
         try {
-          await this.dispatchTask(opts.name, opts.task, opts.model);
+          await this.dispatchTask(opts.name, opts.task, opts.model, opts.issueUrl);
         } catch (firstErr) {
           // Wait and retry once — the container may need more time
           await new Promise((resolve) => setTimeout(resolve, 10000));
           try {
-            await this.dispatchTask(opts.name, opts.task, opts.model);
+            await this.dispatchTask(opts.name, opts.task, opts.model, opts.issueUrl);
           } catch (retryErr) {
             const msg = retryErr instanceof Error ? retryErr.message : String(retryErr);
             this.registry.updateStackStatus(opts.name, 'failed', `Task dispatch failed after retry: ${msg}`);
@@ -358,7 +360,7 @@ export class StackManager {
     );
   }
 
-  async dispatchTask(stackId: string, prompt: string, model?: string): Promise<Task> {
+  async dispatchTask(stackId: string, prompt: string, model?: string, issueUrl?: string): Promise<Task> {
     // Resolve "auto" → undefined so the CLI never receives "--model auto"
     if (model === 'auto') {
       model = undefined;
@@ -367,7 +369,17 @@ export class StackManager {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
-    const task = this.registry.createTask(stackId, prompt, model);
+    // If a GitHub issue URL is provided, fetch the full issue context
+    // (title, body, comments) and prepend it to the prompt
+    let enrichedPrompt = prompt;
+    if (issueUrl) {
+      const issueContext = await fetchIssueContext(issueUrl);
+      if (issueContext) {
+        enrichedPrompt = `${issueContext}\n\n---\n\n## Task\n\n${prompt}`;
+      }
+    }
+
+    const task = this.registry.createTask(stackId, enrichedPrompt, model);
 
     try {
       const claudeContainer = await this.findClaudeContainer(stack);
@@ -384,7 +396,7 @@ export class StackManager {
       // preventing the infinite-loop and not-logged-in bugs.
       const cliArgs = ['task', stackId];
       if (model) cliArgs.push('--model', model);
-      cliArgs.push(prompt);
+      cliArgs.push(enrichedPrompt);
       const result = await this.runCli(stack.project_dir, cliArgs);
 
       if (result.exitCode !== 0) {
@@ -639,6 +651,25 @@ export class StackManager {
       total_tokens: totalInput + totalOutput,
       per_stack: perStack.sort((a, b) => b.total_tokens - a.total_tokens),
     };
+  }
+
+  getRateLimitState(): { is_rate_limited: boolean; reset_at: string | null } {
+    const stacks = this.registry.listStacks();
+    let latestReset: string | null = null;
+    let isRateLimited = false;
+
+    for (const stack of stacks) {
+      if (stack.status === 'rate_limited') {
+        isRateLimited = true;
+        if (stack.rate_limit_reset_at) {
+          if (!latestReset || stack.rate_limit_reset_at > latestReset) {
+            latestReset = stack.rate_limit_reset_at;
+          }
+        }
+      }
+    }
+
+    return { is_rate_limited: isRateLimited, reset_at: latestReset };
   }
 
   // --- Private helpers ---

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -295,8 +295,8 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   ipcMain.handle(
     'tasks:dispatch',
-    async (_event, stackId: string, prompt: string, model?: string) => {
-      return stackManager.dispatchTask(stackId, prompt, model);
+    async (_event, stackId: string, prompt: string, model?: string, issueUrl?: string) => {
+      return stackManager.dispatchTask(stackId, prompt, model, issueUrl);
     }
   );
 

--- a/src/main/runtime/docker.ts
+++ b/src/main/runtime/docker.ts
@@ -215,7 +215,7 @@ export class DockerRuntime implements ContainerRuntime {
         const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
         const input = remainder.length > 0 ? Buffer.concat([remainder, buf]) : buf;
         const { frames, remainder: leftover } = demuxDockerStream(input);
-        remainder = leftover;
+        remainder = leftover as Buffer<ArrayBuffer>;
         for (const frame of frames) {
           yield frame.content;
         }
@@ -264,7 +264,7 @@ export class DockerRuntime implements ContainerRuntime {
         // A single data event may contain multiple frames or partial frames.
         const input = remainder.length > 0 ? Buffer.concat([remainder, chunk]) : chunk;
         const result = demuxDockerStream(input);
-        remainder = result.remainder;
+        remainder = result.remainder as Buffer<ArrayBuffer>;
 
         for (const frame of result.frames) {
           if (frame.type === 1) stdout += frame.content;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,7 +20,7 @@ export interface SandstormAPI {
     setPr: (id: string, prUrl: string, prNumber: number) => Promise<void>;
   };
   tasks: {
-    dispatch: (stackId: string, prompt: string, model?: string) => Promise<unknown>;
+    dispatch: (stackId: string, prompt: string, model?: string, issueUrl?: string) => Promise<unknown>;
     list: (stackId: string) => Promise<unknown[]>;
   };
   diff: {
@@ -94,8 +94,8 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('stacks:setPr', id, prUrl, prNumber),
   },
   tasks: {
-    dispatch: (stackId, prompt, model?) =>
-      ipcRenderer.invoke('tasks:dispatch', stackId, prompt, model),
+    dispatch: (stackId, prompt, model?, issueUrl?) =>
+      ipcRenderer.invoke('tasks:dispatch', stackId, prompt, model, issueUrl),
     list: (stackId) => ipcRenderer.invoke('tasks:list', stackId),
   },
   diff: {

--- a/tests/unit/github-issue.test.ts
+++ b/tests/unit/github-issue.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseIssueUrl, formatIssueForPrompt, fetchGitHubIssue, fetchIssueContext, GitHubIssue } from '../../src/main/control-plane/github-issue';
+import { execFile } from 'child_process';
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+const mockedExecFile = vi.mocked(execFile);
+
+describe('parseIssueUrl', () => {
+  it('parses a full GitHub issue URL', () => {
+    const result = parseIssueUrl('https://github.com/onomojo/sandstorm/issues/111');
+    expect(result).toEqual({ owner: 'onomojo', repo: 'sandstorm', number: 111 });
+  });
+
+  it('parses a URL without https://', () => {
+    const result = parseIssueUrl('github.com/owner/repo/issues/42');
+    expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 42 });
+  });
+
+  it('parses a URL with http://', () => {
+    const result = parseIssueUrl('http://github.com/owner/repo/issues/7');
+    expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 7 });
+  });
+
+  it('returns null for non-issue URLs', () => {
+    expect(parseIssueUrl('https://github.com/owner/repo/pulls/5')).toBeNull();
+    expect(parseIssueUrl('https://gitlab.com/owner/repo/issues/5')).toBeNull();
+    expect(parseIssueUrl('not a url')).toBeNull();
+    expect(parseIssueUrl('')).toBeNull();
+  });
+
+  it('returns null for issue URL without a number', () => {
+    expect(parseIssueUrl('https://github.com/owner/repo/issues/')).toBeNull();
+  });
+});
+
+describe('formatIssueForPrompt', () => {
+  const baseIssue: GitHubIssue = {
+    title: 'Fix login bug',
+    body: 'Login fails when password contains special characters.',
+    state: 'OPEN',
+    author: 'testuser',
+    createdAt: '2026-03-20T10:00:00Z',
+    labels: ['bug', 'auth'],
+    comments: [],
+  };
+
+  it('formats an issue with no comments', () => {
+    const result = formatIssueForPrompt(baseIssue);
+    expect(result).toContain('## GitHub Issue: Fix login bug');
+    expect(result).toContain('**State:** OPEN');
+    expect(result).toContain('@testuser');
+    expect(result).toContain('**Labels:** bug, auth');
+    expect(result).toContain('Login fails when password contains special characters.');
+    expect(result).not.toContain('### Comments');
+  });
+
+  it('formats an issue with comments', () => {
+    const issue: GitHubIssue = {
+      ...baseIssue,
+      comments: [
+        { author: 'reviewer', body: 'Can you add a test for this?', createdAt: '2026-03-21T09:00:00Z' },
+        { author: 'testuser', body: 'Done, added regression test.', createdAt: '2026-03-21T10:00:00Z' },
+      ],
+    };
+    const result = formatIssueForPrompt(issue);
+    expect(result).toContain('### Comments (2)');
+    expect(result).toContain('**@reviewer** on 2026-03-21T09:00:00Z:');
+    expect(result).toContain('Can you add a test for this?');
+    expect(result).toContain('**@testuser** on 2026-03-21T10:00:00Z:');
+    expect(result).toContain('Done, added regression test.');
+  });
+
+  it('handles empty body', () => {
+    const issue: GitHubIssue = { ...baseIssue, body: '' };
+    const result = formatIssueForPrompt(issue);
+    expect(result).toContain('(no description)');
+  });
+
+  it('handles no labels', () => {
+    const issue: GitHubIssue = { ...baseIssue, labels: [] };
+    const result = formatIssueForPrompt(issue);
+    expect(result).not.toContain('**Labels:**');
+  });
+});
+
+describe('fetchGitHubIssue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches and parses issue JSON from gh CLI', async () => {
+    const ghResponse = JSON.stringify({
+      title: 'Test issue',
+      body: 'Issue body',
+      state: 'OPEN',
+      author: { login: 'octocat' },
+      createdAt: '2026-03-20T10:00:00Z',
+      labels: [{ name: 'bug' }],
+      comments: [
+        {
+          author: { login: 'commenter' },
+          body: 'A comment',
+          createdAt: '2026-03-21T12:00:00Z',
+        },
+      ],
+    });
+
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, ghResponse, '');
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await fetchGitHubIssue('owner', 'repo', 42);
+    expect(result).toEqual({
+      title: 'Test issue',
+      body: 'Issue body',
+      state: 'OPEN',
+      author: 'octocat',
+      createdAt: '2026-03-20T10:00:00Z',
+      labels: ['bug'],
+      comments: [
+        { author: 'commenter', body: 'A comment', createdAt: '2026-03-21T12:00:00Z' },
+      ],
+    });
+
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'view', '42', '--repo', 'owner/repo', '--json', 'title,body,state,author,comments,labels,createdAt'],
+      { timeout: 30000 },
+      expect.any(Function),
+    );
+  });
+
+  it('returns null when gh CLI fails', async () => {
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(new Error('gh not found'), '', 'command not found: gh');
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await fetchGitHubIssue('owner', 'repo', 1);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when JSON is invalid', async () => {
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, 'not json', '');
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await fetchGitHubIssue('owner', 'repo', 1);
+    expect(result).toBeNull();
+  });
+});
+
+describe('fetchIssueContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for non-GitHub URLs', async () => {
+    const result = await fetchIssueContext('not-a-github-url');
+    expect(result).toBeNull();
+    expect(mockedExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns formatted context for valid issue URL', async () => {
+    const ghResponse = JSON.stringify({
+      title: 'Include comments in stack dispatch',
+      body: 'We need to include comments.',
+      state: 'OPEN',
+      author: { login: 'dev' },
+      createdAt: '2026-03-25T10:00:00Z',
+      labels: [],
+      comments: [
+        { author: { login: 'pm' }, body: 'This is important!', createdAt: '2026-03-26T10:00:00Z' },
+      ],
+    });
+
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, ghResponse, '');
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await fetchIssueContext('https://github.com/onomojo/sandstorm/issues/111');
+    expect(result).toContain('## GitHub Issue: Include comments in stack dispatch');
+    expect(result).toContain('This is important!');
+    expect(result).toContain('@pm');
+  });
+
+  it('returns null when gh fetch fails', async () => {
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(new Error('fail'), '', '');
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const result = await fetchIssueContext('https://github.com/owner/repo/issues/1');
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -275,7 +275,7 @@ describe('IPC Handlers', () => {
 
       const result = await invokeHandler('tasks:dispatch', 'stack-1', 'fix bug');
       expect(result).toEqual(task);
-      expect(mockStackManager.dispatchTask).toHaveBeenCalledWith('stack-1', 'fix bug', undefined);
+      expect(mockStackManager.dispatchTask).toHaveBeenCalledWith('stack-1', 'fix bug', undefined, undefined);
     });
 
     it('tasks:dispatch passes model parameter when provided', async () => {
@@ -284,7 +284,7 @@ describe('IPC Handlers', () => {
 
       const result = await invokeHandler('tasks:dispatch', 'stack-1', 'fix bug', 'opus');
       expect(result).toEqual(task);
-      expect(mockStackManager.dispatchTask).toHaveBeenCalledWith('stack-1', 'fix bug', 'opus');
+      expect(mockStackManager.dispatchTask).toHaveBeenCalledWith('stack-1', 'fix bug', 'opus', undefined);
     });
 
     it('tasks:list delegates to stackManager.getTasksForStack', async () => {

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -74,7 +74,8 @@ describe('MCP tools', () => {
       expect(stackManager.dispatchTask).toHaveBeenCalledWith(
         'test-stack',
         'Fix a typo',
-        'auto'
+        'auto',
+        undefined
       );
     });
 
@@ -88,7 +89,8 @@ describe('MCP tools', () => {
       expect(stackManager.dispatchTask).toHaveBeenCalledWith(
         'test-stack',
         'Refactor auth',
-        'sonnet'
+        'sonnet',
+        undefined
       );
     });
 
@@ -101,7 +103,24 @@ describe('MCP tools', () => {
       expect(stackManager.dispatchTask).toHaveBeenCalledWith(
         'test-stack',
         'Some task',
+        undefined,
         undefined
+      );
+    });
+
+    it('passes issueUrl through to dispatchTask', async () => {
+      await handleToolCall('dispatch_task', {
+        stackId: 'test-stack',
+        prompt: 'Fix the bug',
+        model: 'opus',
+        issueUrl: 'https://github.com/owner/repo/issues/42',
+      });
+
+      expect(stackManager.dispatchTask).toHaveBeenCalledWith(
+        'test-stack',
+        'Fix the bug',
+        'opus',
+        'https://github.com/owner/repo/issues/42'
       );
     });
   });


### PR DESCRIPTION
## Summary

- Adds `fetchIssueContext()` in `src/main/control-plane/github-issue.ts` that shells out to `gh issue view` to fetch full issue data (title, body, comments with timestamps/authors)
- Threads new `issueUrl` parameter through MCP tool definitions, IPC handlers, preload bridge, and stack manager
- Enriches the task prompt with formatted issue context (body + all comments) before dispatching to inner Claude
- Falls back gracefully to the original prompt if `gh` is unavailable or the fetch fails

Fixes #111

## Test plan

- [x] New `tests/unit/github-issue.test.ts` covers fetching, formatting, and fallback behavior
- [x] Updated `tests/unit/tools.test.ts` and `tests/unit/ipc-handlers.test.ts` for the new `issueUrl` parameter
- [x] All 713 tests passing
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)