### PR TITLE
Env-friction fixes: spec-gate resume exemption + container auto-start

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -477,6 +477,24 @@ export class StackManager {
     this.startInBackground(stack, stackId).catch(() => {});
   }
 
+  /**
+   * Synchronously bring the stack's containers up. Used by `dispatchTask`
+   * to recover from a paused-stack state (env-friction fix, #273). Unlike
+   * `startInBackground`, this awaits completion and re-throws so the
+   * caller can surface failure to the user.
+   */
+  private async ensureStackContainersRunning(stack: Stack, stackId: string): Promise<void> {
+    const result = await this.runCli(stack.project_dir, ['start', stackId]);
+    if (result.exitCode !== 0) {
+      throw new SandstormError(
+        ErrorCode.COMPOSE_FAILED,
+        result.stderr.trim() || result.stdout.trim() || 'Failed to start stack containers before dispatch'
+      );
+    }
+    this.registry.updateStackStatus(stackId, 'up');
+    this.notifyUpdate();
+  }
+
   private async startInBackground(stack: Stack, stackId: string): Promise<void> {
     try {
       const result = await this.runCli(stack.project_dir, ['start', stackId]);
@@ -671,14 +689,21 @@ export class StackManager {
       model = undefined;
     }
 
-    // Enforce spec quality gate when dispatching to a stack with a ticket
-    // or when the prompt references a GitHub issue
-    this.enforceSpecGate({
-      ticket: stack.ticket ?? undefined,
-      task: prompt,
-      gateApproved: opts?.gateApproved,
-      forceBypass: opts?.forceBypass,
-    });
+    // Spec quality gate: enforced on the FIRST dispatch (usually the one
+    // `createStack` issues with the ticket body). If the stack already has
+    // prior task history, treat this call as a resume/continuation — the
+    // gate ran at creation time, and re-enforcing it now would block every
+    // legitimate resume. This is the #273 env-friction fix.
+    const priorTasks = this.registry.getTasksForStack(stackId);
+    const isResume = priorTasks.length > 0;
+    if (!isResume) {
+      this.enforceSpecGate({
+        ticket: stack.ticket ?? undefined,
+        task: prompt,
+        gateApproved: opts?.gateApproved,
+        forceBypass: opts?.forceBypass,
+      });
+    }
 
     // If the stack has a ticket number, fetch the full ticket context
     // via the project's fetch-ticket script and prepend it to the prompt
@@ -694,7 +719,16 @@ export class StackManager {
     const runtime = this.getRuntimeForStack(stack);
 
     try {
-      const claudeContainer = await this.findClaudeContainer(stack, runtime);
+      let claudeContainer = await this.findClaudeContainer(stack, runtime);
+
+      // Env-friction fix: if containers are exited (common pause/resume
+      // scenario), bring the stack up synchronously before dispatching
+      // rather than failing and forcing the caller to re-probe. Status is
+      // re-checked after the start so we act on the fresh container.
+      if (claudeContainer.status !== 'running') {
+        await this.ensureStackContainersRunning(stack, stackId);
+        claudeContainer = await this.findClaudeContainer(stack, runtime);
+      }
 
       // Wait for the inner Claude agent to be ready before dispatching
       await this.waitForClaudeReady(claudeContainer.id, runtime);

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -410,6 +410,144 @@ describe('StackManager', () => {
     });
   });
 
+  describe('dispatchTask env-friction fixes (spec-gate resume exemption + container auto-start)', () => {
+    function makeTicketStack(id: string, ticket = '250') {
+      return {
+        ...makeStack(id),
+        ticket,
+      };
+    }
+
+    it('enforces the spec gate on the FIRST dispatch when the stack has a ticket and no approval', async () => {
+      registry.createStack(makeTicketStack('gate-first'));
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      await expect(
+        manager.dispatchTask('gate-first', 'Continue work')
+      ).rejects.toThrow(/gateApproved|spec.?check/i);
+    });
+
+    it('SKIPS the spec gate on subsequent dispatches when the stack has prior task history (resume)', async () => {
+      registry.createStack(makeTicketStack('gate-resume'));
+      // Seed a prior task → stack has been dispatched to before.
+      registry.createTask('gate-resume', 'initial prompt', 'sonnet');
+
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'ok',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      // No gateApproved, no forceBypass — but should succeed because it's a resume.
+      await expect(
+        manager.dispatchTask('gate-resume', 'Continue from where you left off')
+      ).resolves.toEqual(expect.objectContaining({ stack_id: 'gate-resume' }));
+
+      // Verify we reached the CLI dispatch, i.e. we didn't bail early on the gate.
+      expect(runCliSpy).toHaveBeenCalledWith(
+        '/proj',
+        expect.arrayContaining(['task', 'gate-resume'])
+      );
+    });
+
+    it('still honors forceBypass on the first dispatch when gate is not approved', async () => {
+      registry.createStack(makeTicketStack('gate-bypass'));
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      await expect(
+        manager.dispatchTask('gate-bypass', 'New work', undefined, { forceBypass: true })
+      ).resolves.toBeDefined();
+    });
+
+    it('starts the stack containers via the CLI when the claude container is not running at dispatch time', async () => {
+      registry.createStack(makeStack('autostart'));
+
+      // First listContainers call returns a STOPPED claude container. After
+      // the auto-start runs, listContainers returns a running one.
+      let call = 0;
+      (runtime.listContainers as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        call++;
+        return [
+          {
+            id: 'claude-container-1',
+            name: 'sandstorm-proj-autostart-claude-1',
+            image: 'sandstorm-claude',
+            status: call === 1 ? 'exited' : ('running' as const),
+            state: call === 1 ? 'exited' : 'running',
+            ports: [],
+            labels: {},
+            created: new Date().toISOString(),
+          },
+        ];
+      });
+
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('autostart', 'resume');
+
+      // The CLI should have been invoked to start the stack BEFORE the dispatch call.
+      const startCall = runCliSpy.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === 'start'
+      );
+      expect(startCall).toBeDefined();
+      expect(startCall![1]).toEqual(['start', 'autostart']);
+
+      // Dispatch itself still runs after the start.
+      const taskCall = runCliSpy.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === 'task'
+      );
+      expect(taskCall).toBeDefined();
+    });
+
+    it('does NOT run the start CLI when the claude container is already running', async () => {
+      registry.createStack(makeStack('already-up'));
+      // Default mock returns status: 'running' already.
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('already-up', 'go');
+
+      const startCall = runCliSpy.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === 'start'
+      );
+      expect(startCall).toBeUndefined();
+    });
+
+    it('surfaces a COMPOSE_FAILED error when the auto-start CLI call fails', async () => {
+      registry.createStack(makeStack('autostart-fail'));
+      (runtime.listContainers as ReturnType<typeof vi.fn>).mockResolvedValue([
+        {
+          id: 'claude-container-1',
+          name: 'sandstorm-proj-autostart-fail-claude-1',
+          image: 'sandstorm-claude',
+          status: 'exited' as const,
+          state: 'exited',
+          ports: [],
+          labels: {},
+          created: new Date().toISOString(),
+        },
+      ]);
+
+      vi.spyOn(manager, 'runCli').mockImplementation(async (_dir, args) => {
+        if (args[0] === 'start') {
+          return { stdout: '', stderr: 'start failed: docker daemon unavailable', exitCode: 1 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      await expect(
+        manager.dispatchTask('autostart-fail', 'resume')
+      ).rejects.toThrow(/start failed|docker daemon/);
+    });
+  });
+
   describe('waitForClaudeReady', () => {
     it('resolves immediately when readiness file exists', async () => {
       registry.createStack(makeStack('ready-test'));


### PR DESCRIPTION
Independent of the skills migration — lands env fixes that drive baseline orchestrator cost down before any skill work matters.

## Root cause (from #254 investigation)
Canonical scenario: 323K tokens, 22 sub-turns. Tool-call pattern included a dispatch_task that was rejected for GATE_CHECK_REQUIRED even though the stack was being resumed, plus a Bash \`docker start\` dance because the stack's containers had exited while paused. Both friction points force the orchestrator to spend 5+ extra sub-turns recovering from state the backend should handle itself.

## Changes
1. **Spec-gate resume exemption** — \`dispatchTask\` skips \`enforceSpecGate\` when the target stack already has task history (\`registry.getTasksForStack(stackId).length > 0\`). The gate runs once at creation time; subsequent dispatches are treated as continuations. No more \`GATE_CHECK_REQUIRED\` → retry-with-forceBypass round on every resume.
2. **Container auto-start** — \`dispatchTask\` checks \`claudeContainer.status\`. If anything other than \`running\`, it awaits a new \`ensureStackContainersRunning\` helper that runs \`sandstorm start <id>\` via the CLI and updates registry status. If it fails, the error is surfaced as \`COMPOSE_FAILED\` rather than silently failing downstream.

## Not doing
- Not touching createStack's gate check. First dispatch of a fresh ticket-linked stack still requires approval.
- Not touching the \`sandstorm\` skill or MCP tool docs. Those stay honest about the gate semantics for initial dispatches.
- Not modifying \`startInBackground\` (used by non-dispatch flows).

## Test plan
- [x] 141 stack-manager tests pass (6 new + all existing)
- [x] \`npx tsc --noEmit\` clean
- [x] Typecheck + tests green
- [ ] Post-rebuild canonical-scenario telemetry re-run: the \`exp1-baseline\` equivalent should drop meaningfully. Expect ~4-6 fewer sub-turns (skip retry + skip Bash-docker-start), ~80-100K fewer tokens.

## Rebuild required
This touches main-process code; needs \`npm run release\` to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)