### PR TITLE
Restrict orchestrator Claude to a tools allowlist (#256)

### DIFF
--- a/sandstorm-cli/SANDSTORM_OUTER.md
+++ b/sandstorm-cli/SANDSTORM_OUTER.md
@@ -23,6 +23,10 @@ You CAN plan, discuss, research, and collaborate with the user. When it's time t
 
 **You do NOT read application code to plan.** The host repo may be on any branch — reading it for planning leads to wrong-branch contamination. All code exploration happens inside the stack.
 
+## Built-in Tool Allowlist
+
+You have a **restricted** set of Claude Code built-in tools: `Bash`, `Read`, `Grep`, `Glob`. Every other built-in (`Edit`, `Write`, `MultiEdit`, `NotebookEdit`, `Agent`, `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`/`TaskStop`/`TaskOutput`, `WebFetch`, `WebSearch`, `LSP`) is **denied**. Do not attempt to call them — they are not available. Code changes happen inside stacks via MCP (`create_stack`, `dispatch_task`, etc.); web research, if needed, happens inside the stack too.
+
 ---
 
 ## Command Reference

--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -23,6 +23,7 @@ import {
   StackInfo,
   zeroSessionTokens,
 } from './types';
+import { resolveOuterClaudeTools } from './tools-allowlist';
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — must be longer than MCP tool chain (300s ephemeral + 310s bridge)
 
@@ -674,6 +675,10 @@ rl.on('line', async (line) => {
       '--input-format', 'stream-json',
       '--output-format', 'stream-json',
       '--dangerously-skip-permissions',
+      // Restrict the orchestrator to an allowlist of built-in tools. Every
+      // denied tool's schema drops out of the context the CLI re-sends on
+      // every turn — the single largest static-bloat lever per #254. #256.
+      '--tools', resolveOuterClaudeTools(session.projectDir).join(','),
     ];
 
     if (fs.existsSync(systemPromptFile)) {

--- a/src/main/agent/tools-allowlist.ts
+++ b/src/main/agent/tools-allowlist.ts
@@ -1,0 +1,53 @@
+/**
+ * Outer Claude tools allowlist (#256).
+ *
+ * Pure, electron-free module. The logic here is exercised via unit tests
+ * against a real temp filesystem — do not import electron from this file.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Default allowlist of Claude Code built-in tools that the outer orchestrator
+ * is allowed to invoke. Everything else (Edit, Write, Agent, Task*, WebFetch,
+ * WebSearch, LSP, NotebookEdit, MultiEdit, etc.) is denied by omission — the
+ * outer Claude's job is to delegate to stacks via MCP, not to edit code or
+ * fetch the web itself. Denying them strips their schemas from the context
+ * re-sent on every outer turn.
+ */
+export const DEFAULT_OUTER_CLAUDE_TOOLS: readonly string[] = Object.freeze([
+  'Bash',
+  'Read',
+  'Grep',
+  'Glob',
+]);
+
+/**
+ * Resolve the effective tool allowlist for the outer orchestrator.
+ * A project can override via `.sandstorm/context/settings.json`:
+ *   { "outerClaudeTools": ["Bash", "Read", "Edit"] }
+ * The override must be a non-empty array of non-empty strings; anything
+ * else (malformed JSON, missing file, missing key, wrong type, empty array,
+ * non-string entries) falls back to the default.
+ */
+export function resolveOuterClaudeTools(projectDir?: string): string[] {
+  if (projectDir) {
+    const settingsPath = path.join(projectDir, '.sandstorm', 'context', 'settings.json');
+    try {
+      const raw = fs.readFileSync(settingsPath, 'utf-8');
+      const parsed = JSON.parse(raw) as { outerClaudeTools?: unknown };
+      const override = parsed?.outerClaudeTools;
+      if (
+        Array.isArray(override) &&
+        override.length > 0 &&
+        override.every((t): t is string => typeof t === 'string' && t.length > 0)
+      ) {
+        return [...override];
+      }
+    } catch {
+      // File missing / malformed / non-parseable → fall through to defaults
+    }
+  }
+  return [...DEFAULT_OUTER_CLAUDE_TOOLS];
+}

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -549,6 +549,79 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
     });
   });
 
