### PR TITLE
Remove diff embedding from review agent prompt

### DIFF
--- a/sandstorm-cli/docker/review-prompt.md
+++ b/sandstorm-cli/docker/review-prompt.md
@@ -1,10 +1,19 @@
 # Code Review — Fresh Context
 
-You are a code review agent. You have been given the original task description and the current git diff. You have NO prior context from the execution agent — review the changes with fresh eyes.
+You are a code review agent. You have NO prior context from the execution agent — review the changes with fresh eyes.
+
+## Discovering Changes
+
+Before reviewing, use git tools to discover what changed:
+
+- Run `git status` to see which files were modified, added, or deleted
+- Run `git diff HEAD` (or `git diff HEAD -- <file>` for a specific file) to inspect the changes
+- Read files directly if you need more context
+- You decide what to inspect and how deeply — skip generated files or large data files that are not relevant to the task
 
 ## Your Job
 
-Review the diff below against the original task. Evaluate:
+Review the changes against the original task. Evaluate:
 
 1. **Requirements compliance** — Does the code do what the task asked for? If the task specifies an approach (e.g., "use X, do NOT use Y"), does the code comply? **This is the highest-priority criterion. A "better" approach that violates explicit task requirements is a REVIEW_FAIL.**
 2. **Architecture** — Does the change fit existing patterns in the codebase?

