### PR TITLE
Add live workflow progress indicator to stack details view

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -849,6 +849,12 @@ export class StackManager {
     };
   }
 
+  // --- Workflow Progress ---
+
+  async getWorkflowProgress(stackId: string) {
+    return this.taskWatcher.getWorkflowProgress(stackId);
+  }
+
   // --- Token Usage ---
 
   getStackTokenUsage(stackId: string): TokenUsageStats {

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -3,11 +3,24 @@ import { Registry, Task } from './registry';
 import { ContainerRuntime } from '../runtime/types';
 import { parseTokenUsage, parsePhaseTokenTotals, parsePhaseTokenSteps } from './token-parser';
 
+export interface WorkflowProgressData {
+  stackId: string;
+  currentPhase: 'execution' | 'review' | 'verify' | 'idle';
+  outerIteration: number;
+  innerIteration: number;
+  phases: Array<{ phase: string; status: 'pending' | 'running' | 'passed' | 'failed' }>;
+  steps: Array<{ phase: string; iteration: number; input_tokens: number; output_tokens: number; live: boolean }>;
+  taskPrompt: string | null;
+  startedAt: string | null;
+  model: string | null;
+}
+
 export interface TaskEvents {
   'task:started': { stackId: string; task: Task };
   'task:completed': { stackId: string; task: Task };
   'task:failed': { stackId: string; task: Task };
   'task:output': { stackId: string; taskId: number; data: string };
+  'task:workflow-progress': WorkflowProgressData;
 }
 
 /** Max consecutive exec failures before marking a task as failed */
@@ -42,6 +55,8 @@ export class TaskWatcher extends EventEmitter {
 
   /** Track active output streams for cleanup */
   private activeOutputStreams = new Map<string, AbortController>();
+  /** Track container IDs for each watched stack (for on-demand progress queries) */
+  private containerIds = new Map<string, string>();
 
   constructor(
     private registry: Registry,
@@ -79,6 +94,7 @@ export class TaskWatcher extends EventEmitter {
     this.errorCounts.set(stackId, 0);
     this.seenRunning.set(stackId, false);
     this.stalePollCounts.set(stackId, 0);
+    this.containerIds.set(stackId, containerId);
 
     this.schedulePoll(stackId, containerId, this.pollInterval);
   }
@@ -93,6 +109,7 @@ export class TaskWatcher extends EventEmitter {
     this.seenRunning.delete(stackId);
     this.stalePollCounts.delete(stackId);
     this.lastTokenPoll.delete(stackId);
+    this.containerIds.delete(stackId);
 
     // Abort any active output stream
     const controller = this.activeOutputStreams.get(stackId);
@@ -336,6 +353,135 @@ export class TaskWatcher extends EventEmitter {
   }
 
   /**
+   * Read current workflow progress from the container (phase, iterations, live tokens).
+   * Called during the token poll interval while a task is running.
+   */
+  private async readWorkflowProgress(
+    stackId: string,
+    containerId: string,
+    task: Task
+  ): Promise<WorkflowProgressData> {
+    const runtime = this.getRuntimeForStack(stackId);
+
+    // Read phase timing, iteration counts, and token files in parallel
+    const [timingResult, reviewIterResult, verifyRetryResult, execTokenResult, reviewTokenResult] = await Promise.all([
+      runtime.exec(containerId, ['cat', '/tmp/claude-phase-timing.txt']).catch(() => ({ stdout: '' })),
+      runtime.exec(containerId, ['cat', '/tmp/claude-task.review-iterations']).catch(() => ({ stdout: '' })),
+      runtime.exec(containerId, ['cat', '/tmp/claude-task.verify-retries']).catch(() => ({ stdout: '' })),
+      runtime.exec(containerId, ['cat', '/tmp/claude-tokens-execution']).catch(() => ({ stdout: '' })),
+      runtime.exec(containerId, ['cat', '/tmp/claude-tokens-review']).catch(() => ({ stdout: '' })),
+    ]);
+
+    // Parse iteration counts
+    const reviewIterations = parseInt(reviewIterResult.stdout.trim(), 10) || 0;
+    const verifyRetries = parseInt(verifyRetryResult.stdout.trim(), 10) || 0;
+
+    // Derive current phase from timing file
+    const timing: Record<string, string> = {};
+    for (const line of timingResult.stdout.trim().split('\n').filter(Boolean)) {
+      const [key, value] = line.split('=', 2);
+      if (key && value) timing[key] = value;
+    }
+
+    let currentPhase: WorkflowProgressData['currentPhase'] = 'execution';
+    const phases: WorkflowProgressData['phases'] = [];
+
+    if (timing.verify_started_at && !timing.verify_finished_at) {
+      currentPhase = 'verify';
+      phases.push({ phase: 'execution', status: 'passed' });
+      phases.push({ phase: 'review', status: 'passed' });
+      phases.push({ phase: 'verify', status: 'running' });
+    } else if (timing.review_started_at && !timing.review_finished_at) {
+      currentPhase = 'review';
+      phases.push({ phase: 'execution', status: 'passed' });
+      phases.push({ phase: 'review', status: 'running' });
+      phases.push({ phase: 'verify', status: 'pending' });
+    } else if (timing.review_finished_at && timing.verify_finished_at) {
+      // Both finished — verify failed, back to execution (outer loop retry)
+      currentPhase = 'execution';
+      phases.push({ phase: 'execution', status: 'running' });
+      phases.push({ phase: 'review', status: 'pending' });
+      phases.push({ phase: 'verify', status: 'failed' });
+    } else if (timing.review_finished_at && !timing.verify_started_at) {
+      // Review finished, verify not started — review failed, back to execution
+      currentPhase = 'execution';
+      phases.push({ phase: 'execution', status: 'running' });
+      phases.push({ phase: 'review', status: 'failed' });
+      phases.push({ phase: 'verify', status: 'pending' });
+    } else {
+      // Default: execution phase
+      phases.push({ phase: 'execution', status: 'running' });
+      phases.push({ phase: 'review', status: 'pending' });
+      phases.push({ phase: 'verify', status: 'pending' });
+    }
+
+    // Parse per-step token data
+    const tokenSteps = parsePhaseTokenSteps(execTokenResult.stdout, reviewTokenResult.stdout);
+    const steps: WorkflowProgressData['steps'] = tokenSteps.map((s) => ({
+      phase: s.phase,
+      iteration: s.iteration,
+      input_tokens: s.input_tokens,
+      output_tokens: s.output_tokens,
+      live: false,
+    }));
+
+    // Mark the last step matching the current phase as live
+    for (let i = steps.length - 1; i >= 0; i--) {
+      if (steps[i].phase === currentPhase) {
+        steps[i].live = true;
+        break;
+      }
+    }
+
+    // If no step exists for the current phase yet, add a live placeholder
+    if (!steps.some((s) => s.phase === currentPhase)) {
+      const iteration = currentPhase === 'verify'
+        ? verifyRetries + 1
+        : reviewIterations + 1;
+      steps.push({
+        phase: currentPhase,
+        iteration,
+        input_tokens: 0,
+        output_tokens: 0,
+        live: true,
+      });
+    }
+
+    // Outer iteration = verify retries + 1, inner = review iterations within current outer
+    const outerIteration = verifyRetries + 1;
+    const innerIteration = reviewIterations + 1;
+
+    return {
+      stackId,
+      currentPhase,
+      outerIteration,
+      innerIteration,
+      phases,
+      steps,
+      taskPrompt: task.prompt,
+      startedAt: task.started_at,
+      model: task.resolved_model || task.model,
+    };
+  }
+
+  /**
+   * Get the current workflow progress for a stack (on-demand, for IPC handlers).
+   */
+  async getWorkflowProgress(stackId: string): Promise<WorkflowProgressData | null> {
+    const task = this.registry.getRunningTask(stackId);
+    if (!task) return null;
+
+    const containerId = this.containerIds.get(stackId);
+    if (!containerId) return null;
+
+    try {
+      return await this.readWorkflowProgress(stackId, containerId, task);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Read whatever metadata files exist for a task (used during teardown
    * to capture partial data before the container is removed).
    */
@@ -385,7 +531,7 @@ export class TaskWatcher extends EventEmitter {
         this.seenRunning.set(stackId, true);
         this.errorCounts.set(stackId, 0);
 
-        // Poll tokens periodically while running (throttled)
+        // Poll tokens and workflow progress periodically while running (throttled)
         const now = Date.now();
         const lastPoll = this.lastTokenPoll.get(stackId) ?? 0;
         if (now - lastPoll >= this.tokenPollInterval) {
@@ -393,6 +539,11 @@ export class TaskWatcher extends EventEmitter {
           const runningTask = this.registry.getRunningTask(stackId);
           if (runningTask) {
             this.readTaskTokens(runningTask.id, stackId, containerId).catch(() => {});
+            this.readWorkflowProgress(stackId, containerId, runningTask)
+              .then((progress) => {
+                this.emit('task:workflow-progress', progress);
+              })
+              .catch(() => {});
           }
         }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -174,6 +174,10 @@ async function initializeApp(): Promise<void> {
     mainWindow?.webContents.send('task:output', { stackId, data });
   });
 
+  taskWatcher.on('task:workflow-progress', (progress) => {
+    mainWindow?.webContents.send('task:workflow-progress', progress);
+  });
+
   // Forward Docker connection status to renderer
   if (dockerConnectionManager) {
     dockerConnectionManager.on('connected', () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -552,6 +552,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return registry.getTaskTokenSteps(taskId);
   });
 
+  ipcMain.handle('tasks:workflowProgress', async (_event, stackId: string) => {
+    return stackManager.getWorkflowProgress(stackId);
+  });
+
   // --- Diff ---
 
   ipcMain.handle('diff:get', async (_event, stackId: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -55,6 +55,7 @@ export interface SandstormAPI {
     dispatch: (stackId: string, prompt: string, model?: string) => Promise<unknown>;
     list: (stackId: string) => Promise<unknown[]>;
     tokenSteps: (taskId: number) => Promise<unknown[]>;
+    workflowProgress: (stackId: string) => Promise<unknown>;
   };
   diff: {
     get: (stackId: string) => Promise<string>;
@@ -168,6 +169,7 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('tasks:dispatch', stackId, prompt, model),
     list: (stackId) => ipcRenderer.invoke('tasks:list', stackId),
     tokenSteps: (taskId) => ipcRenderer.invoke('tasks:tokenSteps', taskId),
+    workflowProgress: (stackId) => ipcRenderer.invoke('tasks:workflowProgress', stackId),
   },
   diff: {
     get: (stackId) => ipcRenderer.invoke('diff:get', stackId),

--- a/src/renderer/components/StackDetail.tsx
+++ b/src/renderer/components/StackDetail.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useAppStore, Task, TaskTokenStep, StackMetrics } from '../store';
+import { useAppStore, Task, TaskTokenStep, StackMetrics, WorkflowProgress } from '../store';
 import { ServiceList } from './ServiceList';
 import { TaskOutput } from './TaskOutput';
 import { DiffViewer } from './DiffViewer';
 import { LogViewer } from './LogViewer';
+import { WorkflowProgressPanel } from './WorkflowProgress';
 import { formatTokenCount, formatBytes, formatMs } from '../utils/format';
 
 type Tab = 'output' | 'diff' | 'logs' | 'history';
@@ -33,6 +34,7 @@ export function StackDetail({
   const [selectedLogContainer, setSelectedLogContainer] = useState<string | null>(null);
   const [dispatching, setDispatching] = useState(false);
   const [taskModel, setTaskModel] = useState<string>('sonnet');
+  const [workflowProgress, setWorkflowProgress] = useState<WorkflowProgress | null>(null);
 
   const loadTasks = useCallback(async () => {
     const taskList = await window.sandstorm.tasks.list(stackId);
@@ -63,6 +65,54 @@ export function StackDetail({
     if (activeTab === 'history') loadTasks();
     if (activeTab === 'diff') loadDiff();
   }, [activeTab, loadTasks, loadDiff]);
+
+  // Poll workflow progress for running stacks and listen for live updates
+  useEffect(() => {
+    if (!stack || stack.status !== 'running') {
+      setWorkflowProgress(null);
+      return;
+    }
+
+    // Initial fetch
+    window.sandstorm.tasks.workflowProgress(stackId)
+      .then((progress) => {
+        if (progress) setWorkflowProgress(progress as WorkflowProgress);
+      })
+      .catch(() => {});
+
+    // Listen for live updates
+    const unsubscribe = window.sandstorm.on('task:workflow-progress', (data: unknown) => {
+      const progress = data as WorkflowProgress;
+      if (progress && progress.stackId === stackId) {
+        setWorkflowProgress(progress);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [stackId, stack?.status]);
+
+  // Clear workflow progress when task completes
+  useEffect(() => {
+    const unsubComplete = window.sandstorm.on('task:completed', (data: unknown) => {
+      const event = data as { stackId: string };
+      if (event.stackId === stackId) {
+        setWorkflowProgress(null);
+      }
+    });
+    const unsubFailed = window.sandstorm.on('task:failed', (data: unknown) => {
+      const event = data as { stackId: string };
+      if (event.stackId === stackId) {
+        setWorkflowProgress(null);
+      }
+    });
+
+    return () => {
+      unsubComplete();
+      unsubFailed();
+    };
+  }, [stackId]);
 
   if (!stack) {
     return (
@@ -136,6 +186,8 @@ export function StackDetail({
             : stack.status === 'rate_limited'
               ? 'bg-orange-500/10 border-orange-500/20 text-orange-400'
               : 'bg-gray-500/10 border-gray-500/20 text-gray-400';
+
+  const showWorkflowPanel = workflowProgress !== null;
 
   return (
     <div className="h-full flex flex-col animate-fade-in">
@@ -252,62 +304,75 @@ export function StackDetail({
         }}
       />
 
-      {/* Tabs */}
-      <div className="border-b border-sandstorm-border px-5 shrink-0">
-        <div className="flex gap-0.5">
-          {TAB_CONFIG.map(({ key, label, icon }) => (
-            <button
-              key={key}
-              onClick={() => setActiveTab(key)}
-              className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
-                activeTab === key
-                  ? 'border-sandstorm-accent text-sandstorm-text'
-                  : 'border-transparent text-sandstorm-muted hover:text-sandstorm-text-secondary'
-              }`}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-70">
-                <path d={icon}/>
-              </svg>
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
+      {/* Two-column layout: workflow progress (left) + tabs (right) */}
+      <div className="flex-1 overflow-hidden flex">
+        {/* Left column: workflow progress panel */}
+        {showWorkflowPanel && (
+          <div className="w-[35%] min-w-[260px] max-w-[380px] border-r border-sandstorm-border flex flex-col overflow-hidden shrink-0">
+            <WorkflowProgressPanel progress={workflowProgress} />
+          </div>
+        )}
 
-      {/* Tab content */}
-      <div className="flex-1 overflow-hidden">
-        {activeTab === 'output' && (
-          <TaskOutput
-            stackId={stackId}
-            runtime={stack.runtime}
-            claudeContainerId={
-              stack.services.find((s) => s.name === 'claude')?.containerId ?? null
-            }
-          />
-        )}
-        {activeTab === 'diff' && <DiffViewer diff={diff} />}
-        {activeTab === 'logs' && (
-          <LogViewer
-            services={stack.services}
-            runtime={stack.runtime}
-            selectedContainerId={selectedLogContainer}
-          />
-        )}
-        {activeTab === 'history' && (
-          <div className="p-5 overflow-y-auto h-full">
-            {tasks.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-32 text-sandstorm-muted">
-                <p className="text-sm">No tasks dispatched yet</p>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {tasks.map((task) => (
-                  <TaskHistoryCard key={task.id} task={task} />
-                ))}
+        {/* Right column: tabs + content */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {/* Tabs */}
+          <div className="border-b border-sandstorm-border px-5 shrink-0">
+            <div className="flex gap-0.5">
+              {TAB_CONFIG.map(({ key, label, icon }) => (
+                <button
+                  key={key}
+                  onClick={() => setActiveTab(key)}
+                  className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                    activeTab === key
+                      ? 'border-sandstorm-accent text-sandstorm-text'
+                      : 'border-transparent text-sandstorm-muted hover:text-sandstorm-text-secondary'
+                  }`}
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-70">
+                    <path d={icon}/>
+                  </svg>
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Tab content */}
+          <div className="flex-1 overflow-hidden">
+            {activeTab === 'output' && (
+              <TaskOutput
+                stackId={stackId}
+                runtime={stack.runtime}
+                claudeContainerId={
+                  stack.services.find((s) => s.name === 'claude')?.containerId ?? null
+                }
+              />
+            )}
+            {activeTab === 'diff' && <DiffViewer diff={diff} />}
+            {activeTab === 'logs' && (
+              <LogViewer
+                services={stack.services}
+                runtime={stack.runtime}
+                selectedContainerId={selectedLogContainer}
+              />
+            )}
+            {activeTab === 'history' && (
+              <div className="p-5 overflow-y-auto h-full">
+                {tasks.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-32 text-sandstorm-muted">
+                    <p className="text-sm">No tasks dispatched yet</p>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {tasks.map((task) => (
+                      <TaskHistoryCard key={task.id} task={task} />
+                    ))}
+                  </div>
+                )}
               </div>
             )}
           </div>
-        )}
+        </div>
       </div>
 
       {/* New task input + action buttons */}

--- a/src/renderer/components/WorkflowProgress.tsx
+++ b/src/renderer/components/WorkflowProgress.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { WorkflowProgress as WorkflowProgressType, WorkflowPhaseState } from '../store';
+import { formatTokenCount } from '../utils/format';
+
+function PhaseBox({ phase, label }: { phase: WorkflowPhaseState; label: string }) {
+  const isRunning = phase.status === 'running';
+  const isPassed = phase.status === 'passed';
+  const isFailed = phase.status === 'failed';
+
+  let borderColor = 'border-sandstorm-border';
+  let bgColor = 'bg-sandstorm-surface';
+  let textColor = 'text-sandstorm-muted';
+  let statusIcon = '';
+
+  if (isRunning) {
+    borderColor = 'border-blue-500/50';
+    bgColor = 'bg-blue-500/10';
+    textColor = 'text-blue-400';
+  } else if (isPassed) {
+    borderColor = 'border-emerald-500/50';
+    bgColor = 'bg-emerald-500/10';
+    textColor = 'text-emerald-400';
+    statusIcon = '\u2713';
+  } else if (isFailed) {
+    borderColor = 'border-red-500/50';
+    bgColor = 'bg-red-500/10';
+    textColor = 'text-red-400';
+    statusIcon = '\u2717';
+  }
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center px-3 py-2 rounded-lg border ${borderColor} ${bgColor} min-w-[80px]`}
+      data-testid={`phase-${phase.phase}`}
+    >
+      <span className={`text-xs font-medium ${textColor}`}>{label}</span>
+      <span className={`text-[10px] mt-0.5 ${textColor}`}>
+        {isRunning && (
+          <span className="inline-flex items-center gap-1">
+            <span className="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse" />
+            running
+          </span>
+        )}
+        {isPassed && statusIcon}
+        {isFailed && statusIcon}
+        {phase.status === 'pending' && '\u2014'}
+      </span>
+    </div>
+  );
+}
+
+function Arrow() {
+  return (
+    <svg width="20" height="12" viewBox="0 0 20 12" className="text-sandstorm-muted shrink-0 mx-0.5">
+      <path d="M0 6h16M12 2l4 4-4 4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function DownArrow() {
+  return (
+    <svg width="12" height="20" viewBox="0 0 12 20" className="text-sandstorm-muted shrink-0 my-0.5">
+      <path d="M6 0v16M2 12l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function WorkflowProgressPanel({ progress }: { progress: WorkflowProgressType }) {
+  const { outerIteration, innerIteration, phases, steps, taskPrompt, startedAt, model } = progress;
+
+  const executionPhase = phases.find((p) => p.phase === 'execution') ?? { phase: 'execution' as const, status: 'pending' as const };
+  const reviewPhase = phases.find((p) => p.phase === 'review') ?? { phase: 'review' as const, status: 'pending' as const };
+  const verifyPhase = phases.find((p) => p.phase === 'verify') ?? { phase: 'verify' as const, status: 'pending' as const };
+
+  // Calculate elapsed time
+  const elapsed = startedAt ? Math.floor((Date.now() - new Date(startedAt + (startedAt.endsWith('Z') ? '' : 'Z')).getTime()) / 1000) : 0;
+  const elapsedStr = elapsed >= 60 ? `${Math.floor(elapsed / 60)}m ${elapsed % 60}s` : `${elapsed}s`;
+
+  // Calculate totals
+  const totalInput = steps.reduce((sum, s) => sum + s.input_tokens, 0);
+  const totalOutput = steps.reduce((sum, s) => sum + s.output_tokens, 0);
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto" data-testid="workflow-progress-panel">
+      {/* Loop counters */}
+      <div className="px-4 pt-4 pb-2">
+        <h3 className="text-[11px] font-semibold uppercase tracking-wider text-sandstorm-muted mb-2">Workflow Progress</h3>
+        <div className="flex gap-3 text-xs">
+          <div className="flex items-center gap-1.5 bg-sandstorm-bg px-2 py-1 rounded-md border border-sandstorm-border">
+            <span className="text-sandstorm-muted">Outer Loop:</span>
+            <span className="text-sandstorm-text font-medium tabular-nums" data-testid="outer-loop-counter">{outerIteration} of 5</span>
+          </div>
+          <div className="flex items-center gap-1.5 bg-sandstorm-bg px-2 py-1 rounded-md border border-sandstorm-border">
+            <span className="text-sandstorm-muted">Inner Loop:</span>
+            <span className="text-sandstorm-text font-medium tabular-nums" data-testid="inner-loop-counter">{innerIteration} of 5</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Visual stepper */}
+      <div className="px-4 py-3">
+        <div className="flex items-center justify-center">
+          <PhaseBox phase={executionPhase} label="Execution" />
+          <Arrow />
+          <PhaseBox phase={reviewPhase} label="Review" />
+        </div>
+        <div className="flex justify-end pr-[40px] -mt-0.5">
+          <DownArrow />
+        </div>
+        <div className="flex justify-end pr-0">
+          <div className="mr-[0px] flex justify-center" style={{ width: '80px', marginRight: 'calc(50% - 82px)' }}>
+            <PhaseBox phase={verifyPhase} label="Verify" />
+          </div>
+        </div>
+      </div>
+
+      {/* Separator */}
+      <div className="mx-4 border-t border-sandstorm-border" />
+
+      {/* Step token usage table */}
+      <div className="px-4 pt-3 pb-2">
+        <h3 className="text-[11px] font-semibold uppercase tracking-wider text-sandstorm-muted mb-2">Step Token Usage</h3>
+        <div className="text-[10px] font-mono tabular-nums" data-testid="step-token-table">
+          {/* Header */}
+          <div className="flex text-sandstorm-muted font-medium mb-1 border-b border-sandstorm-border pb-1">
+            <span className="flex-1">Phase</span>
+            <span className="w-16 text-right">Input</span>
+            <span className="w-16 text-right">Output</span>
+          </div>
+          {/* Rows */}
+          {steps.map((step, i) => (
+            <div
+              key={`${step.phase}-${step.iteration}-${i}`}
+              className={`flex py-0.5 ${step.live ? 'text-blue-400' : 'text-sandstorm-text-secondary'}`}
+            >
+              <span className="flex-1 capitalize">
+                {step.phase} {step.iteration}
+              </span>
+              <span className="w-16 text-right">
+                {formatTokenCount(step.input_tokens)}{step.live ? '\u25B2' : ''}
+              </span>
+              <span className="w-16 text-right">
+                {formatTokenCount(step.output_tokens)}{step.live ? '\u25B2' : ''}
+              </span>
+            </div>
+          ))}
+          {/* Total row */}
+          {steps.length > 0 && (
+            <div className="flex pt-1 mt-1 border-t border-sandstorm-border text-sandstorm-text font-medium">
+              <span className="flex-1">Total</span>
+              <span className="w-16 text-right">{formatTokenCount(totalInput)}</span>
+              <span className="w-16 text-right">{formatTokenCount(totalOutput)}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Bottom info bar */}
+      <div className="mt-auto mx-4 mb-3 pt-2 border-t border-sandstorm-border">
+        {taskPrompt && (
+          <p className="text-[10px] text-sandstorm-text-secondary truncate mb-1" title={taskPrompt}>
+            Task: &ldquo;{taskPrompt}&rdquo;
+          </p>
+        )}
+        <div className="flex items-center gap-2 text-[10px] text-sandstorm-muted tabular-nums">
+          {startedAt && <span>Started: {new Date(startedAt + (startedAt.endsWith('Z') ? '' : 'Z')).toLocaleTimeString()}</span>}
+          {startedAt && <span className="text-sandstorm-border">|</span>}
+          <span>Elapsed: {elapsedStr}</span>
+          {model && <span className="text-sandstorm-border">|</span>}
+          {model && <span>Model: {model}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -80,6 +80,34 @@ export interface TaskTokenStep {
   output_tokens: number;
 }
 
+export type WorkflowPhase = 'execution' | 'review' | 'verify' | 'idle';
+export type PhaseStatus = 'pending' | 'running' | 'passed' | 'failed';
+
+export interface WorkflowPhaseState {
+  phase: WorkflowPhase;
+  status: PhaseStatus;
+}
+
+export interface WorkflowStepTokens {
+  phase: string;
+  iteration: number;
+  input_tokens: number;
+  output_tokens: number;
+  live: boolean;
+}
+
+export interface WorkflowProgress {
+  stackId: string;
+  currentPhase: WorkflowPhase;
+  outerIteration: number;
+  innerIteration: number;
+  phases: WorkflowPhaseState[];
+  steps: WorkflowStepTokens[];
+  taskPrompt: string | null;
+  startedAt: string | null;
+  model: string | null;
+}
+
 export interface OuterClaudeTokenUsage {
   project_dir: string;
   input_tokens: number;
@@ -251,6 +279,11 @@ interface AppState {
   rateLimitState: RateLimitState | null;
   accountUsage: UsageSnapshot | null;
 
+  // Live workflow progress (per-stack)
+  workflowProgress: Record<string, WorkflowProgress>;
+  updateWorkflowProgress: (stackId: string, progress: WorkflowProgress) => void;
+  clearWorkflowProgress: (stackId: string) => void;
+
   // Stale workspaces
   staleWorkspaces: StaleWorkspace[];
   staleWorkspacesLoading: boolean;
@@ -373,6 +406,7 @@ declare global {
         dispatch: (stackId: string, prompt: string, model?: string) => Promise<Task>;
         list: (stackId: string) => Promise<Task[]>;
         tokenSteps: (taskId: number) => Promise<TaskTokenStep[]>;
+        workflowProgress: (stackId: string) => Promise<WorkflowProgress | null>;
       };
       diff: {
         get: (stackId: string) => Promise<string>;
@@ -499,6 +533,20 @@ export const useAppStore = create<AppState>((set, get) => ({
   globalTokenUsage: null,
   rateLimitState: null,
   accountUsage: null,
+
+  // Live workflow progress
+  workflowProgress: {},
+  updateWorkflowProgress: (stackId, progress) => {
+    set((state) => ({
+      workflowProgress: { ...state.workflowProgress, [stackId]: progress },
+    }));
+  },
+  clearWorkflowProgress: (stackId) => {
+    set((state) => {
+      const { [stackId]: _, ...rest } = state.workflowProgress;
+      return { workflowProgress: rest };
+    });
+  },
 
   // Model settings
   globalModelSettings: { inner_model: 'sonnet', outer_model: 'opus' },

--- a/tests/unit/components/StackDetail.test.tsx
+++ b/tests/unit/components/StackDetail.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { StackDetail } from '../../../src/renderer/components/StackDetail';
-import { useAppStore, Stack } from '../../../src/renderer/store';
+import { useAppStore, Stack, WorkflowProgress } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
 
 function makeStack(overrides: Partial<Stack> = {}): Stack {
@@ -388,6 +388,63 @@ describe('StackDetail', () => {
       expect(detail.textContent).toContain('Execution');
       expect(detail.textContent).toContain('Review');
     });
+  });
+
+  it('shows workflow progress panel for running stack with progress data', async () => {
+    const progressData: WorkflowProgress = {
+      stackId: 'detail-stack',
+      currentPhase: 'review',
+      outerIteration: 1,
+      innerIteration: 2,
+      phases: [
+        { phase: 'execution', status: 'passed' },
+        { phase: 'review', status: 'running' },
+        { phase: 'verify', status: 'pending' },
+      ],
+      steps: [
+        { phase: 'execution', iteration: 1, input_tokens: 5000, output_tokens: 2000, live: false },
+        { phase: 'review', iteration: 1, input_tokens: 3000, output_tokens: 1000, live: true },
+      ],
+      taskPrompt: 'Fix the login bug',
+      startedAt: new Date().toISOString(),
+      model: 'sonnet',
+    };
+
+    useAppStore.setState({
+      stacks: [makeStack({ status: 'running' })],
+    });
+    api.tasks.workflowProgress.mockResolvedValue(progressData);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-progress-panel')).toBeDefined();
+    });
+    expect(screen.getByTestId('outer-loop-counter').textContent).toBe('1 of 5');
+    expect(screen.getByTestId('inner-loop-counter').textContent).toBe('2 of 5');
+  });
+
+  it('does not show workflow panel when stack is not running', () => {
+    useAppStore.setState({
+      stacks: [makeStack({ status: 'completed' })],
+    });
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+    expect(screen.queryByTestId('workflow-progress-panel')).toBeNull();
+  });
+
+  it('does not show workflow panel when no progress data available', async () => {
+    useAppStore.setState({
+      stacks: [makeStack({ status: 'running' })],
+    });
+    api.tasks.workflowProgress.mockResolvedValue(null);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+
+    // Wait for async call to settle
+    await waitFor(() => {
+      expect(api.tasks.workflowProgress).toHaveBeenCalledWith('detail-stack');
+    });
+    expect(screen.queryByTestId('workflow-progress-panel')).toBeNull();
   });
 
   it('shows aggregate fallback when no per-step data exists', async () => {

--- a/tests/unit/components/WorkflowProgress.test.tsx
+++ b/tests/unit/components/WorkflowProgress.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { WorkflowProgressPanel } from '../../../src/renderer/components/WorkflowProgress';
+import { WorkflowProgress } from '../../../src/renderer/store';
+import { mockSandstormApi } from './setup';
+
+function makeProgress(overrides: Partial<WorkflowProgress> = {}): WorkflowProgress {
+  return {
+    stackId: 'test-stack',
+    currentPhase: 'execution',
+    outerIteration: 1,
+    innerIteration: 1,
+    phases: [
+      { phase: 'execution', status: 'running' },
+      { phase: 'review', status: 'pending' },
+      { phase: 'verify', status: 'pending' },
+    ],
+    steps: [
+      { phase: 'execution', iteration: 1, input_tokens: 5000, output_tokens: 2000, live: true },
+    ],
+    taskPrompt: 'Fix the login bug',
+    startedAt: new Date().toISOString(),
+    model: 'sonnet',
+    ...overrides,
+  };
+}
+
+describe('WorkflowProgressPanel', () => {
+  beforeEach(() => {
+    mockSandstormApi();
+  });
+
+  it('renders the workflow progress panel', () => {
+    render(<WorkflowProgressPanel progress={makeProgress()} />);
+    expect(screen.getByTestId('workflow-progress-panel')).toBeDefined();
+  });
+
+  it('displays loop counters', () => {
+    render(<WorkflowProgressPanel progress={makeProgress({ outerIteration: 2, innerIteration: 3 })} />);
+    expect(screen.getByTestId('outer-loop-counter').textContent).toBe('2 of 5');
+    expect(screen.getByTestId('inner-loop-counter').textContent).toBe('3 of 5');
+  });
+
+  it('shows execution phase as running', () => {
+    render(<WorkflowProgressPanel progress={makeProgress()} />);
+    const executionPhase = screen.getByTestId('phase-execution');
+    expect(executionPhase.textContent).toContain('Execution');
+    expect(executionPhase.textContent).toContain('running');
+  });
+
+  it('shows review phase as passed', () => {
+    const progress = makeProgress({
+      currentPhase: 'verify',
+      phases: [
+        { phase: 'execution', status: 'passed' },
+        { phase: 'review', status: 'passed' },
+        { phase: 'verify', status: 'running' },
+      ],
+    });
+    render(<WorkflowProgressPanel progress={progress} />);
+    const reviewPhase = screen.getByTestId('phase-review');
+    expect(reviewPhase.textContent).toContain('Review');
+    expect(reviewPhase.textContent).toContain('\u2713');
+  });
+
+  it('shows verify phase as failed', () => {
+    const progress = makeProgress({
+      currentPhase: 'execution',
+      outerIteration: 2,
+      phases: [
+        { phase: 'execution', status: 'running' },
+        { phase: 'review', status: 'pending' },
+        { phase: 'verify', status: 'failed' },
+      ],
+    });
+    render(<WorkflowProgressPanel progress={progress} />);
+    const verifyPhase = screen.getByTestId('phase-verify');
+    expect(verifyPhase.textContent).toContain('Verify');
+    expect(verifyPhase.textContent).toContain('\u2717');
+  });
+
+  it('renders step token table with live indicator', () => {
+    const progress = makeProgress({
+      steps: [
+        { phase: 'execution', iteration: 1, input_tokens: 45200, output_tokens: 12100, live: false },
+        { phase: 'review', iteration: 1, input_tokens: 38700, output_tokens: 8400, live: false },
+        { phase: 'execution', iteration: 2, input_tokens: 52100, output_tokens: 15300, live: true },
+      ],
+    });
+    render(<WorkflowProgressPanel progress={progress} />);
+    const table = screen.getByTestId('step-token-table');
+    expect(table.textContent).toContain('execution 1');
+    expect(table.textContent).toContain('review 1');
+    expect(table.textContent).toContain('execution 2');
+    // Live indicator (▲)
+    expect(table.textContent).toContain('\u25B2');
+    // Total row
+    expect(table.textContent).toContain('Total');
+  });
+
+  it('shows task prompt in bottom bar', () => {
+    render(<WorkflowProgressPanel progress={makeProgress({ taskPrompt: 'Refactor auth handler' })} />);
+    expect(screen.getByText(/Refactor auth handler/)).toBeDefined();
+  });
+
+  it('shows model name', () => {
+    render(<WorkflowProgressPanel progress={makeProgress({ model: 'opus' })} />);
+    expect(screen.getByText('Model: opus')).toBeDefined();
+  });
+
+  it('renders all three phase boxes', () => {
+    render(<WorkflowProgressPanel progress={makeProgress()} />);
+    expect(screen.getByTestId('phase-execution')).toBeDefined();
+    expect(screen.getByTestId('phase-review')).toBeDefined();
+    expect(screen.getByTestId('phase-verify')).toBeDefined();
+  });
+
+  it('calculates token totals correctly', () => {
+    const progress = makeProgress({
+      steps: [
+        { phase: 'execution', iteration: 1, input_tokens: 1000, output_tokens: 500, live: false },
+        { phase: 'review', iteration: 1, input_tokens: 2000, output_tokens: 800, live: false },
+      ],
+    });
+    render(<WorkflowProgressPanel progress={progress} />);
+    const table = screen.getByTestId('step-token-table');
+    // Total input: 3000 = 3.0k, Total output: 1300 = 1.3k
+    expect(table.textContent).toContain('3.0k');
+    expect(table.textContent).toContain('1.3k');
+  });
+});

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -38,6 +38,7 @@ export function mockSandstormApi() {
       dispatch: vi.fn().mockResolvedValue({ id: 1, stack_id: 'test', prompt: '', model: null, status: 'running' }),
       list: vi.fn().mockResolvedValue([]),
       tokenSteps: vi.fn().mockResolvedValue([]),
+      workflowProgress: vi.fn().mockResolvedValue(null),
     },
     diff: {
       get: vi.fn().mockResolvedValue(''),

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -51,6 +51,7 @@ const {
     getStackTokenUsage: vi.fn(),
     getGlobalTokenUsage: vi.fn(),
     getRateLimitState: vi.fn(),
+    getWorkflowProgress: vi.fn(),
   };
 
   const mockDockerRuntime = {
@@ -869,6 +870,7 @@ describe('IPC Handlers', () => {
       'tasks:dispatch',
       'tasks:list',
       'tasks:tokenSteps',
+      'tasks:workflowProgress',
       'diff:get',
       'push:execute',
       'ports:get',

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -1116,4 +1116,126 @@ describe('TaskWatcher', () => {
 
     watcher.unwatchAll();
   });
+
+  it('getWorkflowProgress returns progress data for running task', async () => {
+    const runtime: ContainerRuntime = {
+      name: 'mock',
+      composeUp: vi.fn(),
+      composeDown: vi.fn(),
+      listContainers: vi.fn().mockResolvedValue([]),
+      inspect: vi.fn(),
+      logs: vi.fn(),
+      exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+        if (cmd.includes('/tmp/claude-task.status')) {
+          return { exitCode: 0, stdout: 'running', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-phase-timing.txt')) {
+          return { exitCode: 0, stdout: 'execution_started_at=2026-04-07T10:00:00Z\nexecution_finished_at=2026-04-07T10:01:00Z\nreview_started_at=2026-04-07T10:01:01Z\n', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-task.review-iterations')) {
+          return { exitCode: 0, stdout: '2', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-task.verify-retries')) {
+          return { exitCode: 0, stdout: '0', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-tokens-execution')) {
+          return { exitCode: 0, stdout: '{"in":1000,"out":500,"iter":1,"phase":"execution"}\n', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-tokens-review')) {
+          return { exitCode: 0, stdout: '{"in":800,"out":300,"iter":1,"phase":"review"}\n', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      version: vi.fn().mockResolvedValue('Mock 1.0'),
+    };
+
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+
+    registry.createTask('watch-stack', 'test progress task');
+    watcher.watch('watch-stack', 'container-123');
+
+    const progress = await watcher.getWorkflowProgress('watch-stack');
+
+    expect(progress).not.toBeNull();
+    expect(progress!.stackId).toBe('watch-stack');
+    expect(progress!.currentPhase).toBe('review');
+    expect(progress!.outerIteration).toBe(1);
+    expect(progress!.innerIteration).toBe(3); // reviewIterations (2) + 1
+    expect(progress!.phases).toEqual([
+      { phase: 'execution', status: 'passed' },
+      { phase: 'review', status: 'running' },
+      { phase: 'verify', status: 'pending' },
+    ]);
+    expect(progress!.steps.length).toBeGreaterThanOrEqual(2);
+    expect(progress!.taskPrompt).toBe('test progress task');
+
+    watcher.unwatchAll();
+  });
+
+  it('getWorkflowProgress returns null when no running task', async () => {
+    const runtime = createMockRuntime('running');
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+
+    const progress = await watcher.getWorkflowProgress('watch-stack');
+    expect(progress).toBeNull();
+
+    watcher.unwatchAll();
+  });
+
+  it('getWorkflowProgress returns null when stack not being watched', async () => {
+    const runtime = createMockRuntime('running');
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+
+    registry.createTask('watch-stack', 'test task');
+
+    const progress = await watcher.getWorkflowProgress('watch-stack');
+    expect(progress).toBeNull();
+
+    watcher.unwatchAll();
+  });
+
+  it('emits workflow progress during token poll', async () => {
+    let pollCount = 0;
+    const runtime: ContainerRuntime = {
+      name: 'mock',
+      composeUp: vi.fn(),
+      composeDown: vi.fn(),
+      listContainers: vi.fn().mockResolvedValue([]),
+      inspect: vi.fn(),
+      logs: vi.fn(),
+      exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+        if (cmd.includes('/tmp/claude-task.status')) {
+          pollCount++;
+          return { exitCode: 0, stdout: 'running', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-phase-timing.txt')) {
+          return { exitCode: 0, stdout: 'execution_started_at=2026-04-07T10:00:00Z\n', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      version: vi.fn().mockResolvedValue('Mock 1.0'),
+    };
+
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 20,
+      tokenPollInterval: 20,
+    });
+
+    registry.createTask('watch-stack', 'test progress task');
+
+    const progressPromise = new Promise<void>((resolve) => {
+      watcher.on('task:workflow-progress', (progress) => {
+        expect(progress.stackId).toBe('watch-stack');
+        expect(progress.currentPhase).toBe('execution');
+        resolve();
+      });
+    });
+
+    watcher.watch('watch-stack', 'container-123');
+
+    await progressPromise;
+    watcher.unwatchAll();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a two-column layout to the stack details page: workflow progress panel (35% left) alongside existing tab content (65% right)
- Visual stepper shows Execution → Review → Verify phases with live status badges (✓ passed, ✗ failed, ●running with pulse animation)
- Loop counters display outer/inner iteration (e.g., "Outer Loop: 1 of 5")
- Per-step token usage table with live-updating ▲ indicators for the active phase and frozen rows for completed steps
- Bottom bar shows task prompt, elapsed time, and model
- Backend reads phase timing, iteration counts, and token data from container files via `readWorkflowProgress()`, emitting `task:workflow-progress` IPC events every 10s
- Panel automatically appears when a task is running with progress data and clears on task completion/failure

## Test plan

- [x] 10 WorkflowProgress component tests (phase rendering, loop counters, token table, live indicators, totals)
- [x] 3 StackDetail tests (workflow panel shown for running stacks, hidden for completed, hidden when no data)
- [x] 4 task-watcher tests (getWorkflowProgress with data, null when no task, null when not watched, progress emission during poll)
- [x] IPC handler test updated for new channel
- [x] All 1172 tests passing

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)