### PR TITLE
Capture tool_use from assistant content blocks (fix empty tool_calls)

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -894,8 +894,29 @@ rl.on('line', async (line) => {
 
           // Count sub-API-calls: each type:"assistant" event is one API response.
           // A direct reply has sub_turn_count=1; a tool-use chain produces >= 2.
+          // Also walk the assistant message content for tool_use blocks —
+          // some CLI builds (observed on the orchestrator path) emit tool_use
+          // here instead of via separate content_block_start events, so we
+          // capture from both paths and dedupe by tool_use_id.
           if (parsed.type === 'assistant') {
             session.subTurnCount += 1;
+            const assistantMsg = (parsed as { message?: { content?: unknown } }).message;
+            const assistantContent = assistantMsg?.content;
+            if (Array.isArray(assistantContent)) {
+              for (const block of assistantContent as Array<Record<string, unknown>>) {
+                if (block?.type !== 'tool_use') continue;
+                const id = typeof block.id === 'string' ? block.id : undefined;
+                const name = typeof block.name === 'string' ? block.name : undefined;
+                if (!id || !name) continue;
+                if (session.toolCallsInCycle.some((c) => c.tool_use_id === id)) continue;
+                session.toolCallsInCycle.push({
+                  name,
+                  tool_use_id: id,
+                  tool_result_bytes: 0,
+                });
+                this.log(`Tool call: tab=${tabId} tool=${name} id=${id}`);
+              }
+            }
           }
 
           // type:"user" carries tool_result blocks that the bridge returned to

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -866,6 +866,130 @@ describe('Token telemetry wiring (#262 tactic A)', () => {
     backend.destroy();
   });
 
+  it('captures tool_use blocks embedded in type:"assistant" message content (#262 instrumentation fix)', async () => {
+    // Some Claude CLI builds emit tool_use inline on type:"assistant" events
+    // instead of via separate content_block_start events. We must capture
+    // them on both paths — this test exercises the assistant-only path.
+    process.env.SANDSTORM_TOKEN_TELEMETRY = '1';
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backend = new ClaudeBackend();
+    backend.sendMessage('tel-assistant-tool-use', 'check it', '/proj');
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const emit = (obj: unknown): void => {
+      proc.stdout.emit('data', Buffer.from(JSON.stringify(obj) + '\n'));
+    };
+
+    emit({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: 'Checking...' },
+          { type: 'tool_use', name: 'Bash', id: 'tu_a', input: { command: 'docker ps' } },
+        ],
+      },
+    });
+    emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu_a', content: 'CONTAINER ID   ...' }],
+      },
+    });
+
+    emit({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', name: 'Bash', id: 'tu_b', input: { command: 'git diff' } },
+        ],
+      },
+    });
+    emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu_b', content: 'diff --git ...' }],
+      },
+    });
+
+    emit({ type: 'assistant', message: { content: [{ type: 'text', text: 'Done.' }] } });
+    emit({
+      type: 'result',
+      result: 'ok',
+      usage: {
+        input_tokens: 5,
+        output_tokens: 50,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 45_000,
+      },
+    });
+
+    const telemetryAppends = vi
+      .mocked(fs.appendFileSync)
+      .mock.calls.filter((c) => String(c[0]).endsWith('sandstorm-desktop-token-telemetry.jsonl'));
+    const event = JSON.parse((telemetryAppends[0][1] as string).trim());
+
+    expect(event.sub_turn_count).toBe(3);
+    expect(event.tool_calls).toEqual([
+      { name: 'Bash', tool_result_bytes: Buffer.byteLength('CONTAINER ID   ...', 'utf8') },
+      { name: 'Bash', tool_result_bytes: Buffer.byteLength('diff --git ...', 'utf8') },
+    ]);
+
+    backend.destroy();
+  });
+
+  it('does not double-count when tool_use appears in both content_block_start and assistant content (#262 dedupe)', async () => {
+    process.env.SANDSTORM_TOKEN_TELEMETRY = '1';
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backend = new ClaudeBackend();
+    backend.sendMessage('tel-dedupe', 'x', '/proj');
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const emit = (obj: unknown): void => {
+      proc.stdout.emit('data', Buffer.from(JSON.stringify(obj) + '\n'));
+    };
+
+    // Same tool_use id arrives via both content_block_start AND assistant.content
+    emit({ type: 'content_block_start', content_block: { type: 'tool_use', name: 'Bash', id: 'dup' } });
+    emit({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', name: 'Bash', id: 'dup', input: {} }],
+      },
+    });
+    emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'dup', content: 'result' }],
+      },
+    });
+    emit({ type: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } });
+    emit({
+      type: 'result',
+      result: 'ok',
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 10,
+      },
+    });
+
+    const telemetryAppends = vi
+      .mocked(fs.appendFileSync)
+      .mock.calls.filter((c) => String(c[0]).endsWith('sandstorm-desktop-token-telemetry.jsonl'));
+    const event = JSON.parse((telemetryAppends[0][1] as string).trim());
+
+    expect(event.tool_calls).toHaveLength(1);
+    expect(event.tool_calls[0]).toEqual({ name: 'Bash', tool_result_bytes: 6 });
+
+    backend.destroy();
+  });
+
   it('resets sub_turn_count and tool_calls between successive user messages', async () => {
     process.env.SANDSTORM_TOKEN_TELEMETRY = '1';
     const fs = await import('fs');


### PR DESCRIPTION
Follow-up to the now-merged #264. Live telemetry from a real 283k-token session showed:

```json
{ "sub_turn_count": 17, "tool_calls": [] }
```

`sub_turn_count: 17` is right — one user message did cause 17 API round-trips — but the empty `tool_calls` hid which tools were called. That's an instrumentation bug, not a real "zero tools" signal.

## Root cause

The orchestrator's Claude CLI build emits `tool_use` **inline inside `type:"assistant"` message.content[]**, not via separate `content_block_start` events. My earlier instrumentation only listened on `content_block_start`, so tool names were never captured on this code path. The `Tool call:` log lines from `src/main/agent/claude-backend.ts:863` also weren't firing for the same reason.

## Fix

In `src/main/agent/claude-backend.ts`, when a `type:"assistant"` event arrives, also walk `message.content[]` for blocks of `type === "tool_use"`, pull `name` and `id`, and push into `session.toolCallsInCycle` — same shape as the existing `content_block_start` path. Dedupe by `tool_use_id` so any CLI version that emits both paths doesn't double-count.

The existing `content_block_start` path is kept unchanged, so older or differently-configured CLI builds continue to work.

## Tests

Two new cases in `tests/unit/claude-backend.test.ts`:
1. **`captures tool_use blocks embedded in type:"assistant" message content`** — emits a chain of assistant events with inline `tool_use` blocks (and no `content_block_start`), verifies both `Bash` calls are captured with correct `tool_result_bytes`.
2. **`does not double-count when tool_use appears in both content_block_start and assistant content`** — emits the same `tool_use_id` on both paths, verifies only one entry lands in `tool_calls`.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npx vitest run tests/unit/claude-backend.test.ts` — 52/52 pass.
- [ ] Manual: merge + rebuild, rerun with `SANDSTORM_TOKEN_TELEMETRY=1`, confirm the next telemetry line shows a populated `tool_calls` list with real tool names and byte sizes.

## Why this matters now

The #264 instrumentation without this fix gives us sub-turn *counts* but not the *names* of which tools are chewing up the chain. With this fix in place, the user's next session will show exactly which tool calls (Bash, get_diff, list_stacks, etc.) are getting invoked 17 times — which is what actually unblocks the decision between the two possible fix directions (orchestrator-is-router redesign vs. per-tool payload caps).

Refs #262, #264.