### PR TITLE
Guard verify.sh and docker-compose.yml from being silently overwritten on re-init

### DIFF
--- a/sandstorm-cli/lib/init.sh
+++ b/sandstorm-cli/lib/init.sh
@@ -429,56 +429,60 @@ echo "  Created .sandstorm/docker-compose.yml"
 # ---------------------------------------------------------------------------
 VERIFY_SCRIPT="$SANDSTORM_CONFIG_DIR/verify.sh"
 
-# Auto-detect verify commands based on project files
-{
-  echo "#!/bin/bash"
-  echo "#"
-  echo "# Sandstorm verify script — commands run during the verification step."
-  echo "# Each command runs in sequence. If any fails, verification fails."
-  echo "#"
-  echo "# Use 'sandstorm-exec <service> <command>' to run on service containers."
-  echo "# Edit this file to match your project's test/lint/build commands."
-  echo "#"
-  echo "set -e"
-  echo ""
+if [ -f "$VERIFY_SCRIPT" ]; then
+  echo "  Skipping .sandstorm/verify.sh — already exists (preserving user edits)"
+else
+  # Auto-detect verify commands based on project files
+  {
+    echo "#!/bin/bash"
+    echo "#"
+    echo "# Sandstorm verify script — commands run during the verification step."
+    echo "# Each command runs in sequence. If any fails, verification fails."
+    echo "#"
+    echo "# Use 'sandstorm-exec <service> <command>' to run on service containers."
+    echo "# Edit this file to match your project's test/lint/build commands."
+    echo "#"
+    echo "set -e"
+    echo ""
 
-  # Check for Node.js project indicators
-  if [ -f "$PROJECT_ROOT/package.json" ]; then
-    # Read package.json scripts to determine what's available
-    HAS_TEST=$(python3 -c "import json; d=json.load(open('$PROJECT_ROOT/package.json')); print('yes' if 'test' in d.get('scripts',{}) else 'no')" 2>/dev/null || echo "no")
-    HAS_BUILD=$(python3 -c "import json; d=json.load(open('$PROJECT_ROOT/package.json')); print('yes' if 'build' in d.get('scripts',{}) else 'no')" 2>/dev/null || echo "no")
-    HAS_TYPECHECK=$(python3 -c "import json; d=json.load(open('$PROJECT_ROOT/package.json')); print('yes' if 'typecheck' in d.get('scripts',{}) else 'no')" 2>/dev/null || echo "no")
-    HAS_TSCONFIG=$([ -f "$PROJECT_ROOT/tsconfig.json" ] && echo "yes" || echo "no")
+    # Check for Node.js project indicators
+    if [ -f "$PROJECT_ROOT/package.json" ]; then
+      # Read package.json scripts to determine what's available
+      HAS_TEST=$(python3 -c "import json; d=json.load(open('$PROJECT_ROOT/package.json')); print('yes' if 'test' in d.get('scripts',{}) else 'no')" 2>/dev/null || echo "no")
+      HAS_BUILD=$(python3 -c "import json; d=json.load(open('$PROJECT_ROOT/package.json')); print('yes' if 'build' in d.get('scripts',{}) else 'no')" 2>/dev/null || echo "no")
+      HAS_TYPECHECK=$(python3 -c "import json; d=json.load(open('$PROJECT_ROOT/package.json')); print('yes' if 'typecheck' in d.get('scripts',{}) else 'no')" 2>/dev/null || echo "no")
+      HAS_TSCONFIG=$([ -f "$PROJECT_ROOT/tsconfig.json" ] && echo "yes" || echo "no")
 
-    if [ "$HAS_TEST" = "yes" ]; then echo "npm test"; fi
-    if [ "$HAS_TYPECHECK" = "yes" ]; then
-      echo "npm run typecheck"
-    elif [ "$HAS_TSCONFIG" = "yes" ]; then
-      echo "npx tsc --noEmit"
+      if [ "$HAS_TEST" = "yes" ]; then echo "npm test"; fi
+      if [ "$HAS_TYPECHECK" = "yes" ]; then
+        echo "npm run typecheck"
+      elif [ "$HAS_TSCONFIG" = "yes" ]; then
+        echo "npx tsc --noEmit"
+      fi
+      if [ "$HAS_BUILD" = "yes" ]; then echo "npm run build"; fi
     fi
-    if [ "$HAS_BUILD" = "yes" ]; then echo "npm run build"; fi
-  fi
 
-  # Check for Ruby/Rails
-  if [ -f "$PROJECT_ROOT/Gemfile" ]; then
-    if [ -f "$PROJECT_ROOT/bin/rails" ]; then
-      echo "# sandstorm-exec api bash -c 'cd /rails && bin/rails test'"
+    # Check for Ruby/Rails
+    if [ -f "$PROJECT_ROOT/Gemfile" ]; then
+      if [ -f "$PROJECT_ROOT/bin/rails" ]; then
+        echo "# sandstorm-exec api bash -c 'cd /rails && bin/rails test'"
+      fi
     fi
-  fi
 
-  # Check for Python
-  if [ -f "$PROJECT_ROOT/requirements.txt" ] || [ -f "$PROJECT_ROOT/pyproject.toml" ]; then
-    echo "# sandstorm-exec app pytest"
-  fi
+    # Check for Python
+    if [ -f "$PROJECT_ROOT/requirements.txt" ] || [ -f "$PROJECT_ROOT/pyproject.toml" ]; then
+      echo "# sandstorm-exec app pytest"
+    fi
 
-  # Check for Go
-  if [ -f "$PROJECT_ROOT/go.mod" ]; then
-    echo "# sandstorm-exec app go test ./..."
-  fi
-} > "$VERIFY_SCRIPT"
+    # Check for Go
+    if [ -f "$PROJECT_ROOT/go.mod" ]; then
+      echo "# sandstorm-exec app go test ./..."
+    fi
+  } > "$VERIFY_SCRIPT"
 
