### PR TITLE
Add missing xauth package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtk-3-0 \
     libdbus-1-3 \
     xvfb \
+    xauth \
   && rm -rf /var/lib/apt/lists/*
 
 ENV DISPLAY=:99


### PR DESCRIPTION
## Summary
- The app container crashes on startup with `xvfb-run: error: xauth command not found`
- `xauth` is required by `xvfb-run` to manage X11 authentication cookies but was missing from the Dockerfile's apt-get install list

## Test plan
- [x] Verified xauth is not in the current built image (`dpkg -l xauth` shows "not installed")
- [ ] Rebuild image and confirm app container starts without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)