### PR TITLE
Port spec-and-dispatch compound skill (spec_check + spec_refine + create_stack)

### DIFF
--- a/sandstorm-cli/skills/spec-and-dispatch/SKILL.md
+++ b/sandstorm-cli/skills/spec-and-dispatch/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: spec-and-dispatch
+description: "Use this skill whenever the user wants to take an existing ticket / issue, run the Sandstorm spec quality gate on it, and then (once it passes) create a stack with the ticket's verbatim body as the initial task. Trigger phrases include: 'take ticket N and build it', 'spec and dispatch N', 'fire up a stack for ticket N', 'let's work on #N', 'start issue N in a stack', 'create a stack for issue N, run the gate first'. This skill is the full start-to-dispatch flow for a ticket: fetch ticket → spec_check → (refine loop if needed) → create_stack with gateApproved=true and the ticket body as the initial task. Do NOT trigger for: dispatching follow-up work to an EXISTING stack (that's the sandstorm / check-and-resume flow), running the spec gate in isolation (that's the sandstorm-spec skill), or creating a stack without a ticket."
+---
+
+# /spec-and-dispatch
+
+End-to-end flow from a ticket number to a running stack.
+
+## Extract from the user's message
+
+- **Ticket ID** (required)
+- **Stack name** (optional — if missing, ask the user. A good default is derived from the ticket slug, e.g. `fix-auth-bug-28`, but let the user confirm.)
+
+## Run the gate first
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/spec-and-dispatch/scripts/spec-and-dispatch.sh" check <ticket-id>
+```
+
+The script prints the spec_check result payload. Three outcomes:
+
+1. **Passed** (`passed:true`) → proceed to "Create the stack" below.
+2. **Gaps** (`passed:false` with `questions`) → present the questions to the user. On their reply:
+   ```bash
+   echo "<user's answers verbatim>" | bash "$SANDSTORM_SKILLS_DIR/spec-and-dispatch/scripts/spec-and-dispatch.sh" refine <ticket-id>
+   ```
+   Loop through questions/answers until `passed:true`.
+3. **Error** → relay to the user; stop.
+
+## Create the stack
+
+Once the gate passes, confirm the stack name with the user if you don't already have one. Then:
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/spec-and-dispatch/scripts/spec-and-dispatch.sh" create <ticket-id> <stack-name>
+```
+
+The script fetches the ticket body verbatim and dispatches it as the initial task with `gateApproved:true`. No summarization, no rewrite — the ticket is the source of truth per `feedback_pass_issue_verbatim.md`. It prints `OK stack=<name> ticket=<n> task=<task-id>` or `ERROR phase=<where> reason=<...>`.
+
+Relay the result.
+
+## Hard rules
+
+- **Never summarize or rewrite the ticket body.** The script passes it verbatim; don't try to "improve" it.
+- **Never set `branch: main`.** Omit the branch arg — it defaults to the stack name.
+- **Never skip the gate** by calling `create` before `check` succeeds. The spec-gate pass is the precondition for dispatch.
+- **Never call `spec_check`, `spec_refine`, or `create_stack` MCP tools directly.** This skill is the only path for this workflow.
+- One ticket per invocation.

