### PR TITLE
check-and-resume-stack: verify container state before trusting DB 'running'

### DIFF
--- a/sandstorm-cli/skills/check-and-resume-stack/scripts/check-and-resume.sh
+++ b/sandstorm-cli/skills/check-and-resume-stack/scripts/check-and-resume.sh
@@ -55,23 +55,59 @@ fi
 # Pull a state label from common response shapes.
 STATE="$(echo "$STATUS_JSON" | jq -r '.result.state // .result.status // .result.taskState // "unknown"')"
 
+# Before trusting a "running" verdict from the DB, verify the containers
+# actually are up. The DB status can drift stale when the user pauses
+# (docker stop) or the OS kills containers — the tasks row stays
+# 'running' but the claude/app containers are exited. Treating that as
+# running leads to the skill silently no-op'ing on what the user actually
+# sees as a paused stack.
+CONTAINERS_LIVE="unknown"
+if [[ "$STATE" == "running" ]]; then
+  LIST_JSON="$(call_bridge list_stacks '{}' 2>/dev/null || echo '{"result":[]}')"
+  # Collect service statuses for THIS stack. Accept either .name or .id
+  # as the match key since different call shapes may carry one or both.
+  SERVICES_STATUSES="$(echo "$LIST_JSON" | jq -r --arg id "$RESOLVED_ID" '
+    (.result // .result.stacks // []) | .[]? |
+    select((.name // "") == $id or (.id // "") == $id) |
+    (.services // []) | .[]? |
+    (.status // .state // "unknown")
+  ')"
+  if [[ -z "${SERVICES_STATUSES//[[:space:]]/}" ]]; then
+    # No services info returned — can't verify. Fall through and trust
+    # the DB state rather than second-guessing.
+    CONTAINERS_LIVE="unknown"
+  elif printf '%s\n' "$SERVICES_STATUSES" | grep -qv '^running$'; then
+    # At least one service is not 'running' → DB is stale.
+    CONTAINERS_LIVE="stale"
+  else
+    CONTAINERS_LIVE="live"
+  fi
+fi
+
 case "$STATE" in
   running)
-    echo "STATE=running id=$RESOLVED_ID action=none"
+    if [[ "$CONTAINERS_LIVE" == "stale" ]]; then
+      # DB said running but containers are down → treat as resumable.
+      # Fall through to the resumable branch below.
+      STATE="paused_stale"
+    else
+      echo "STATE=running id=$RESOLVED_ID action=none containers=$CONTAINERS_LIVE"
+      exit 0
+    fi
     ;;
   completed)
     echo "STATE=completed id=$RESOLVED_ID action=none"
-    ;;
-  *)
-    # idle / paused / failed / unknown — treat as resumable.
-    RESUME_INPUT='{"stackId":"'"$RESOLVED_ID"'","prompt":"Continue from where you left off. Do not redo completed work. Pick up the next unfinished step.","forceBypass":true}'
-    DISPATCH_JSON="$(call_bridge dispatch_task "$RESUME_INPUT" 2>/dev/null || echo '{"error":"dispatch_failed"}')"
-    if echo "$DISPATCH_JSON" | jq -e '.error' >/dev/null 2>&1; then
-      REASON="$(echo "$DISPATCH_JSON" | jq -r '.error')"
-      echo "STATE=$STATE id=$RESOLVED_ID action=resume_failed reason=\"$REASON\""
-      exit 0
-    fi
-    TASK_ID="$(echo "$DISPATCH_JSON" | jq -r '.result.taskId // .result.id // .result // "unknown"' | head -c 48)"
-    echo "STATE=$STATE id=$RESOLVED_ID action=resumed task=$TASK_ID"
+    exit 0
     ;;
 esac
+
+# idle / paused / failed / paused_stale / unknown — treat as resumable.
+RESUME_INPUT='{"stackId":"'"$RESOLVED_ID"'","prompt":"Continue from where you left off. Do not redo completed work. Pick up the next unfinished step.","forceBypass":true}'
+DISPATCH_JSON="$(call_bridge dispatch_task "$RESUME_INPUT" 2>/dev/null || echo '{"error":"dispatch_failed"}')"
+if echo "$DISPATCH_JSON" | jq -e '.error' >/dev/null 2>&1; then
+  REASON="$(echo "$DISPATCH_JSON" | jq -r '.error')"
+  echo "STATE=$STATE id=$RESOLVED_ID action=resume_failed reason=\"$REASON\""
+  exit 0
+fi
+TASK_ID="$(echo "$DISPATCH_JSON" | jq -r '.result.taskId // .result.id // .result // "unknown"' | head -c 48)"
+echo "STATE=$STATE id=$RESOLVED_ID action=resumed task=$TASK_ID"


### PR DESCRIPTION
Correctness fix called out after the post-plugin-dir canonical-scenario run.

## The bug
The DB tasks row stays \`state: running\` after the user pauses (containers stopped via docker). The check-and-resume-stack skill trusted the DB status and returned \`STATE=running action=none\` — so it made the 95K-token run look like a win when it had actually skipped the real work. Baseline's 323K run caught this drift by doing full investigation; the skill's minimum-path guidance cut that out.

## Fix (script-only)
When \`get_task_status\` returns \`state=running\`, the script now does a follow-up \`list_stacks\` call and inspects this stack's \`services[]\`. If any service status is not \`running\`, the verdict becomes \`paused_stale\` and we fall through to the resume branch. The \`ensureStackContainersRunning\` fix in #274's \`dispatchTask\` backend then brings the containers back up before dispatching.

Output shape now includes \`containers=<live|stale|unknown>\` so you can see why the skill chose what it chose.

## Sub-turn impact
Skill + Bash = still 2 outer tool calls. The extra bridge call (list_stacks) happens inside the script and doesn't show up in the outer telemetry.

## Test plan
- [x] \`bash -n\` syntax OK
- [ ] Post-rebuild: pause stack (UI "Stop" → containers exit → DB still says running), run canonical prompt, observe:
  - Skill fires
  - Script outputs \`STATE=paused_stale ... action=resumed task=<id>\` (or containers=stale variant)
  - Containers come back up via the \`ensureStackContainersRunning\` path in backend
  - Workflow completes — stack actually resumed this time

Also flags a deeper design question for follow-up: the DB-status-can-drift-from-container-reality problem is not unique to this skill. Other tools that read task_status will have the same blind spot. Could be addressed in the backend by having \`get_task_status\` cross-check container state internally — separate ticket worth opening if the issue recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)