### PR TITLE
Port spec_check + spec_refine to compound script-backed skill

### DIFF
--- a/sandstorm-cli/skills/sandstorm-spec/SKILL.md
+++ b/sandstorm-cli/skills/sandstorm-spec/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: sandstorm-spec
+description: "Use this skill whenever the user wants to run the Sandstorm spec quality gate on a ticket, check whether a ticket is ready for agent dispatch, or iterate on a ticket that failed the gate. Trigger phrases include: 'run spec check on ticket N', '/spec-check N', 'is ticket 123 ready', 'check the spec for 178', 'refine the spec for N with these answers', 'here are my answers: ...', 'add my answers and re-check ticket N', 'iterate on the gaps for 42'. This skill wraps the spec_check and spec_refine workflows with a single deterministic script so the orchestrator doesn't have to carry the evaluation logic in its own context. Prefer this skill over the generic sandstorm skill whenever the user's intent is spec-gate evaluation or refinement on a named ticket. Do NOT trigger for: dispatching tasks, creating stacks, reviewing code diffs, or any workflow that isn't specifically about running the spec quality gate."
+---
+
+# /sandstorm-spec
+
+Wraps the Sandstorm spec quality gate (`spec_check` and `spec_refine`) behind a single script. Two subcommands.
+
+## Identify the subcommand from the user's message
+
+**Use `check`** when the user is asking whether a ticket is ready, running a fresh spec check, or there's no prior question-and-answer context in this conversation.
+
+**Use `refine`** when the user is providing answers to gaps that were surfaced by a previous check. Look for cues like "here are my answers," "the answers are," or a direct reply to a gap question you just surfaced.
+
+## Run the script exactly once per turn
+
+For `check`:
+```bash
+bash "$SANDSTORM_SKILLS_DIR/sandstorm-spec/scripts/sandstorm-spec.sh" check <ticket-id>
+```
+
+For `refine` (user's answers piped verbatim on stdin):
+```bash
+echo "<user's answers verbatim>" | bash "$SANDSTORM_SKILLS_DIR/sandstorm-spec/scripts/sandstorm-spec.sh" refine <ticket-id>
+```
+
+The script prints a JSON payload from the underlying spec agent. Relay its key fields to the user:
+
+- If `passed: true` → report "spec gate passed" and stop.
+- If `passed: false` with `questions` → present the questions to the user and wait for their reply. On the reply, invoke `refine`.
+- If the script prints an error line starting with `ERROR`, relay the error.
+
+## Hard rules
+
+- **NEVER call the `spec_check` or `spec_refine` MCP tools directly.** This skill is the only path.
+- **NEVER edit the ticket yourself.** The spec agent inside the script handles updates.
+- **One script invocation per user message.** Do not re-run without user input.

--- a/sandstorm-cli/skills/sandstorm-spec/scripts/sandstorm-spec.sh
+++ b/sandstorm-cli/skills/sandstorm-spec/scripts/sandstorm-spec.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Script-backed spec-gate skill (#268 continuation).
+# Wraps the `spec_check` and `spec_refine` MCP tools in a single
+# deterministic entry point. The orchestrator only has to run one Bash
+# call per user message; the script calls the in-process MCP bridge via
+# HTTP.
+#
+# Usage:
+#   sandstorm-spec.sh check  <ticket-id>
+#   sandstorm-spec.sh refine <ticket-id>    # user answers on stdin
+
+set -euo pipefail
+
+SUBCOMMAND="${1:-}"
+TICKET_ID="${2:-}"
+PROJECT_DIR="${PWD}"
+
+if [[ -z "$SUBCOMMAND" || -z "$TICKET_ID" ]]; then
+  echo "ERROR reason=missing_arg expected=\"{check|refine} <ticket-id>\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+call_bridge() {
+  curl -fsS -X POST \
+    -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$1" \
+    "$SANDSTORM_BRIDGE_URL/tool-call"
+}
+
+case "$SUBCOMMAND" in
+  check)
+    INPUT=$(jq -cn --arg t "$TICKET_ID" --arg d "$PROJECT_DIR" \
+      '{name:"spec_check", input:{ticketId:$t, projectDir:$d}}')
+    RESP="$(call_bridge "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    echo "$RESP" | jq -c '.result // {error: (.error // "unknown_error")}'
+    ;;
+  refine)
+    # userAnswers are expected on stdin — empty string means "no answers yet,
+    # just re-fetch the gaps" which is the intended behavior of spec_refine.
+    USER_ANSWERS=""
+    if [[ ! -t 0 ]]; then
+      USER_ANSWERS="$(cat)"
+    fi
+    INPUT=$(jq -cn \
+      --arg t "$TICKET_ID" \
+      --arg d "$PROJECT_DIR" \
+      --arg u "$USER_ANSWERS" \
+      '{name:"spec_refine", input:{ticketId:$t, projectDir:$d, userAnswers:$u}}')
+    RESP="$(call_bridge "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    echo "$RESP" | jq -c '.result // {error: (.error // "unknown_error")}'
+    ;;
+  *)
+    echo "ERROR reason=unknown_subcommand got=\"$SUBCOMMAND\" expected=\"check|refine\""
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
First MCP-tool port on the Ticket D migration path. Depends on #272 (skill injection infrastructure).

## Summary
- New compound skill `sandstorm-spec` at `sandstorm-cli/skills/sandstorm-spec/` (bundled via extraResources, available in every project).
- SKILL.md describes when to `check` a ticket vs `refine` based on whether the user is providing answers to prior gaps.
- `scripts/sandstorm-spec.sh` is a subcommand-style curl client to the in-process MCP bridge. One script invocation per user message, clean pass-through of the underlying agent's `.result` payload.
- User answers flow to `refine` via stdin (piped from the skill body) so multi-line / special-char answers don't need arg escaping.

## Why compound vs two separate skills
The user-facing workflow is one loop: check → gaps surface → user answers → refine. A single skill keeps both halves under one description/body so the model doesn't have to reason about which of two similar skills to pick. Matches the "compound workflow" pattern Ticket C established.

## Cost posture — honest read
Prefix growth from this skill alone (description in context per sub-turn): ~1.7 KB.
MCP schemas being replaced (spec_check + spec_refine): ~1.1 KB combined.

**This PR is prep, not a cost win yet.** Until MCP is removed in Ticket D-final, we're paying both costs simultaneously. The point of landing this now is:
- D-final becomes a single surgical "remove MCP" commit rather than "port then remove" sequence
- User can see how the skill triggers against real workflows before we cut over
- Further MCP→skill ports follow the same pattern this establishes

## Test plan
- [x] SKILL.md frontmatter parseable by existing skill-enumerator tests (folder pattern validated in #272)
- [x] Script `bash -n` syntax check passes
- [ ] Post-rebuild, `/spec-check 250` style prompts route through `Skill(sandstorm-spec)` → `Bash(sandstorm-spec.sh check 250)` instead of `mcp__sandstorm-tools__spec_check`. Verifiable via telemetry tool_calls.

## Merge order
After #272. Independent of #273 and #274 — they don't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)