### PR TITLE
Add Electron system dependencies to Dockerfile for headless container support (fixes #144)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,28 @@
 FROM node:22
 
+# Electron system dependencies (headless)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libxshmfence1 \
+    libgtk-3-0 \
+    libdbus-1-3 \
+    xvfb \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV DISPLAY=:99
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -7,4 +30,4 @@ RUN npm ci
 
 COPY . .
 
-CMD ["npm", "run", "dev"]
+CMD ["xvfb-run", "--auto-servernum", "npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - .:/app
       - node_modules:/app/node_modules
-    command: npm run dev
+    command: ["xvfb-run", "--auto-servernum", "npm", "run", "dev"]
 
 volumes:
   node_modules:

--- a/tests/unit/project-dockerfile.test.ts
+++ b/tests/unit/project-dockerfile.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('Project Dockerfile', () => {
+  const dockerfilePath = resolve(__dirname, '../../Dockerfile');
+  const dockerfile = readFileSync(dockerfilePath, 'utf-8');
+
+  const requiredPackages = [
+    'libnss3',
+    'libatk1.0-0',
+    'libatk-bridge2.0-0',
+    'libcups2',
+    'libdrm2',
+    'libxkbcommon0',
+    'libgbm1',
+    'libasound2',
+    'libgtk-3-0',
+    'xvfb',
+  ];
+
+  it.each(requiredPackages)('includes Electron dependency: %s', (pkg) => {
+    expect(dockerfile).toContain(pkg);
+  });
+
+  it('CMD uses xvfb-run with --auto-servernum', () => {
+    expect(dockerfile).toMatch(/CMD\s.*xvfb-run.*--auto-servernum/);
+  });
+
+  it('sets DISPLAY environment variable', () => {
+    expect(dockerfile).toMatch(/ENV\s+DISPLAY=/);
+  });
+});
+
+describe('docker-compose.yml app service', () => {
+  const composePath = resolve(__dirname, '../../docker-compose.yml');
+  const compose = readFileSync(composePath, 'utf-8');
+
+  it('uses xvfb-run in command to support headless Electron', () => {
+    expect(compose).toContain('xvfb-run');
+  });
+});


### PR DESCRIPTION
## Summary

- Installed Electron/Chromium system dependencies in the project `Dockerfile` (libnss3, libgtk-3-0, libatk, libgbm, libdrm, xvfb, etc.)
- Added `xvfb-run --auto-servernum` to provide a virtual framebuffer for headless Electron
- Set `ENV DISPLAY=:99` as fallback for child processes
- Fixed `docker-compose.yml` `command:` to use `xvfb-run` — it was overriding the Dockerfile CMD and bypassing the virtual framebuffer entirely
- Added tests validating Dockerfile dependencies and docker-compose compatibility

The app container was crashing immediately with `libnss3.so: cannot open shared object file` because `node:22` doesn't include the system libraries Electron requires.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] New tests pass (13 tests covering required packages, CMD structure, compose compatibility)
- [ ] Build app Docker image and verify Electron starts without missing library errors
- [ ] Spin up a full stack and confirm both app and claude containers stay running

🤖 Generated with [Claude Code](https://claude.com/claude-code)