--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -116,10 +116,6 @@ run_review() {
   local original_prompt="$1"
   local iteration="${2:-1}"
 
-  # Capture diffs to files to avoid bash variable size limits and special char mangling
-  (cd /app && git diff HEAD 2>/dev/null) > /tmp/claude-review-diff.txt
-  (cd /app && git ls-files --others --exclude-standard -z 2>/dev/null | xargs -0 -I{} git diff --no-index /dev/null {} 2>/dev/null || true) > /tmp/claude-review-untracked.txt
-
   # Build the review prompt from template
   local review_prompt_file="/tmp/claude-review-prompt.txt"
   local template=""
@@ -141,24 +137,14 @@ run_review() {
     fi
   fi
 
-  # Assemble the review prompt
+  # Assemble the review prompt (template + original task only — no diff content)
+  # The review agent discovers changes itself via git status / git diff
   {
     cat "$template"
     echo ""
     echo "## Original Task"
     echo ""
     echo "$original_prompt"
-    echo ""
-    echo "## Current Diff (staged + unstaged)"
-    echo ""
-    echo '```diff'
-    cat /tmp/claude-review-diff.txt
-    if [ -s /tmp/claude-review-untracked.txt ]; then
-      echo ""
-      echo "# New (untracked) files:"
-      cat /tmp/claude-review-untracked.txt
-    fi
-    echo '```'
   } > "$review_prompt_file"
 
   log_loop "Starting review agent with fresh context..."
@@ -167,7 +153,7 @@ run_review() {
   run_claude "$review_prompt_file" /tmp/claude-review-raw.log /tmp/claude-review-task.log review "$iteration" "${MODEL_ARGS[@]}"
   local review_exit=$?
 
-  rm -f "$review_prompt_file" /tmp/claude-review-diff.txt /tmp/claude-review-untracked.txt
+  rm -f "$review_prompt_file"
 
   if [ $review_exit -ne 0 ]; then
     log_loop "Review agent crashed (exit $review_exit), treating as REVIEW_FAIL"

--- a/sandstorm-cli/lib/init.sh
+++ b/sandstorm-cli/lib/init.sh
@@ -577,11 +577,20 @@ REVIEW_PROMPT="$SANDSTORM_CONFIG_DIR/review-prompt.md"
 cat > "$REVIEW_PROMPT" << 'REVIEWPROMPT'
 # Code Review — Fresh Context
 
-You are a code review agent. You have been given the original task description and the current git diff. You have NO prior context from the execution agent — review the changes with fresh eyes.
+You are a code review agent. You have NO prior context from the execution agent — review the changes with fresh eyes.
+
+## Discovering Changes
+
+Before reviewing, use git tools to discover what changed:
+
+- Run `git status` to see which files were modified, added, or deleted
+- Run `git diff HEAD` (or `git diff HEAD -- <file>` for a specific file) to inspect the changes
+- Read files directly if you need more context
+- You decide what to inspect and how deeply — skip generated files or large data files that are not relevant to the task
 
 ## Your Job
 
-Review the diff below against the original task. Evaluate:
+Review the changes against the original task. Evaluate:
 
 1. **Requirements compliance** — Does the code do what the task asked for? If the task specifies an approach (e.g., "use X, do NOT use Y"), does the code comply? **This is the highest-priority criterion. A "better" approach that violates explicit task requirements is a REVIEW_FAIL.**
 2. **Architecture** — Does the change fit existing patterns in the codebase?

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -58,9 +58,10 @@ describe('task-runner.sh dual-loop workflow', () => {
       expect(taskRunner).toContain('run_review()')
     })
 
-    it('generates a diff for the review agent', () => {
-      // The review function should capture git diff for the review prompt
-      expect(taskRunner).toContain('git diff HEAD')
+    it('does not embed a diff in the review agent prompt', () => {
+      // The review agent discovers changes itself via git tools — no diff is embedded
+      expect(taskRunner).not.toContain('cat /tmp/claude-review-diff.txt')
+      expect(taskRunner).not.toContain('Current Diff (staged + unstaged)')
     })
 
     it('uses the review-prompt.md template', () => {
@@ -143,16 +144,22 @@ describe('task-runner.sh dual-loop workflow', () => {
   // ── Diff handling ──────────────────────────────────────────────────
 
   describe('review diff handling', () => {
-    it('pipes diff to a file instead of storing in a variable', () => {
-      expect(taskRunner).toContain('> /tmp/claude-review-diff.txt')
+    it('does NOT create a temp diff file', () => {
+      expect(taskRunner).not.toContain('> /tmp/claude-review-diff.txt')
     })
 
-    it('pipes untracked diff to a file', () => {
-      expect(taskRunner).toContain('> /tmp/claude-review-untracked.txt')
+    it('does NOT create a temp untracked diff file', () => {
+      expect(taskRunner).not.toContain('> /tmp/claude-review-untracked.txt')
     })
 
-    it('uses cat to include diff in review prompt', () => {
-      expect(taskRunner).toContain('cat /tmp/claude-review-diff.txt')
+    it('does NOT embed diff content in the review prompt', () => {
+      expect(taskRunner).not.toContain('cat /tmp/claude-review-diff.txt')
+      expect(taskRunner).not.toContain('Current Diff (staged + unstaged)')
+    })
+
+    it('assembles review prompt from template and original task only', () => {
+      // The comment in the script documents this constraint
+      expect(taskRunner).toContain('no diff content')
     })
   })
 
@@ -592,6 +599,18 @@ describe('review-prompt.md template', () => {
   it('instructs the review agent to pay attention to issue comments', () => {
     expect(reviewPrompt.toLowerCase()).toContain('comments')
     expect(reviewPrompt).toContain('Requirements evolve')
+  })
+
+  it('does NOT claim a diff was given to the agent', () => {
+    expect(reviewPrompt).not.toContain('the current git diff')
+  })
+
+  it('instructs the review agent to run git status to discover changes', () => {
+    expect(reviewPrompt).toContain('git status')
+  })
+
+  it('instructs the review agent to run git diff to inspect changes', () => {
+    expect(reviewPrompt).toContain('git diff HEAD')
   })
 })
 


### PR DESCRIPTION
## Summary

- Removed inline diff embedding from `run_review()` in `task-runner.sh` — the review agent now discovers changes itself via `git status` and `git diff HEAD`
- Updated `review-prompt.md` with "Discovering Changes" section instructing the agent to use git tools
- Updated the generated review prompt heredoc in `init.sh` with the same changes
- Updated tests to verify no diff content is embedded and git discovery instructions are present

## Why

Large diffs (e.g., a 4MB `seed_questions.json` export) caused the review agent to crash with prompt-too-long errors, burning through all inner loop iterations. The review agent is a full Claude instance with tool access — it can run git commands itself.

## Test plan

- [x] Review passes on first iteration
- [x] Verify step passes
- [x] All existing tests pass with updated assertions
- [x] New tests verify no diff embedding and git discovery instructions

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)