### PR TITLE
Fix usage stats on macOS: spawn-helper missing execute permission

### DIFF
--- a/src/main/control-plane/account-usage.ts
+++ b/src/main/control-plane/account-usage.ts
@@ -79,9 +79,47 @@ let nodePtyModule: typeof import('node-pty') | null = null;
 let nodePtyLoadAttempted = false;
 let nodePtyLoadError: string | null = null;
 
+/**
+ * Ensure the node-pty spawn-helper binary has execute permission.
+ *
+ * npm does not preserve file permissions on prebuilt binaries, so
+ * `spawn-helper` ships as 644 after `npm install`. Without the execute
+ * bit every `pty.spawn()` call fails with "posix_spawnp failed." on
+ * macOS (and potentially Linux). This fixes it at runtime before the
+ * first spawn attempt.
+ */
+export function ensureSpawnHelperPermissions(): void {
+  if (process.platform === 'win32') return;
+
+  try {
+    // Resolve the node-pty package directory
+    const nodePtyPath = require.resolve('node-pty');
+    const nodePtyDir = path.dirname(nodePtyPath);
+    // prebuilds live at <node-pty>/prebuilds/<platform>-<arch>/spawn-helper
+    const platformArch = `${process.platform}-${process.arch}`;
+    const helperPath = path.join(nodePtyDir, '..', 'prebuilds', platformArch, 'spawn-helper');
+
+    if (!fs.existsSync(helperPath)) return;
+
+    const stat = fs.statSync(helperPath);
+    const isExecutable = (stat.mode & 0o111) !== 0;
+    if (!isExecutable) {
+      fs.chmodSync(helperPath, stat.mode | 0o755);
+      console.log('[account-usage] Fixed spawn-helper execute permission:', helperPath);
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn('[account-usage] Could not verify spawn-helper permissions:', message);
+  }
+}
+
 async function loadNodePty(): Promise<typeof import('node-pty') | null> {
   if (nodePtyLoadAttempted) return nodePtyModule;
   nodePtyLoadAttempted = true;
+
+  // Fix spawn-helper permissions before loading — must happen first because
+  // node-pty's spawn() will fail on macOS if the helper isn't executable.
+  ensureSpawnHelperPermissions();
 
   try {
     nodePtyModule = await import('node-pty');

--- a/tests/unit/account-usage-spawn-helper.test.ts
+++ b/tests/unit/account-usage-spawn-helper.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the ensureSpawnHelperPermissions() runtime fix.
+ *
+ * On macOS, npm does not preserve execute permissions on node-pty's
+ * prebuilt spawn-helper binary (ships as 644). Without the execute bit,
+ * every pty.spawn() call fails with "posix_spawnp failed."
+ *
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('ensureSpawnHelperPermissions', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('fixes permissions when spawn-helper is not executable', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const chmodSyncMock = vi.fn();
+    vi.doMock('fs', () => ({
+      default: {
+        existsSync: () => true,
+        statSync: () => ({ mode: 0o100644 }),
+        chmodSync: chmodSyncMock,
+      },
+      existsSync: () => true,
+      statSync: () => ({ mode: 0o100644 }),
+      chmodSync: chmodSyncMock,
+    }));
+
+    const mod = await import('../../src/main/control-plane/account-usage');
+    mod.ensureSpawnHelperPermissions();
+
+    expect(chmodSyncMock).toHaveBeenCalledTimes(1);
+    const calledMode = chmodSyncMock.mock.calls[0][1];
+    expect(calledMode & 0o111).not.toBe(0);
+  });
+
+  it('skips fix when spawn-helper is already executable', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const chmodSyncMock = vi.fn();
+    vi.doMock('fs', () => ({
+      default: {
+        existsSync: () => true,
+        statSync: () => ({ mode: 0o100755 }),
+        chmodSync: chmodSyncMock,
+      },
+      existsSync: () => true,
+      statSync: () => ({ mode: 0o100755 }),
+      chmodSync: chmodSyncMock,
+    }));
+
+    const mod = await import('../../src/main/control-plane/account-usage');
+    mod.ensureSpawnHelperPermissions();
+
+    expect(chmodSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('skips entirely on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    const existsSyncMock = vi.fn();
+    vi.doMock('fs', () => ({
+      default: { existsSync: existsSyncMock },
+      existsSync: existsSyncMock,
+      statSync: vi.fn(),
+      chmodSync: vi.fn(),
+    }));
+
+    const mod = await import('../../src/main/control-plane/account-usage');
+    mod.ensureSpawnHelperPermissions();
+
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('handles missing spawn-helper gracefully', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const chmodSyncMock = vi.fn();
+    vi.doMock('fs', () => ({
+      default: {
+        existsSync: () => false,
+        statSync: vi.fn(),
+        chmodSync: chmodSyncMock,
+      },
+      existsSync: () => false,
+      statSync: vi.fn(),
+      chmodSync: chmodSyncMock,
+    }));
+
+    const mod = await import('../../src/main/control-plane/account-usage');
+    mod.ensureSpawnHelperPermissions();
+
+    expect(chmodSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('handles filesystem errors gracefully without throwing', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    vi.doMock('fs', () => ({
+      default: {
+        existsSync: () => { throw new Error('permission denied'); },
+        statSync: vi.fn(),
+        chmodSync: vi.fn(),
+      },
+      existsSync: () => { throw new Error('permission denied'); },
+      statSync: vi.fn(),
+      chmodSync: vi.fn(),
+    }));
+
+    const mod = await import('../../src/main/control-plane/account-usage');
+    expect(() => mod.ensureSpawnHelperPermissions()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** `npm install` does not preserve file permissions on prebuilt binaries. node-pty's `spawn-helper` ships as 644 (no execute bit) on macOS. Without it, every `pty.spawn()` call fails with `posix_spawnp failed.` — this is why usage stats worked on Linux (where the permission was preserved) but never worked on Mac.
- **Fix:** Added `ensureSpawnHelperPermissions()` to `account-usage.ts` that detects and fixes the permission at runtime before the first `pty.spawn()` call. Runs once during `loadNodePty()`, is a no-op on Windows, and degrades gracefully if the filesystem is unwritable.
- **5 new unit tests** covering: permission fix applied, already-executable skip, Windows skip, missing helper, and filesystem error handling.

## How it was verified

1. Reset `spawn-helper` to broken permissions (644) on macOS Apple Silicon
2. Confirmed `pty.spawn('/bin/echo', ['hello'])` fails with `posix_spawnp failed.`
3. Ran the runtime fix — permissions corrected to 755
4. Confirmed `pty.spawn` succeeds
5. Ran full usage POC: spawned `claude`, sent `/usage`, parsed output — **89% session, 37% weekly, 6% Sonnet** all parsed correctly on Mac
6. All 41 account-usage unit tests pass (30 + 6 + 5 new)

Refs #213

## Test plan

- [x] `ensureSpawnHelperPermissions` fixes 644 → 755 on macOS
- [x] Skips when already executable
- [x] No-op on Windows
- [x] Graceful degradation on filesystem errors
- [x] All existing account-usage tests still pass
- [x] Manual verification: full `/usage` pipeline works on macOS (Apple Silicon, node-pty 1.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)