### PR TITLE
Fix live workflow progress: reliable data flow and always-visible panel (#202)

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -303,6 +303,10 @@ while true; do
     # Initialize phase timing file
     > /tmp/claude-phase-timing.txt
 
+    # Initialize iteration count files for live monitoring
+    echo "0" > /tmp/claude-task.review-iterations
+    echo "0" > /tmp/claude-task.verify-retries
+
     # ── Step 1: Initial execution pass ──────────────────────────────────
 
     log_loop "Starting initial execution pass..."
@@ -374,6 +378,8 @@ while true; do
       while [ $INNER_ITERATION -lt $MAX_INNER_ITERATIONS ] && [ $REVIEW_PASSED -eq 0 ]; do
         INNER_ITERATION=$((INNER_ITERATION + 1))
         TOTAL_REVIEW_ITERATIONS=$((TOTAL_REVIEW_ITERATIONS + 1))
+        # Update iteration count file for live monitoring
+        echo "${TOTAL_REVIEW_ITERATIONS}" > /tmp/claude-task.review-iterations
 
         log_loop "Review iteration $INNER_ITERATION/$MAX_INNER_ITERATIONS (outer $OUTER_ITERATION/$MAX_OUTER_ITERATIONS)"
 
@@ -457,6 +463,8 @@ while true; do
         break
       else
         TOTAL_VERIFY_RETRIES=$((TOTAL_VERIFY_RETRIES + 1))
+        # Update verify retries file for live monitoring
+        echo "${TOTAL_VERIFY_RETRIES}" > /tmp/claude-task.verify-retries
         log_loop "Verify FAILED, outer iteration $OUTER_ITERATION/$MAX_OUTER_ITERATIONS"
 
         if [ $OUTER_ITERATION -ge $MAX_OUTER_ITERATIONS ]; then

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -66,7 +66,7 @@ export class TaskWatcher extends EventEmitter {
   ) {
     super();
     this.pollInterval = options?.pollInterval ?? 2000;
-    this.tokenPollInterval = options?.tokenPollInterval ?? 10_000;
+    this.tokenPollInterval = options?.tokenPollInterval ?? 5_000;
   }
 
   /**
@@ -476,7 +476,8 @@ export class TaskWatcher extends EventEmitter {
 
     try {
       return await this.readWorkflowProgress(stackId, containerId, task);
-    } catch {
+    } catch (err) {
+      console.warn(`[TaskWatcher] getWorkflowProgress failed for ${stackId}:`, (err as Error)?.message ?? err);
       return null;
     }
   }
@@ -528,22 +529,28 @@ export class TaskWatcher extends EventEmitter {
       const status = result.stdout.trim();
 
       if (status === 'running') {
+        const wasFirstRunning = !this.seenRunning.get(stackId);
         this.seenRunning.set(stackId, true);
         this.errorCounts.set(stackId, 0);
 
         // Poll tokens and workflow progress periodically while running (throttled)
+        // On the first "running" poll, fetch immediately to avoid startup delay
         const now = Date.now();
         const lastPoll = this.lastTokenPoll.get(stackId) ?? 0;
-        if (now - lastPoll >= this.tokenPollInterval) {
+        if (wasFirstRunning || now - lastPoll >= this.tokenPollInterval) {
           this.lastTokenPoll.set(stackId, now);
           const runningTask = this.registry.getRunningTask(stackId);
           if (runningTask) {
-            this.readTaskTokens(runningTask.id, stackId, containerId).catch(() => {});
+            this.readTaskTokens(runningTask.id, stackId, containerId).catch((err) => {
+              console.warn(`[TaskWatcher] Failed to read tokens for ${stackId}:`, err?.message ?? err);
+            });
             this.readWorkflowProgress(stackId, containerId, runningTask)
               .then((progress) => {
                 this.emit('task:workflow-progress', progress);
               })
-              .catch(() => {});
+              .catch((err) => {
+                console.warn(`[TaskWatcher] Failed to read workflow progress for ${stackId}:`, err?.message ?? err);
+              });
           }
         }
 

--- a/src/renderer/components/StackDetail.tsx
+++ b/src/renderer/components/StackDetail.tsx
@@ -187,7 +187,27 @@ export function StackDetail({
               ? 'bg-orange-500/10 border-orange-500/20 text-orange-400'
               : 'bg-gray-500/10 border-gray-500/20 text-gray-400';
 
-  const showWorkflowPanel = workflowProgress !== null;
+  const isRunning = stack.status === 'running';
+
+  // Default workflow progress for running stacks when no container data has arrived yet
+  const defaultWorkflowProgress: WorkflowProgress = {
+    stackId,
+    currentPhase: 'execution',
+    outerIteration: 1,
+    innerIteration: 1,
+    phases: [
+      { phase: 'execution', status: 'running' },
+      { phase: 'review', status: 'pending' },
+      { phase: 'verify', status: 'pending' },
+    ],
+    steps: [],
+    taskPrompt: null,
+    startedAt: null,
+    model: null,
+  };
+
+  const effectiveWorkflowProgress = workflowProgress ?? (isRunning ? defaultWorkflowProgress : null);
+  const showWorkflowPanel = effectiveWorkflowProgress !== null;
 
   return (
     <div className="h-full flex flex-col animate-fade-in">
@@ -309,7 +329,7 @@ export function StackDetail({
         {/* Left column: workflow progress panel */}
         {showWorkflowPanel && (
           <div className="w-[35%] min-w-[260px] max-w-[380px] border-r border-sandstorm-border flex flex-col overflow-hidden shrink-0">
-            <WorkflowProgressPanel progress={workflowProgress} />
+            <WorkflowProgressPanel progress={effectiveWorkflowProgress!} />
           </div>
         )}
 

