### PR TITLE
Fix: register bundled skills via --plugin-dir so Skill tool can load them

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -606,7 +606,19 @@ export class ClaudeBackend implements AgentBackend {
     if (!fs.existsSync(basePath)) return null;
     try {
       const base = fs.readFileSync(basePath, 'utf-8');
-      const composed = composeSystemPromptWithSkills(base, projectDir, path.join(cliDir, 'skills'));
+      // Skills bundled under `sandstorm-cli/skills/` are exposed to the
+      // subprocess as a Claude Code plugin via `--plugin-dir` (added to
+      // spawn args below). The CLI registers them under the
+      // plugin-name:skill-name pattern, so the injected system-prompt
+      // description has to use the same prefix or the model will call a
+      // name the CLI doesn't recognize (70-byte "skill not found"
+      // error, debugged post-D-final).
+      const composed = composeSystemPromptWithSkills(
+        base,
+        projectDir,
+        path.join(cliDir, 'skills'),
+        path.basename(cliDir)
+      );
       if (composed === base) return basePath;
       const tmpDir = path.join(os.tmpdir(), `sandstorm-orchestrator-${process.pid}`);
       fs.mkdirSync(tmpDir, { recursive: true });
@@ -645,6 +657,15 @@ export class ClaudeBackend implements AgentBackend {
     const resolvedPromptFile = this.resolveSystemPromptFile(systemPromptFile, cwd, tabId);
     if (resolvedPromptFile) {
       args.push('--system-prompt-file', resolvedPromptFile);
+    }
+
+    // Register the Sandstorm-bundled skills with the CLI as a plugin.
+    // Without this, `Skill(name=…)` invocations fail with "skill not
+    // found" even though the description is advertised in the prompt.
+    // `cliDir` contains a top-level `skills/` dir, which is exactly the
+    // plugin-root layout Claude Code expects.
+    if (fs.existsSync(path.join(cliDir, 'skills'))) {
+      args.push('--plugin-dir', cliDir);
     }
 
     if (this.modelResolver && session.projectDir) {

--- a/src/main/agent/skill-enumeration.ts
+++ b/src/main/agent/skill-enumeration.ts
@@ -67,8 +67,18 @@ function parseFrontmatter(content: string): { name?: string; description?: strin
  * Enumerate folder-pattern skills under a given directory. Each
  * `<skillsRoot>/<name>/SKILL.md` with valid `name` + `description`
  * frontmatter is returned; anything else is silently skipped.
+ *
+ * When `namespace` is provided, returned skill names are prefixed
+ * `<namespace>:<raw-name>` so the injected prompt matches exactly how
+ * Claude Code registers plugin-provided skills (plugin `sandstorm-cli`
+ * surfaces `check-and-resume-stack` as
+ * `sandstorm-cli:check-and-resume-stack` in the `init.skills` list).
+ * The returned `path` always points at the unprefixed SKILL.md on disk.
  */
-export function enumerateSkillsFromDir(skillsRoot: string): SkillDescriptor[] {
+export function enumerateSkillsFromDir(
+  skillsRoot: string,
+  namespace?: string
+): SkillDescriptor[] {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(skillsRoot, { withFileTypes: true });
@@ -88,7 +98,8 @@ export function enumerateSkillsFromDir(skillsRoot: string): SkillDescriptor[] {
     }
     const fm = parseFrontmatter(content);
     if (!fm || !fm.name || !fm.description) continue;
-    descriptors.push({ name: fm.name, description: fm.description, path: skillPath });
+    const displayName = namespace ? `${namespace}:${fm.name}` : fm.name;
+    descriptors.push({ name: displayName, description: fm.description, path: skillPath });
   }
   return descriptors;
 }
@@ -106,15 +117,20 @@ export function enumerateProjectSkills(projectDir: string): SkillDescriptor[] {
 
 /**
  * Enumerate skills from the Sandstorm-bundled skills dir and the
- * project's `.claude/skills/` merged together. On name collisions the
- * project skill wins (mirrors Claude Code's project > bundled
- * precedence). Results sorted by name for deterministic output.
+ * project's `.claude/skills/` merged together. When
+ * `bundledNamespace` is set, bundled skill names are prefixed so the
+ * injected description matches what the CLI registers under
+ * `--plugin-dir` (plugin-name:skill-name). Project-local skills are
+ * never prefixed. Results sorted by name for deterministic output.
  */
 export function enumerateSkills(options: {
   projectDir?: string;
   bundledSkillsDir?: string;
+  bundledNamespace?: string;
 }): SkillDescriptor[] {
-  const bundled = options.bundledSkillsDir ? enumerateSkillsFromDir(options.bundledSkillsDir) : [];
+  const bundled = options.bundledSkillsDir
+    ? enumerateSkillsFromDir(options.bundledSkillsDir, options.bundledNamespace)
+    : [];
   const project = options.projectDir
     ? enumerateSkillsFromDir(path.join(options.projectDir, '.claude', 'skills'))
     : [];
@@ -146,9 +162,10 @@ export function formatSkillsSection(skills: SkillDescriptor[]): string {
 export function composeSystemPromptWithSkills(
   basePrompt: string,
   projectDir: string,
-  bundledSkillsDir?: string
+  bundledSkillsDir?: string,
+  bundledNamespace?: string
 ): string {
-  const skills = enumerateSkills({ projectDir, bundledSkillsDir });
+  const skills = enumerateSkills({ projectDir, bundledSkillsDir, bundledNamespace });
   const section = formatSkillsSection(skills);
   if (!section) return basePrompt;
   const separator = basePrompt.endsWith('\n') ? '\n' : '\n\n';

--- a/tests/unit/skill-enumeration.test.ts
+++ b/tests/unit/skill-enumeration.test.ts
@@ -177,6 +177,46 @@ describe('enumerateSkills — bundled + project merge (#268)', () => {
     const skills = enumerateSkillsFromDir(bundledDir);
     expect(skills.map((s) => s.name).sort()).toEqual(['a', 'b']);
   });
+
+  it('prefixes bundled skill names with the namespace when provided (#plugin-dir)', () => {
+    writeBundledSkill('check-and-resume-stack', 'desc');
+    writeBundledSkill('list-stacks', 'desc2');
+    const skills = enumerateSkills({
+      projectDir,
+      bundledSkillsDir: bundledDir,
+      bundledNamespace: 'sandstorm-cli',
+    });
+    expect(skills.map((s) => s.name).sort()).toEqual([
+      'sandstorm-cli:check-and-resume-stack',
+      'sandstorm-cli:list-stacks',
+    ]);
+  });
+
+  it('does NOT prefix project-local skills even when a bundledNamespace is provided', () => {
+    writeBundledSkill('b-skill', 'bundled');
+    writeProjectSkill('p-skill', 'project');
+    const skills = enumerateSkills({
+      projectDir,
+      bundledSkillsDir: bundledDir,
+      bundledNamespace: 'sandstorm-cli',
+    });
+    // Project name is unprefixed; bundled is prefixed.
+    expect(skills.map((s) => s.name).sort()).toEqual([
+      'p-skill',
+      'sandstorm-cli:b-skill',
+    ]);
+  });
+
+  it('SkillDescriptor.path still points at the unprefixed SKILL.md on disk', () => {
+    writeBundledSkill('my-skill', 'desc');
+    const skills = enumerateSkills({
+      projectDir,
+      bundledSkillsDir: bundledDir,
+      bundledNamespace: 'ns',
+    });
+    expect(skills[0].name).toBe('ns:my-skill');
+    expect(skills[0].path.endsWith(path.join('my-skill', 'SKILL.md'))).toBe(true);
+  });
 });
 
 describe('composeSystemPromptWithSkills with bundledSkillsDir (#268)', () => {


### PR DESCRIPTION
Critical post-D-final bugfix. The 1.2M-token canonical-scenario run this morning (vs 323K baseline) was traced to skill-invocation failing silently.

## Root cause
Empirically verified with \`claude --output-format json ... "say hi"\` against our composed prompt: the CLI's \`init.skills\` list contained **zero** of our 8 bundled skills. The model tried to call \`Skill(name="check-and-resume-stack")\`, got a ~70-byte "skill not found" back, and without MCP to fall back on went into raw-Bash investigation mode — 27 docker/shell/cat probes, 44 sub-turns.

The CLI scans \`.claude/skills/\` (project-local) and user-global dirs for the Skill tool. Skills under \`sandstorm-cli/skills/\` were invisible to it even though our enumerator happily read them into the prompt.

## Fix
- Pass \`--plugin-dir <cliDir>\` to \`ensureProcess\`. Claude Code's plugin loader treats \`<plugin-root>/skills/<name>/SKILL.md\` as a skill source. All 8 now register as \`sandstorm-cli:<name>\`.
- Since the CLI registers with a namespace prefix, the injected description section must match or the model invokes a name the CLI doesn't recognize. Extended \`enumerateSkillsFromDir\` with a \`namespace\` parameter; bundled skills get prefixed, project-local \`.claude/skills/\` stay unprefixed.
- Defensive guard: only pass \`--plugin-dir\` when \`<cliDir>/skills\` actually exists.

## Verified (local)
\`\`\`
claude -p --plugin-dir /home/onomojo/Work/sandstorm-desktop/sandstorm-cli ...
\`\`\`
init.skills now includes:
\`\`\`
sandstorm-cli:check-and-resume-stack
sandstorm-cli:sandstorm-spec
sandstorm-cli:stack-pr
sandstorm-cli:stack-teardown
sandstorm-cli:review-and-pr
sandstorm-cli:spec-and-dispatch
sandstorm-cli:stack-inspect
sandstorm-cli:list-stacks
\`\`\`

## Tests
- 3 new cases in \`skill-enumeration.test.ts\`: namespace prefix, project-stays-unprefixed when namespace given, SkillDescriptor.path still resolves to unprefixed filesystem path.
- All 78 skill-enumeration + claude-backend tests pass.
- \`npx tsc --noEmit\` clean.

## Still open after this merges
- User flagged an orphaned \`250\` workspace dir (no registered stack, no Docker container — just a leftover filesystem dir). Separate cleanup; not related to the plugin-dir fix.
- Stack-ID disambiguation for future: user suggested always-unique numeric IDs to eliminate prefix-match ambiguity entirely. Own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)