### PR TITLE
Add missing token-counter.sh COPY to Dockerfile (fixes #141)

### DIFF
--- a/sandstorm-cli/docker/Dockerfile
+++ b/sandstorm-cli/docker/Dockerfile
@@ -64,9 +64,10 @@ RUN npm install -g chrome-devtools-mcp@latest
 COPY docker/entrypoint.sh /usr/bin/sandstorm-entrypoint.sh
 COPY docker/task-runner.sh /usr/bin/sandstorm-task-runner.sh
 COPY docker/sandstorm-exec /usr/bin/sandstorm-exec
+COPY docker/token-counter.sh /usr/bin/token-counter.sh
 COPY docker/SANDSTORM_INNER.md /usr/bin/SANDSTORM_INNER.md
 COPY docker/review-prompt.md /usr/bin/review-prompt.md
-RUN chmod +x /usr/bin/sandstorm-entrypoint.sh /usr/bin/sandstorm-task-runner.sh /usr/bin/sandstorm-exec
+RUN chmod +x /usr/bin/sandstorm-entrypoint.sh /usr/bin/sandstorm-task-runner.sh /usr/bin/sandstorm-exec /usr/bin/token-counter.sh
 
 ARG SANDSTORM_APP_VERSION=unknown
 LABEL sandstorm.app-version=${SANDSTORM_APP_VERSION}


### PR DESCRIPTION
## Summary

- Added missing `COPY docker/token-counter.sh /usr/bin/token-counter.sh` line to the Dockerfile
- Added `token-counter.sh` to the `chmod +x` line so it's executable in the container

`token-counter.sh` was introduced in #133 but its COPY line was never added to the Dockerfile. This meant freshly built container images had no token counter, breaking the `tee >(bash "$counter_script" ...)` pipeline in `task-runner.sh`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (pre-existing better-sqlite3 native module failures unrelated)
- [ ] Spin up a stack and verify token counting works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)