### PR TITLE
Fix packaged macOS app: unpack spawn-helper from asar

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,6 +10,7 @@ files:
   - package.json
 asarUnpack:
   - "**/*.node"
+  - "**/spawn-helper"
 extraResources:
   - from: sandstorm-cli
     to: sandstorm-cli

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,12 @@ echo "    Platform: $platform"
 echo "==> Installing dependencies..."
 npm ci
 
+echo "==> Fixing node-pty spawn-helper permissions..."
+# npm does not preserve execute permissions on prebuilt binaries.
+# node-pty's spawn-helper must be executable for pty.spawn() to work on macOS/Linux.
+find node_modules/node-pty -name spawn-helper -exec chmod +x {} \;
+echo "    spawn-helper permissions fixed."
+
 echo "==> Writing build version..."
 git rev-parse --short HEAD > src/renderer/build-version.txt
 echo "    Commit: $(cat src/renderer/build-version.txt)"

--- a/src/main/control-plane/account-usage.ts
+++ b/src/main/control-plane/account-usage.ts
@@ -97,7 +97,11 @@ export function ensureSpawnHelperPermissions(): void {
     const nodePtyDir = path.dirname(nodePtyPath);
     // prebuilds live at <node-pty>/prebuilds/<platform>-<arch>/spawn-helper
     const platformArch = `${process.platform}-${process.arch}`;
-    const helperPath = path.join(nodePtyDir, '..', 'prebuilds', platformArch, 'spawn-helper');
+    let helperPath = path.join(nodePtyDir, '..', 'prebuilds', platformArch, 'spawn-helper');
+
+    // In a packaged Electron app, native files are in app.asar.unpacked/
+    // (node-pty's own code does this same replacement in unixTerminal.js)
+    helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
 
     if (!fs.existsSync(helperPath)) return;
 


### PR DESCRIPTION
## Summary

PR #227 fixed the runtime permission detection but missed two critical packaging issues that prevent it from working in `npm run release` builds:

- **`electron-builder.yml`**: Added `**/spawn-helper` to `asarUnpack` — without this, the spawn-helper binary was trapped inside `app.asar` where it can't be executed
- **`scripts/build.sh`**: Added `chmod +x` on spawn-helper after `npm ci` (which resets permissions to 644) and before packaging, so the unpacked file retains execute permission
- **`account-usage.ts`**: Added `app.asar` → `app.asar.unpacked` path rewrite in the runtime fallback (same pattern node-pty uses internally in `unixTerminal.js:31`)

Verified: after `electron-builder --mac`, spawn-helper lands at `app.asar.unpacked/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper` with 755 permissions.

Refs #213

## Test plan

- [x] All 41 account-usage unit tests pass
- [x] `npm run build` succeeds
- [x] `electron-builder --mac` packages correctly
- [x] spawn-helper appears in `app.asar.unpacked/` with execute permission
- [ ] Manual: `npm run release` on macOS, launch app, verify usage stats appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)