### PR TITLE
D-final: Remove MCP layer — the payoff

### DIFF
--- a/sandstorm-cli/skills/list-stacks/SKILL.md
+++ b/sandstorm-cli/skills/list-stacks/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: list-stacks
+description: "Use this skill whenever the user asks for a listing / overview / enumeration of their Sandstorm stacks. Trigger phrases include: 'list my stacks', 'what stacks do I have', 'show me all my stacks', 'list stacks', 'what's running', 'give me a rundown of the stacks', 'which stacks are active'. This is a pure listing — it returns every stack with its status and services. Do NOT trigger for: asking about ONE specific stack (that's check-and-resume-stack or stack-inspect), creating a new stack (that's spec-and-dispatch), or any action on a stack."
+---
+
+# /list-stacks
+
+Pure listing. Run the script exactly once, relay the JSON payload to the user as a readable table:
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/list-stacks/scripts/list-stacks.sh"
+```
+
+The script prints the raw JSON array returned by `list_stacks`. Format it for the user — typically a markdown table with columns: ID, project, ticket, branch, status, services. Do not follow up with other tool calls; listing is the complete action.
+
+Do not call the `list_stacks` MCP tool directly — this skill is the only path.

--- a/sandstorm-cli/skills/list-stacks/scripts/list-stacks.sh
+++ b/sandstorm-cli/skills/list-stacks/scripts/list-stacks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Script-backed list-stacks skill (Ticket D continuation).
+# Lists every stack with status + services via the in-process MCP bridge.
+
+set -euo pipefail
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+RESP="$(curl -fsS -X POST \
+  -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"list_stacks","input":{}}' \
+  "$SANDSTORM_BRIDGE_URL/tool-call" 2>/dev/null || echo '{"error":"call_failed"}')"
+
+if echo "$RESP" | jq -e '.error' >/dev/null 2>&1; then
+  REASON="$(echo "$RESP" | jq -r '.error')"
+  echo "ERROR reason=\"$REASON\""
+  exit 0
+fi
+
+echo "$RESP" | jq -c '.result // []'

--- a/sandstorm-cli/skills/stack-inspect/SKILL.md
+++ b/sandstorm-cli/skills/stack-inspect/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: stack-inspect
+description: "Use this skill whenever the user wants to see DETAILED output, logs, or uncommitted changes from a specific Sandstorm stack. Trigger phrases include: 'show me the output of stack X', 'what did stack X log', 'show the task output for X', 'show container logs for stack X', 'what changed in stack X', 'show me the diff in stack X', 'what's happening inside stack X', 'dump stack X's output', 'get logs for stack X's claude container'. The skill covers three read-only probes — task output, container logs, and uncommitted diff — as subcommands. Do NOT trigger for: a quick status check (that's check-and-resume-stack), listing all stacks (that's list-stacks), or anything that modifies state. Prefer the narrower subcommand (output / logs / diff) over 'all' when the user is specific about what they want."
+---
+
+# /stack-inspect
+
+Read-only inspection of a stack. Pick the right subcommand based on what the user asked for.
+
+## Subcommands
+
+```bash
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" output <stack-id>
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" logs   <stack-id> [service]
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" diff   <stack-id>
+bash "$SANDSTORM_SKILLS_DIR/stack-inspect/scripts/stack-inspect.sh" all    <stack-id>
+```
+
+- `output` → latest task output (last 50 lines by default).
+- `logs [service]` → container logs. Omit `service` for all containers; specify `claude` or `app` to narrow.
+- `diff` → uncommitted changes in the stack's workspace.
+- `all` → condensed version of all three sections. Use sparingly — this is the most expensive variant.
+
+The script prints the unwrapped bridge result. Relay it to the user, trimmed if very long.
+
+## Hard rules
+
+- One stack per invocation. If the user names multiple, ask which one.
+- Don't call `get_task_output`, `get_logs`, or `get_diff` MCP tools directly — this skill is the only path for these read-only queries.
+- Don't follow up with `dispatch_task` or any mutation. If the user wants to act on what they saw, that's a different skill (check-and-resume-stack, review-and-pr).

--- a/sandstorm-cli/skills/stack-inspect/scripts/stack-inspect.sh
+++ b/sandstorm-cli/skills/stack-inspect/scripts/stack-inspect.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Script-backed stack-inspect skill (Ticket D continuation).
+# Read-only probes against a stack via the in-process MCP bridge.
+#
+#   stack-inspect.sh output <stack-id>
+#   stack-inspect.sh logs   <stack-id> [service]
+#   stack-inspect.sh diff   <stack-id>
+#   stack-inspect.sh all    <stack-id>
+
+set -euo pipefail
+
+SUBCOMMAND="${1:-}"
+STACK_ID="${2:-}"
+
+if [[ -z "$SUBCOMMAND" || -z "$STACK_ID" ]]; then
+  echo "ERROR reason=missing_arg expected=\"{output|logs|diff|all} <stack-id> [<service>]\""
+  exit 0
+fi
+
+: "${SANDSTORM_BRIDGE_URL:?bridge url not set}"
+: "${SANDSTORM_BRIDGE_TOKEN:?bridge token not set}"
+
+call_bridge() {
+  local payload
+  payload=$(jq -cn --arg name "$1" --argjson input "$2" '{name:$name, input:$input}')
+  curl -fsS -X POST \
+    -H "X-Auth-Token: $SANDSTORM_BRIDGE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$SANDSTORM_BRIDGE_URL/tool-call" 2>/dev/null || echo '{"error":"call_failed"}'
+}
+
+unwrap() {
+  # Prints .result as-is, or a single-line ERROR if the bridge reported one.
+  local resp="$1"
+  local label="$2"
+  if echo "$resp" | jq -e '.error' >/dev/null 2>&1; then
+    local reason
+    reason="$(echo "$resp" | jq -r '.error')"
+    echo "ERROR section=$label reason=\"$reason\""
+    return 1
+  fi
+  echo "$resp" | jq -r '.result // ""'
+}
+
+do_output() {
+  local resp
+  resp="$(call_bridge get_task_output "{\"stackId\":\"$STACK_ID\"}")"
+  unwrap "$resp" output
+}
+
+do_logs() {
+  local service="${1:-}"
+  local input
+  if [[ -n "$service" ]]; then
+    input="{\"stackId\":\"$STACK_ID\",\"service\":\"$service\"}"
+  else
+    input="{\"stackId\":\"$STACK_ID\"}"
+  fi
+  local resp
+  resp="$(call_bridge get_logs "$input")"
+  unwrap "$resp" logs
+}
+
+do_diff() {
+  local resp
+  resp="$(call_bridge get_diff "{\"stackId\":\"$STACK_ID\"}")"
+  unwrap "$resp" diff
+}
+
+case "$SUBCOMMAND" in
+  output) do_output ;;
+  logs)   do_logs "${3:-}" ;;
+  diff)   do_diff ;;
+  all)
+    echo "=== OUTPUT ==="
+    do_output || true
+    echo ""
+    echo "=== LOGS ==="
+    do_logs || true
+    echo ""
+    echo "=== DIFF ==="
+    do_diff || true
+    ;;
+  *)
+    echo "ERROR reason=unknown_subcommand got=\"$SUBCOMMAND\" expected=\"output|logs|diff|all\""
+    exit 0
+    ;;
+esac

--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -12,7 +12,7 @@ import fs from 'fs';
 import os from 'os';
 import { BrowserWindow, shell } from 'electron';
 import { app } from 'electron';
-import { handleToolCall, tools } from '../claude/tools';
+import { handleToolCall } from '../claude/tools';
 import { cliDir } from '../index';
 import {
   AgentBackend,
@@ -87,7 +87,6 @@ export class ClaudeBackend implements AgentBackend {
   private bridgeServer: Server | null = null;
   private bridgePort = 0;
   private bridgeToken: string;
-  private mcpConfigPath: string | null = null;
   private mainWindow: BrowserWindow | null = null;
   private logStream: fs.WriteStream | null = null;
   private timeoutMs: number;
@@ -161,7 +160,6 @@ export class ClaudeBackend implements AgentBackend {
 
   async initialize(): Promise<void> {
     await this.startBridgeServer();
-    this.writeMcpConfig();
   }
 
   private startBridgeServer(): Promise<void> {
@@ -203,111 +201,6 @@ export class ClaudeBackend implements AgentBackend {
         resolve();
       });
     });
-  }
-
-  private writeMcpConfig(): void {
-    const tmpDir = path.join(os.tmpdir(), `sandstorm-mcp-${process.pid}`);
-    fs.mkdirSync(tmpDir, { recursive: true });
-
-    const serverScriptPath = path.join(tmpDir, 'mcp-server.mjs');
-    const serverScript = `import http from 'http';
-import { createInterface } from 'readline';
-
-const BRIDGE_PORT = ${this.bridgePort};
-const BRIDGE_TOKEN = '${this.bridgeToken}';
-const TOOLS = ${JSON.stringify(tools)};
-
-const rl = createInterface({ input: process.stdin });
-
-function send(msg) {
-  process.stdout.write(JSON.stringify(msg) + '\\n');
-}
-
-async function callBridge(name, input) {
-  return new Promise((resolve, reject) => {
-    const data = JSON.stringify({ name, input });
-    const req = http.request({
-      hostname: '127.0.0.1',
-      port: BRIDGE_PORT,
-      path: '/tool-call',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Auth-Token': BRIDGE_TOKEN,
-        'Content-Length': Buffer.byteLength(data),
-      },
-      timeout: 310_000,
-    }, (res) => {
-      let body = '';
-      res.on('data', (chunk) => { body += chunk; });
-      res.on('end', () => {
-        try {
-          const parsed = JSON.parse(body);
-          if (parsed.error) reject(new Error(parsed.error));
-          else resolve(parsed.result);
-        } catch (e) { reject(e); }
-      });
-    });
-    req.on('timeout', () => {
-      req.destroy();
-      reject(new Error('Bridge request timed out after 310s'));
-    });
-    req.on('error', reject);
-    req.write(data);
-    req.end();
-  });
-}
-
-rl.on('line', async (line) => {
-  try {
-    const msg = JSON.parse(line);
-    if (msg.method === 'initialize') {
-      send({ jsonrpc: '2.0', id: msg.id, result: {
-        protocolVersion: '2024-11-05',
-        capabilities: { tools: {} },
-        serverInfo: { name: 'sandstorm-tools', version: '1.0.0' },
-      }});
-    } else if (msg.method === 'notifications/initialized') {
-      // No response needed
-    } else if (msg.method === 'tools/list') {
-      send({ jsonrpc: '2.0', id: msg.id, result: {
-        tools: TOOLS.map(t => ({
-          name: t.name,
-          description: t.description,
-          inputSchema: t.inputSchema,
-        })),
-      }});
-    } else if (msg.method === 'tools/call') {
-      const { name, arguments: args } = msg.params;
-      try {
-        const result = await callBridge(name, args || {});
-        send({ jsonrpc: '2.0', id: msg.id, result: {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        }});
-      } catch (err) {
-        send({ jsonrpc: '2.0', id: msg.id, result: {
-          content: [{ type: 'text', text: 'Error: ' + err.message }],
-          isError: true,
-        }});
-      }
-    }
-  } catch {
-    // Ignore malformed input
-  }
-});
-`;
-    fs.writeFileSync(serverScriptPath, serverScript);
-
-    this.mcpConfigPath = path.join(tmpDir, 'mcp-config.json');
-    const mcpConfig = {
-      mcpServers: {
-        'sandstorm-tools': {
-          command: 'node',
-          args: [serverScriptPath],
-        },
-      },
-    };
-    fs.writeFileSync(this.mcpConfigPath, JSON.stringify(mcpConfig));
   }
 
   // --- Session management (AgentBackend interface) ---
@@ -754,10 +647,6 @@ rl.on('line', async (line) => {
       args.push('--system-prompt-file', resolvedPromptFile);
     }
 
-    if (this.mcpConfigPath) {
-      args.push('--mcp-config', this.mcpConfigPath);
-    }
-
     if (this.modelResolver && session.projectDir) {
       const outerModel = this.modelResolver(session.projectDir);
       args.push('--model', outerModel);
@@ -1094,13 +983,5 @@ rl.on('line', async (line) => {
     this.logStream?.end();
     this.logStream = null;
     this.telemetry.close();
-    if (this.mcpConfigPath) {
-      const tmpDir = path.dirname(this.mcpConfigPath);
-      try {
-        fs.rmSync(tmpDir, { recursive: true });
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
   }
 }

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -1,7 +1,10 @@
 /**
- * MCP tool definitions that Claude can use to interact with the control plane.
- * These are exposed to the Claude chat window so the AI can create stacks,
- * dispatch tasks, and manage the lifecycle programmatically.
+ * Control-plane tool handlers. Historically these were registered as MCP
+ * tools so the outer Claude could invoke them as model-facing tools; as
+ * of the Ticket D migration the orchestrator reaches them exclusively
+ * through script-backed skills that hit the in-process HTTP bridge. The
+ * handler dispatch (`handleToolCall`) is unchanged — only the MCP
+ * advertisement layer went away.
  */
 
 import path from 'path';
@@ -31,187 +34,12 @@ export function validateProjectDir(projectDir: unknown): { error: string } | nul
   return null;
 }
 
-export interface ToolDefinition {
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-}
 
-export const tools: ToolDefinition[] = [
-  {
-    name: 'create_stack',
-    description:
-      'Create a new Sandstorm stack with a name, project directory, and optional task. When a ticket is specified or the task references a GitHub issue, gateApproved must be true (run /spec-check first) or forceBypass must be true.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        name: { type: 'string', description: 'Stack name (e.g., "auth-refactor")' },
-        projectDir: { type: 'string', description: 'Absolute path to the project directory' },
-        ticket: { type: 'string', description: 'Ticket ID (e.g., "EXP-342")' },
-        branch: { type: 'string', description: 'Git branch name' },
-        description: { type: 'string', description: 'Short description of the work' },
-        runtime: { type: 'string', enum: ['docker', 'podman'], description: 'Container runtime' },
-        task: { type: 'string', description: 'Task to dispatch immediately after creation' },
-        gateApproved: { type: 'boolean', description: 'Set to true after running /spec-check and getting user approval. Required when a ticket is specified or the task references a GitHub issue.' },
-        forceBypass: { type: 'boolean', description: 'Set to true to bypass the spec quality gate. Only use when the user explicitly requests skipping the gate.' },
-        model: {
-          type: 'string',
-          enum: ['auto', 'sonnet', 'opus'],
-          description: 'Claude model for inner agent. If omitted, uses the project\'s configured default model (set in Model Settings). When explicitly set to "auto", YOU must analyze the task complexity and choose the best model via lightweight triage:\n\n**Choose "sonnet" (fast & efficient) when:**\n- Typo fixes, config changes, simple bug fixes\n- Well-defined tasks with clear scope (1-3 files)\n- Routine refactors following existing patterns\n- Straightforward feature additions with no design decisions\n\n**Choose "opus" (most capable) when:**\n- Architectural changes or multi-file features requiring design decisions\n- Tricky bugs that need deep reasoning or cross-cutting analysis\n- Security-sensitive or performance-critical work\n- Tasks involving new patterns not yet established in the codebase\n- Open-ended features where the approach is ambiguous\n\nWhen you choose a model via triage, communicate your reasoning briefly (e.g., "Using Sonnet — straightforward config change" or "Using Opus — multi-file architectural refactor").',
-        },
-      },
-      required: ['name', 'projectDir'],
-    },
-  },
-  {
-    name: 'list_stacks',
-    description: 'List all current stacks with their status and services',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-    },
-  },
-  {
-    name: 'dispatch_task',
-    description: 'Dispatch a task to an existing stack. When the stack has a ticket or the prompt references a GitHub issue, gateApproved must be true (run /spec-check first) or forceBypass must be true.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID to dispatch to' },
-        prompt: { type: 'string', description: 'Task description for inner Claude' },
-        gateApproved: { type: 'boolean', description: 'Set to true after running /spec-check and getting user approval. Required when a ticket is specified or the prompt references a GitHub issue.' },
-        forceBypass: { type: 'boolean', description: 'Set to true to bypass the spec quality gate. Only use when the user explicitly requests skipping the gate.' },
-        model: {
-          type: 'string',
-          enum: ['auto', 'sonnet', 'opus'],
-          description: 'Claude model for this task. If omitted, uses the project\'s configured default model (set in Model Settings). When explicitly set to "auto", YOU must analyze the task complexity and choose the best model via lightweight triage:\n\n**Choose "sonnet"** for: typo fixes, config changes, simple bugs, well-defined tasks (1-3 files), routine refactors, straightforward additions.\n**Choose "opus"** for: architectural changes, multi-file features with design decisions, tricky bugs, security/performance-critical work, new patterns, ambiguous scope.\n\nCommunicate your reasoning briefly when auto-selecting.',
-        },
-      },
-      required: ['stackId', 'prompt'],
-    },
-  },
-  {
-    name: 'get_diff',
-    description: 'Get the git diff from a stack',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID' },
-      },
-      required: ['stackId'],
-    },
-  },
-  {
-    name: 'push_stack',
-    description: 'Commit and push changes from a stack',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID' },
-        message: { type: 'string', description: 'Commit message' },
-      },
-      required: ['stackId'],
-    },
-  },
-  {
-    name: 'get_task_status',
-    description:
-      'Get the current task status for a stack (running, completed, failed, idle)',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID' },
-      },
-      required: ['stackId'],
-    },
-  },
-  {
-    name: 'get_task_output',
-    description:
-      'Get the latest output from the running or most recent task in a stack',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID' },
-        lines: {
-          type: 'number',
-          description: 'Number of lines to return (default: 50)',
-        },
-      },
-      required: ['stackId'],
-    },
-  },
-  {
-    name: 'teardown_stack',
-    description:
-      'Tear down a stack — stops containers, removes workspace, archives to history',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID to tear down' },
-      },
-      required: ['stackId'],
-    },
-  },
-  {
-    name: 'get_logs',
-    description:
-      'Get container logs from a stack, optionally filtered to a specific service',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID' },
-        service: {
-          type: 'string',
-          description:
-            'Service name to get logs for (e.g., "claude", "app"). Omit for all services.',
-        },
-      },
-      required: ['stackId'],
-    },
-  },
-  {
-    name: 'set_pr',
-    description:
-      'Record that a pull request was created for a stack. Updates the stack status to pr_created and stores the PR URL and number.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        stackId: { type: 'string', description: 'Stack ID' },
-        prUrl: { type: 'string', description: 'Full URL of the pull request' },
-        prNumber: { type: 'number', description: 'Pull request number' },
-      },
-      required: ['stackId', 'prUrl', 'prNumber'],
-    },
-  },
-  {
-    name: 'spec_check',
-    description:
-      'Run the spec quality gate against a ticket. Spawns an ephemeral agent to evaluate the ticket against the project\'s quality gate criteria. Returns a structured pass/fail report with gaps and assumptions. Use this instead of running /spec-check in-session to avoid inflating the outer session with evaluation tokens.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        ticketId: { type: 'string', description: 'Ticket ID (e.g., "178", "#178", "PROJ-123")' },
-        projectDir: { type: 'string', description: 'Absolute path to the project directory' },
-      },
-      required: ['ticketId', 'projectDir'],
-    },
-  },
-  {
-    name: 'spec_refine',
-    description:
-      'Refine a ticket that failed the spec quality gate. Spawns an ephemeral agent to incorporate user answers into the ticket and re-evaluate. Call without userAnswers to get the initial gaps and questions. Call with userAnswers to update the ticket and re-check. The outer Claude shuttles questions/answers between the user and this tool — each call is a fresh ephemeral process.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        ticketId: { type: 'string', description: 'Ticket ID (e.g., "178", "#178")' },
-        projectDir: { type: 'string', description: 'Absolute path to the project directory' },
-        userAnswers: { type: 'string', description: 'User answers to the gap questions from the previous spec_check or spec_refine call. Omit on the first call to get the initial gaps.' },
-      },
-      required: ['ticketId', 'projectDir'],
-    },
-  },
-];
+/**
+ * MCP tool schemas were removed in Ticket D-final (#__). `handleToolCall`
+ * remains because script-backed skills invoke it through the local HTTP
+ * bridge by name; no external MCP server advertises these schemas anymore.
+ */
 
 export async function handleToolCall(
   name: string,

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -564,21 +564,17 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
       expect(spawnedArgs[toolsIdx + 1]).toBe('Bash,Read,Grep,Glob,Skill');
     });
 
-    it('places --tools before --system-prompt-file and --mcp-config', async () => {
+    it('does not pass --mcp-config (MCP layer removed in Ticket D-final)', async () => {
       const { spawn } = await import('child_process');
       const spawnMock = spawn as ReturnType<typeof vi.fn>;
       spawnMock.mockClear();
 
-      backend.sendMessage('tab-tools-order', 'hello', '/tmp');
+      backend.sendMessage('tab-no-mcp', 'hello', '/tmp');
 
       const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
-      const toolsIdx = spawnedArgs.indexOf('--tools');
-      const mcpIdx = spawnedArgs.indexOf('--mcp-config');
-      expect(toolsIdx).toBeGreaterThan(-1);
-      expect(mcpIdx).toBeGreaterThan(-1);
-      // --tools comes before --mcp-config so it lives in the stable prefix
-      // that cache-hits turn-to-turn.
-      expect(toolsIdx).toBeLessThan(mcpIdx);
+      expect(spawnedArgs).not.toContain('--mcp-config');
+      // --tools is still present as the built-in allowlist.
+      expect(spawnedArgs).toContain('--tools');
     });
 
     it('does not include denied tools in the --tools arg', async () => {

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { tools, handleToolCall, validateProjectDir } from '../../src/main/claude/tools';
+import { handleToolCall, validateProjectDir } from '../../src/main/claude/tools';
 
 // Mock the stackManager and agentBackend imports
 vi.mock('../../src/main/index', () => ({
@@ -31,28 +31,6 @@ describe('MCP tools', () => {
     vi.clearAllMocks();
     // Default: script exists and is executable (individual tests override as needed)
     vi.mocked(getScriptStatus).mockReturnValue('ok');
-  });
-
-  describe('tool definitions', () => {
-    it('create_stack model enum includes auto, sonnet, opus', () => {
-      const createStack = tools.find((t) => t.name === 'create_stack')!;
-      const modelProp = (createStack.inputSchema.properties as Record<string, { enum?: string[] }>).model;
-      expect(modelProp.enum).toEqual(['auto', 'sonnet', 'opus']);
-    });
-
-    it('dispatch_task model enum includes auto, sonnet, opus', () => {
-      const dispatchTask = tools.find((t) => t.name === 'dispatch_task')!;
-      const modelProp = (dispatchTask.inputSchema.properties as Record<string, { enum?: string[] }>).model;
-      expect(modelProp.enum).toEqual(['auto', 'sonnet', 'opus']);
-    });
-
-    it('create_stack model description mentions triage and complexity signals', () => {
-      const createStack = tools.find((t) => t.name === 'create_stack')!;
-      const modelProp = (createStack.inputSchema.properties as Record<string, { description?: string }>).model;
-      expect(modelProp.description).toContain('triage');
-      expect(modelProp.description).toContain('architectural');
-      expect(modelProp.description).toContain('Security');
-    });
   });
 
   describe('handleToolCall — model passthrough', () => {
@@ -122,20 +100,6 @@ describe('MCP tools', () => {
         undefined,
         { gateApproved: undefined, forceBypass: undefined }
       );
-    });
-  });
-
-  describe('tool definitions — spec tools', () => {
-    it('spec_check tool is defined with required ticketId and projectDir', () => {
-      const specCheck = tools.find((t) => t.name === 'spec_check');
-      expect(specCheck).toBeDefined();
-      expect(specCheck!.inputSchema.required).toEqual(['ticketId', 'projectDir']);
-    });
-
-    it('spec_refine tool is defined with required ticketId and projectDir', () => {
-      const specRefine = tools.find((t) => t.name === 'spec_refine');
-      expect(specRefine).toBeDefined();
-      expect(specRefine!.inputSchema.required).toEqual(['ticketId', 'projectDir']);
     });
   });
 


### PR DESCRIPTION
The commit that realizes the cost savings the whole migration was for. Depends on #278, #279, #280 — merge those first so every MCP tool has a skill replacement in place before MCP itself goes away.

## What gets removed
- \`--mcp-config\` arg in \`claude-backend.ts\` spawn args. ~8 KB of stack-tool JSON schemas drop out of the orchestrator's static prefix on every sub-turn.
- \`writeMcpConfig()\` + the embedded Node MCP-server template. ~90 lines of generated code no longer needed.
- \`mcpConfigPath\` field + destroy-time cleanup.
- \`tools[]\` array + \`ToolDefinition\` interface in \`src/main/claude/tools.ts\`. ~180 lines of MCP JSON schemas.

## What stays — still load-bearing
- \`startBridgeServer\` + the \`/tool-call\` HTTP endpoint. Script-backed skills POST to it.
- \`handleToolCall\` and every case branch. Skills invoke by name.
- \`bridgeToken\` + \`bridgePort\` for auth.

The local HTTP bridge stays alive. It's just that the only things calling it are now bash scripts from skills, not an MCP server subprocess.

## Expected cost reduction
- Static prefix: **~8 KB savings per sub-turn**.
- Skill-port prefix growth: ~5 KB (compound skill descriptions).
- Net per-sub-turn: **~3 KB reduction.**
- End-state canonical-scenario projection from earlier math: ~60 K tokens vs 323 K baseline. ~80% reduction.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 281 relevant tests pass (tools, claude-backend, skill-enumeration, stack-manager, tools-allowlist, token-telemetry)
- [ ] Post-rebuild canonical-scenario re-run with telemetry. Compare vs exp1-baseline (323 K / 22 sub-turns).
- [ ] If a skill has a bug that only surfaces post-MCP-removal, that's the first thing we iterate on. The fallback safety net of "model picks MCP" is gone.

## Merge order (from this session)
1. #278 \`review-and-pr\`
2. #279 \`spec-and-dispatch\`
3. #280 \`stack-inspect + list-stacks\`
4. **#281 (this PR)** — after all three above

🤖 Generated with [Claude Code](https://claude.com/claude-code)