### PR TITLE
Fix deadlock: outer Claude stream-json session never receives init event

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -289,22 +289,19 @@ rl.on('line', async (line) => {
     this.log(`Message received for tab=${tabId}`);
 
     // If process is alive and currently processing a response, queue the message
-    if (session.process && session.fullResponse !== '' || (session.process && !session.ready)) {
+    if (session.process && session.fullResponse !== '') {
       session.pendingMessages.push(message);
       this.log(`Message queued for tab=${tabId} (queue size: ${session.pendingMessages.length})`);
       this.mainWindow?.webContents.send(`agent:queued:${tabId}`);
       return;
     }
 
-    // Ensure persistent process exists, then send the message
+    // Ensure persistent process exists, then send the message immediately.
+    // Note: Claude CLI with --input-format stream-json does NOT emit the
+    // system init event until it receives input on stdin, so we must write
+    // the message first — not wait for init.
     this.ensureProcess(tabId);
-
-    if (session.process && session.ready) {
-      this.writeMessage(tabId, message);
-    } else {
-      // Process is starting up — queue and it'll be sent after init
-      session.pendingMessages.push(message);
-    }
+    this.writeMessage(tabId, message);
   }
 
   getHistory(tabId: string): AgentSessionHistory {
@@ -650,16 +647,10 @@ rl.on('line', async (line) => {
         try {
           const parsed = JSON.parse(line);
 
-          // Detect init event — process is ready to accept messages
+          // Detect init event — process confirmed ready
           if (parsed.type === 'system' && parsed.subtype === 'init' && !session.ready) {
             session.ready = true;
             this.log(`Claude process ready for tab=${tabId}`);
-            // Send any queued messages
-            if (session.pendingMessages.length > 0) {
-              const next = session.pendingMessages.shift()!;
-              this.log(`Dequeuing message after init for tab=${tabId} (remaining: ${session.pendingMessages.length})`);
-              this.writeMessage(tabId, next);
-            }
             continue;
           }
 

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -182,12 +182,11 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
       expect(spawnedProcesses.length).toBe(1);
     });
 
-    it('writes NDJSON to stdin for messages after init', () => {
+    it('writes NDJSON to stdin immediately on first message (no init wait)', () => {
       backend.sendMessage('tab1', 'hello', '/tmp');
       const proc = getLastProcess();
-      emitInit(proc);
 
-      // The queued message should have been written to stdin
+      // Message should be written to stdin immediately — NOT queued waiting for init
       expect(proc.stdin.write).toHaveBeenCalledWith(
         expect.stringContaining('"type":"user"')
       );
@@ -360,19 +359,70 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
       expect(secondWrite).toBeDefined();
     });
 
-    it('sends queued message after init event', () => {
-      // Send message before init event
+    it('writes first message to stdin immediately without waiting for init', () => {
       backend.sendMessage('tab1', 'hello', '/tmp');
       const proc = getLastProcess();
 
-      // Message should be queued, not written yet
-      const writesBeforeInit = proc.stdin.write.mock.calls.length;
+      // Message should be written to stdin immediately — no init event needed
+      expect(proc.stdin.write).toHaveBeenCalledTimes(1);
+      expect(proc.stdin.write).toHaveBeenCalledWith(
+        expect.stringContaining('hello')
+      );
 
-      // Now emit init
+      // Init event arrives later (as it does in real Claude CLI)
       emitInit(proc);
 
-      // Message should have been written
-      expect(proc.stdin.write.mock.calls.length).toBeGreaterThan(writesBeforeInit);
+      // No additional writes from init — the message was already sent
+      expect(proc.stdin.write).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('no init-gate deadlock', () => {
+    it('does not deadlock when init event requires input first', () => {
+      // This test verifies the fix for issue #181:
+      // Claude CLI with --input-format stream-json does NOT emit the
+      // system init event until it receives input on stdin. The old code
+      // waited for init before sending the first message, causing a deadlock.
+      backend.sendMessage('tab1', 'count to ten', '/tmp');
+      const proc = getLastProcess();
+
+      // Message must be written to stdin BEFORE any init event
+      expect(proc.stdin.write).toHaveBeenCalledTimes(1);
+      const written = proc.stdin.write.mock.calls[0][0] as string;
+      expect(written).toContain('count to ten');
+      expect(written).toContain('"type":"user"');
+
+      // Now init arrives (triggered by the input we just sent)
+      emitInit(proc);
+      expect(proc.stdin.write).toHaveBeenCalledTimes(1); // no extra writes
+
+      // Process responds normally
+      emitAssistant(proc, '1 2 3 4 5 6 7 8 9 10');
+      emitResult(proc);
+
+      const history = backend.getHistory('tab1');
+      expect(history.messages).toHaveLength(2);
+      expect(history.messages[1].content).toBe('1 2 3 4 5 6 7 8 9 10');
+      expect(history.processing).toBe(false);
+    });
+
+    it('still queues messages when a response is in progress', () => {
+      backend.sendMessage('tab1', 'first', '/tmp');
+      const proc = getLastProcess();
+      emitInit(proc);
+      emitAssistant(proc, 'partial response');
+
+      // Second message while first is processing (fullResponse is non-empty)
+      backend.sendMessage('tab1', 'second', '/tmp');
+      const queued = findMessages('agent:queued:tab1');
+      expect(queued.length).toBe(1);
+
+      // Complete first response — second should be dequeued
+      emitResult(proc);
+      const secondWrite = proc.stdin.write.mock.calls.find((call: [string]) =>
+        call[0].includes('second')
+      );
+      expect(secondWrite).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes a deadlock where the app waited for a `system init` event before sending the first message to Claude CLI's stdin, but Claude CLI with `--input-format stream-json` doesn't emit init until it receives input — both sides waited on each other forever
- Messages are now written to stdin immediately after process spawn; init event retained for diagnostics only
- Adds regression tests for the deadlock scenario and verifies message queuing still works during active responses

## Test plan

- [x] All 29 claude-backend tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual test: open app, send a message to outer Claude, verify it responds instead of hanging on "thinking"

Fixes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)