### PR TITLE
Fix: Inject verify.sh from host .sandstorm/ into stack workspaces

### DIFF
--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -270,18 +270,12 @@ case "$COMMAND" in
       for f in "$PROJECT_ROOT"/.env*; do
         [ -f "$f" ] && cp "$f" "$WORKSPACE/" 2>/dev/null
       done
-      # Inject host .sandstorm/ config files into the workspace clone so that
-      # verify.sh, review-prompt.md, scripts/, context/, etc. are available
-      # inside the container at /app/.sandstorm/. workspaces/ and stacks/ are
-      # workspace-specific and must not be copied.
-      SANDSTORM_INJECT_ITEMS="verify.sh review-prompt.md docker-compose.yml scripts context spec-quality-gate.md config"
-      for item in $SANDSTORM_INJECT_ITEMS; do
-        src="$PROJECT_ROOT/.sandstorm/$item"
-        if [ -e "$src" ]; then
-          mkdir -p "$WORKSPACE/.sandstorm"
-          cp -r "$src" "$WORKSPACE/.sandstorm/" 2>/dev/null || true
-        fi
-      done
+      # Inject verify.sh from host .sandstorm/ into the workspace clone so the
+      # verify step has the script available inside the container at /app/.sandstorm/.
+      if [ -f "$PROJECT_ROOT/.sandstorm/verify.sh" ]; then
+        mkdir -p "$WORKSPACE/.sandstorm"
+        cp "$PROJECT_ROOT/.sandstorm/verify.sh" "$WORKSPACE/.sandstorm/verify.sh" 2>/dev/null || true
+      fi
       # Remap ports in env files to match sandstorm stack offsets
       if [ -n "${PORT_MAP:-}" ]; then
         IFS=',' read -ra ENTRIES <<< "$PORT_MAP"

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -270,6 +270,18 @@ case "$COMMAND" in
       for f in "$PROJECT_ROOT"/.env*; do
         [ -f "$f" ] && cp "$f" "$WORKSPACE/" 2>/dev/null
       done
+      # Inject host .sandstorm/ config files into the workspace clone so that
+      # verify.sh, review-prompt.md, scripts/, context/, etc. are available
+      # inside the container at /app/.sandstorm/. workspaces/ and stacks/ are
+      # workspace-specific and must not be copied.
+      SANDSTORM_INJECT_ITEMS="verify.sh review-prompt.md docker-compose.yml scripts context spec-quality-gate.md config"
+      for item in $SANDSTORM_INJECT_ITEMS; do
+        src="$PROJECT_ROOT/.sandstorm/$item"
+        if [ -e "$src" ]; then
+          mkdir -p "$WORKSPACE/.sandstorm"
+          cp -r "$src" "$WORKSPACE/.sandstorm/" 2>/dev/null || true
+        fi
+      done
       # Remap ports in env files to match sandstorm stack offsets
       if [ -n "${PORT_MAP:-}" ]; then
         IFS=',' read -ra ENTRIES <<< "$PORT_MAP"

--- a/tests/unit/sandstorm-config-injection.test.ts
+++ b/tests/unit/sandstorm-config-injection.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('stack.sh .sandstorm/ config injection', () => {
+  const stackShPath = resolve(__dirname, '../../sandstorm-cli/lib/stack.sh');
+  const stackSh = readFileSync(stackShPath, 'utf-8');
+
+  it('injects verify.sh into workspace .sandstorm/', () => {
+    expect(stackSh).toContain('verify.sh');
+    expect(stackSh).toContain('SANDSTORM_INJECT_ITEMS');
+  });
+
+  it('injects review-prompt.md into workspace .sandstorm/', () => {
+    expect(stackSh).toContain('review-prompt.md');
+  });
+
+  it('injects docker-compose.yml into workspace .sandstorm/', () => {
+    // The injected docker-compose.yml is the sandstorm one, not the project one
+    expect(stackSh).toContain('SANDSTORM_INJECT_ITEMS');
+    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*docker-compose\.yml/);
+  });
+
+  it('injects scripts/ directory recursively', () => {
+    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*scripts/);
+    expect(stackSh).toContain('cp -r');
+  });
+
+  it('injects context/ directory recursively', () => {
+    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*context/);
+  });
+
+  it('injects spec-quality-gate.md', () => {
+    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*spec-quality-gate\.md/);
+  });
+
+  it('injects config file', () => {
+    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*\bconfig\b/);
+  });
+
+  it('does NOT inject workspaces/ directory', () => {
+    // workspaces/ is workspace-specific and must not be copied
+    expect(stackSh).not.toMatch(/SANDSTORM_INJECT_ITEMS=.*workspaces/);
+  });
+
+  it('does NOT inject stacks/ directory', () => {
+    // stacks/ is workspace-specific and must not be copied
+    expect(stackSh).not.toMatch(/SANDSTORM_INJECT_ITEMS=.*\bstacks\b/);
+  });
+
+  it('skips missing files silently (uses -e check and || true)', () => {
+    // Should use [ -e "$src" ] to check existence before copying
+    expect(stackSh).toContain('[ -e "$src" ]');
+    // Should suppress errors from cp
+    expect(stackSh).toMatch(/cp -r.*\|\| true/);
+  });
+
+  it('creates .sandstorm directory in workspace before copying', () => {
+    expect(stackSh).toContain('mkdir -p "$WORKSPACE/.sandstorm"');
+  });
+
+  it('copies from $PROJECT_ROOT/.sandstorm/ as source', () => {
+    expect(stackSh).toContain('$PROJECT_ROOT/.sandstorm/');
+  });
+
+  it('only injects on initial clone (inside the "if no .git" block)', () => {
+    // The injection must be inside the workspace clone block
+    // Verify the structure: injection code appears between clone_workspace call and port remapping
+    const cloneBlock = stackSh.match(
+      /if \[ ! -d "\$WORKSPACE\/\.git" \]([\s\S]*?)fi\s*\n\s*#\s*Make workspace world-readable/
+    );
+    expect(cloneBlock).not.toBeNull();
+    expect(cloneBlock![1]).toContain('SANDSTORM_INJECT_ITEMS');
+  });
+});

