### PR TITLE
Port review-and-pr compound skill (get_diff + push_stack + set_pr)

### DIFF
--- a/sandstorm-cli/skills/review-and-pr/SKILL.md
+++ b/sandstorm-cli/skills/review-and-pr/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: review-and-pr
+description: "Use this skill whenever the user is ready to publish the work from an existing Sandstorm stack — reviewing the diff, pushing to its branch, opening a pull request, and recording the PR on the stack. Trigger phrases include: 'make a PR for stack X', 'publish stack X', 'push and PR stack X', 'the diff looks good, ship it', 'open a pull request for stack X', 'finalize stack X', 'commit and push stack X to a PR'. This is the end-of-workflow publish step for a stack that has completed its task and whose diff the user has seen (or is about to see via this skill). Do NOT trigger for: pushing WITHOUT a PR, creating a stack from scratch, dispatching new work, or any workflow where there are no changes to publish. Do NOT trigger if the stack is still running — the skill assumes the task is finished."
+---
+
+# /review-and-pr
+
+End-to-end publish flow. Two phases; run them in order.
+
+## Phase 1 — preview
+
+Show the uncommitted changes in the stack so you can craft a meaningful PR title and body:
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/review-and-pr/scripts/review-and-pr.sh" preview <stack-id>
+```
+
+The script prints the diff unchanged. Read it. If it's empty (`DIFF_EMPTY`), tell the user there's nothing to publish and stop — do NOT call phase 2.
+
+## Phase 2 — publish
+
+Craft a PR title and body:
+
+- **Title** — short, under ~70 chars, follows the project's recent commit/PR style. If the stack has a ticket number, lead with the ticket context (e.g. "Fix auth token expiry (#28)").
+- **Body** — a task-completion summary, per `feedback_pr_descriptions.md`: what was done, why, anything notable. NOT generic boilerplate.
+
+Pipe the body on stdin:
+
+```bash
+echo "<PR body text>" | bash "$SANDSTORM_SKILLS_DIR/review-and-pr/scripts/review-and-pr.sh" publish <stack-id> "<PR title>"
+```
+
+The script commits + pushes the stack's branch, opens the PR via the project's `.sandstorm/scripts/create-pr.sh`, parses out the PR number and URL, and records them back against the stack via `set_pr`. It prints one line:
+
+`OK stack=<id> pr=<number> url=<url>`
+
+Or on failure: `ERROR phase=<phase> reason=<...>`.
+
+Relay the line to the user.
+
+## Hard rules
+
+- **Never skip phase 1.** The user sees the diff (via your summary) before anything is pushed.
+- **Never call `get_diff`, `push_stack`, or `set_pr` MCP tools directly.** This skill is the only path for this workflow.
+- **Never pass `main` as a branch name.** Branches default to the stack name; don't override.
+- One stack per invocation.

--- a/sandstorm-cli/skills/review-and-pr/scripts/review-and-pr.sh
+++ b/sandstorm-cli/skills/review-and-pr/scripts/review-and-pr.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Script-backed review-and-pr compound skill (Ticket D continuation).
+# Two subcommands:
+#
+#   review-and-pr.sh preview <stack-id>
+#     -> prints the uncommitted diff from the stack workspace
+#
+#   review-and-pr.sh publish <stack-id> "<pr-title>"   (body on stdin)
+#     -> push_stack + project create-pr.sh + set_pr, all in one shot
+#
+# The model is responsible for phase separation and for authoring the
+# title + body; the script handles the deterministic wiring.
+
+set -euo pipefail
+
+SUBCOMMAND="${1:-}"
+STACK_ID="${2:-}"
+
+if [[ -z "$SUBCOMMAND" || -z "$STACK_ID" ]]; then
+  echo "ERROR phase=args reason=missing expected=\"{preview|publish} <stack-id> [<title>]\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+call_bridge() {
+  # $1 = name, $2 = input-json
+  local payload
+  payload=$(jq -cn --arg name "$1" --argjson input "$2" '{name:$name, input:$input}')
+  curl -fsS -X POST \
+    -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$SANDSTORM_BRIDGE_URL/tool-call"
+}
+
+case "$SUBCOMMAND" in
+  preview)
+    DIFF_RESP="$(call_bridge get_diff "{\"stackId\":\"$STACK_ID\"}" 2>/dev/null || echo '{"error":"call_failed"}')"
+    if echo "$DIFF_RESP" | jq -e '.error' >/dev/null 2>&1; then
+      REASON="$(echo "$DIFF_RESP" | jq -r '.error')"
+      echo "ERROR phase=preview reason=\"$REASON\" id=$STACK_ID"
+      exit 0
+    fi
+    DIFF="$(echo "$DIFF_RESP" | jq -r '.result // ""')"
+    if [[ -z "${DIFF//[[:space:]]/}" ]]; then
+      echo "DIFF_EMPTY id=$STACK_ID"
+      exit 0
+    fi
+    echo "$DIFF"
+    ;;
+
+  publish)
+    PR_TITLE="${3:-}"
+    if [[ -z "$PR_TITLE" ]]; then
+      echo "ERROR phase=publish reason=missing_title expected=\"publish <stack-id> '<title>'\""
+      exit 0
+    fi
+    # Body from stdin (possibly empty — still allowed, body is optional on gh pr create).
+    PR_BODY=""
+    if [[ ! -t 0 ]]; then
+      PR_BODY="$(cat)"
+    fi
+
+    # 1) push_stack via bridge (runs the CLI push + branch push).
+    PUSH_RESP="$(call_bridge push_stack "{\"stackId\":\"$STACK_ID\"}" 2>/dev/null || echo '{"error":"call_failed"}')"
+    if echo "$PUSH_RESP" | jq -e '.error' >/dev/null 2>&1; then
+      REASON="$(echo "$PUSH_RESP" | jq -r '.error')"
+      echo "ERROR phase=push reason=\"$REASON\" id=$STACK_ID"
+      exit 0
+    fi
+
+    # 2) Open the PR via the project's create-pr.sh helper.
+    CREATE_SCRIPT="$PWD/.sandstorm/scripts/create-pr.sh"
+    if [[ ! -x "$CREATE_SCRIPT" ]]; then
+      echo "ERROR phase=pr_create reason=\"project .sandstorm/scripts/create-pr.sh missing or not executable\" id=$STACK_ID"
+      exit 0
+    fi
+    # Pass body via --body-file to handle arbitrary length / special chars.
+    BODY_FILE="$(mktemp)"
+    trap 'rm -f "$BODY_FILE"' EXIT
+    printf '%s' "$PR_BODY" >"$BODY_FILE"
+    PR_OUTPUT="$("$CREATE_SCRIPT" --title "$PR_TITLE" --body-file "$BODY_FILE" 2>&1)" || {
+      echo "ERROR phase=pr_create reason=\"$(echo "$PR_OUTPUT" | tr '\n' ' ' | head -c 300)\" id=$STACK_ID"
+      exit 0
+    }
+
+    # Parse the PR URL and number from create-pr.sh output. It typically prints
+    # the URL like https://github.com/org/repo/pull/123 on its last line.
+    PR_URL="$(printf '%s\n' "$PR_OUTPUT" | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | tail -1)"
+    if [[ -z "$PR_URL" ]]; then
+      echo "ERROR phase=pr_create reason=\"no_pr_url_in_output\" output=\"$(printf '%s' "$PR_OUTPUT" | tr '\n' ' ' | head -c 200)\" id=$STACK_ID"
+      exit 0
+    fi
+    PR_NUMBER="$(echo "$PR_URL" | grep -oE '[0-9]+$')"
+
+    # 3) Record the PR against the stack.
+    SET_PR_INPUT=$(jq -cn --arg s "$STACK_ID" --arg u "$PR_URL" --argjson n "$PR_NUMBER" \
+      '{stackId:$s, prUrl:$u, prNumber:$n}')
+    SET_RESP="$(call_bridge set_pr "$SET_PR_INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    if echo "$SET_RESP" | jq -e '.error' >/dev/null 2>&1; then
+      REASON="$(echo "$SET_RESP" | jq -r '.error')"
+      # PR is already live even if we couldn't record it; report the URL.
+      echo "ERROR phase=set_pr reason=\"$REASON\" id=$STACK_ID pr=$PR_NUMBER url=$PR_URL"
+      exit 0
+    fi
+
+    echo "OK stack=$STACK_ID pr=$PR_NUMBER url=$PR_URL"
+    ;;
+
+  *)
+    echo "ERROR phase=args reason=unknown_subcommand got=\"$SUBCOMMAND\" expected=\"preview|publish\""
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
Next in the MCP→skills migration. Collapses the "ship the work" flow into one skill with preview/publish phases.

## Summary
- \`sandstorm-cli/skills/review-and-pr/\` with SKILL.md + scripts/review-and-pr.sh.
- \`preview <stack-id>\`: fetches diff via get_diff bridge call. Prints \`DIFF_EMPTY\` if nothing staged so the model stops.
- \`publish <stack-id> "<title>"\` (body on stdin): push_stack → project's \`.sandstorm/scripts/create-pr.sh\` → parse URL/number → set_pr. Prints \`OK stack=<id> pr=<n> url=<u>\` or \`ERROR phase=<where>\`.
- Enforces phase separation so the model reviews the diff before anything is pushed. Per \`feedback_pr_descriptions.md\`, model authors real PR copy; script doesn't add boilerplate.

## Coverage progress
After this merges, MCP tools with skill replacements:
- ✅ list_stacks, get_task_status, dispatch_task (inside check-and-resume script)
- ✅ spec_check, spec_refine (sandstorm-spec)
- ✅ set_pr (stack-pr standalone + reused in review-and-pr)
- ✅ teardown_stack (stack-teardown)
- ✅ get_diff, push_stack (review-and-pr)

Remaining: create_stack, get_task_output, get_logs. Then D-final.

## Test plan
- [x] \`bash -n\` syntax check
- [x] SKILL.md folder pattern, enumerator tests cover it
- [ ] Post-rebuild probe: "make a PR for stack X" invokes Skill → preview → (model authors title/body) → publish. Telemetry shows 3 tool calls instead of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)