-chmod +x "$VERIFY_SCRIPT"
-echo "  Created .sandstorm/verify.sh"
+  chmod +x "$VERIFY_SCRIPT"
+  echo "  Created .sandstorm/verify.sh"
+fi
 
 # ---------------------------------------------------------------------------
 # Generate .sandstorm/spec-quality-gate.md (ticket readiness criteria)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -297,50 +297,61 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       );
 
       const composePath = path.join(sandstormDir, 'docker-compose.yml');
-      fs.writeFileSync(
-        composePath,
-        [
-          '# Sandstorm stack override — Claude workspace only.',
-          '# This project has no docker-compose services of its own.',
-          '#',
-          '# Do not run standalone. Sandstorm chains it automatically.',
-          '',
-          'services:',
-          '  claude:',
-          `    image: sandstorm-${projectName}-claude`,
-          '    build:',
-          '      context: ${SANDSTORM_DIR}',
-          '      dockerfile: docker/Dockerfile',
-          '      args:',
-          '        SANDSTORM_APP_VERSION: ${SANDSTORM_APP_VERSION:-unknown}',
-          '    environment:',
-          '      - GIT_USER_NAME',
-          '      - GIT_USER_EMAIL',
-          '      - SANDSTORM_PROJECT',
-          '      - SANDSTORM_STACK_ID',
-          '    volumes:',
-          '      - ${SANDSTORM_WORKSPACE}:/app',
-          '      - /var/run/docker.sock:/var/run/docker.sock',
-          '    healthcheck:',
-          '      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]',
-          '      interval: 3s',
-          '      timeout: 2s',
-          '      retries: 60',
-          '    tty: true',
-          '    stdin_open: true',
-          '',
-        ].join('\n'),
-      );
+      const skippedFiles: string[] = [];
+      if (fs.existsSync(composePath)) {
+        console.info('[projects:initialize] docker-compose.yml already exists — not overwriting');
+        skippedFiles.push('docker-compose.yml');
+      } else {
+        fs.writeFileSync(
+          composePath,
+          [
+            '# Sandstorm stack override — Claude workspace only.',
+            '# This project has no docker-compose services of its own.',
+            '#',
+            '# Do not run standalone. Sandstorm chains it automatically.',
+            '',
+            'services:',
+            '  claude:',
+            `    image: sandstorm-${projectName}-claude`,
+            '    build:',
+            '      context: ${SANDSTORM_DIR}',
+            '      dockerfile: docker/Dockerfile',
+            '      args:',
+            '        SANDSTORM_APP_VERSION: ${SANDSTORM_APP_VERSION:-unknown}',
+            '    environment:',
+            '      - GIT_USER_NAME',
+            '      - GIT_USER_EMAIL',
+            '      - SANDSTORM_PROJECT',
+            '      - SANDSTORM_STACK_ID',
+            '    volumes:',
+            '      - ${SANDSTORM_WORKSPACE}:/app',
+            '      - /var/run/docker.sock:/var/run/docker.sock',
+            '    healthcheck:',
+            '      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]',
+            '      interval: 3s',
+            '      timeout: 2s',
+            '      retries: 60',
+            '    tty: true',
+            '    stdin_open: true',
+            '',
+          ].join('\n'),
+        );
+      }
 
       // Generate verify.sh based on project files (shared auto-detection)
       const verifyLines = autoDetectVerifyLines(directory);
       const verifyPath = path.join(sandstormDir, 'verify.sh');