--- a/tests/unit/components/StackDetail.test.tsx
+++ b/tests/unit/components/StackDetail.test.tsx
@@ -432,7 +432,7 @@ describe('StackDetail', () => {
     expect(screen.queryByTestId('workflow-progress-panel')).toBeNull();
   });
 
-  it('does not show workflow panel when no progress data available', async () => {
+  it('shows default workflow panel when running stack has no progress data yet', async () => {
     useAppStore.setState({
       stacks: [makeStack({ status: 'running' })],
     });
@@ -440,10 +440,23 @@ describe('StackDetail', () => {
 
     render(<StackDetail stackId="detail-stack" onBack={onBack} />);
 
-    // Wait for async call to settle
+    // Even with null progress data, a running stack should show the default panel
     await waitFor(() => {
-      expect(api.tasks.workflowProgress).toHaveBeenCalledWith('detail-stack');
+      expect(screen.getByTestId('workflow-progress-panel')).toBeDefined();
     });
+    // Default state shows Execution as running
+    const executionPhase = screen.getByTestId('phase-execution');
+    expect(executionPhase.textContent).toContain('running');
+    // Default loop counters
+    expect(screen.getByTestId('outer-loop-counter').textContent).toBe('1 of 5');
+    expect(screen.getByTestId('inner-loop-counter').textContent).toBe('1 of 5');
+  });
+
+  it('does not show workflow panel when stack is not running and no progress data', () => {
+    useAppStore.setState({
+      stacks: [makeStack({ status: 'idle' })],
+    });
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
     expect(screen.queryByTestId('workflow-progress-panel')).toBeNull();
   });
 

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -1238,4 +1238,56 @@ describe('TaskWatcher', () => {
     await progressPromise;
     watcher.unwatchAll();
   });
+
+  it('emits workflow progress immediately on first running poll even with long token interval', async () => {
+    const runtime: ContainerRuntime = {
+      name: 'mock',
+      composeUp: vi.fn(),
+      composeDown: vi.fn(),
+      listContainers: vi.fn().mockResolvedValue([]),
+      inspect: vi.fn(),
+      logs: vi.fn(),
+      exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+        if (cmd.includes('/tmp/claude-task.status')) {
+          return { exitCode: 0, stdout: 'running', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-phase-timing.txt')) {
+          return { exitCode: 0, stdout: 'execution_started_at=2026-04-07T10:00:00Z\n', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-task.review-iterations')) {
+          return { exitCode: 0, stdout: '2', stderr: '' };
+        }
+        if (cmd.includes('/tmp/claude-task.verify-retries')) {
+          return { exitCode: 0, stdout: '1', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      version: vi.fn().mockResolvedValue('Mock 1.0'),
+    };
+
+    // Long token poll interval — but first poll should still emit immediately
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 20,
+      tokenPollInterval: 60_000,
+    });
+
+    registry.createTask('watch-stack', 'test first poll progress');
+
+    const progressPromise = new Promise<void>((resolve) => {
+      watcher.on('task:workflow-progress', (progress) => {
+        expect(progress.stackId).toBe('watch-stack');
+        expect(progress.currentPhase).toBe('execution');
+        expect(progress.outerIteration).toBe(2); // verify retries + 1
+        expect(progress.innerIteration).toBe(3); // review iterations + 1
+        resolve();
+      });
+    });
+
+    watcher.watch('watch-stack', 'container-123');
+
+    // Should resolve quickly despite 60s token poll interval
+    await progressPromise;
+    watcher.unwatchAll();
+  });
 });


### PR DESCRIPTION
## Summary

- **task-runner.sh**: Initialize `review-iterations`/`verify-retries` to `0` at task start and update incrementally inside the loops — previously only written at end-of-task, making them unavailable during live monitoring
- **StackDetail.tsx**: Show default workflow progress panel ("Execution: running, Outer 1/5, Inner 1/5") for any running stack even before container data arrives — previously the panel was invisible until perfect data existed
- **task-watcher.ts**: Reduce token poll interval from 10s to 5s, emit workflow progress immediately on first "running" poll (bypasses throttle), replace silent `.catch(() => {})` with `console.warn` error logging

### Root cause

Three compounding issues made the workflow progress panel from PR #204 completely invisible:
1. Iteration count files only written at end-of-task — not available during live execution
2. Panel gated on non-null progress data — never shows until container files exist
3. First poll delayed by token poll throttle — up to 10s delay before any data emission, with silent error swallowing hiding failures

## Test plan

- [x] StackDetail shows default workflow panel for running stacks with no progress data
- [x] StackDetail hides workflow panel for non-running stacks
- [x] TaskWatcher emits workflow progress immediately on first running poll even with long token interval
- [x] All existing WorkflowProgress and StackDetail tests pass

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)