--- a/tests/unit/sandstorm-config-injection.test.ts
+++ b/tests/unit/sandstorm-config-injection.test.ts
@@ -8,68 +8,32 @@ describe('stack.sh .sandstorm/ config injection', () => {
 
   it('injects verify.sh into workspace .sandstorm/', () => {
     expect(stackSh).toContain('verify.sh');
-    expect(stackSh).toContain('SANDSTORM_INJECT_ITEMS');
+    expect(stackSh).toContain('$PROJECT_ROOT/.sandstorm/verify.sh');
+    expect(stackSh).toContain('$WORKSPACE/.sandstorm/verify.sh');
   });
 
-  it('injects review-prompt.md into workspace .sandstorm/', () => {
-    expect(stackSh).toContain('review-prompt.md');
+  it('does NOT inject other files (review-prompt.md, scripts/, context/, etc.)', () => {
+    expect(stackSh).not.toContain('review-prompt.md');
+    expect(stackSh).not.toContain('SANDSTORM_INJECT_ITEMS');
+    expect(stackSh).not.toMatch(/cp.*\.sandstorm\/scripts/);
+    expect(stackSh).not.toMatch(/cp.*\.sandstorm\/context/);
+    expect(stackSh).not.toMatch(/cp.*spec-quality-gate/);
   });
 
-  it('injects docker-compose.yml into workspace .sandstorm/', () => {
-    // The injected docker-compose.yml is the sandstorm one, not the project one
-    expect(stackSh).toContain('SANDSTORM_INJECT_ITEMS');
-    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*docker-compose\.yml/);
-  });
-
-  it('injects scripts/ directory recursively', () => {
-    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*scripts/);
-    expect(stackSh).toContain('cp -r');
-  });
-
-  it('injects context/ directory recursively', () => {
-    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*context/);
-  });
-
-  it('injects spec-quality-gate.md', () => {
-    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*spec-quality-gate\.md/);
-  });
-
-  it('injects config file', () => {
-    expect(stackSh).toMatch(/SANDSTORM_INJECT_ITEMS=.*\bconfig\b/);
-  });
-
-  it('does NOT inject workspaces/ directory', () => {
-    // workspaces/ is workspace-specific and must not be copied
-    expect(stackSh).not.toMatch(/SANDSTORM_INJECT_ITEMS=.*workspaces/);
-  });
-
-  it('does NOT inject stacks/ directory', () => {
-    // stacks/ is workspace-specific and must not be copied
-    expect(stackSh).not.toMatch(/SANDSTORM_INJECT_ITEMS=.*\bstacks\b/);
-  });
-
-  it('skips missing files silently (uses -e check and || true)', () => {
-    // Should use [ -e "$src" ] to check existence before copying
-    expect(stackSh).toContain('[ -e "$src" ]');
-    // Should suppress errors from cp
-    expect(stackSh).toMatch(/cp -r.*\|\| true/);
+  it('skips injection silently if verify.sh does not exist', () => {
+    // Uses -f check before copying
+    expect(stackSh).toContain('[ -f "$PROJECT_ROOT/.sandstorm/verify.sh" ]');
   });
 
   it('creates .sandstorm directory in workspace before copying', () => {
     expect(stackSh).toContain('mkdir -p "$WORKSPACE/.sandstorm"');
   });
 
-  it('copies from $PROJECT_ROOT/.sandstorm/ as source', () => {
-    expect(stackSh).toContain('$PROJECT_ROOT/.sandstorm/');
-  });
-
   it('only injects on initial clone (inside the "if no .git" block)', () => {
-    // The injection must be inside the workspace clone block
-    // Verify the structure: injection code appears between clone_workspace call and port remapping
     const cloneBlock = stackSh.match(
       /if \[ ! -d "\$WORKSPACE\/\.git" \]([\s\S]*?)fi\s*\n\s*#\s*Make workspace world-readable/
     );
     expect(cloneBlock).not.toBeNull();
-    expect(cloneBlock![1]).toContain('SANDSTORM_INJECT_ITEMS');
+    expect(cloneBlock![1]).toContain('verify.sh');
   });
 });


### PR DESCRIPTION
## Summary

- Copies `.sandstorm/verify.sh` from the host project into the workspace during initial clone, following the same pattern as `.env` file injection
- Skips silently if `verify.sh` doesn't exist on the host
- Without this fix, `verify.sh` was missing in stacks and the verify step silently skipped with "No .sandstorm/verify.sh found", allowing broken code to pass the gate

## Test plan

- [x] 5 tests in `sandstorm-config-injection.test.ts` covering verify.sh injection, exclusion of other files, silent skip, and clone-gate constraint
- [x] All existing tests pass

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)