### PR TITLE
Fix container auto-start: sandstorm CLI uses 'up', not 'start'

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -484,7 +484,7 @@ export class StackManager {
    * caller can surface failure to the user.
    */
   private async ensureStackContainersRunning(stack: Stack, stackId: string): Promise<void> {
-    const result = await this.runCli(stack.project_dir, ['start', stackId]);
+    const result = await this.runCli(stack.project_dir, ['up', stackId]);
     if (result.exitCode !== 0) {
       throw new SandstormError(
         ErrorCode.COMPOSE_FAILED,
@@ -497,7 +497,7 @@ export class StackManager {
 
   private async startInBackground(stack: Stack, stackId: string): Promise<void> {
     try {
-      const result = await this.runCli(stack.project_dir, ['start', stackId]);
+      const result = await this.runCli(stack.project_dir, ['up', stackId]);
       if (result.exitCode !== 0) {
         throw new SandstormError(ErrorCode.COMPOSE_FAILED, result.stderr.trim() || result.stdout.trim() || 'Stack start failed');
       }

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -491,10 +491,10 @@ describe('StackManager', () => {
 
       // The CLI should have been invoked to start the stack BEFORE the dispatch call.
       const startCall = runCliSpy.mock.calls.find(
-        ([, args]) => Array.isArray(args) && args[0] === 'start'
+        ([, args]) => Array.isArray(args) && args[0] === 'up'
       );
       expect(startCall).toBeDefined();
-      expect(startCall![1]).toEqual(['start', 'autostart']);
+      expect(startCall![1]).toEqual(['up', 'autostart']);
 
       // Dispatch itself still runs after the start.
       const taskCall = runCliSpy.mock.calls.find(
@@ -515,7 +515,7 @@ describe('StackManager', () => {
       await manager.dispatchTask('already-up', 'go');
 
       const startCall = runCliSpy.mock.calls.find(
-        ([, args]) => Array.isArray(args) && args[0] === 'start'
+        ([, args]) => Array.isArray(args) && args[0] === 'up'
       );
       expect(startCall).toBeUndefined();
     });
@@ -536,7 +536,7 @@ describe('StackManager', () => {
       ]);
 
       vi.spyOn(manager, 'runCli').mockImplementation(async (_dir, args) => {
-        if (args[0] === 'start') {
+        if (args[0] === 'up') {
           return { stdout: '', stderr: 'start failed: docker daemon unavailable', exitCode: 1 };
         }
         return { stdout: '', stderr: '', exitCode: 0 };
@@ -812,7 +812,7 @@ describe('StackManager', () => {
       manager.startStack('start-bg');
 
       await vi.waitFor(() => {
-        expect(runCliSpy).toHaveBeenCalledWith('/proj', ['start', 'start-bg']);
+        expect(runCliSpy).toHaveBeenCalledWith('/proj', ['up', 'start-bg']);
       }, { timeout: 5000 });
     });
 


### PR DESCRIPTION
Pre-existing bug surfaced by the post-plugin-dir canonical-scenario run. The script correctly detected the stack was paused-stale (containers exited but DB said running), called dispatch_task, the backend invoked the sandstorm CLI with \`['start', stackId]\` — and that silently failed.

## The bug
\`sandstorm-cli/bin/sandstorm\` lists valid subcommands:

\`\`\`
STACK_COMMANDS="up|down|task|task-status|task-output|diff|push|publish|status|exec|claude|register|logs"
\`\`\`

No \`start\`. \`sandstorm up <id>\` is the real command — idempotent for already-cloned workspaces (guards on \`.git\` existence before re-cloning) and it composes-up the containers.

This bug existed at two call sites, both pre-existing to this session's work:
- \`ensureStackContainersRunning\` (added in #274, my fix) — swapped to \`up\`
- \`startInBackground\` (pre-existing, used by the UI Start button — probably has been failing quietly for a while; UI reports "failed" and users re-try via other paths) — swapped to \`up\`

## Impact
After this + rebuild, the check-and-resume-stack skill's \`paused_stale\` path should actually bring containers back up and dispatch the resume — the full workflow the canonical scenario was measuring.

## Tests
- 141 stack-manager tests pass.
- env-friction tests updated to assert \`['up', 'autostart']\`/\`['up', 'start-bg']\` instead of \`['start', ...]\`.
- \`npx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)