### PR TITLE
Port set_pr + teardown_stack to script-backed skills

### DIFF
--- a/sandstorm-cli/skills/sandstorm-spec/SKILL.md
+++ b/sandstorm-cli/skills/sandstorm-spec/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: sandstorm-spec
+description: "Use this skill whenever the user wants to run the Sandstorm spec quality gate on a ticket, check whether a ticket is ready for agent dispatch, or iterate on a ticket that failed the gate. Trigger phrases include: 'run spec check on ticket N', '/spec-check N', 'is ticket 123 ready', 'check the spec for 178', 'refine the spec for N with these answers', 'here are my answers: ...', 'add my answers and re-check ticket N', 'iterate on the gaps for 42'. This skill wraps the spec_check and spec_refine workflows with a single deterministic script so the orchestrator doesn't have to carry the evaluation logic in its own context. Prefer this skill over the generic sandstorm skill whenever the user's intent is spec-gate evaluation or refinement on a named ticket. Do NOT trigger for: dispatching tasks, creating stacks, reviewing code diffs, or any workflow that isn't specifically about running the spec quality gate."
+---
+
+# /sandstorm-spec
+
+Wraps the Sandstorm spec quality gate (`spec_check` and `spec_refine`) behind a single script. Two subcommands.
+
+## Identify the subcommand from the user's message
+
+**Use `check`** when the user is asking whether a ticket is ready, running a fresh spec check, or there's no prior question-and-answer context in this conversation.
+
+**Use `refine`** when the user is providing answers to gaps that were surfaced by a previous check. Look for cues like "here are my answers," "the answers are," or a direct reply to a gap question you just surfaced.
+
+## Run the script exactly once per turn
+
+For `check`:
+```bash
+bash "$SANDSTORM_SKILLS_DIR/sandstorm-spec/scripts/sandstorm-spec.sh" check <ticket-id>
+```
+
+For `refine` (user's answers piped verbatim on stdin):
+```bash
+echo "<user's answers verbatim>" | bash "$SANDSTORM_SKILLS_DIR/sandstorm-spec/scripts/sandstorm-spec.sh" refine <ticket-id>
+```
+
+The script prints a JSON payload from the underlying spec agent. Relay its key fields to the user:
+
+- If `passed: true` → report "spec gate passed" and stop.
+- If `passed: false` with `questions` → present the questions to the user and wait for their reply. On the reply, invoke `refine`.
+- If the script prints an error line starting with `ERROR`, relay the error.
+
+## Hard rules
+
+- **NEVER call the `spec_check` or `spec_refine` MCP tools directly.** This skill is the only path.
+- **NEVER edit the ticket yourself.** The spec agent inside the script handles updates.
+- **One script invocation per user message.** Do not re-run without user input.

--- a/sandstorm-cli/skills/sandstorm-spec/scripts/sandstorm-spec.sh
+++ b/sandstorm-cli/skills/sandstorm-spec/scripts/sandstorm-spec.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Script-backed spec-gate skill (#268 continuation).
+# Wraps the `spec_check` and `spec_refine` MCP tools in a single
+# deterministic entry point. The orchestrator only has to run one Bash
+# call per user message; the script calls the in-process MCP bridge via
+# HTTP.
+#
+# Usage:
+#   sandstorm-spec.sh check  <ticket-id>
+#   sandstorm-spec.sh refine <ticket-id>    # user answers on stdin
+
+set -euo pipefail
+
+SUBCOMMAND="${1:-}"
+TICKET_ID="${2:-}"
+PROJECT_DIR="${PWD}"
+
+if [[ -z "$SUBCOMMAND" || -z "$TICKET_ID" ]]; then
+  echo "ERROR reason=missing_arg expected=\"{check|refine} <ticket-id>\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+call_bridge() {
+  curl -fsS -X POST \
+    -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$1" \
+    "$SANDSTORM_BRIDGE_URL/tool-call"
+}
+
+case "$SUBCOMMAND" in
+  check)
+    INPUT=$(jq -cn --arg t "$TICKET_ID" --arg d "$PROJECT_DIR" \
+      '{name:"spec_check", input:{ticketId:$t, projectDir:$d}}')
+    RESP="$(call_bridge "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    echo "$RESP" | jq -c '.result // {error: (.error // "unknown_error")}'
+    ;;
+  refine)
+    # userAnswers are expected on stdin — empty string means "no answers yet,
+    # just re-fetch the gaps" which is the intended behavior of spec_refine.
+    USER_ANSWERS=""
+    if [[ ! -t 0 ]]; then
+      USER_ANSWERS="$(cat)"
+    fi
+    INPUT=$(jq -cn \
+      --arg t "$TICKET_ID" \
+      --arg d "$PROJECT_DIR" \
+      --arg u "$USER_ANSWERS" \
+      '{name:"spec_refine", input:{ticketId:$t, projectDir:$d, userAnswers:$u}}')
+    RESP="$(call_bridge "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    echo "$RESP" | jq -c '.result // {error: (.error // "unknown_error")}'
+    ;;
+  *)
+    echo "ERROR reason=unknown_subcommand got=\"$SUBCOMMAND\" expected=\"check|refine\""
+    exit 0
+    ;;
+esac

