### PR TITLE
Port stack-inspect + list-stacks skills (final MCP tool ports)

### DIFF
--- a/sandstorm-cli/skills/list-stacks/SKILL.md
+++ b/sandstorm-cli/skills/list-stacks/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: list-stacks
+description: "Use this skill whenever the user asks for a listing / overview / enumeration of their Sandstorm stacks. Trigger phrases include: 'list my stacks', 'what stacks do I have', 'show me all my stacks', 'list stacks', 'what's running', 'give me a rundown of the stacks', 'which stacks are active'. This is a pure listing — it returns every stack with its status and services. Do NOT trigger for: asking about ONE specific stack (that's check-and-resume-stack or stack-inspect), creating a new stack (that's spec-and-dispatch), or any action on a stack."
+---
+
+# /list-stacks
+
+Pure listing. Run the script exactly once, relay the JSON payload to the user as a readable table:
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/list-stacks/scripts/list-stacks.sh"
+```
+
+The script prints the raw JSON array returned by `list_stacks`. Format it for the user — typically a markdown table with columns: ID, project, ticket, branch, status, services. Do not follow up with other tool calls; listing is the complete action.
+
+Do not call the `list_stacks` MCP tool directly — this skill is the only path.

--- a/sandstorm-cli/skills/list-stacks/scripts/list-stacks.sh
+++ b/sandstorm-cli/skills/list-stacks/scripts/list-stacks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Script-backed list-stacks skill (Ticket D continuation).
+# Lists every stack with status + services via the in-process MCP bridge.
+
+set -euo pipefail
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+RESP="$(curl -fsS -X POST \
+  -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"list_stacks","input":{}}' \
+  "$SANDSTORM_BRIDGE_URL/tool-call" 2>/dev/null || echo '{"error":"call_failed"}')"
+
+if echo "$RESP" | jq -e '.error' >/dev/null 2>&1; then
+  REASON="$(echo "$RESP" | jq -r '.error')"
+  echo "ERROR reason=\"$REASON\""
+  exit 0
+fi
+
+echo "$RESP" | jq -c '.result // []'

--- a/sandstorm-cli/skills/stack-inspect/SKILL.md
+++ b/sandstorm-cli/skills/stack-inspect/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: stack-inspect
+description: "Use this skill whenever the user wants to see DETAILED output, logs, or uncommitted changes from a specific Sandstorm stack. Trigger phrases include: 'show me the output of stack X', 'what did stack X log', 'show the task output for X', 'show container logs for stack X', 'what changed in stack X', 'show me the diff in stack X', 'what's happening inside stack X', 'dump stack X's output', 'get logs for stack X's claude container'. The skill covers three read-only probes — task output, container logs, and uncommitted diff — as subcommands. Do NOT trigger for: a quick status check (that's check-and-resume-stack), listing all stacks (that's list-stacks), or anything that modifies state. Prefer the narrower subcommand (output / logs / diff) over 'all' when the user is specific about what they want."
+---
+
+# /stack-inspect
+
+Read-only inspection of a stack. Pick the right subcommand based on what the user asked for.
+
+## Subcommands
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" output <stack-id>
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" logs   <stack-id> [service]
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" diff   <stack-id>
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" all    <stack-id>
+```
+
+- `output` → latest task output (last 50 lines by default).
+- `logs [service]` → container logs. Omit `service` for all containers; specify `claude` or `app` to narrow.
+- `diff` → uncommitted changes in the stack's workspace.
+- `all` → condensed version of all three sections. Use sparingly — this is the most expensive variant.
+
+The script prints the unwrapped bridge result. Relay it to the user, trimmed if very long.
+
+## Hard rules
+
+- One stack per invocation. If the user names multiple, ask which one.
+- Don't call `get_task_output`, `get_logs`, or `get_diff` MCP tools directly — this skill is the only path for these read-only queries.
+- Don't follow up with `dispatch_task` or any mutation. If the user wants to act on what they saw, that's a different skill (check-and-resume-stack, review-and-pr).

