### PR TITLE
Fix false 'not initialized' detection when .sandstorm/docker-compose.yml is missing

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -181,7 +181,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       const sandstormDir = path.join(directory, '.sandstorm');
       const configPath = path.join(sandstormDir, 'config');
       const composePath = path.join(sandstormDir, 'docker-compose.yml');
-      const isInitialized = fs.existsSync(configPath) && fs.existsSync(composePath);
+      const isInitialized = fs.existsSync(configPath);
 
       // Auto-sync skills if project is initialized but skills are missing
       if (isInitialized) {

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -513,13 +513,16 @@ describe('IPC Handlers', () => {
         expect(result).toBe(false);
       });
 
-      it('returns false when docker-compose.yml is missing', async () => {
+      it('returns true when .sandstorm/config exists without docker-compose.yml (regression #187)', async () => {
+        // Projects initialized via CLI may only have .sandstorm/config; the compose
+        // file lives at the project root. The config file alone is sufficient proof
+        // of initialization.
         const sandstormDir = path.join(tmpDir, '.sandstorm');
         fs.mkdirSync(sandstormDir, { recursive: true });
-        fs.writeFileSync(path.join(sandstormDir, 'config'), 'PROJECT_NAME=test');
+        fs.writeFileSync(path.join(sandstormDir, 'config'), 'PROJECT_NAME=test\nCOMPOSE_FILE=docker-compose.yml');
 
         const result = await invokeHandler('projects:checkInit', tmpDir);
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
 
       it('returns false for non-existent directory', async () => {


### PR DESCRIPTION
## Summary

- Fixes #187 — projects with `.sandstorm/config` but no `.sandstorm/docker-compose.yml` were falsely showing "Sandstorm not initialized"
- The `checkInit` handler required both files; now `.sandstorm/config` alone is sufficient since it contains the compose file reference (`COMPOSE_FILE=docker-compose.yml` pointing to the project root)
- Updated regression test to verify config-only projects are correctly detected as initialized

## Test plan

- [x] Existing `checkInit` tests pass (4/4)
- [ ] Open a project that has `.sandstorm/config` but no `.sandstorm/docker-compose.yml` — should show as initialized
- [ ] Open a project with no `.sandstorm/` directory — should still show as not initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)