### PR TITLE
Orchestrator skill discoverability (#266)

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -24,6 +24,7 @@ import {
   zeroSessionTokens,
 } from './types';
 import { resolveOuterClaudeTools } from './tools-allowlist';
+import { composeSystemPromptWithSkills } from './skill-enumeration';
 import { TokenTelemetry, ToolCallRecord, isTelemetryEnabled } from './token-telemetry';
 
 /** In-flight per-cycle tracking; tool_use_id is only retained in memory. */
@@ -693,6 +694,39 @@ rl.on('line', async (line) => {
   }
 
   /**
+   * Compose the orchestrator system prompt with a per-project skills
+   * enumeration (#266). `--system-prompt-file` replaces Claude Code's
+   * default system prompt and thereby suppresses the built-in
+   * "Available Skills" reminder; this helper re-injects it by reading
+   * `.claude/skills/<name>/SKILL.md` frontmatter at spawn time and
+   * appending a skills section to SANDSTORM_OUTER.md. Writes the
+   * composed prompt to a tmp file and returns its path, or returns the
+   * original path if composition fails. Returns null when the base
+   * prompt file doesn't exist, so the caller can fall through to the
+   * CLI's default system prompt.
+   */
+  private resolveSystemPromptFile(
+    basePath: string,
+    projectDir: string,
+    tabId: string
+  ): string | null {
+    if (!fs.existsSync(basePath)) return null;
+    try {
+      const base = fs.readFileSync(basePath, 'utf-8');
+      const composed = composeSystemPromptWithSkills(base, projectDir);
+      if (composed === base) return basePath;
+      const tmpDir = path.join(os.tmpdir(), `sandstorm-orchestrator-${process.pid}`);
+      fs.mkdirSync(tmpDir, { recursive: true });
+      const safeTab = tabId.replace(/[^A-Za-z0-9._-]/g, '_');
+      const outPath = path.join(tmpDir, `system-prompt-${safeTab}.md`);
+      fs.writeFileSync(outPath, composed, 'utf-8');
+      return outPath;
+    } catch {
+      return basePath;
+    }
+  }
+
+  /**
    * Ensure a persistent Claude process is running for the given tab.
    * Spawns one if none exists. The process stays alive across messages.
    */
@@ -702,6 +736,7 @@ rl.on('line', async (line) => {
 
     const systemPromptFile = path.join(cliDir, 'SANDSTORM_OUTER.md');
     const claudeBin = getClaudeBin();
+    const cwd = session.projectDir || process.cwd();
 
     const args: string[] = [
       '--print',
@@ -714,8 +749,9 @@ rl.on('line', async (line) => {
       '--tools', resolveOuterClaudeTools(session.projectDir).join(','),
     ];
 
-    if (fs.existsSync(systemPromptFile)) {
-      args.push('--system-prompt-file', systemPromptFile);
+    const resolvedPromptFile = this.resolveSystemPromptFile(systemPromptFile, cwd, tabId);
+    if (resolvedPromptFile) {
+      args.push('--system-prompt-file', resolvedPromptFile);
     }
 
     if (this.mcpConfigPath) {
@@ -726,8 +762,6 @@ rl.on('line', async (line) => {
       const outerModel = this.modelResolver(session.projectDir);
       args.push('--model', outerModel);
     }
-
-    const cwd = session.projectDir || process.cwd();
 
     const child = spawn(claudeBin, args, {
       cwd,

--- a/src/main/agent/skill-enumeration.ts
+++ b/src/main/agent/skill-enumeration.ts
@@ -1,0 +1,123 @@
+/**
+ * Skill enumeration for the orchestrator subprocess (#266).
+ *
+ * Claude Code injects an "Available Skills" system-reminder into its
+ * DEFAULT system prompt. The orchestrator passes `--system-prompt-file
+ * SANDSTORM_OUTER.md`, which REPLACES that default — so the reminder
+ * vanishes and skills become invisible to the model (even though the
+ * CLI still registers them).
+ *
+ * This module enumerates project-local skills at spawn time and formats
+ * them as an injection block that `ensureProcess` appends to the
+ * base system prompt. Pure/electron-free so it can be unit-tested
+ * against a real temp directory without mocks.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface SkillDescriptor {
+  name: string;
+  description: string;
+  path: string;
+}
+
+/** Parse minimal YAML frontmatter looking for `name` and `description`. */
+function parseFrontmatter(content: string): { name?: string; description?: string } | null {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const body = match[1];
+  const out: { name?: string; description?: string } = {};
+  const lines = body.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const kv = line.match(/^(name|description)\s*:\s*(.*)$/);
+    if (!kv) {
+      i++;
+      continue;
+    }
+    const key = kv[1] as 'name' | 'description';
+    let raw = kv[2].trim();
+    // Handle quoted single-line values.
+    if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+      raw = raw.slice(1, -1);
+    } else if (raw.startsWith('"')) {
+      // Multi-line double-quoted value: consume until closing quote.
+      let acc = raw.slice(1);
+      i++;
+      while (i < lines.length) {
+        const next = lines[i];
+        if (next.endsWith('"')) {
+          acc += '\n' + next.slice(0, -1);
+          break;
+        }
+        acc += '\n' + next;
+        i++;
+      }
+      raw = acc;
+    }
+    out[key] = raw;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Enumerate skills at `<projectDir>/.claude/skills/<name>/SKILL.md`.
+ * Returns only entries whose SKILL.md has non-empty `name` and
+ * `description` in the frontmatter; other files are silently skipped.
+ * Results sorted by name for deterministic system-prompt output.
+ */
+export function enumerateProjectSkills(projectDir: string): SkillDescriptor[] {
+  const skillsRoot = path.join(projectDir, '.claude', 'skills');
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(skillsRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const descriptors: SkillDescriptor[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillPath = path.join(skillsRoot, entry.name, 'SKILL.md');
+    let content: string;
+    try {
+      content = fs.readFileSync(skillPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const fm = parseFrontmatter(content);
+    if (!fm || !fm.name || !fm.description) continue;
+    descriptors.push({ name: fm.name, description: fm.description, path: skillPath });
+  }
+  descriptors.sort((a, b) => a.name.localeCompare(b.name));
+  return descriptors;
+}
+
+/**
+ * Format the injection block. Mirrors the shape of Claude Code's
+ * default system-reminder so the model recognizes the pattern.
+ */
+export function formatSkillsSection(skills: SkillDescriptor[]): string {
+  if (skills.length === 0) return '';
+  const lines = ['## Available Skills', '', 'The following skills are available for use with the Skill tool:', ''];
+  for (const skill of skills) {
+    lines.push(`- ${skill.name}: ${skill.description}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Compose a full system prompt: base text, then the skills section if
+ * any skills are present. Returns the base unchanged when the project
+ * has no registered skills.
+ */
+export function composeSystemPromptWithSkills(basePrompt: string, projectDir: string): string {
+  const skills = enumerateProjectSkills(projectDir);
+  const section = formatSkillsSection(skills);
+  if (!section) return basePrompt;
+  const separator = basePrompt.endsWith('\n') ? '\n' : '\n\n';
+  return `${basePrompt}${separator}${section}\n`;
+}

--- a/src/main/agent/tools-allowlist.ts
+++ b/src/main/agent/tools-allowlist.ts
@@ -15,12 +15,17 @@ import path from 'path';
  * outer Claude's job is to delegate to stacks via MCP, not to edit code or
  * fetch the web itself. Denying them strips their schemas from the context
  * re-sent on every outer turn.
+ *
+ * `Skill` is on the list so the orchestrator can invoke project-local skills
+ * enumerated at spawn time (#266). Skill descriptions ride in the system
+ * prompt; skill bodies load lazily when the tool is called.
  */
 export const DEFAULT_OUTER_CLAUDE_TOOLS: readonly string[] = Object.freeze([
   'Bash',
   'Read',
   'Grep',
   'Glob',
+  'Skill',
 ]);
 
 /**

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -561,7 +561,7 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
       const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
       const toolsIdx = spawnedArgs.indexOf('--tools');
       expect(toolsIdx).toBeGreaterThan(-1);
-      expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob');
+      expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob,Skill');
     });
 
     it('places --tools before --system-prompt-file and --mcp-config', async () => {
@@ -619,7 +619,7 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
 
       const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
       const toolsIdx = spawnedArgs.indexOf('--tools');
-      expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob');
+      expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob,Skill');
     });
   });
 

--- a/tests/unit/resolve-outer-claude-tools.test.ts
+++ b/tests/unit/resolve-outer-claude-tools.test.ts
@@ -29,8 +29,8 @@ describe('resolveOuterClaudeTools (#256)', () => {
     fs.writeFileSync(path.join(dir, 'settings.json'), content, 'utf-8');
   }
 
-  it('default allowlist is exactly Bash, Read, Grep, Glob', () => {
-    expect([...DEFAULT_OUTER_CLAUDE_TOOLS]).toEqual(['Bash', 'Read', 'Grep', 'Glob']);
+  it('default allowlist is exactly Bash, Read, Grep, Glob, Skill', () => {
+    expect([...DEFAULT_OUTER_CLAUDE_TOOLS]).toEqual(['Bash', 'Read', 'Grep', 'Glob', 'Skill']);
   });
 
   it('returns the default allowlist when no projectDir is provided', () => {

--- a/tests/unit/skill-enumeration.test.ts
+++ b/tests/unit/skill-enumeration.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  enumerateProjectSkills,
+  formatSkillsSection,
+  composeSystemPromptWithSkills,
+} from '../../src/main/agent/skill-enumeration';
+
+/**
+ * Pure tests for the orchestrator skill enumerator (#266). Writes real
+ * SKILL.md fixtures to a temp directory so we exercise the same fs
+ * paths as production without mocking.
+ */
+describe('enumerateProjectSkills (#266)', () => {
+  let tmpDir: string;
+  let skillsRoot: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandstorm-skill-enum-'));
+    skillsRoot = path.join(tmpDir, '.claude', 'skills');
+    fs.mkdirSync(skillsRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSkill(name: string, frontmatter: string, body = '# body\n'): void {
+    const dir = path.join(skillsRoot, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${frontmatter}\n---\n\n${body}`, 'utf-8');
+  }
+
+  it('returns an empty list when projectDir has no .claude/skills', () => {
+    const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandstorm-skill-bare-'));
+    try {
+      expect(enumerateProjectSkills(bareDir)).toEqual([]);
+    } finally {
+      fs.rmSync(bareDir, { recursive: true, force: true });
+    }
+  });
+
+  it('enumerates a single folder-pattern skill', () => {
+    writeSkill('alpha', 'name: alpha\ndescription: Alpha description');
+    const skills = enumerateProjectSkills(tmpDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('alpha');
+    expect(skills[0].description).toBe('Alpha description');
+    expect(skills[0].path.endsWith(path.join('alpha', 'SKILL.md'))).toBe(true);
+  });
+
+  it('returns skills sorted alphabetically by name for deterministic output', () => {
+    writeSkill('zulu', 'name: zulu\ndescription: Last');
+    writeSkill('alpha', 'name: alpha\ndescription: First');
+    writeSkill('mike', 'name: mike\ndescription: Middle');
+    const skills = enumerateProjectSkills(tmpDir);
+    expect(skills.map((s) => s.name)).toEqual(['alpha', 'mike', 'zulu']);
+  });
+
+  it('parses double-quoted description values', () => {
+    writeSkill('quoted', 'name: quoted\ndescription: "Use this when X happens: say Y."');
+    const [skill] = enumerateProjectSkills(tmpDir);
+    expect(skill.description).toBe('Use this when X happens: say Y.');
+  });
+
+  it('parses single-quoted description values', () => {
+    writeSkill('sq', "name: sq\ndescription: 'Single-quoted value'");
+    const [skill] = enumerateProjectSkills(tmpDir);
+    expect(skill.description).toBe('Single-quoted value');
+  });
+
+  it('skips skills missing either name or description', () => {
+    writeSkill('nameonly', 'name: nameonly');
+    writeSkill('descronly', 'description: lone description');
+    writeSkill('valid', 'name: valid\ndescription: Valid');
+    const skills = enumerateProjectSkills(tmpDir);
+    expect(skills.map((s) => s.name)).toEqual(['valid']);
+  });
+
+  it('skips folders without a SKILL.md file', () => {
+    fs.mkdirSync(path.join(skillsRoot, 'empty-folder'), { recursive: true });
+    writeSkill('has-skill', 'name: has-skill\ndescription: ok');
+    const skills = enumerateProjectSkills(tmpDir);
+    expect(skills.map((s) => s.name)).toEqual(['has-skill']);
+  });
+
+  it('skips skills with malformed frontmatter (no delimiters)', () => {
+    const dir = path.join(skillsRoot, 'broken');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), 'name: broken\ndescription: no-dashes', 'utf-8');
+    writeSkill('good', 'name: good\ndescription: ok');
+    const skills = enumerateProjectSkills(tmpDir);
+    expect(skills.map((s) => s.name)).toEqual(['good']);
+  });
+
+  it('ignores loose .md files directly under .claude/skills/ (folder pattern only)', () => {
+    fs.writeFileSync(
+      path.join(skillsRoot, 'flat.md'),
+      '---\nname: flat\ndescription: Ignored\n---\n',
+      'utf-8'
+    );
+    writeSkill('folder', 'name: folder\ndescription: Picked up');
+    const skills = enumerateProjectSkills(tmpDir);
+    expect(skills.map((s) => s.name)).toEqual(['folder']);
+  });
+});
+
+describe('formatSkillsSection (#266)', () => {
+  it('returns an empty string for an empty skill list', () => {
+    expect(formatSkillsSection([])).toBe('');
+  });
+
+  it('formats one skill as a bullet with name and description', () => {
+    const section = formatSkillsSection([
+      { name: 'alpha', description: 'do alpha', path: '/x/alpha/SKILL.md' },
+    ]);
+    expect(section).toContain('## Available Skills');
+    expect(section).toContain('The following skills are available for use with the Skill tool:');
+    expect(section).toContain('- alpha: do alpha');
+  });
+
+  it('formats multiple skills in the given order', () => {
+    const section = formatSkillsSection([
+      { name: 'alpha', description: 'A', path: '/a' },
+      { name: 'beta', description: 'B', path: '/b' },
+    ]);
+    const alphaIdx = section.indexOf('- alpha:');
+    const betaIdx = section.indexOf('- beta:');
+    expect(alphaIdx).toBeGreaterThan(-1);
+    expect(betaIdx).toBeGreaterThan(alphaIdx);
+  });
+});
+
+describe('composeSystemPromptWithSkills (#266)', () => {
+  let tmpDir: string;
+  let skillsRoot: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandstorm-skill-compose-'));
+    skillsRoot = path.join(tmpDir, '.claude', 'skills');
+    fs.mkdirSync(skillsRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSkill(name: string, description: string): void {
+    const dir = path.join(skillsRoot, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${description}\n---\n\nbody\n`,
+      'utf-8'
+    );
+  }
+
+  it('returns the base prompt unchanged when no skills are present', () => {
+    const base = '# Orchestrator\n\nDo orchestrator things.\n';
+    expect(composeSystemPromptWithSkills(base, tmpDir)).toBe(base);
+  });
+
+  it('appends an Available Skills section when skills exist', () => {
+    writeSkill('sandstorm', 'Manage stacks');
+    const base = '# Orchestrator\n';
+    const composed = composeSystemPromptWithSkills(base, tmpDir);
+    expect(composed.startsWith(base)).toBe(true);
+    expect(composed).toContain('## Available Skills');
+    expect(composed).toContain('- sandstorm: Manage stacks');
+  });
+
+  it('adds a blank line separator when the base does not end with a newline', () => {
+    writeSkill('x', 'desc');
+    const base = '# Orchestrator';
+    const composed = composeSystemPromptWithSkills(base, tmpDir);
+    expect(composed).toContain('Orchestrator\n\n## Available Skills');
+  });
+
+  it('adds a single newline separator when the base already ends with a newline', () => {
+    writeSkill('x', 'desc');
+    const base = '# Orchestrator\n';
+    const composed = composeSystemPromptWithSkills(base, tmpDir);
+    expect(composed).toContain('Orchestrator\n\n## Available Skills');
+    // But not three newlines in a row
+    expect(composed).not.toContain('\n\n\n## Available Skills');
+  });
+
+  it('orders skills deterministically (alphabetical) regardless of fs order', () => {
+    writeSkill('zeta', 'last');
+    writeSkill('alpha', 'first');
+    writeSkill('mu', 'middle');
+    const composed = composeSystemPromptWithSkills('base', tmpDir);
+    const idxA = composed.indexOf('alpha');
+    const idxM = composed.indexOf('mu');
+    const idxZ = composed.indexOf('zeta');
+    expect(idxA).toBeLessThan(idxM);
+    expect(idxM).toBeLessThan(idxZ);
+  });
+});


### PR DESCRIPTION
Closes #266.

## Summary
- Enumerate project-local skills at orchestrator spawn time and inject an "Available Skills" section into a composed system prompt alongside `SANDSTORM_OUTER.md`. Skills are invisible to the subprocess today because `--system-prompt-file` replaces Claude Code's default prompt (which carries the built-in skills reminder).
- Add `Skill` to the default tools allowlist so the model can actually invoke what it now sees.
- Preserves the orchestrator-only role — `SANDSTORM_OUTER.md` still leads; skills section appends.

## Investigation findings (per ticket A)
- `claude --help` has no `--skills-dir` flag that works with `--system-prompt-file`. Enumeration-and-inject is the only path that satisfies "keep SANDSTORM_OUTER.md authoritative."
- The CLI already registers skills automatically (`init.skills: [...]`) as long as they follow the folder pattern `.claude/skills/<name>/SKILL.md`. Loose `.md` files under `.claude/skills/` are ignored.
- Enumeration happens at spawn time (not build time) so skills added while the app runs are picked up on the next session; nothing to regenerate.

## Smoke test (out-of-tree)
Dropped a throwaway `.claude/skills/pineapple-test/SKILL.md` with frontmatter `description: Use this skill whenever the user mentions the word "pineapple". Returns the secret code word "GUAVA-7342".` and ran:
```
claude -p --system-prompt-file <composed> --tools "Read,Grep,Glob,Skill" "Invoke the pineapple-test skill and report exactly what it returns."
```
Init event: `skills: [..., "pineapple-test", ...]`. Model invoked the Skill tool and returned `The secret code word is GUAVA-7342.` The pineapple-test fixture was deleted before committing.

## Files
- `src/main/agent/skill-enumeration.ts` (new, pure/electron-free): frontmatter parser + `enumerateProjectSkills` + `composeSystemPromptWithSkills`.
- `src/main/agent/claude-backend.ts`: new `resolveSystemPromptFile` writes the composed prompt to `${os.tmpdir()}/sandstorm-orchestrator-${pid}/system-prompt-<tab>.md` and passes that via `--system-prompt-file`.
- `src/main/agent/tools-allowlist.ts`: add `Skill` to `DEFAULT_OUTER_CLAUDE_TOOLS`.
- Tests: 17 new unit tests for skill enumeration (real fs, no mocks); existing claude-backend and resolve-outer-claude-tools tests updated for new allowlist.

## Test plan
- [x] `npx vitest run tests/unit/skill-enumeration.test.ts` — 17/17
- [x] `npx vitest run tests/unit/claude-backend.test.ts` — 52/52
- [x] `npx vitest run tests/unit/resolve-outer-claude-tools.test.ts` — 13/13
- [x] `npx tsc --noEmit` — clean
- [x] End-to-end smoke: throwaway skill registers in `init.skills` and is invoked by the model via `Skill` when running the orchestrator subprocess with the composed prompt.
- [ ] In-app verification after next `npm run release` — open a tab, check the orchestrator can `/sandstorm` (or any other folder-pattern skill) and the composed prompt sits at `${tmpdir()}/sandstorm-orchestrator-*/`.

## Out of scope
- Authoring real skills (that's #268 onward).
- Touching MCP — skills and MCP coexist for the whole migration.
- Build-time generator (runtime composition is simpler; no regeneration step for users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)