--- a/sandstorm-cli/skills/spec-and-dispatch/scripts/spec-and-dispatch.sh
+++ b/sandstorm-cli/skills/spec-and-dispatch/scripts/spec-and-dispatch.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Script-backed spec-and-dispatch compound skill (Ticket D continuation).
+# Three subcommands wrapping the full "ticket → spec gate → create stack
+# with verbatim ticket body" flow.
+#
+#   spec-and-dispatch.sh check  <ticket-id>
+#   spec-and-dispatch.sh refine <ticket-id>          # user answers on stdin
+#   spec-and-dispatch.sh create <ticket-id> <stack-name>
+
+set -euo pipefail
+
+SUBCOMMAND="${1:-}"
+TICKET_ID="${2:-}"
+PROJECT_DIR="${PWD}"
+
+if [[ -z "$SUBCOMMAND" || -z "$TICKET_ID" ]]; then
+  echo "ERROR phase=args reason=missing expected=\"{check|refine|create} <ticket-id> [<stack-name>]\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+call_bridge() {
+  local payload
+  payload=$(jq -cn --arg name "$1" --argjson input "$2" '{name:$name, input:$input}')
+  curl -fsS -X POST \
+    -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$SANDSTORM_BRIDGE_URL/tool-call"
+}
+
+fetch_ticket_body() {
+  # Uses the project's fetch-ticket helper (same one the MCP
+  # handleSpecCheck path uses). Returns the ticket body on stdout or
+  # empty on failure — caller decides how to handle missing.
+  local script="$PROJECT_DIR/.sandstorm/scripts/fetch-ticket.sh"
+  if [[ ! -x "$script" ]]; then
+    return 1
+  fi
+  "$script" "$TICKET_ID" 2>/dev/null
+}
+
+case "$SUBCOMMAND" in
+  check)
+    INPUT=$(jq -cn --arg t "$TICKET_ID" --arg d "$PROJECT_DIR" \
+      '{ticketId:$t, projectDir:$d}')
+    RESP="$(call_bridge spec_check "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    echo "$RESP" | jq -c '.result // {error: (.error // "unknown_error")}'
+    ;;
+
+  refine)
+    USER_ANSWERS=""
+    if [[ ! -t 0 ]]; then
+      USER_ANSWERS="$(cat)"
+    fi
+    INPUT=$(jq -cn \
+      --arg t "$TICKET_ID" \
+      --arg d "$PROJECT_DIR" \
+      --arg u "$USER_ANSWERS" \
+      '{ticketId:$t, projectDir:$d, userAnswers:$u}')
+    RESP="$(call_bridge spec_refine "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    echo "$RESP" | jq -c '.result // {error: (.error // "unknown_error")}'
+    ;;
+
+  create)
+    STACK_NAME="${3:-}"
+    if [[ -z "$STACK_NAME" ]]; then
+      echo "ERROR phase=args reason=missing_stack_name expected=\"create <ticket-id> <stack-name>\""
+      exit 0
+    fi
+
+    TICKET_BODY="$(fetch_ticket_body)" || {
+      echo "ERROR phase=fetch_ticket reason=\"fetch-ticket.sh missing or failed\" ticket=$TICKET_ID"
+      exit 0
+    }
+    if [[ -z "${TICKET_BODY//[[:space:]]/}" ]]; then
+      echo "ERROR phase=fetch_ticket reason=empty_body ticket=$TICKET_ID"
+      exit 0
+    fi
+
+    INPUT=$(jq -cn \
+      --arg name "$STACK_NAME" \
+      --arg dir "$PROJECT_DIR" \
+      --arg ticket "$TICKET_ID" \
+      --arg task "$TICKET_BODY" \
+      '{name:$name, projectDir:$dir, ticket:$ticket, task:$task, gateApproved:true}')
+
+    RESP="$(call_bridge create_stack "$INPUT" 2>/dev/null || echo '{"error":"call_failed"}')"
+    if echo "$RESP" | jq -e '.error' >/dev/null 2>&1; then
+      REASON="$(echo "$RESP" | jq -r '.error')"
+      echo "ERROR phase=create_stack reason=\"$REASON\" ticket=$TICKET_ID stack=$STACK_NAME"
+      exit 0
+    fi
+    # Stack creation schedules a background build. The create_stack response
+    # returns the Stack row; the initial task (if passed via `task` field)
+    # dispatches once the stack is up. We just report the mapping.
+    RESULT_ID="$(echo "$RESP" | jq -r '.result.id // .result.name // "unknown"')"
+    echo "OK stack=$RESULT_ID ticket=$TICKET_ID"
+    ;;
+
+  *)
+    echo "ERROR phase=args reason=unknown_subcommand got=\"$SUBCOMMAND\" expected=\"check|refine|create\""
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
The biggest compound skill on the migration path. Closes the "ticket → running stack" flow with one skill invocation.

## Summary
- \`sandstorm-cli/skills/spec-and-dispatch/\` bundled via extraResources.
- Three subcommands:
  - \`check <ticket-id>\` → spec_check via bridge.
  - \`refine <ticket-id>\` (answers on stdin) → spec_refine via bridge.
  - \`create <ticket-id> <stack-name>\` → fetches ticket body verbatim via project's fetch-ticket.sh, then create_stack via bridge with \`gateApproved:true\`, \`task:<verbatim body>\`, \`ticket:<id>\`.

## Coverage progress
With this merged, MCP tools with skill replacements:
- ✅ list_stacks, get_task_status, dispatch_task (check-and-resume-stack)
- ✅ spec_check, spec_refine (sandstorm-spec + spec-and-dispatch)
- ✅ set_pr (stack-pr + review-and-pr)
- ✅ teardown_stack (stack-teardown)
- ✅ get_diff, push_stack (review-and-pr)
- ✅ **create_stack** (spec-and-dispatch)

Remaining before D-final: \`get_task_output\`, \`get_logs\`. Those are next PR — one compound \`stack-inspect\` skill plus a tiny \`list-stacks\` standalone.

## Design notes
- Duplicates the spec_check/spec_refine bridge calls that sandstorm-spec already wraps. Intentional: keeps the skill self-contained so the model isn't chained across two skills during one workflow. Slight prefix-byte cost vs the saved reasoning-across-skills cost.
- \`fetch-ticket.sh\` is project-local; script errors cleanly if missing.
- Never summarizes the ticket body (\`feedback_pass_issue_verbatim.md\`).
- Never passes \`branch:main\` (\`feedback_always_feature_branches.md\`).

## Test plan
- [x] \`bash -n\` syntax OK
- [x] SKILL.md folder pattern (enumerator tests cover mechanism)
- [ ] Post-rebuild: "take ticket 250 and build it" → Skill → check → (maybe refine) → create. Telemetry shows 2-3 tool calls vs the ~8-calls baseline path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)