### PR TITLE
Per-turn token telemetry for outer Claude (#262 tactic A)

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -24,6 +24,7 @@ import {
   zeroSessionTokens,
 } from './types';
 import { resolveOuterClaudeTools } from './tools-allowlist';
+import { TokenTelemetry, isTelemetryEnabled } from './token-telemetry';
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — must be longer than MCP tool chain (300s ephemeral + 310s bridge)
 
@@ -41,6 +42,8 @@ interface ClaudeSession {
   stderrBuffer: string;
   cancelledTurn: boolean;   // true when the user cancelled the current turn (process kept alive)
   cancelFallback: ReturnType<typeof setTimeout> | null; // fallback kill timer after cancel
+  turnIndex: number;            // 0-based index of completed turns in this session
+  lastResultAt: number | null;  // Date.now() of the previous `type:"result"` event, for telemetry deltas
 }
 
 function getClaudeBin(): string {
@@ -81,6 +84,7 @@ export class ClaudeBackend implements AgentBackend {
   private logStream: fs.WriteStream | null = null;
   private timeoutMs: number;
   private modelResolver?: (projectDir: string) => string;
+  private telemetry: TokenTelemetry;
 
   constructor(
     timeoutMs?: number,
@@ -90,6 +94,24 @@ export class ClaudeBackend implements AgentBackend {
     this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.modelResolver = modelResolver;
     this.initLogger();
+    this.telemetry = this.initTelemetry();
+  }
+
+  /**
+   * Opt-in per-turn token telemetry (#262 tactic A). Off unless
+   * `SANDSTORM_TOKEN_TELEMETRY=1` is set. Writes JSONL to the app's userData
+   * dir so it sits next to the existing claude log.
+   */
+  private initTelemetry(): TokenTelemetry {
+    const enabled = isTelemetryEnabled();
+    let filePath = '';
+    try {
+      const dir = typeof app !== 'undefined' && app.getPath ? app.getPath('userData') : os.tmpdir();
+      filePath = path.join(dir, 'sandstorm-desktop-token-telemetry.jsonl');
+    } catch {
+      filePath = path.join(os.tmpdir(), 'sandstorm-desktop-token-telemetry.jsonl');
+    }
+    return new TokenTelemetry({ filePath, enabled });
   }
 
   getSessionTokens(tabId: string): OuterClaudeSessionTokens {
@@ -304,6 +326,8 @@ rl.on('line', async (line) => {
         stderrBuffer: '',
         cancelledTurn: false,
         cancelFallback: null,
+        turnIndex: 0,
+        lastResultAt: null,
       };
       this.sessions.set(tabId, session);
     }
@@ -781,6 +805,30 @@ rl.on('line', async (line) => {
                   prev.cache_read_input_tokens + (usage.cache_read_input_tokens ?? 0),
               });
               this.emitSessionTokens(tabId);
+
+              // Per-turn telemetry (#262 tactic A). No-op when the opt-in
+              // env flag is off. Measurement lands first so later tactics
+              // have a baseline.
+              if (this.telemetry.active) {
+                const now = Date.now();
+                const secondsSincePrev =
+                  session.lastResultAt === null
+                    ? null
+                    : (now - session.lastResultAt) / 1000;
+                this.telemetry.record({
+                  ts: new Date(now).toISOString(),
+                  tabId,
+                  projectDir: session.projectDir,
+                  turn_index: session.turnIndex,
+                  seconds_since_prev_turn: secondsSincePrev,
+                  input_tokens: usage.input_tokens ?? 0,
+                  output_tokens: usage.output_tokens ?? 0,
+                  cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+                  cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+                });
+              }
+              session.turnIndex += 1;
+              session.lastResultAt = Date.now();
             }
 
             if (session.fullResponse) {
@@ -914,6 +962,7 @@ rl.on('line', async (line) => {
     this.bridgeServer?.close();
     this.logStream?.end();
     this.logStream = null;
+    this.telemetry.close();
     if (this.mcpConfigPath) {
       const tmpDir = path.dirname(this.mcpConfigPath);
       try {

--- a/src/main/agent/token-telemetry.ts
+++ b/src/main/agent/token-telemetry.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-turn token telemetry for the outer Claude orchestrator (#262 tactic A).
+ *
+ * Pure, electron-free module. Writes JSON Lines to a caller-supplied path so
+ * tests can target a temp file without any mocking. The production wiring
+ * lives in claude-backend.ts.
+ *
+ * Schema (one line per completed turn):
+ *   {
+ *     "ts": ISO-8601,
+ *     "tabId": string,
+ *     "projectDir": string | undefined,
+ *     "turn_index": number (0-based within a session),
+ *     "seconds_since_prev_turn": number | null (null on the first turn),
+ *     "input_tokens": number,
+ *     "output_tokens": number,
+ *     "cache_creation_input_tokens": number,
+ *     "cache_read_input_tokens": number
+ *   }
+ *
+ * Off by default. Opt in with the env var `SANDSTORM_TOKEN_TELEMETRY=1`.
+ */
+
+import { appendFileSync } from 'fs';
+
+export interface TokenTelemetryEvent {
+  ts: string;
+  tabId: string;
+  projectDir?: string;
+  turn_index: number;
+  seconds_since_prev_turn: number | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+}
+
+export interface TokenTelemetryOptions {
+  /** Absolute path to the JSONL sink. */
+  filePath: string;
+  /** When false, `record()` is a no-op. */
+  enabled: boolean;
+}
+
+export class TokenTelemetry {
+  private enabled: boolean;
+  private readonly filePath: string;
+
+  constructor(opts: TokenTelemetryOptions) {
+    this.enabled = opts.enabled;
+    this.filePath = opts.filePath;
+  }
+
+  /** True when telemetry is accepting records (not disabled, not marked dead). */
+  get active(): boolean {
+    return this.enabled;
+  }
+
+  record(event: TokenTelemetryEvent): void {
+    if (!this.enabled) return;
+    try {
+      appendFileSync(this.filePath, JSON.stringify(event) + '\n');
+    } catch {
+      // Best effort — if the sink becomes unwritable, disable rather than
+      // letting telemetry failures break the orchestrator.
+      this.enabled = false;
+    }
+  }
+
+  /** Stop accepting further records. Subsequent `record()` calls are no-ops. */
+  close(): void {
+    this.enabled = false;
+  }
+}
+
+/**
+ * Read the telemetry opt-in flag from an environment bag. Default off — the
+ * flag must be explicitly set to `1` to enable. Any other value (including
+ * `true`, `yes`, etc.) is ignored to keep the contract precise.
+ */
+export function isTelemetryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.SANDSTORM_TOKEN_TELEMETRY === '1';
+}

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -65,6 +65,7 @@ vi.mock('fs', async (importOriginal) => {
     existsSync: vi.fn().mockReturnValue(false),
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
+    appendFileSync: vi.fn(),
     readFileSync: vi.fn().mockImplementation(() => {
       throw new Error('File not found');
     }),
@@ -685,6 +686,95 @@ describe('Watchdog timeout is longer than MCP tool chain', () => {
     const timeoutMs = (backend as unknown as { timeoutMs: number }).timeoutMs;
     expect(timeoutMs).toBe(600_000);
     expect(timeoutMs).toBeGreaterThan(310_000); // Must exceed bridge timeout
+    backend.destroy();
+  });
+});
+
+describe('Token telemetry wiring (#262 tactic A)', () => {
+  let origFlag: string | undefined;
+
+  beforeEach(() => {
+    origFlag = process.env.SANDSTORM_TOKEN_TELEMETRY;
+  });
+
+  afterEach(() => {
+    if (origFlag === undefined) delete process.env.SANDSTORM_TOKEN_TELEMETRY;
+    else process.env.SANDSTORM_TOKEN_TELEMETRY = origFlag;
+  });
+
+  it('does not emit telemetry appends when the flag is off', async () => {
+    delete process.env.SANDSTORM_TOKEN_TELEMETRY;
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backend = new ClaudeBackend();
+    // A full turn lifecycle — any telemetry append would happen inside the
+    // result handler. With the flag off, zero appends to the telemetry path.
+    backend.sendMessage('tel-off', 'hi', '/tmp');
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    proc.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          type: 'result',
+          result: 'ok',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 0,
+          },
+        }) + '\n'
+      )
+    );
+
+    const telemetryAppends = vi
+      .mocked(fs.appendFileSync)
+      .mock.calls.filter((c) => String(c[0]).endsWith('sandstorm-desktop-token-telemetry.jsonl'));
+    expect(telemetryAppends.length).toBe(0);
+
+    backend.destroy();
+  });
+
+  it('writes a per-turn telemetry line when the flag is on', async () => {
+    process.env.SANDSTORM_TOKEN_TELEMETRY = '1';
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backend = new ClaudeBackend();
+    backend.sendMessage('tel-on', 'hi', '/proj');
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    proc.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          type: 'result',
+          result: 'ok',
+          usage: {
+            input_tokens: 1234,
+            output_tokens: 56,
+            cache_creation_input_tokens: 28_000,
+            cache_read_input_tokens: 0,
+          },
+        }) + '\n'
+      )
+    );
+
+    const telemetryAppends = vi
+      .mocked(fs.appendFileSync)
+      .mock.calls.filter((c) => String(c[0]).endsWith('sandstorm-desktop-token-telemetry.jsonl'));
+    expect(telemetryAppends.length).toBe(1);
+    const jsonLine = telemetryAppends[0][1] as string;
+    const event = JSON.parse(jsonLine.trim());
+    expect(event.tabId).toBe('tel-on');
+    expect(event.projectDir).toBe('/proj');
+    expect(event.turn_index).toBe(0);
+    expect(event.seconds_since_prev_turn).toBeNull();
+    expect(event.input_tokens).toBe(1234);
+    expect(event.output_tokens).toBe(56);
+    expect(event.cache_creation_input_tokens).toBe(28_000);
+    expect(event.cache_read_input_tokens).toBe(0);
+
     backend.destroy();
   });
 });