-      fs.writeFileSync(verifyPath, verifyLines.join('\n') + '\n', { mode: 0o755 });
+      if (fs.existsSync(verifyPath)) {
+        console.info('[projects:initialize] verify.sh already exists — not overwriting');
+        skippedFiles.push('verify.sh');
+      } else {
+        fs.writeFileSync(verifyPath, verifyLines.join('\n') + '\n', { mode: 0o755 });
+      }
 
       // Generate spec quality gate with default criteria
       saveSpecQualityGate(directory, getDefaultSpecQualityGate());
 
-      return { success: true };
+      return { success: true, skippedFiles: skippedFiles.length > 0 ? skippedFiles : undefined };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { success: false, error: `Failed to create .sandstorm config: ${msg}` };
@@ -431,9 +442,13 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       try {
         const sandstormDir = path.join(directory, '.sandstorm');
 
-        // Save verify.sh
+        // Save verify.sh — only write if it doesn't already exist; the migration
+        // UI shows auto-detected content, not the existing file, so overwriting
+        // here would silently destroy user customizations.
         const verifyPath = path.join(sandstormDir, 'verify.sh');
-        fs.writeFileSync(verifyPath, verifyScript, { mode: 0o755 });
+        if (!fs.existsSync(verifyPath)) {
+          fs.writeFileSync(verifyPath, verifyScript, { mode: 0o755 });
+        }
 
         // Ensure spec quality gate exists
         ensureSpecQualityGate(directory);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,7 +7,7 @@ export interface SandstormAPI {
     remove: (id: number) => Promise<void>;
     browse: () => Promise<string | null>;
     checkInit: (directory: string) => Promise<{ state: 'uninitialized' | 'partial' | 'full' }>;
-    initialize: (directory: string) => Promise<{ success: boolean; error?: string }>;
+    initialize: (directory: string) => Promise<{ success: boolean; error?: string; skippedFiles?: string[] }>;
     checkMigration: (directory: string) => Promise<{
       needsMigration: boolean;
       missingVerifyScript?: boolean;

--- a/src/renderer/components/UninitializedProject.tsx
+++ b/src/renderer/components/UninitializedProject.tsx
@@ -5,6 +5,7 @@ export function UninitializedProject({ project }: { project: Project }) {
   const [initializing, setInitializing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
+  const [skippedFiles, setSkippedFiles] = useState<string[]>([]);
 
   const handleInitialize = async () => {
     setInitializing(true);
@@ -12,6 +13,7 @@ export function UninitializedProject({ project }: { project: Project }) {
     try {
       const result = await window.sandstorm.projects.initialize(project.directory);
       if (result.success) {
+        setSkippedFiles(result.skippedFiles ?? []);
         setInitialized(true);
       } else {
         setError(result.error || 'Initialization failed');
@@ -33,6 +35,16 @@ export function UninitializedProject({ project }: { project: Project }) {
         </div>
         <p className="text-sm font-medium text-sandstorm-text mb-1">Sandstorm initialized!</p>
         <p className="text-xs text-sandstorm-muted">You can now create stacks for this project.</p>
+        {skippedFiles.length > 0 && (
+          <div className="mt-4 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5 max-w-xs">
+            <p className="font-medium mb-1">Some files already existed and were not overwritten:</p>
+            <ul className="list-disc list-inside space-y-0.5">
+              {skippedFiles.map((f) => (
+                <li key={f} className="font-mono">{f}</li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -383,7 +383,7 @@ declare global {
         remove: (id: number) => Promise<void>;
         browse: () => Promise<string | null>;
         checkInit: (directory: string) => Promise<{ state: 'uninitialized' | 'partial' | 'full' }>;
-        initialize: (directory: string) => Promise<{ success: boolean; error?: string }>;
+        initialize: (directory: string) => Promise<{ success: boolean; error?: string; skippedFiles?: string[] }>;
         checkMigration: (directory: string) => Promise<{
           needsMigration: boolean;
           missingVerifyScript?: boolean;

--- a/tests/unit/components/UninitializedProject.test.tsx
+++ b/tests/unit/components/UninitializedProject.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { UninitializedProject } from '../../../src/renderer/components/UninitializedProject';
+import { mockSandstormApi } from './setup';
+
+const project = { id: 1, name: 'myproject', directory: '/my/project', added_at: '' };
+
+describe('UninitializedProject', () => {
+  let api: ReturnType<typeof mockSandstormApi>;
+
+  beforeEach(() => {
+    api = mockSandstormApi();
+  });
+
+  it('renders the initialize button initially', () => {
+    render(<UninitializedProject project={project} />);
+    expect(screen.getByText('Initialize Sandstorm')).toBeDefined();
+  });
+
+  it('shows success state after successful initialization with no skipped files', async () => {
+    api.projects.initialize.mockResolvedValue({ success: true });
+    render(<UninitializedProject project={project} />);
+
+    fireEvent.click(screen.getByText('Initialize Sandstorm'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sandstorm initialized!')).toBeDefined();
+    });
+    expect(screen.queryByText(/already existed/)).toBeNull();
+  });
+
+  it('shows skipped files notice when initialization skips pre-existing files', async () => {
+    api.projects.initialize.mockResolvedValue({
+      success: true,
+      skippedFiles: ['verify.sh', 'docker-compose.yml'],
+    });
+    render(<UninitializedProject project={project} />);
+
+    fireEvent.click(screen.getByText('Initialize Sandstorm'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sandstorm initialized!')).toBeDefined();
+    });
+    expect(screen.getByText(/already existed and were not overwritten/)).toBeDefined();
+    expect(screen.getByText('verify.sh')).toBeDefined();
+    expect(screen.getByText('docker-compose.yml')).toBeDefined();
+  });
+
+  it('does not show skipped files notice when skippedFiles is empty', async () => {
+    api.projects.initialize.mockResolvedValue({ success: true, skippedFiles: [] });
+    render(<UninitializedProject project={project} />);
+
+    fireEvent.click(screen.getByText('Initialize Sandstorm'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sandstorm initialized!')).toBeDefined();
+    });
+    expect(screen.queryByText(/already existed/)).toBeNull();
+  });
+
+  it('shows error message when initialization fails', async () => {
+    api.projects.initialize.mockResolvedValue({ success: false, error: 'Permission denied' });
+    render(<UninitializedProject project={project} />);
+
+    fireEvent.click(screen.getByText('Initialize Sandstorm'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Permission denied')).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -607,6 +607,134 @@ describe('IPC Handlers', () => {
         // Cleanup
         fs.rmSync(tmpDir, { recursive: true, force: true });
       });
+
+      describe('overwrite guard — fallback path (no project compose file)', () => {
+        let tmpDir: string;
+
+        beforeEach(() => {
+          tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-init-guard-'));
+          // Ensure .sandstorm/ exists so the fallback can be exercised
+          fs.mkdirSync(path.join(tmpDir, '.sandstorm', 'stacks'), { recursive: true });
+        });
+
+        afterEach(() => {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        /** Trigger the fallback by simulating a CLI failure on a dir with no project compose file */
+        async function runFallback(dir: string) {
+          const child = new EventEmitter();
+          const stdout = new EventEmitter();
+          const stderr = new EventEmitter();
+          Object.assign(child, { stdout, stderr, stdin: null });
+          mockSpawn.mockReturnValue(child);
+
+          const promise = invokeHandler('projects:initialize', dir);
+          child.emit('close', 1); // CLI fails → fallback runs
+          return promise;
+        }
+
+        it('does not overwrite an existing verify.sh', async () => {
+          const verifyPath = path.join(tmpDir, '.sandstorm', 'verify.sh');
+          const originalContent = '#!/bin/bash\nsandstorm-exec app bunx jest\n';
+          fs.writeFileSync(verifyPath, originalContent, { mode: 0o755 });
+
+          const result = await runFallback(tmpDir);
+
+          expect(result).toMatchObject({ success: true });
+          expect(fs.readFileSync(verifyPath, 'utf-8')).toBe(originalContent);
+        });
+
+        it('reports skippedFiles when verify.sh already exists', async () => {
+          const verifyPath = path.join(tmpDir, '.sandstorm', 'verify.sh');
+          fs.writeFileSync(verifyPath, '#!/bin/bash\necho hi\n', { mode: 0o755 });
+
+          const result = (await runFallback(tmpDir)) as { success: boolean; skippedFiles?: string[] };
+
+          expect(result.success).toBe(true);
+          expect(result.skippedFiles).toContain('verify.sh');
+        });
+
+        it('does not overwrite an existing docker-compose.yml', async () => {
+          const composePath = path.join(tmpDir, '.sandstorm', 'docker-compose.yml');
+          const originalContent = 'services:\n  myservice:\n    image: myimage\n';
+          fs.writeFileSync(composePath, originalContent);
+
+          const result = await runFallback(tmpDir);
+
+          expect(result).toMatchObject({ success: true });
+          expect(fs.readFileSync(composePath, 'utf-8')).toBe(originalContent);
+        });
+
+        it('reports skippedFiles when docker-compose.yml already exists', async () => {
+          const composePath = path.join(tmpDir, '.sandstorm', 'docker-compose.yml');
+          fs.writeFileSync(composePath, 'services: {}');
+
+          const result = (await runFallback(tmpDir)) as { success: boolean; skippedFiles?: string[] };
+
+          expect(result.success).toBe(true);
+          expect(result.skippedFiles).toContain('docker-compose.yml');
+        });
+
+        it('writes verify.sh when it does not exist', async () => {
+          const verifyPath = path.join(tmpDir, '.sandstorm', 'verify.sh');
+          expect(fs.existsSync(verifyPath)).toBe(false);
+
+          const result = await runFallback(tmpDir);
+
+          expect(result).toMatchObject({ success: true });
+          expect(fs.existsSync(verifyPath)).toBe(true);
+          const skipped = (result as { skippedFiles?: string[] }).skippedFiles ?? [];
+          expect(skipped).not.toContain('verify.sh');
+        });
+
+        it('writes docker-compose.yml when it does not exist', async () => {
+          const composePath = path.join(tmpDir, '.sandstorm', 'docker-compose.yml');
+          expect(fs.existsSync(composePath)).toBe(false);
+
+          const result = await runFallback(tmpDir);
+
+          expect(result).toMatchObject({ success: true });
+          expect(fs.existsSync(composePath)).toBe(true);
+          const skipped = (result as { skippedFiles?: string[] }).skippedFiles ?? [];
+          expect(skipped).not.toContain('docker-compose.yml');
+        });
+      });
+    });
+
+    describe('projects:saveMigration', () => {
+      let tmpDir: string;
+
+      beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-migration-test-'));
+        fs.mkdirSync(path.join(tmpDir, '.sandstorm'), { recursive: true });
+      });
+
+      afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      });
+
+      it('does not overwrite an existing verify.sh', async () => {
+        const verifyPath = path.join(tmpDir, '.sandstorm', 'verify.sh');
+        const originalContent = '#!/bin/bash\nsandstorm-exec app npm test\n';
+        fs.writeFileSync(verifyPath, originalContent, { mode: 0o755 });
+
+        const result = await invokeHandler('projects:saveMigration', tmpDir, '#!/bin/bash\necho replaced\n', {});
+
+        expect(result).toMatchObject({ success: true });
+        expect(fs.readFileSync(verifyPath, 'utf-8')).toBe(originalContent);
+      });
+
+      it('writes verify.sh when it does not exist', async () => {
+        const verifyPath = path.join(tmpDir, '.sandstorm', 'verify.sh');
+        expect(fs.existsSync(verifyPath)).toBe(false);
+
+        const newContent = '#!/bin/bash\necho ok\n';
+        const result = await invokeHandler('projects:saveMigration', tmpDir, newContent, {});
+
+        expect(result).toMatchObject({ success: true });
+        expect(fs.readFileSync(verifyPath, 'utf-8')).toBe(newContent);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #251.

## The bug

`projects:initialize` (and `projects:saveMigration`) were writing `.sandstorm/verify.sh` and `.sandstorm/docker-compose.yml` **unconditionally** — no existence check, no backup, no prompt. Any user-customized verify script (with real test/lint/build commands) would be silently replaced with the auto-detected stub on re-init, producing a silent false-green verify: the stack appears to pass because nothing is actually being run.

Because `.sandstorm/` is commonly gitignored, there's no recovery path once the overwrite happens.

## The fix — minimum acceptable from the ticket: `existsSync` guard + UI notice

### `src/main/ipc.ts`
- `projects:initialize` fallback now checks `fs.existsSync` before writing either `verify.sh` or `docker-compose.yml`. Pre-existing files are preserved and logged.
- Handler returns a `skippedFiles: string[]` field naming which files were preserved.
- `projects:saveMigration` now also guards `verify.sh` — the migration UI shows auto-detected content, not the live file, so a naive write would destroy user customizations.

### `sandstorm-cli/lib/init.sh`
- Belt-and-suspenders: the CLI counterpart now skips `verify.sh` if it exists, even though the outer config-gating should normally prevent re-entry.

### IPC contract
- `src/preload/index.ts` and `src/renderer/store.ts` updated to include `skippedFiles?: string[]` in the `initialize` return type.

### UI notice
- `UninitializedProject.tsx` now displays an amber callout listing any preserved files, so the user knows their customizations weren't clobbered.

## Tests

- `tests/unit/ipc-handlers.test.ts` — 8 new tests covering the fallback path guards:
  - Pre-existing `verify.sh` / `docker-compose.yml` are not overwritten
  - `skippedFiles` correctly reports each preserved file
  - Missing files are still written (guard is per-file, not batched)
  - `projects:saveMigration` preserves existing verify.sh
- `tests/unit/components/UninitializedProject.test.tsx` (new file) — renderer test for the skipped-files UI notice

## Pre-existing test failures (not introduced by this PR)

Surfaced by a separate diagnostic run on a clean branch:
- 6 failures in `tests/unit/integration-xvfb.test.ts` — test assertions on `.sandstorm/verify.sh` contents (which is gitignored and machine-specific)
- Build failure: `src/renderer/App.tsx` imports missing `./build-version.txt?raw`

These predate this PR and are environmental/build-setup issues unrelated to the overwrite guard. They will be tracked separately.

## Test plan

- [ ] Fresh init: verify.sh and docker-compose.yml created as expected, no skip notice
- [ ] Customize verify.sh, re-trigger initialize: file contents preserved unchanged, UI shows skip notice listing verify.sh
- [ ] Same flow for docker-compose.yml
- [ ] Save migration with existing verify.sh: existing file not overwritten
- [ ] New tests pass: `npm test tests/unit/ipc-handlers.test.ts tests/unit/components/UninitializedProject.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)