### PR TITLE
Include full issue context in dispatch and enforce requirements in review

### DIFF
--- a/sandstorm-cli/docker/review-prompt.md
+++ b/sandstorm-cli/docker/review-prompt.md
@@ -6,14 +6,26 @@ You are a code review agent. You have been given the original task description a
 
 Review the diff below against the original task. Evaluate:
 
-1. **Architecture** — Does the change fit existing patterns in the codebase?
-2. **Best practices** — Is the code idiomatic, with proper error handling?
-3. **Separation of concerns** — No god functions, proper layering?
-4. **DRY** — No unnecessary duplication?
-5. **Security** — No injection, XSS, leaked secrets, OWASP top 10 issues?
-6. **Scalability** — Will it hold up under load?
-7. **Optimizations** — Unnecessary allocations, N+1 queries, etc.?
-8. **Test coverage** — Are the tests meaningful and sufficient?
+1. **Requirements compliance** — Does the code do what the task asked for? If the task specifies an approach (e.g., "use X, do NOT use Y"), does the code comply? **This is the highest-priority criterion. A "better" approach that violates explicit task requirements is a REVIEW_FAIL.**
+2. **Architecture** — Does the change fit existing patterns in the codebase?
+3. **Best practices** — Is the code idiomatic, with proper error handling?
+4. **Separation of concerns** — No god functions, proper layering?
+5. **DRY** — No unnecessary duplication?
+6. **Security** — No injection, XSS, leaked secrets, OWASP top 10 issues?
+7. **Scalability** — Will it hold up under load?
+8. **Optimizations** — Unnecessary allocations, N+1 queries, etc.?
+9. **Test coverage** — Are the tests meaningful and sufficient?
+
+## Understanding the Task Context
+
+The "Original Task" section below may include:
+
+- **Issue body** — The original requirements
+- **Issue comments** — Follow-up discussion, clarifications, corrections, and evolved requirements
+
+**Pay close attention to comments, especially recent ones.** Requirements evolve through discussion. A comment may override or refine the original issue body. If the issue says "do X" but a later comment says "actually do Y instead", the code should do Y.
+
+Read the full history to understand how the team arrived at the current requirements before reviewing.
 
 ## Output Format
 
