### PR TITLE
Fix MCP tools resolving .sandstorm/ files from wrong directory

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -4,9 +4,32 @@
  * dispatch tasks, and manage the lifecycle programmatically.
  */
 
+import path from 'path';
 import { stackManager, agentBackend } from '../index';
 import { fetchTicketContext, getScriptStatus } from '../control-plane/ticket-fetcher';
 import { getSpecQualityGate } from '../spec-quality-gate';
+
+/**
+ * Validate that projectDir is a non-empty absolute path.
+ * Returns an error object if invalid, or null if valid.
+ */
+export function validateProjectDir(projectDir: unknown): { error: string } | null {
+  if (!projectDir || typeof projectDir !== 'string' || !projectDir.trim()) {
+    return {
+      error:
+        'projectDir is required and must be a non-empty string. ' +
+        'Pass the absolute path to the project directory (e.g., "/home/user/my-project").',
+    };
+  }
+  if (!path.isAbsolute(projectDir)) {
+    return {
+      error:
+        `projectDir must be an absolute path, got relative path: "${projectDir}". ` +
+        'Use the full path (e.g., "/home/user/my-project") instead of a relative path like "." or "./project".',
+    };
+  }
+  return null;
+}
 
 export interface ToolDefinition {
   name: string;
@@ -195,7 +218,9 @@ export async function handleToolCall(
   input: Record<string, unknown>
 ): Promise<unknown> {
   switch (name) {
-    case 'create_stack':
+    case 'create_stack': {
+      const dirError = validateProjectDir(input.projectDir);
+      if (dirError) return dirError;
       return stackManager.createStack({
         name: input.name as string,
         projectDir: input.projectDir as string,
@@ -208,6 +233,7 @@ export async function handleToolCall(
         gateApproved: input.gateApproved as boolean | undefined,
         forceBypass: input.forceBypass as boolean | undefined,
       });
+    }
 
     case 'list_stacks':
       return stackManager.listStacksWithServices();
@@ -260,18 +286,24 @@ export async function handleToolCall(
       );
       return { success: true };
 
-    case 'spec_check':
+    case 'spec_check': {
+      const dirError = validateProjectDir(input.projectDir);
+      if (dirError) return dirError;
       return handleSpecCheck(
         input.ticketId as string,
         input.projectDir as string
       );
+    }
 
-    case 'spec_refine':
+    case 'spec_refine': {
+      const dirError = validateProjectDir(input.projectDir);
+      if (dirError) return dirError;
       return handleSpecRefine(
         input.ticketId as string,
         input.projectDir as string,
         input.userAnswers as string | undefined
       );
+    }
 
     default:
       throw new Error(`Unknown tool: ${name}`);
@@ -282,12 +314,15 @@ async function handleSpecCheck(
   ticketId: string,
   projectDir: string
 ): Promise<unknown> {
+  const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', 'fetch-ticket.sh');
+  console.log(`[sandstorm] spec_check: projectDir="${projectDir}", scriptPath="${scriptPath}"`);
+
   const scriptStatus = getScriptStatus(projectDir);
   if (scriptStatus === 'missing') {
     return {
       passed: false,
       reason:
-        "fetch-ticket.sh not found at .sandstorm/scripts/fetch-ticket.sh. " +
+        `fetch-ticket.sh not found at ${scriptPath}. ` +
         "Run 'sandstorm init' to auto-generate it for your ticket system (Jira or GitHub Issues), " +
         "or create it manually: the script receives a ticket ID as $1 and must output the ticket body to stdout.",
     };
@@ -296,8 +331,8 @@ async function handleSpecCheck(
     return {
       passed: false,
       reason:
-        "fetch-ticket.sh exists but is not executable. " +
-        "Fix with: chmod +x .sandstorm/scripts/fetch-ticket.sh",
+        `fetch-ticket.sh exists but is not executable. ` +
+        `Fix with: chmod +x ${scriptPath}`,
     };
   }
 
@@ -309,10 +344,11 @@ async function handleSpecCheck(
     };
   }
 
+  const gatePath = path.join(projectDir, '.sandstorm', 'spec-quality-gate.md');
   const gate = getSpecQualityGate(projectDir);
   if (!gate) {
     return {
-      error: 'No quality gate configured. Run sandstorm init or create .sandstorm/spec-quality-gate.md.',
+      error: `No quality gate configured at ${gatePath}. Run sandstorm init or create .sandstorm/spec-quality-gate.md.`,
     };
   }
 
@@ -364,12 +400,15 @@ async function handleSpecRefine(
   projectDir: string,
   userAnswers?: string
 ): Promise<unknown> {
+  const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', 'fetch-ticket.sh');
+  console.log(`[sandstorm] spec_refine: projectDir="${projectDir}", scriptPath="${scriptPath}"`);
+
   const scriptStatus = getScriptStatus(projectDir);
   if (scriptStatus === 'missing') {
     return {
       passed: false,
       reason:
-        "fetch-ticket.sh not found at .sandstorm/scripts/fetch-ticket.sh. " +
+        `fetch-ticket.sh not found at ${scriptPath}. ` +
         "Run 'sandstorm init' to auto-generate it for your ticket system (Jira or GitHub Issues), " +
         "or create it manually: the script receives a ticket ID as $1 and must output the ticket body to stdout.",
     };
@@ -378,8 +417,8 @@ async function handleSpecRefine(
     return {
       passed: false,
       reason:
-        "fetch-ticket.sh exists but is not executable. " +
-        "Fix with: chmod +x .sandstorm/scripts/fetch-ticket.sh",
+        `fetch-ticket.sh exists but is not executable. ` +
+        `Fix with: chmod +x ${scriptPath}`,
     };
   }
 
@@ -391,10 +430,11 @@ async function handleSpecRefine(
     };
   }
 
+  const gatePath = path.join(projectDir, '.sandstorm', 'spec-quality-gate.md');
   const gate = getSpecQualityGate(projectDir);
   if (!gate) {
     return {
-      error: 'No quality gate configured. Run sandstorm init or create .sandstorm/spec-quality-gate.md.',
+      error: `No quality gate configured at ${gatePath}. Run sandstorm init or create .sandstorm/spec-quality-gate.md.`,
     };
   }
 

--- a/src/main/control-plane/ticket-fetcher.ts
+++ b/src/main/control-plane/ticket-fetcher.ts
@@ -9,6 +9,7 @@ export type ScriptStatus = 'ok' | 'missing' | 'not_executable';
  */
 export function getScriptStatus(projectDir: string): ScriptStatus {
   const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', 'fetch-ticket.sh');
+  console.log(`[sandstorm] getScriptStatus: checking "${scriptPath}"`);
   if (!fs.existsSync(scriptPath)) return 'missing';
   try {
     fs.accessSync(scriptPath, fs.constants.X_OK);
@@ -28,6 +29,7 @@ export async function fetchTicketContext(
   projectDir: string
 ): Promise<string | null> {
   const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', 'fetch-ticket.sh');
+  console.log(`[sandstorm] fetchTicketContext: projectDir="${projectDir}", scriptPath="${scriptPath}"`);
 
   if (!fs.existsSync(scriptPath)) {
     console.warn(

--- a/src/main/spec-quality-gate.ts
+++ b/src/main/spec-quality-gate.ts
@@ -65,6 +65,7 @@ List every assumption the agent would make if it started now.
  */
 export function getSpecQualityGate(projectDir: string): string {
   const filePath = path.join(projectDir, '.sandstorm', QUALITY_GATE_FILE);
+  console.log(`[sandstorm] getSpecQualityGate: checking "${filePath}"`);
   if (!fs.existsSync(filePath)) return '';
   return fs.readFileSync(filePath, 'utf-8');
 }

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { tools, handleToolCall } from '../../src/main/claude/tools';
+import { tools, handleToolCall, validateProjectDir } from '../../src/main/claude/tools';
 
 // Mock the stackManager and agentBackend imports
 vi.mock('../../src/main/index', () => ({
@@ -218,6 +218,182 @@ describe('MCP tools', () => {
       }) as { passed: boolean; report: string };
 
       expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('validateProjectDir', () => {
+    it('returns null for valid absolute paths', () => {
+      expect(validateProjectDir('/home/user/project')).toBeNull();
+      expect(validateProjectDir('/tmp/my-project')).toBeNull();
+      expect(validateProjectDir('/home/user/path with spaces/project')).toBeNull();
+    });
+
+    it('returns error for empty string', () => {
+      const result = validateProjectDir('');
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('required');
+    });
+
+    it('returns error for undefined', () => {
+      const result = validateProjectDir(undefined);
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('required');
+    });
+
+    it('returns error for null', () => {
+      const result = validateProjectDir(null);
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('required');
+    });
+
+    it('returns error for whitespace-only string', () => {
+      const result = validateProjectDir('   ');
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('required');
+    });
+
+    it('returns error for relative path "."', () => {
+      const result = validateProjectDir('.');
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('absolute path');
+      expect(result!.error).toContain('"."');
+    });
+
+    it('returns error for relative path "./project"', () => {
+      const result = validateProjectDir('./project');
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('absolute path');
+    });
+
+    it('returns error for relative path "project"', () => {
+      const result = validateProjectDir('project');
+      expect(result).not.toBeNull();
+      expect(result!.error).toContain('absolute path');
+    });
+
+    it('returns error for non-string types', () => {
+      expect(validateProjectDir(123)).not.toBeNull();
+      expect(validateProjectDir(true)).not.toBeNull();
+      expect(validateProjectDir({})).not.toBeNull();
+    });
+  });
+
+  describe('handleToolCall — projectDir validation', () => {
+    it('spec_check rejects empty projectDir', async () => {
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '',
+      }) as { error: string };
+      expect(result.error).toContain('required');
+    });
+
+    it('spec_check rejects relative projectDir', async () => {
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '.',
+      }) as { error: string };
+      expect(result.error).toContain('absolute path');
+    });
+
+    it('spec_check rejects undefined projectDir', async () => {
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+      }) as { error: string };
+      expect(result.error).toContain('required');
+    });
+
+    it('spec_refine rejects empty projectDir', async () => {
+      const result = await handleToolCall('spec_refine', {
+        ticketId: '42',
+        projectDir: '',
+      }) as { error: string };
+      expect(result.error).toContain('required');
+    });
+
+    it('spec_refine rejects relative projectDir', async () => {
+      const result = await handleToolCall('spec_refine', {
+        ticketId: '42',
+        projectDir: './my-project',
+      }) as { error: string };
+      expect(result.error).toContain('absolute path');
+    });
+
+    it('create_stack rejects empty projectDir', async () => {
+      const result = await handleToolCall('create_stack', {
+        name: 'test',
+        projectDir: '',
+      }) as { error: string };
+      expect(result.error).toContain('required');
+    });
+
+    it('create_stack rejects relative projectDir', async () => {
+      const result = await handleToolCall('create_stack', {
+        name: 'test',
+        projectDir: '.',
+      }) as { error: string };
+      expect(result.error).toContain('absolute path');
+    });
+
+    it('spec_check accepts valid absolute projectDir', async () => {
+      vi.mocked(getScriptStatus).mockReturnValue('missing');
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/home/user/my-project',
+      }) as { passed: boolean; reason: string };
+      // Should proceed to script check, not fail on validation
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain('/home/user/my-project/.sandstorm/scripts/fetch-ticket.sh');
+    });
+  });
+
+  describe('handleToolCall — error messages include full paths', () => {
+    it('spec_check missing script error includes absolute path', async () => {
+      vi.mocked(getScriptStatus).mockReturnValue('missing');
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/home/user/my-project',
+      }) as { passed: boolean; reason: string };
+      expect(result.reason).toContain('/home/user/my-project/.sandstorm/scripts/fetch-ticket.sh');
+    });
+
+    it('spec_check not-executable error includes absolute path', async () => {
+      vi.mocked(getScriptStatus).mockReturnValue('not_executable');
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/home/user/my-project',
+      }) as { passed: boolean; reason: string };
+      expect(result.reason).toContain('chmod +x /home/user/my-project/.sandstorm/scripts/fetch-ticket.sh');
+    });
+
+    it('spec_check no-quality-gate error includes absolute path', async () => {
+      vi.mocked(getScriptStatus).mockReturnValue('ok');
+      vi.mocked(fetchTicketContext).mockResolvedValue('# Ticket body');
+      vi.mocked(getSpecQualityGate).mockReturnValue('');
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/home/user/my-project',
+      }) as { error: string };
+      expect(result.error).toContain('/home/user/my-project/.sandstorm/spec-quality-gate.md');
+    });
+
+    it('spec_refine missing script error includes absolute path', async () => {
+      vi.mocked(getScriptStatus).mockReturnValue('missing');
+      const result = await handleToolCall('spec_refine', {
+        ticketId: '42',
+        projectDir: '/home/user/my-project',
+      }) as { passed: boolean; reason: string };
+      expect(result.reason).toContain('/home/user/my-project/.sandstorm/scripts/fetch-ticket.sh');
+    });
+
+    it('spec_refine no-quality-gate error includes absolute path', async () => {
+      vi.mocked(getScriptStatus).mockReturnValue('ok');
+      vi.mocked(fetchTicketContext).mockResolvedValue('# Ticket body');
+      vi.mocked(getSpecQualityGate).mockReturnValue('');
+      const result = await handleToolCall('spec_refine', {
+        ticketId: '42',
+        projectDir: '/home/user/my-project',
+      }) as { error: string };
+      expect(result.error).toContain('/home/user/my-project/.sandstorm/spec-quality-gate.md');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #193 — MCP tools (`spec_check`, `spec_refine`) and `create_stack` failed to find `.sandstorm/` project files when `projectDir` was empty, relative, or missing.

**Root cause:** When `projectDir` is `""`, `"."`, or a relative path, `path.join(projectDir, '.sandstorm', ...)` resolves to a relative path. `fs.existsSync` then checks relative to the Electron main process cwd (the app installation directory), not the active project directory — so files are never found even though they exist.

**Fix (4 files, +231/-12 lines):**
- Added `validateProjectDir()` that rejects empty, non-string, and relative paths with clear error messages
- Applied validation at `handleToolCall` entry point for `create_stack`, `spec_check`, `spec_refine`
- All error messages now include full absolute paths (e.g., `/home/user/project/.sandstorm/scripts/fetch-ticket.sh`) instead of relative ones
- Added debug logging showing resolved `projectDir` and file paths across `ticket-fetcher.ts`, `spec-quality-gate.ts`, and `tools.ts`
- 20 new unit tests covering validation and error message path assertions

## Test plan

- [x] All 1028 tests pass
- [x] No type errors (`tsc --noEmit` clean)
- [x] Review passed first iteration
- [ ] Verify `spec_check` with valid absolute `projectDir` finds `.sandstorm/` files
- [ ] Verify empty/relative `projectDir` returns clear error instead of silent "not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)