### PR TITLE
Sub-turn instrumentation: surface API-call count + tool sizes per cycle (#262)

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -24,7 +24,12 @@ import {
   zeroSessionTokens,
 } from './types';
 import { resolveOuterClaudeTools } from './tools-allowlist';
-import { TokenTelemetry, isTelemetryEnabled } from './token-telemetry';
+import { TokenTelemetry, ToolCallRecord, isTelemetryEnabled } from './token-telemetry';
+
+/** In-flight per-cycle tracking; tool_use_id is only retained in memory. */
+interface InFlightToolCall extends ToolCallRecord {
+  tool_use_id: string;
+}
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — must be longer than MCP tool chain (300s ephemeral + 310s bridge)
 
@@ -44,6 +49,8 @@ interface ClaudeSession {
   cancelFallback: ReturnType<typeof setTimeout> | null; // fallback kill timer after cancel
   turnIndex: number;            // 0-based index of completed turns in this session
   lastResultAt: number | null;  // Date.now() of the previous `type:"result"` event, for telemetry deltas
+  subTurnCount: number;         // count of type:"assistant" events since the last type:"result" (= API calls in the current tool-use chain)
+  toolCallsInCycle: InFlightToolCall[]; // MCP tool calls made since the last type:"result"; reset on record
 }
 
 function getClaudeBin(): string {
@@ -328,6 +335,8 @@ rl.on('line', async (line) => {
         cancelFallback: null,
         turnIndex: 0,
         lastResultAt: null,
+        subTurnCount: 0,
+        toolCallsInCycle: [],
       };
       this.sessions.set(tabId, session);
     }
@@ -825,10 +834,18 @@ rl.on('line', async (line) => {
                   output_tokens: usage.output_tokens ?? 0,
                   cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
                   cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+                  sub_turn_count: session.subTurnCount,
+                  tool_calls: session.toolCallsInCycle.map((c) => ({
+                    name: c.name,
+                    tool_result_bytes: c.tool_result_bytes,
+                  })),
                 });
               }
               session.turnIndex += 1;
               session.lastResultAt = Date.now();
+              // Reset per-cycle counters for the next user-message turn.
+              session.subTurnCount = 0;
+              session.toolCallsInCycle = [];
             }
 
             if (session.fullResponse) {
@@ -856,16 +873,62 @@ rl.on('line', async (line) => {
             continue;
           }
 
-          // Log tool_use events for observability
+          // Log tool_use events for observability + telemetry (#262 sub-turn instrumentation)
           if (parsed.type === 'content_block_start') {
             const contentBlock = (parsed as { content_block?: { type?: string; name?: string; id?: string } }).content_block;
             if (contentBlock?.type === 'tool_use') {
               this.log(`Tool call: tab=${tabId} tool=${contentBlock.name} id=${contentBlock.id}`);
+              if (contentBlock.name && contentBlock.id) {
+                session.toolCallsInCycle.push({
+                  name: contentBlock.name,
+                  tool_use_id: contentBlock.id,
+                  tool_result_bytes: 0,
+                });
+              }
             }
           }
           if (parsed.type === 'content_block_stop') {
             const idx = (parsed as { index?: number }).index;
             this.log(`Tool call ended: tab=${tabId} block_index=${idx}`);
+          }
+
+          // Count sub-API-calls: each type:"assistant" event is one API response.
+          // A direct reply has sub_turn_count=1; a tool-use chain produces >= 2.
+          if (parsed.type === 'assistant') {
+            session.subTurnCount += 1;
+          }
+
+          // type:"user" carries tool_result blocks that the bridge returned to
+          // the model. Associate each tool_result's text size with its
+          // originating tool_use_id so we can see which tools fed the biggest
+          // payloads into the transcript.
+          if (parsed.type === 'user') {
+            const msg = (parsed as { message?: { content?: unknown } }).message;
+            const content = msg?.content;
+            if (Array.isArray(content)) {
+              for (const block of content as Array<Record<string, unknown>>) {
+                if (block?.type !== 'tool_result') continue;
+                const toolUseId = block.tool_use_id as string | undefined;
+                if (!toolUseId) continue;
+                const record = session.toolCallsInCycle.find(
+                  (c) => c.tool_use_id === toolUseId
+                );
+                if (!record) continue;
+                const blockContent = block.content;
+                let bytes = 0;
+                if (typeof blockContent === 'string') {
+                  bytes = Buffer.byteLength(blockContent, 'utf8');
+                } else if (Array.isArray(blockContent)) {
+                  for (const inner of blockContent as Array<Record<string, unknown>>) {
+                    if (typeof inner?.text === 'string') {
+                      bytes += Buffer.byteLength(inner.text, 'utf8');
+                    }
+                  }
+                }
+                // Accumulate in case a tool_result arrives in chunks
+                record.tool_result_bytes += bytes;
+              }
+            }
           }
 
           // Extract text for streaming output

--- a/src/main/agent/token-telemetry.ts
+++ b/src/main/agent/token-telemetry.ts
@@ -5,7 +5,7 @@
  * tests can target a temp file without any mocking. The production wiring
  * lives in claude-backend.ts.
  *
- * Schema (one line per completed turn):
+ * Schema (one line per completed user-message cycle):
  *   {
  *     "ts": ISO-8601,
  *     "tabId": string,
@@ -15,13 +15,22 @@
  *     "input_tokens": number,
  *     "output_tokens": number,
  *     "cache_creation_input_tokens": number,
- *     "cache_read_input_tokens": number
+ *     "cache_read_input_tokens": number,
+ *     "sub_turn_count": number (count of type:"assistant" events = API calls in the tool-use chain),
+ *     "tool_calls": [{ "name": string, "tool_result_bytes": number }]
  *   }
  *
  * Off by default. Opt in with the env var `SANDSTORM_TOKEN_TELEMETRY=1`.
  */
 
 import { appendFileSync } from 'fs';
+
+export interface ToolCallRecord {
+  /** MCP tool name invoked by the model (e.g. "get_diff", "dispatch_task"). */
+  name: string;
+  /** UTF-8 byte length of the tool_result text returned to the model. */
+  tool_result_bytes: number;
+}
 
 export interface TokenTelemetryEvent {
   ts: string;
@@ -33,6 +42,20 @@ export interface TokenTelemetryEvent {
   output_tokens: number;
   cache_creation_input_tokens: number;
   cache_read_input_tokens: number;
+  /**
+   * Number of type:"assistant" events emitted by the CLI between the user
+   * message being written to stdin and the type:"result" that produced this
+   * telemetry line. Each assistant event corresponds to one API response, so
+   * this is the sub-API-call count for a tool-use chain. `1` means "direct
+   * reply, no tool use"; `>= 2` means the model ran tools.
+   */
+  sub_turn_count: number;
+  /**
+   * Ordered list of MCP tool calls made during this cycle. Each entry pairs
+   * the tool name (captured from content_block_start) with the UTF-8 byte
+   * length of the tool_result the bridge returned.
+   */
+  tool_calls: ToolCallRecord[];
 }
 
 export interface TokenTelemetryOptions {

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -774,6 +774,163 @@ describe('Token telemetry wiring (#262 tactic A)', () => {
     expect(event.output_tokens).toBe(56);
     expect(event.cache_creation_input_tokens).toBe(28_000);
     expect(event.cache_read_input_tokens).toBe(0);
+    // Direct reply (no tool chain): sub_turn_count defaults to 0 because no
+    // assistant events were streamed before the result in this test, and
+    // tool_calls is the empty list.
+    expect(event.sub_turn_count).toBe(0);
+    expect(event.tool_calls).toEqual([]);
+
+    backend.destroy();
+  });
+
+  it('captures sub_turn_count and tool_calls for a tool-use chain (#262 sub-turn instrumentation)', async () => {
+    process.env.SANDSTORM_TOKEN_TELEMETRY = '1';
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backend = new ClaudeBackend();
+    backend.sendMessage('tel-chain', 'check stack 1', '/proj');
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+
+    const emit = (obj: unknown): void => {
+      proc.stdout.emit('data', Buffer.from(JSON.stringify(obj) + '\n'));
+    };
+
+    // Simulate the exact stream-json event sequence a multi-tool chain would
+    // produce: assistant (1st API call — emits tool_use), user (tool_result
+    // for that tool), assistant (2nd API call — emits 2nd tool_use), user
+    // (2nd tool_result), assistant (3rd API call — final text), result.
+    emit({ type: 'assistant', message: { content: [] } });
+    emit({
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', name: 'list_stacks', id: 'tu_1' },
+    });
+    const listStacksResult = 'x'.repeat(512);
+    emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: listStacksResult }],
+      },
+    });
+
+    emit({ type: 'assistant', message: { content: [] } });
+    emit({
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', name: 'get_diff', id: 'tu_2' },
+    });
+    const getDiffResult = 'y'.repeat(42_000);
+    emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_2',
+            // tool_result content may also arrive as an array of text blocks
+            content: [{ type: 'text', text: getDiffResult }],
+          },
+        ],
+      },
+    });
+
+    emit({ type: 'assistant', message: { content: [] } });
+    emit({
+      type: 'result',
+      result: 'ok',
+      usage: {
+        input_tokens: 17,
+        output_tokens: 280,
+        cache_creation_input_tokens: 3_200,
+        cache_read_input_tokens: 156_000,
+      },
+    });
+
+    const telemetryAppends = vi
+      .mocked(fs.appendFileSync)
+      .mock.calls.filter((c) => String(c[0]).endsWith('sandstorm-desktop-token-telemetry.jsonl'));
+    expect(telemetryAppends.length).toBe(1);
+    const event = JSON.parse((telemetryAppends[0][1] as string).trim());
+
+    expect(event.tabId).toBe('tel-chain');
+    expect(event.cache_read_input_tokens).toBe(156_000);
+    // Three assistant events = three sub-API-calls
+    expect(event.sub_turn_count).toBe(3);
+    // Two tools called, in order, with their tool_result byte sizes
+    expect(event.tool_calls).toEqual([
+      { name: 'list_stacks', tool_result_bytes: 512 },
+      { name: 'get_diff', tool_result_bytes: 42_000 },
+    ]);
+
+    backend.destroy();
+  });
+
+  it('resets sub_turn_count and tool_calls between successive user messages', async () => {
+    process.env.SANDSTORM_TOKEN_TELEMETRY = '1';
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backend = new ClaudeBackend();
+    backend.sendMessage('tel-reset', 'first', '/proj');
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const emit = (obj: unknown): void => {
+      proc.stdout.emit('data', Buffer.from(JSON.stringify(obj) + '\n'));
+    };
+
+    // First message: 1 tool call, 2 assistant events
+    emit({ type: 'assistant', message: { content: [] } });
+    emit({
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', name: 'list_stacks', id: 'a1' },
+    });
+    emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'a1', content: 'stacks' }],
+      },
+    });
+    emit({ type: 'assistant', message: { content: [] } });
+    emit({
+      type: 'result',
+      result: 'ok',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 50,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 50_000,
+      },
+    });
+
+    // Second message: 1 assistant event, no tool calls
+    backend.sendMessage('tel-reset', 'second', '/proj');
+    emit({ type: 'assistant', message: { content: [] } });
+    emit({
+      type: 'result',
+      result: 'ok',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 100,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 50_000,
+      },
+    });
+
+    const telemetryAppends = vi
+      .mocked(fs.appendFileSync)
+      .mock.calls.filter((c) => String(c[0]).endsWith('sandstorm-desktop-token-telemetry.jsonl'));
+    expect(telemetryAppends.length).toBe(2);
+
+    const first = JSON.parse((telemetryAppends[0][1] as string).trim());
+    const second = JSON.parse((telemetryAppends[1][1] as string).trim());
+
+    expect(first.sub_turn_count).toBe(2);
+    expect(first.tool_calls).toEqual([{ name: 'list_stacks', tool_result_bytes: 6 }]);
+
+    // Second turn must be independent — cycle counters reset on result.
+    expect(second.sub_turn_count).toBe(1);
+    expect(second.tool_calls).toEqual([]);
 
     backend.destroy();
   });

