### PR TITLE
Fix crash when stack has null ID in database

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -502,6 +502,9 @@ export class Registry {
   // --- Stacks ---
 
   createStack(stack: Omit<Stack, 'created_at' | 'updated_at' | 'error' | 'pr_url' | 'pr_number' | 'total_input_tokens' | 'total_output_tokens' | 'total_execution_input_tokens' | 'total_execution_output_tokens' | 'total_review_input_tokens' | 'total_review_output_tokens' | 'rate_limit_reset_at' | 'current_model'>): Stack {
+    if (!stack.id) {
+      throw new Error('Stack id is required and cannot be null or empty');
+    }
     const normalizedDir = path.resolve(stack.project_dir);
     this.db.prepare(
       `INSERT INTO stacks (id, project, project_dir, ticket, branch, description, status, runtime)
@@ -518,10 +521,10 @@ export class Registry {
   }
 
   listStacks(): Stack[] {
-    return this.db.prepare(
+    return (this.db.prepare(
       `SELECT s.*, (SELECT model FROM tasks WHERE stack_id = s.id ORDER BY id DESC LIMIT 1) as current_model
-       FROM stacks s ORDER BY s.created_at DESC`
-    ).all() as Stack[];
+       FROM stacks s WHERE s.id IS NOT NULL ORDER BY s.created_at DESC`
+    ).all() as Stack[]);
   }
 
   updateStackStatus(id: string, status: StackStatus, error?: string): void {

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -96,7 +96,7 @@ export interface RateLimitState {
  * Segments must consist only of lowercase alphanumeric characters, hyphens, and underscores.
  */
 export function sanitizeComposeName(input: string): string {
-  const name = input
+  const name = (input ?? '')
     .toLowerCase()
     .replace(/\s+/g, '-')       // spaces → hyphens
     .replace(/[^a-z0-9_-]/g, '') // strip invalid chars

--- a/src/main/runtime/docker.ts
+++ b/src/main/runtime/docker.ts
@@ -375,7 +375,7 @@ export class DockerRuntime implements ContainerRuntime {
   }
 
   private mapState(state: string): string {
-    const normalized = state.toLowerCase();
+    const normalized = (state ?? 'unknown').toLowerCase();
     if (normalized === 'running') return 'running';
     if (normalized === 'exited') return 'exited';
     if (normalized === 'restarting') return 'restarting';

--- a/src/main/runtime/podman.ts
+++ b/src/main/runtime/podman.ts
@@ -189,7 +189,7 @@ export class PodmanRuntime implements ContainerRuntime {
   }
 
   private mapState(state: string): string {
-    const normalized = state.toLowerCase();
+    const normalized = (state ?? 'unknown').toLowerCase();
     if (normalized === 'running') return 'running';
     if (normalized === 'exited') return 'exited';
     if (normalized === 'restarting') return 'restarting';


### PR DESCRIPTION
## Summary

- A corrupt stack row with a NULL `id` column caused `sanitizeComposeName()` to call `.toLowerCase()` on `null`, crashing the `stacks:list` IPC handler and making the entire app unusable ("Failed to refresh stacks" error with no way to recover)
- Added null guards at four layers: input validation in `createStack()`, `WHERE s.id IS NOT NULL` filter in `listStacks()` query, and defensive null coalescing in `sanitizeComposeName()` and `mapState()` (both Docker and Podman runtimes)
- Root cause was a stack inserted with a null name/id — the validation on `createStack` now prevents this from happening again

## Test plan

- [ ] Verify app starts and loads stacks list without error
- [ ] Create a new stack and confirm it works normally
- [ ] Manually insert a null-id row in the DB and confirm the app handles it gracefully instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)