@@ -34,10 +46,11 @@ Issues:
 ...
 ```
 
-Categories: ARCHITECTURE, BEST_PRACTICE, SEPARATION, DRY, SECURITY, SCALABILITY, OPTIMIZATION, TEST_COVERAGE, BUG
+Categories: REQUIREMENTS, ARCHITECTURE, BEST_PRACTICE, SEPARATION, DRY, SECURITY, SCALABILITY, OPTIMIZATION, TEST_COVERAGE, BUG
 
 ## Rules
 
+- **If the task explicitly specifies an implementation approach, do NOT suggest alternatives.** The task requirements reflect decisions already made. Your job is to review the implementation quality within those constraints, not to second-guess the constraints themselves.
 - Be pragmatic. Only fail the review for genuine issues, not style preferences.
 - Minor nits (variable naming preferences, comment style) are NOT grounds for REVIEW_FAIL.
 - Missing tests for new functionality IS grounds for REVIEW_FAIL.

--- a/src/main/control-plane/github-issue.ts
+++ b/src/main/control-plane/github-issue.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'child_process';
+
+interface IssueComment {
+  author: { login: string };
+  body: string;
+  createdAt: string;
+}
+
+interface IssueData {
+  title: string;
+  body: string;
+  state: string;
+  author: { login: string };
+  createdAt: string;
+  labels: Array<{ name: string }>;
+  comments: IssueComment[];
+}
+
+/**
+ * Fetch a GitHub issue with all comments using the `gh` CLI.
+ * Returns a formatted string with the full issue context, or null if fetching fails.
+ */
+export async function fetchIssueContext(
+  issueNumber: string,
+  projectDir: string
+): Promise<string | null> {
+  try {
+    const json = await ghIssueView(issueNumber, projectDir);
+    const data: IssueData = JSON.parse(json);
+    return formatIssueContext(data);
+  } catch {
+    return null;
+  }
+}
+
+function ghIssueView(issueNumber: string, cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'gh',
+      [
+        'issue',
+        'view',
+        issueNumber,
+        '--json',
+        'title,body,state,author,comments,labels,createdAt',
+      ],
+      { cwd, timeout: 15000 },
+      (err, stdout) => {
+        if (err) return reject(err);
+        resolve(stdout);
+      }
+    );
+  });
+}
+
+function formatIssueContext(data: IssueData): string {
+  const lines: string[] = [];
+
+  lines.push(`# Issue: ${data.title}`);
+  lines.push('');
+  if (data.labels.length > 0) {
+    lines.push(`Labels: ${data.labels.map((l) => l.name).join(', ')}`);
+  }
+  lines.push(`State: ${data.state}`);
+  lines.push(`Author: @${data.author.login}`);
+  lines.push(`Created: ${data.createdAt}`);
+  lines.push('');
+  lines.push('## Description');
+  lines.push('');
+  lines.push(data.body);
+
+  if (data.comments.length > 0) {
+    lines.push('');
+    lines.push('## Comments');
+    for (const comment of data.comments) {
+      lines.push('');
+      lines.push(`### @${comment.author.login} — ${comment.createdAt}`);
+      lines.push('');
+      lines.push(comment.body);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -6,6 +6,7 @@ import { PortAllocator, ServicePort } from './port-allocator';
 import { TaskWatcher } from './task-watcher';
 import { ContainerRuntime, Container, ContainerStats } from '../runtime/types';
 import { SandstormError, ErrorCode } from '../errors';
+import { fetchIssueContext } from './github-issue';
 
 export interface CreateStackOpts {
   name: string;
@@ -366,6 +367,15 @@ export class StackManager {
 
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    // If the stack has a ticket number, fetch the full issue context
+    // (title, body, all comments) and prepend it to the prompt
+    if (stack.ticket) {
+      const issueContext = await fetchIssueContext(stack.ticket, stack.project_dir);
+      if (issueContext) {
+        prompt = `${issueContext}\n\n---\n\n## Task\n\n${prompt}`;
+      }
+    }
 
     const task = this.registry.createTask(stackId, prompt, model);
 

--- a/tests/unit/github-issue.test.ts
+++ b/tests/unit/github-issue.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchIssueContext } from '../../src/main/control-plane/github-issue';
+import * as child_process from 'child_process';
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+const mockExecFile = vi.mocked(child_process.execFile);
+
+describe('fetchIssueContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns formatted issue with title, body, and comments', async () => {
+    const issueData = {
+      title: 'Fix auth bug',
+      body: 'The auth token expires too early.',
+      state: 'OPEN',
+      author: { login: 'alice' },
+      createdAt: '2026-03-20T10:00:00Z',
+      labels: [{ name: 'bug' }],
+      comments: [
+        {
+          author: { login: 'bob' },
+          body: 'I can reproduce this on staging.',
+          createdAt: '2026-03-21T14:00:00Z',
+        },
+        {
+          author: { login: 'alice' },
+          body: 'Actually the issue is in the refresh logic, not the expiry.',
+          createdAt: '2026-03-22T09:00:00Z',
+        },
+      ],
+    };
+
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, JSON.stringify(issueData));
+      return {} as any;
+    });
+
+    const result = await fetchIssueContext('42', '/some/project');
+
+    expect(result).toContain('# Issue: Fix auth bug');
+    expect(result).toContain('The auth token expires too early.');
+    expect(result).toContain('Labels: bug');
+    expect(result).toContain('State: OPEN');
+    expect(result).toContain('Author: @alice');
+    expect(result).toContain('## Comments');
+    expect(result).toContain('### @bob — 2026-03-21T14:00:00Z');
+    expect(result).toContain('I can reproduce this on staging.');
+    expect(result).toContain('### @alice — 2026-03-22T09:00:00Z');
+    expect(result).toContain('Actually the issue is in the refresh logic');
+  });
+
+  it('returns formatted issue without comments section when there are none', async () => {
+    const issueData = {
+      title: 'Add search feature',
+      body: 'We need search.',
+      state: 'OPEN',
+      author: { login: 'alice' },
+      createdAt: '2026-03-20T10:00:00Z',
+      labels: [],
+      comments: [],
+    };
+
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, JSON.stringify(issueData));
+      return {} as any;
+    });
+
+    const result = await fetchIssueContext('10', '/some/project');
+
+    expect(result).toContain('# Issue: Add search feature');
+    expect(result).toContain('We need search.');
+    expect(result).not.toContain('## Comments');
+  });
+
+  it('returns null when gh CLI fails', async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(new Error('gh not found'));
+      return {} as any;
+    });
+
+    const result = await fetchIssueContext('42', '/some/project');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when gh returns invalid JSON', async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, 'not json');
+      return {} as any;
+    });
+
+    const result = await fetchIssueContext('42', '/some/project');
+    expect(result).toBeNull();
+  });
+
+  it('passes the correct arguments to gh CLI', async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(null, JSON.stringify({
+        title: 'Test', body: '', state: 'OPEN',
+        author: { login: 'x' }, createdAt: '', labels: [], comments: [],
+      }));
+      return {} as any;
+    });
+
+    await fetchIssueContext('123', '/my/project');
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'view', '123', '--json', 'title,body,state,author,comments,labels,createdAt'],
+      { cwd: '/my/project', timeout: 15000 },
+      expect.any(Function)
+    );
+  });
+});

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -525,7 +525,7 @@ describe('review-prompt.md template', () => {
   })
 
   it('includes issue category tags for structured output', () => {
-    const tags = ['ARCHITECTURE', 'BEST_PRACTICE', 'SECURITY', 'TEST_COVERAGE', 'BUG']
+    const tags = ['REQUIREMENTS', 'ARCHITECTURE', 'BEST_PRACTICE', 'SECURITY', 'TEST_COVERAGE', 'BUG']
     for (const tag of tags) {
       expect(reviewPrompt).toContain(tag)
     }
@@ -533,6 +533,22 @@ describe('review-prompt.md template', () => {
 
   it('instructs the review agent to be pragmatic', () => {
     expect(reviewPrompt.toLowerCase()).toContain('pragmatic')
+  })
+
+  it('lists requirements compliance as the first review criterion', () => {
+    const reqIndex = reviewPrompt.indexOf('Requirements compliance')
+    const archIndex = reviewPrompt.indexOf('Architecture')
+    expect(reqIndex).toBeGreaterThan(-1)
+    expect(reqIndex).toBeLessThan(archIndex)
+  })
+
+  it('instructs the review agent not to override explicit task approaches', () => {
+    expect(reviewPrompt).toContain('do NOT suggest alternatives')
+  })
+
+  it('instructs the review agent to pay attention to issue comments', () => {
+    expect(reviewPrompt.toLowerCase()).toContain('comments')
+    expect(reviewPrompt).toContain('Requirements evolve')
   })
 })
 


### PR DESCRIPTION
## Summary

- **New `github-issue.ts` module** — shells out to `gh issue view` to fetch full issue data (title, body, all comments with timestamps and authors). No custom API wrapper, no token management — just the `gh` CLI as specified in #111.
- **`stack-manager.ts` enrichment** — `dispatchTask` now auto-detects when a stack has a ticket number, fetches the full issue context, and prepends it to the prompt. Falls back gracefully if `gh` is unavailable.
- **`review-prompt.md` overhaul** — "Requirements compliance" is now criterion #1 (above architecture, best practices, etc.). New "Understanding the Task Context" section tells the review agent to read issue comments and respect evolved requirements. New rule: "If the task explicitly specifies an implementation approach, do NOT suggest alternatives."

## Why

Issue #111 tasks kept producing wrong results (e.g., custom API wrappers when the issue explicitly said "use `gh` CLI"). Root cause: the review agent was steering the execution agent away from the spec by suggesting "better" approaches that violated explicit task requirements. Two fixes needed:
1. The review agent needs the full issue context including comments (#111)
2. The review agent needs to enforce task requirements as the top priority (#124)

Fixes #111, fixes #124

## Test plan

- [x] `tests/unit/github-issue.test.ts` — 5 tests: formatting with comments, no-comments case, CLI failure fallback, invalid JSON fallback, correct CLI arguments
- [x] `tests/unit/task-runner-review-loop.test.ts` — 3 new tests: requirements compliance is first criterion, no-override rule present, comments guidance present
- [x] Existing tests unaffected (168 passing across github-issue, task-runner-review-loop, tools, ipc-handlers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)