--- a/tests/unit/token-telemetry.test.ts
+++ b/tests/unit/token-telemetry.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  TokenTelemetry,
+  isTelemetryEnabled,
+  type TokenTelemetryEvent,
+} from '../../src/main/agent/token-telemetry';
+
+/**
+ * Pure-function tests for #262 tactic A (per-turn token telemetry). No
+ * mocking — the module is deliberately electron-free so tests target a real
+ * temp file.
+ */
+describe('TokenTelemetry (#262 tactic A)', () => {
+  let tmpDir: string;
+  let sinkPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandstorm-token-telemetry-'));
+    sinkPath = path.join(tmpDir, 'telemetry.jsonl');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function sampleEvent(partial: Partial<TokenTelemetryEvent> = {}): TokenTelemetryEvent {
+    return {
+      ts: '2026-04-18T00:00:00.000Z',
+      tabId: 't-1',
+      projectDir: '/proj',
+      turn_index: 0,
+      seconds_since_prev_turn: null,
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_creation_input_tokens: 30000,
+      cache_read_input_tokens: 0,
+      ...partial,
+    };
+  }
+
+  function readEvents(): TokenTelemetryEvent[] {
+    if (!fs.existsSync(sinkPath)) return [];
+    return fs
+      .readFileSync(sinkPath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as TokenTelemetryEvent);
+  }
+
+  it('writes no file when disabled', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: false });
+    tel.record(sampleEvent());
+    tel.close();
+    expect(fs.existsSync(sinkPath)).toBe(false);
+    expect(tel.active).toBe(false);
+  });
+
+  it('writes one JSONL line per recorded event when enabled', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    expect(tel.active).toBe(true);
+    tel.record(sampleEvent({ turn_index: 0 }));
+    tel.record(sampleEvent({ turn_index: 1, seconds_since_prev_turn: 612 }));
+    tel.record(sampleEvent({ turn_index: 2, seconds_since_prev_turn: 15 }));
+    tel.close();
+
+    const events = readEvents();
+    expect(events).toHaveLength(3);
+    expect(events[0].turn_index).toBe(0);
+    expect(events[0].seconds_since_prev_turn).toBeNull();
+    expect(events[1].turn_index).toBe(1);
+    expect(events[1].seconds_since_prev_turn).toBe(612);
+    expect(events[2].turn_index).toBe(2);
+    expect(events[2].seconds_since_prev_turn).toBe(15);
+  });
+
+  it('preserves all token-accounting fields verbatim', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    tel.record(
+      sampleEvent({
+        input_tokens: 1234,
+        output_tokens: 56,
+        cache_creation_input_tokens: 28_000,
+        cache_read_input_tokens: 2_000,
+      })
+    );
+    tel.close();
+
+    const [event] = readEvents();
+    expect(event.input_tokens).toBe(1234);
+    expect(event.output_tokens).toBe(56);
+    expect(event.cache_creation_input_tokens).toBe(28_000);
+    expect(event.cache_read_input_tokens).toBe(2_000);
+  });
+
+  it('appends to an existing file rather than truncating', () => {
+    fs.writeFileSync(sinkPath, JSON.stringify(sampleEvent({ turn_index: 99 })) + '\n', 'utf-8');
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    tel.record(sampleEvent({ turn_index: 0 }));
+    tel.close();
+
+    const events = readEvents();
+    expect(events.length).toBe(2);
+    expect(events[0].turn_index).toBe(99);
+    expect(events[1].turn_index).toBe(0);
+  });
+
+  it('records the projectDir when set and omits it when undefined', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    tel.record(sampleEvent({ projectDir: '/abs/proj' }));
+    tel.record(sampleEvent({ projectDir: undefined }));
+    tel.close();
+
+    const events = readEvents();
+    expect(events[0].projectDir).toBe('/abs/proj');
+    expect(events[1].projectDir).toBeUndefined();
+  });
+
+  it('record after close is a no-op (no crash, no write)', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    tel.record(sampleEvent({ turn_index: 0 }));
+    tel.close();
+    expect(tel.active).toBe(false);
+    // This must not throw
+    tel.record(sampleEvent({ turn_index: 1 }));
+
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].turn_index).toBe(0);
+  });
+
+  it('gracefully handles an unwritable file path by becoming inactive', () => {
+    const unwritable = path.join(tmpDir, 'does-not-exist-dir', 'telemetry.jsonl');
+    const tel = new TokenTelemetry({ filePath: unwritable, enabled: true });
+    // First record fails internally (parent dir missing); must not throw
+    expect(() => tel.record(sampleEvent())).not.toThrow();
+    // After the first write-error the instance self-disables
+    expect(tel.active).toBe(false);
+    // Further records are also no-ops
+    expect(() => tel.record(sampleEvent())).not.toThrow();
+    expect(fs.existsSync(unwritable)).toBe(false);
+    tel.close();
+  });
+});
+
+describe('isTelemetryEnabled (#262 tactic A)', () => {
+  it('returns true when the env var is exactly "1"', () => {
+    expect(isTelemetryEnabled({ SANDSTORM_TOKEN_TELEMETRY: '1' })).toBe(true);
+  });
+
+  it('returns false when the env var is unset', () => {
+    expect(isTelemetryEnabled({})).toBe(false);
+  });
+
+  it('returns false for truthy-looking but non-"1" values', () => {
+    expect(isTelemetryEnabled({ SANDSTORM_TOKEN_TELEMETRY: 'true' })).toBe(false);
+    expect(isTelemetryEnabled({ SANDSTORM_TOKEN_TELEMETRY: 'yes' })).toBe(false);
+    expect(isTelemetryEnabled({ SANDSTORM_TOKEN_TELEMETRY: 'on' })).toBe(false);
+    expect(isTelemetryEnabled({ SANDSTORM_TOKEN_TELEMETRY: '0' })).toBe(false);
+    expect(isTelemetryEnabled({ SANDSTORM_TOKEN_TELEMETRY: '' })).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements tactic **A** (measurement instrumentation) from #262. This is the "land first" item per the #257 investigation — the baseline for evaluating every later cache-cold mitigation.

## Summary

Off by default. Opt in with `SANDSTORM_TOKEN_TELEMETRY=1`. Each completed outer turn appends one JSON line to `<userData>/sandstorm-desktop-token-telemetry.jsonl`:

```json
{
  "ts": "2026-04-18T00:00:00.000Z",
  "tabId": "t-1",
  "projectDir": "/abs/path",
  "turn_index": 3,
  "seconds_since_prev_turn": 612,
  "input_tokens": 1234,
  "output_tokens": 56,
  "cache_creation_input_tokens": 28000,
  "cache_read_input_tokens": 0
}
```

`seconds_since_prev_turn > 300` **and** `cache_creation_input_tokens > 0` on the same line is the definitive cache cold-start signal. Run a representative session, grep for that combination, sum the `cache_creation` tokens — that's your baseline.

## How to use it

```
SANDSTORM_TOKEN_TELEMETRY=1 ./sandstorm-desktop    # or however the app is launched
# drive the orchestrator through a real workflow
cat ~/.config/sandstorm-desktop/sandstorm-desktop-token-telemetry.jsonl | jq
```

File path resolves via Electron's `app.getPath('userData')`. Falls back to `/tmp` if the app path is unavailable.

## Changes

- **`src/main/agent/token-telemetry.ts`** (new) — pure, electron-free module exporting `TokenTelemetry`, `TokenTelemetryEvent`, `TokenTelemetryOptions`, and `isTelemetryEnabled(env?)`. Synchronous appends via `fs.appendFileSync` (named import so vi.mock('fs') factories in test files reliably capture the calls). Self-disables on first write error — telemetry failures never break the orchestrator.
- **`src/main/agent/claude-backend.ts`** — constructor initializes a `TokenTelemetry` instance for `<userData>/sandstorm-desktop-token-telemetry.jsonl`. `ClaudeSession` gains `turnIndex` and `lastResultAt` fields. The `type:"result"` handler records one event immediately after updating running token totals. `destroy()` closes the sink.
- **`tests/unit/token-telemetry.test.ts`** (new, 10 tests) — real temp-file tests, no mocking: disabled no-op, enabled write-per-record, field-fidelity, append-mode (preserves existing rows), `projectDir` optionality, record-after-close is a no-op, self-disable on unwritable path, `isTelemetryEnabled` env-var parsing (exact `'1'` only — `'true'` / `'yes'` / `'on'` / `'0'` all false).
- **`tests/unit/claude-backend.test.ts`** — 2 new integration tests wire the flag through to an `appendFileSync` assertion against a full `type:"result"` event. `appendFileSync` added to the fs mock list.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm test` — 1426 pass, 6 pre-existing `integration-xvfb.test.ts` failures unrelated to this PR (same count as main).
- [x] 12 new tests all pass.
- [ ] Manual: run the app with `SANDSTORM_TOKEN_TELEMETRY=1`, drive a 5-turn orchestrator session with a > 5-min idle gap, inspect the JSONL and confirm the shape matches the summary above.

## Out of scope (deferred to the rest of #262)

- Harness-side task completion wake-up (tactic B).
- Focus-gated user-gesture heartbeat (tactic C).
- Extended-TTL cache control opt-in (tactic D).
- Composition attribution / UI / inner-Claude telemetry — that's #259.

Refs #254, #257, #262, #259.