--- a/tests/unit/token-telemetry.test.ts
+++ b/tests/unit/token-telemetry.test.ts
@@ -37,6 +37,8 @@ describe('TokenTelemetry (#262 tactic A)', () => {
       output_tokens: 20,
       cache_creation_input_tokens: 30000,
       cache_read_input_tokens: 0,
+      sub_turn_count: 1,
+      tool_calls: [],
       ...partial,
     };
   }
@@ -93,6 +95,41 @@ describe('TokenTelemetry (#262 tactic A)', () => {
     expect(event.output_tokens).toBe(56);
     expect(event.cache_creation_input_tokens).toBe(28_000);
     expect(event.cache_read_input_tokens).toBe(2_000);
+  });
+
+  it('round-trips sub_turn_count and tool_calls (#262 sub-turn instrumentation)', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    tel.record(
+      sampleEvent({
+        turn_index: 0,
+        sub_turn_count: 5,
+        tool_calls: [
+          { name: 'list_stacks', tool_result_bytes: 512 },
+          { name: 'get_task_status', tool_result_bytes: 180 },
+          { name: 'get_diff', tool_result_bytes: 42_000 },
+          { name: 'dispatch_task', tool_result_bytes: 120 },
+        ],
+      })
+    );
+    tel.close();
+
+    const [event] = readEvents();
+    expect(event.sub_turn_count).toBe(5);
+    expect(event.tool_calls).toHaveLength(4);
+    expect(event.tool_calls[2]).toEqual({
+      name: 'get_diff',
+      tool_result_bytes: 42_000,
+    });
+  });
+
+  it('round-trips an empty tool_calls list and sub_turn_count=1 for a direct reply', () => {
+    const tel = new TokenTelemetry({ filePath: sinkPath, enabled: true });
+    tel.record(sampleEvent({ sub_turn_count: 1, tool_calls: [] }));
+    tel.close();
+
+    const [event] = readEvents();
+    expect(event.sub_turn_count).toBe(1);
+    expect(event.tool_calls).toEqual([]);
   });
 
   it('appends to an existing file rather than truncating', () => {


### PR DESCRIPTION
Implementation of the approved plan at `.claude/plans/you-keep-saying-like-deep-journal.md`.

## Why

The existing per-cycle telemetry (#263) can't answer the question the user keeps asking: *"one message blew up to 300k tokens — what did it actually do?"* A single JSONL line like `cache_read_input_tokens: 152,767` doesn't say whether that was one giant API call or N cheap ones. We need to see the sub-structure before committing to any more fixes.

## What changes

Each telemetry line now has two additional fields:

```json
{
  "sub_turn_count": 5,
  "tool_calls": [
    { "name": "list_stacks", "tool_result_bytes": 512 },
    { "name": "get_diff",    "tool_result_bytes": 42000 },
    { "name": "dispatch_task", "tool_result_bytes": 120 }
  ]
}
```

- `sub_turn_count` = number of `type:"assistant"` events emitted by the Claude CLI between the user message being written to stdin and the `type:"result"` that produced this line. `1` = direct reply, no tools. `>= 2` = tool-use chain of N API calls.
- `tool_calls` = ordered list of MCP tools invoked during the cycle, each paired with the UTF-8 byte length of the tool_result text the bridge returned.

Behavior unchanged when `SANDSTORM_TOKEN_TELEMETRY=1` is not set.

## How this answers the diagnostic question

Once this lands and the user re-runs the problem scenario:

- `cache_read_input_tokens / sub_turn_count` ≈ per-sub-call prefix size. Stable ~40–55k across turns confirms the tool-chain-amplification hypothesis (each sub-API-call re-reads the full prefix). If `sub_turn_count` is 1–2 but `cache_read_input_tokens` is still 100k+, the hypothesis is refuted and the problem is actually a bloated static prefix.
- Sorting `tool_calls` by `tool_result_bytes` across the session names the specific MCP tools whose raw outputs are fattening the transcript (the `get_diff` responses, `get_logs` tails, etc.).

That evidence tells us whether the "orchestrator = router" redesign we discussed is the right direction or whether a different lever matters more.

## Implementation

- `src/main/agent/token-telemetry.ts` — `TokenTelemetryEvent` extended with `sub_turn_count: number` and `tool_calls: ToolCallRecord[]` (mandatory). New exported `ToolCallRecord` type.
- `src/main/agent/claude-backend.ts` — `ClaudeSession` gains `subTurnCount` and `toolCallsInCycle`. Stdout handler:
  - increments `subTurnCount` on every `type:"assistant"` event,
  - pushes an in-flight record on `content_block_start` with `tool_use` content block,
  - matches each `tool_result` (arriving via `type:"user"`) against its `tool_use_id` and captures UTF-8 byte length. Handles both string `content` and array-of-text-blocks shapes defensively.
  - resets both per-cycle fields after each telemetry record.

## Tests

- **`tests/unit/token-telemetry.test.ts`** (2 new cases) — schema round-trips `sub_turn_count` + populated `tool_calls`; direct-reply shape round-trips empty `tool_calls` with `sub_turn_count=1`.
- **`tests/unit/claude-backend.test.ts`** (2 new integration tests):
  - Full tool-use chain (3 assistant events, 2 tool_use/tool_result pairs, string + array-of-text-blocks tool_result shapes) produces `sub_turn_count=3` and correct ordered `tool_calls` with exact byte sizes.
  - Per-cycle counters reset cleanly between two successive user messages (first: 2 sub-turns + 1 tool call; second: 1 sub-turn + empty tool_calls).

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm test` — 1430 pass, 6 pre-existing `integration-xvfb.test.ts` failures unrelated to this PR.
- [x] 4 new tests all pass.
- [ ] Manual: rebuild with `SANDSTORM_TOKEN_TELEMETRY=1`, drive the same "check paused stack and resume" scenario, inspect the JSONL, confirm the new fields populate as expected and tell us where the 300k went.

## Out of scope

- Any fix to reduce tokens. This PR is diagnostic only — the plan explicitly stops here until the data comes back.
- UI surfacing of the new fields (#259 covers broader observability).

Refs #254, #257, #262.