+  describe('--tools allowlist (#256)', () => {
+    it('passes --tools with the default allowlist (comma-separated)', async () => {
+      const { spawn } = await import('child_process');
+      const spawnMock = spawn as ReturnType<typeof vi.fn>;
+      spawnMock.mockClear();
+
+      backend.sendMessage('tab-tools-default', 'hello', '/tmp');
+
+      const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+      const toolsIdx = spawnedArgs.indexOf('--tools');
+      expect(toolsIdx).toBeGreaterThan(-1);
+      expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob');
+    });
+
+    it('places --tools before --system-prompt-file and --mcp-config', async () => {
+      const { spawn } = await import('child_process');
+      const spawnMock = spawn as ReturnType<typeof vi.fn>;
+      spawnMock.mockClear();
+
+      backend.sendMessage('tab-tools-order', 'hello', '/tmp');
+
+      const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+      const toolsIdx = spawnedArgs.indexOf('--tools');
+      const mcpIdx = spawnedArgs.indexOf('--mcp-config');
+      expect(toolsIdx).toBeGreaterThan(-1);
+      expect(mcpIdx).toBeGreaterThan(-1);
+      // --tools comes before --mcp-config so it lives in the stable prefix
+      // that cache-hits turn-to-turn.
+      expect(toolsIdx).toBeLessThan(mcpIdx);
+    });
+
+    it('does not include denied tools in the --tools arg', async () => {
+      const { spawn } = await import('child_process');
+      const spawnMock = spawn as ReturnType<typeof vi.fn>;
+      spawnMock.mockClear();
+
+      backend.sendMessage('tab-tools-deny', 'hello', '/tmp');
+
+      const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+      const toolsArg = spawnedArgs[spawnedArgs.indexOf('--tools') + 1];
+      for (const denied of [
+        'Edit',
+        'Write',
+        'MultiEdit',
+        'NotebookEdit',
+        'Agent',
+        'TaskCreate',
+        'TaskUpdate',
+        'TaskList',
+        'TaskGet',
+        'TaskStop',
+        'TaskOutput',
+        'WebFetch',
+        'WebSearch',
+        'LSP',
+      ]) {
+        expect(toolsArg).not.toContain(denied);
+      }
+    });
+
+    it('falls back to defaults when no projectDir is given', async () => {
+      const { spawn } = await import('child_process');
+      const spawnMock = spawn as ReturnType<typeof vi.fn>;
+      spawnMock.mockClear();
+
+      backend.sendMessage('tab-tools-noproj', 'hello');
+
+      const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+      const toolsIdx = spawnedArgs.indexOf('--tools');
+      expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob');
+    });
+  });
+
   describe('initLogger error handling', () => {
     it('does not throw when createWriteStream fails', () => {
       expect(() => new ClaudeBackend(1000)).not.toThrow();

--- a/tests/unit/resolve-outer-claude-tools.test.ts
+++ b/tests/unit/resolve-outer-claude-tools.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  resolveOuterClaudeTools,
+  DEFAULT_OUTER_CLAUDE_TOOLS,
+} from '../../src/main/agent/tools-allowlist';
+
+/**
+ * Pure-function tests for resolveOuterClaudeTools (#256). Uses a real temp
+ * directory so there is no need to mock `fs` or `electron` — the helper
+ * lives in an electron-free module on purpose.
+ */
+describe('resolveOuterClaudeTools (#256)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandstorm-tools-resolve-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSettings(content: string): void {
+    const dir = path.join(tmpDir, '.sandstorm', 'context');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'settings.json'), content, 'utf-8');
+  }
+
+  it('default allowlist is exactly Bash, Read, Grep, Glob', () => {
+    expect([...DEFAULT_OUTER_CLAUDE_TOOLS]).toEqual(['Bash', 'Read', 'Grep', 'Glob']);
+  });
+
+  it('returns the default allowlist when no projectDir is provided', () => {
+    expect(resolveOuterClaudeTools()).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('returns defaults when the project has no .sandstorm/context/settings.json', () => {
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('returns the override when settings.json has a valid outerClaudeTools array', () => {
+    writeSettings(JSON.stringify({ outerClaudeTools: ['Bash', 'Read'] }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual(['Bash', 'Read']);
+  });
+
+  it('returns the override with a single tool', () => {
+    writeSettings(JSON.stringify({ outerClaudeTools: ['Bash'] }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual(['Bash']);
+  });
+
+  it('falls back to defaults when settings.json is malformed JSON', () => {
+    writeSettings('{ not valid json');
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('falls back to defaults when outerClaudeTools is not an array', () => {
+    writeSettings(JSON.stringify({ outerClaudeTools: 'Bash,Read' }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('falls back to defaults when outerClaudeTools is an empty array', () => {
+    writeSettings(JSON.stringify({ outerClaudeTools: [] }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('falls back to defaults when outerClaudeTools contains non-string entries', () => {
+    writeSettings(JSON.stringify({ outerClaudeTools: ['Bash', 42, null] }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('falls back to defaults when outerClaudeTools contains empty strings', () => {
+    writeSettings(JSON.stringify({ outerClaudeTools: ['Bash', ''] }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('falls back to defaults when settings.json has no outerClaudeTools key', () => {
+    writeSettings(JSON.stringify({ unrelated: 'value' }));
+    expect(resolveOuterClaudeTools(tmpDir)).toEqual([...DEFAULT_OUTER_CLAUDE_TOOLS]);
+  });
+
+  it('default list is frozen so the exported reference cannot be mutated', () => {
+    expect(Object.isFrozen(DEFAULT_OUTER_CLAUDE_TOOLS)).toBe(true);
+  });
+
+  it('returns a new array each call (callers may mutate the result without side-effects)', () => {
+    const a = resolveOuterClaudeTools();
+    const b = resolveOuterClaudeTools();
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+    expect(() => a.push('X')).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #256.

## Summary

Pass `--tools` to the outer Claude CLI so only the built-in tools the orchestrator actually uses ship as schemas each turn.

**Default allowlist:** `Bash, Read, Grep, Glob`.

**Denied by omission** (never called by the orchestrator per SANDSTORM_OUTER.md): `Edit, Write, MultiEdit, NotebookEdit, Agent, TaskCreate, TaskUpdate, TaskList, TaskGet, TaskStop, TaskOutput, WebFetch, WebSearch, LSP`.

**Per-project override** via `.sandstorm/context/settings.json`:
```json
{ "outerClaudeTools": ["Bash", "Read", "Edit"] }
```
Override must be a non-empty array of non-empty strings; anything else falls back to the default (malformed JSON, wrong type, empty array, non-string entries, missing key, missing file).

## Changes

- **`src/main/agent/tools-allowlist.ts`** (new) — pure, electron-free module exporting `DEFAULT_OUTER_CLAUDE_TOOLS` and `resolveOuterClaudeTools(projectDir?)`. Kept separate from `claude-backend.ts` so the tests can exercise it against a real temp filesystem without any `vi.mock('electron')` / `vi.mock('fs')` shims.
- **`src/main/agent/claude-backend.ts`** — imports from the new module and pushes `--tools <comma-list>` into `ensureProcess`'s args immediately after `--dangerously-skip-permissions`. The allowlist sits in the stable cacheable prefix of every turn so cache hits carry it.
- **`sandstorm-cli/SANDSTORM_OUTER.md`** — new "Built-in Tool Allowlist" section tells the model exactly which tools it has and which are denied, to prevent wasted tool-call turns.

## Tests

- **`tests/unit/resolve-outer-claude-tools.test.ts`** (new, 13 tests) — default allowlist, override, malformed JSON, wrong type, empty array, non-string entries, empty strings, missing key, missing file, missing projectDir, frozen-default.
- **`tests/unit/claude-backend.test.ts`** — 3 new assertions in a `--tools allowlist (#256)` describe block:
  - `--tools` is passed with the default allowlist `Bash,Read,Grep,Glob`.
  - `--tools` appears before `--mcp-config` in the args (stable prefix).
  - Denied tools are not in the `--tools` arg.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm test` — 1406 pass, 6 pre-existing `integration-xvfb.test.ts` failures unrelated to this PR (same count as main).
- [ ] Manual smoke checklist (requires a running desktop app; flagged here so you can run through in-product):
  - [ ] List stacks / get diff / get status (read-only flow) still works.
  - [ ] `create_stack` → `dispatch_task` → `get_task_status` still works.
  - [ ] `sandstorm push` still runs via Bash.
  - [ ] `gh pr create` still runs via Bash.
  - [ ] `spec_check` + `spec_refine` MCP tools still work.
  - [ ] Model does not attempt `Edit`, `Write`, or `Agent` calls (or if it does, the CLI cleanly reports the tool is unavailable).

## Out of scope

- MCP tool-response reshaping (#255).
- Prompt-cache cold-start mitigation (#257).
- Trimming the `SANDSTORM_OUTER.md` body itself (near-threshold; bundled naturally with this PR only if it fits, not required by #256).

Refs #254.