### PR TITLE
Fix forceBypass not propagating from create_stack to embedded task dispatch

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -356,12 +356,12 @@ export class StackManager {
       // If a task was provided, dispatch it (with one retry on failure)
       if (opts.task) {
         try {
-          await this.dispatchTask(opts.name, opts.task, opts.model);
+          await this.dispatchTask(opts.name, opts.task, opts.model, { gateApproved: opts.gateApproved, forceBypass: opts.forceBypass });
         } catch (firstErr) {
           // Wait and retry once — the container may need more time
           await new Promise((resolve) => setTimeout(resolve, 10000));
           try {
-            await this.dispatchTask(opts.name, opts.task, opts.model);
+            await this.dispatchTask(opts.name, opts.task, opts.model, { gateApproved: opts.gateApproved, forceBypass: opts.forceBypass });
           } catch (retryErr) {
             const msg = retryErr instanceof Error ? retryErr.message : String(retryErr);
             this.registry.updateStackStatus(opts.name, 'failed', `Task dispatch failed after retry: ${msg}`);

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -528,6 +528,54 @@ describe('StackManager', () => {
         expect(stack!.error).toContain('Task dispatch failed after retry');
       }, { timeout: 25000 });
     }, 30000);
+
+    it('propagates forceBypass to internal dispatchTask call (regression #186)', async () => {
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      const dispatchSpy = vi.spyOn(manager, 'dispatchTask').mockResolvedValue({
+        id: 1, stack_id: 'bypass-prop', prompt: 'Fix issue #99', model: null,
+        status: 'running', exit_code: null, warnings: null, started_at: '', finished_at: null,
+      });
+
+      manager.createStack({
+        name: 'bypass-prop',
+        projectDir: tmpDir,
+        runtime: 'docker',
+        task: 'Fix issue #99',
+        forceBypass: true,
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatchSpy).toHaveBeenCalled();
+      }, { timeout: 5000 });
+
+      const [, , , opts] = dispatchSpy.mock.calls[0];
+      expect(opts?.forceBypass).toBe(true);
+    });
+
+    it('propagates gateApproved to internal dispatchTask call', async () => {
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      const dispatchSpy = vi.spyOn(manager, 'dispatchTask').mockResolvedValue({
+        id: 1, stack_id: 'gate-prop', prompt: 'Fix issue #99', model: null,
+        status: 'running', exit_code: null, warnings: null, started_at: '', finished_at: null,
+      });
+
+      manager.createStack({
+        name: 'gate-prop',
+        projectDir: tmpDir,
+        runtime: 'docker',
+        task: 'Fix issue #99',
+        gateApproved: true,
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatchSpy).toHaveBeenCalled();
+      }, { timeout: 5000 });
+
+      const [, , , opts] = dispatchSpy.mock.calls[0];
+      expect(opts?.gateApproved).toBe(true);
+    });
   });
 
   describe('stopStack', () => {


### PR DESCRIPTION
## Summary

- Fixes #186 — `forceBypass` and `gateApproved` were not being forwarded from `create_stack` to the internal `dispatchTask` calls
- Both dispatch attempts (initial + retry) in `buildStackInBackground` now propagate these options
- Added two regression tests verifying `forceBypass` and `gateApproved` propagation

## Test plan

- [x] All 127 stack-manager tests pass including 2 new regression tests
- [ ] Create a stack with `forceBypass: true` and an inline `task` referencing a ticket — task should dispatch successfully
- [ ] Create a stack with `gateApproved: true` and an inline `task` — task should dispatch successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)