--- a/sandstorm-cli/skills/stack-inspect/scripts/stack-inspect.sh
+++ b/sandstorm-cli/skills/stack-inspect/scripts/stack-inspect.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Script-backed stack-inspect skill (Ticket D continuation).
+# Read-only probes against a stack via the in-process MCP bridge.
+#
+#   stack-inspect.sh output <stack-id>
+#   stack-inspect.sh logs   <stack-id> [service]
+#   stack-inspect.sh diff   <stack-id>
+#   stack-inspect.sh all    <stack-id>
+
+set -euo pipefail
+
+SUBCOMMAND="${1:-}"
+STACK_ID="${2:-}"
+
+if [[ -z "$SUBCOMMAND" || -z "$STACK_ID" ]]; then
+  echo "ERROR reason=missing_arg expected=\"{output|logs|diff|all} <stack-id> [<service>]\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+call_bridge() {
+  local payload
+  payload=$(jq -cn --arg name "$1" --argjson input "$2" '{name:$name, input:$input}')
+  curl -fsS -X POST \
+    -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$SANDSTORM_BRIDGE_URL/tool-call" 2>/dev/null || echo '{"error":"call_failed"}'
+}
+
+unwrap() {
+  # Prints .result as-is, or a single-line ERROR if the bridge reported one.
+  local resp="$1"
+  local label="$2"
+  if echo "$resp" | jq -e '.error' >/dev/null 2>&1; then
+    local reason
+    reason="$(echo "$resp" | jq -r '.error')"
+    echo "ERROR section=$label reason=\"$reason\""
+    return 1
+  fi
+  echo "$resp" | jq -r '.result // ""'
+}
+
+do_output() {
+  local resp
+  resp="$(call_bridge get_task_output "{\"stackId\":\"$STACK_ID\"}")"
+  unwrap "$resp" output
+}
+
+do_logs() {
+  local service="${1:-}"
+  local input
+  if [[ -n "$service" ]]; then
+    input="{\"stackId\":\"$STACK_ID\",\"service\":\"$service\"}"
+  else
+    input="{\"stackId\":\"$STACK_ID\"}"
+  fi
+  local resp
+  resp="$(call_bridge get_logs "$input")"
+  unwrap "$resp" logs
+}
+
+do_diff() {
+  local resp
+  resp="$(call_bridge get_diff "{\"stackId\":\"$STACK_ID\"}")"
+  unwrap "$resp" diff
+}
+
+case "$SUBCOMMAND" in
+  output) do_output ;;
+  logs)   do_logs "${3:-}" ;;
+  diff)   do_diff ;;
+  all)
+    echo "=== OUTPUT ==="
+    do_output || true
+    echo ""
+    echo "=== LOGS ==="
+    do_logs || true
+    echo ""
+    echo "=== DIFF ==="
+    do_diff || true
+    ;;
+  *)
+    echo "ERROR reason=unknown_subcommand got=\"$SUBCOMMAND\" expected=\"output|logs|diff|all\""
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
Final MCP-tool ports. After this merges, every tool in \`src/main/claude/tools.ts\` has a skill replacement and D-final is unblocked.

## Summary
- **stack-inspect** compound — wraps \`get_task_output\`, \`get_logs\`, \`get_diff\`. Subcommands: \`output\`, \`logs\`, \`diff\`, \`all\`. The \`all\` variant prints all three sections with headers for "what's happening in stack X" queries.
- **list-stacks** standalone — wraps \`list_stacks\`. Tiny; skill body tells the model to format the JSON as a table.

## Post-merge coverage
Every MCP tool ported:
- ✅ create_stack (spec-and-dispatch)
- ✅ list_stacks (list-stacks standalone, and inside check-and-resume)
- ✅ dispatch_task (inside check-and-resume; spec-and-dispatch passes initial task via create_stack's task field)
- ✅ get_diff (review-and-pr; stack-inspect)
- ✅ push_stack (review-and-pr)
- ✅ get_task_status (inside check-and-resume)
- ✅ get_task_output (stack-inspect)
- ✅ teardown_stack (stack-teardown)
- ✅ get_logs (stack-inspect)
- ✅ set_pr (stack-pr; review-and-pr)
- ✅ spec_check (sandstorm-spec; spec-and-dispatch)
- ✅ spec_refine (sandstorm-spec; spec-and-dispatch)

Every tool now has a bridge-only script path that doesn't require the MCP layer. D-final can remove:
- \`--mcp-config\` arg in \`claude-backend.ts\` \`ensureProcess\`
- \`writeMcpConfig\` and the embedded MCP server template
- \`src/main/claude/tools.ts\` tool schemas (bridge endpoint keeps handling the same names; it's the MCP tool-surface exposure to the model that goes away)

## Test plan
- [x] \`bash -n\` both scripts
- [x] SKILL.md folder pattern
- [ ] Post-rebuild: "show me the output of stack X" → Skill(stack-inspect) → Bash. "list my stacks" → Skill(list-stacks) → Bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)