--- a/sandstorm-cli/skills/stack-pr/SKILL.md
+++ b/sandstorm-cli/skills/stack-pr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: stack-pr
+description: "Use this skill whenever the user wants to record/link/associate a pull request with an existing Sandstorm stack. Trigger phrases include: 'record PR #N for stack X', 'set PR for stack X to #N', 'link PR https://github.com/.../pull/N to stack X', 'save the PR info on stack X', 'stack X's PR is #N'. Use this after a PR has been opened externally (via gh CLI, the GitHub UI, or push_stack's downstream flow) and the user wants the Sandstorm registry to know about it — the stack status flips to pr_created and the URL/number are stored. Do NOT trigger for: creating the PR itself (that's a separate gh CLI / push flow), tearing down the stack, checking stack status, or unrelated PR operations like merging or closing."
+---
+
+# /stack-pr
+
+Extract from the user's message:
+- The stack ID
+- The PR number (integer)
+- The PR URL (full https URL)
+
+Then run the script exactly once:
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/stack-pr/scripts/set-pr.sh" <stack-id> <pr-number> <pr-url>
+```
+
+The script prints `OK id=<stack> pr=<number>` on success or `ERROR <reason>` on failure. Relay the line.
+
+If any of the three inputs is missing from the user's message, ask the user for it — do NOT guess or look it up. Do not call the `set_pr` MCP tool directly.

--- a/sandstorm-cli/skills/stack-pr/scripts/set-pr.sh
+++ b/sandstorm-cli/skills/stack-pr/scripts/set-pr.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Script-backed wrapper for the set_pr MCP tool.
+# Usage: set-pr.sh <stack-id> <pr-number> <pr-url>
+
+set -euo pipefail
+
+STACK_ID="${1:-}"
+PR_NUMBER="${2:-}"
+PR_URL="${3:-}"
+
+if [[ -z "$STACK_ID" || -z "$PR_NUMBER" || -z "$PR_URL" ]]; then
+  echo "ERROR reason=missing_arg expected=\"<stack-id> <pr-number> <pr-url>\""
+  exit 0
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR reason=invalid_pr_number got=\"$PR_NUMBER\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+INPUT=$(jq -cn \
+  --arg s "$STACK_ID" \
+  --arg u "$PR_URL" \
+  --argjson n "$PR_NUMBER" \
+  '{name:"set_pr", input:{stackId:$s, prUrl:$u, prNumber:$n}}')
+
+RESP="$(curl -fsS -X POST \
+  -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$INPUT" \
+  "$SANDSTORM_BRIDGE_URL/tool-call" 2>/dev/null || echo '{"error":"call_failed"}')"
+
+if echo "$RESP" | jq -e '.error' >/dev/null 2>&1; then
+  REASON="$(echo "$RESP" | jq -r '.error')"
+  echo "ERROR reason=\"$REASON\" id=$STACK_ID"
+  exit 0
+fi
+
+echo "OK id=$STACK_ID pr=$PR_NUMBER"

--- a/sandstorm-cli/skills/stack-teardown/SKILL.md
+++ b/sandstorm-cli/skills/stack-teardown/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: stack-teardown
+description: "Use this skill ONLY when the user has EXPLICITLY asked to tear down, destroy, remove, or dismantle a named Sandstorm stack. Trigger phrases include: 'tear down stack X', 'destroy stack X', 'remove stack X', 'dismantle stack X', 'clean up stack X and all its containers', 'I'm done with stack X, kill it'. This skill stops containers, removes the workspace, and archives the stack — it is IRREVERSIBLE and can lose unpushed work. Do NOT trigger on ambiguous phrases like 'clean up', 'reset', 'start over', 'remove the old one', 'stack is broken', or anything that might imply teardown without literal user words like tear down / destroy / delete. Do NOT trigger for: stopping containers (that's pause, not teardown), checking status, failure recovery, or as a precursor to creating a new stack. When in doubt, ASK the user before running."
+---
+
+# /stack-teardown
+
+Before running: re-read the user's message. Did they literally ask to **tear down, destroy, remove, delete, or dismantle** a named stack? If the intent is ambiguous — even slightly — STOP and ask the user to confirm with the exact stack ID. Teardown is irreversible and has previously caused loss of unpushed work.
+
+Once confirmed, run the script exactly once:
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/stack-teardown/scripts/teardown.sh" <stack-id>
+```
+
+The script prints `OK id=<stack>` on success or `ERROR <reason>` on failure. Relay it.
+
+**Hard rules:**
+- One stack per invocation — no batch teardowns.
+- Never use this as a cleanup step for unrelated workflows.
+- Never call the `teardown_stack` MCP tool directly — go through this skill so the explicit-confirmation rule is visible in context.

