### PR TITLE
Fix: Move MCP config and .sandstorm-ready out of workspace

### DIFF
--- a/sandstorm-cli/docker/entrypoint.sh
+++ b/sandstorm-cli/docker/entrypoint.sh
@@ -44,7 +44,7 @@ fi
 # -------------------------------------------------------------------
 # 2.5. Configure Chrome DevTools MCP for Claude Code
 # -------------------------------------------------------------------
-# Write MCP config to .mcp.json at project root (Claude Code reads this, not settings.json)
+# Write MCP config to /tmp/sandstorm-mcp.json (outside workspace, so it never appears in git)
 # Chrome flags explanation:
 #   --acceptInsecureCerts: Chromium in Docker auto-upgrades HTTP to HTTPS for
 #     internal hostnames (e.g., http://app:3000 -> https://app:3000), which fails
@@ -52,7 +52,7 @@ fi
 #   --no-sandbox: Required when running as root or in containers without a sandbox namespace.
 #   --disable-dev-shm-usage: Prevents crashes from /dev/shm being too small in containers.
 #   --allow-insecure-localhost: Allows HTTP connections to localhost/internal hostnames.
-cat > /app/.mcp.json << 'MCPEOF'
+cat > /tmp/sandstorm-mcp.json << 'MCPEOF'
 {
   "mcpServers": {
     "chrome-devtools": {
@@ -146,7 +146,7 @@ if [ -S /var/run/docker.sock ]; then
 fi
 
 # Signal to other services that the repo is ready
-touch /app/.sandstorm-ready
+touch /tmp/.sandstorm-ready
 
 echo ""
 echo "=========================================="

--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -47,6 +47,7 @@ run_claude() {
 
   cat "$prompt_file" \
     | claude --dangerously-skip-permissions --verbose --output-format stream-json \
+        --mcp-config /tmp/sandstorm-mcp.json --strict-mcp-config \
         "${extra_args[@]}" \
         --include-partial-messages --print -p - 2>&1 \
     | stdbuf -o0 tee -a "$raw_log" \

--- a/sandstorm-cli/lib/init.sh
+++ b/sandstorm-cli/lib/init.sh
@@ -402,7 +402,7 @@ HEADER
       - \${SANDSTORM_CONTEXT}:/sandstorm-context:ro
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
-      test: ["CMD", "test", "-f", "/app/.sandstorm-ready"]
+      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]
       interval: 3s
       timeout: 2s
       retries: 60

--- a/src/main/compose-generator.ts
+++ b/src/main/compose-generator.ts
@@ -259,7 +259,7 @@ export function generateComposeYaml(analysis: ComposeAnalysis): string {
   lines.push('      - ${SANDSTORM_CONTEXT}:/sandstorm-context:ro');
   lines.push('      - /var/run/docker.sock:/var/run/docker.sock');
   lines.push('    healthcheck:');
-  lines.push('      test: ["CMD", "test", "-f", "/app/.sandstorm-ready"]');
+  lines.push('      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]');
   lines.push('      interval: 3s');
   lines.push('      timeout: 2s');
   lines.push('      retries: 60');

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -320,7 +320,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
           '      - ${SANDSTORM_WORKSPACE}:/app',
           '      - /var/run/docker.sock:/var/run/docker.sock',
           '    healthcheck:',
-          '      test: ["CMD", "test", "-f", "/app/.sandstorm-ready"]',
+          '      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]',
           '      interval: 3s',
           '      timeout: 2s',
           '      retries: 60',

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -331,6 +331,14 @@ describe('task-runner.sh dual-loop workflow', () => {
       expect(taskRunner).toContain('local task_log="${3:-/tmp/claude-task.log}"')
     })
 
+    it('passes --mcp-config pointing to /tmp/sandstorm-mcp.json', () => {
+      expect(taskRunner).toContain('--mcp-config /tmp/sandstorm-mcp.json')
+    })
+
+    it('passes --strict-mcp-config to prevent loading workspace .mcp.json', () => {
+      expect(taskRunner).toContain('--strict-mcp-config')
+    })
+
     it('writes raw log for token parsing (append mode)', () => {
       expect(taskRunner).toContain('tee -a "$raw_log"')
     })

--- a/tests/unit/verify-and-context.test.ts
+++ b/tests/unit/verify-and-context.test.ts
@@ -96,6 +96,16 @@ describe('entrypoint.sh service label injection', () => {
   it('filters out the claude container from service list', () => {
     expect(entrypoint).toContain('grep -v -- "-claude-"');
   });
+
+  it('writes MCP config to /tmp/sandstorm-mcp.json, not /app/.mcp.json', () => {
+    expect(entrypoint).toContain('/tmp/sandstorm-mcp.json');
+    expect(entrypoint).not.toContain('/app/.mcp.json');
+  });
+
+  it('writes .sandstorm-ready sentinel to /tmp/, not /app/', () => {
+    expect(entrypoint).toContain('touch /tmp/.sandstorm-ready');
+    expect(entrypoint).not.toContain('touch /app/.sandstorm-ready');
+  });
 });
 
 describe('Dockerfile includes sandstorm-exec', () => {


### PR DESCRIPTION
## Summary

- Moves MCP config from `/app/.mcp.json` to `/tmp/sandstorm-mcp.json` and passes it via `--mcp-config` / `--strict-mcp-config` CLI flags, preventing the workspace file from being overwritten and accidentally committed
- Moves `.sandstorm-ready` healthcheck sentinel from `/app/` to `/tmp/` — it's a runtime signal with no business in the workspace
- Updates healthcheck paths in `compose-generator.ts`, `ipc.ts`, and `init.sh` to match

## Test plan

- [x] New assertions in `verify-and-context.test.ts` confirm entrypoint writes to `/tmp/`, not `/app/`
- [x] New assertions in `task-runner-review-loop.test.ts` confirm `--mcp-config` and `--strict-mcp-config` flags are present
- [x] All existing tests pass

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)