--- a/sandstorm-cli/skills/stack-teardown/scripts/teardown.sh
+++ b/sandstorm-cli/skills/stack-teardown/scripts/teardown.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Script-backed wrapper for the teardown_stack MCP tool.
+# Usage: teardown.sh <stack-id>
+#
+# Irreversible — the skill body is responsible for requiring explicit
+# user confirmation before this script is ever invoked.
+
+set -euo pipefail
+
+STACK_ID="${1:-}"
+if [[ -z "$STACK_ID" ]]; then
+  echo "ERROR reason=missing_stack_id"
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+INPUT=$(jq -cn --arg s "$STACK_ID" '{name:"teardown_stack", input:{stackId:$s}}')
+
+RESP="$(curl -fsS -X POST \
+  -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$INPUT" \
+  "$SANDSTORM_BRIDGE_URL/tool-call" 2>/dev/null || echo '{"error":"call_failed"}')"
+
+if echo "$RESP" | jq -e '.error' >/dev/null 2>&1; then
+  REASON="$(echo "$RESP" | jq -r '.error')"
+  echo "ERROR reason=\"$REASON\" id=$STACK_ID"
+  exit 0
+fi
+
+echo "OK id=$STACK_ID"


### PR DESCRIPTION
Cold-path batch on the Ticket D MCP→skills migration. Depends on #272 (skill injection infrastructure) and #276 (establishes the bundled-skill + script pattern).

## Summary
Two small, independent skills under \`sandstorm-cli/skills/\` — bundled with the AppImage via \`extraResources\`.

- \`stack-pr\` — wraps \`set_pr\`. Records a PR number + URL against an existing stack. Description trigger-tight to "record / link / associate PR with stack X" patterns.
- \`stack-teardown\` — wraps \`teardown_stack\`. **The dangerous one.** SKILL.md body embeds the explicit-confirmation requirement from \`feedback_never_teardown_stacks.md\`: the model must re-verify the user literally asked to tear down / destroy / delete before running. Description deliberately negative about ambiguous terms ("cleanup", "reset", "start over").

Each script is ~30 lines of curl → \`/tool-call\` → unwrap-or-error.

## Cost posture
Still prep, not a cost win. Description bytes-in-prefix per sub-turn: ~900 B each. MCP schemas being replaced are ~200–400 B each. Per the established pattern, savings realize at D-final when the MCP layer is removed.

## Test plan
- [x] \`bash -n\` syntax check on both scripts
- [x] SKILL.md frontmatter parseable by existing enumerator (covered by #272 tests)
- [ ] Post-rebuild probe: "record PR #X on stack Y" and "tear down stack Y" prompts route through the skills. Manual check; telemetry will show \`Skill\` → \`Bash(<script>)\` sequence.

## Merge order
After #272 and #276 (for consistency with the spec skills, though technically this only hard-depends on #272). Independent of #273 and #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)