### PR TITLE
Skill eval methodology: real user phrasings + wrapper scripts (#285)

### DIFF
--- a/docs/skill-evals/README.md
+++ b/docs/skill-evals/README.md
@@ -1,0 +1,89 @@
+# Skill eval methodology
+
+This directory holds the systematic eval harness for every Sandstorm-bundled
+skill. It exists because ad-hoc "try a prompt in an interactive session"
+validation is non-repeatable and silently drifts across model releases. Every
+skill that ships in `sandstorm-cli/skills/` MUST have a trigger eval set here.
+
+## What an eval set looks like
+
+`<skill-name>/trigger-eval.json` is a flat JSON array. Each element:
+
+```json
+{
+  "query": "verbatim user phrasing",
+  "should_trigger": true,
+  "notes": "optional — why this phrasing, or which past session it came from"
+}
+```
+
+Positives (`should_trigger: true`) MUST be real phrasings elicited directly
+from the user — NOT invented. Phrasing is personal; what one user says ("pick
+up where it left off") another never does. Ask the user how they'd talk to
+the skill, skill by skill. Vary the entity ID (stack numbers, ticket
+numbers, names) across queries so the model can't pass by keying on the
+identifier instead of the intent. Target 3–10 positives per skill. Rare
+skills (e.g. stack-teardown) can bottom out at 1 positive — the eval's main
+signal for those is the negative set.
+
+Negatives (`should_trigger: false`) are the other skills' positives. Draw
+from the phrasings the user gave for adjacent skills rather than inventing
+keyword-adjacent strings; that's the real disambiguation test. Target
+≥5 negatives. For destructive skills (stack-teardown), oversample negatives
+aggressively — false-positives cost real work.
+
+## Running the harness
+
+One-shot, single skill:
+
+```bash
+scripts/skill-eval.sh check-and-resume-stack claude-opus-4-6
+```
+
+All skills with eval sets, one model:
+
+```bash
+scripts/run-all-skill-evals.sh claude-opus-4-6
+```
+
+The runner wraps skill-creator's `run_loop.py` — it spins up a temporary
+slash-command with the skill's description, fires the query at `claude -p`,
+and detects Skill-tool invocation via streamed events. Each query runs 3× by
+default; a skill "passes" a query if its trigger rate meets the threshold
+(default 0.5).
+
+Requirements (checked up-front by the wrapper):
+- `ANTHROPIC_API_KEY` in env (used by `run_loop.py`'s improvement step)
+- `claude` CLI on `$PATH`
+- `python3` with the `anthropic` package available (installed alongside
+  Claude Code)
+- The `skill-creator` plugin installed locally
+  (`claude plugin install skill-creator@claude-plugins-official`)
+
+## Results history
+
+Each run writes `results/<model-id>/<iso-timestamp>/results.json` plus a
+sibling HTML report. The per-model subdirectory is what lets us compare
+"opus-4.6 baseline" to "opus-4.7 shipped" without losing the older numbers.
+The top-level `results/<model-id>/latest.json` is a symlink/copy of the most
+recent run for quick reads.
+
+## Acceptance bar
+
+Per the skill-migration plan, a skill passes the bar when:
+- Positive (should-trigger) queries trigger at ≥80% averaged across the set.
+- Negative (should-not-trigger) queries fire <20% of the time.
+- No single positive query has a 0% trigger rate (dead phrasings must be
+  addressed — either reword the skill description or drop the query as
+  unrepresentative).
+
+Miss the bar → tune the SKILL.md description via run_loop's improvement pass
+(`--max-iterations 5`) and commit the improved description.
+
+## Why trigger evals but no behavior evals here yet
+
+Behavior evals (does the skill, once triggered, do the right thing?) for
+script-backed skills need a mock MCP bridge harness. The prototype lives at
+`/tmp/mock-bridge.py` from the #268 session. Generalizing that into
+`scripts/skill-behavior-eval.sh` is a follow-up PR under #285 once the
+trigger-eval shape is in place for every skill.

--- a/docs/skill-evals/check-and-resume-stack/trigger-eval.json
+++ b/docs/skill-evals/check-and-resume-stack/trigger-eval.json
@@ -1,0 +1,21 @@
+[
+  { "query": "what's the status of stack 243", "should_trigger": true },
+  { "query": "what's the status of ticket 24", "should_trigger": true, "notes": "User uses 'stack' and 'ticket' interchangeably" },
+  { "query": "Can you tell me what the current state of ticket 43 is?", "should_trigger": true },
+  { "query": "Can you tell me the current state of stack abc?", "should_trigger": true, "notes": "Non-numeric stack name" },
+  { "query": "Can you check the status of stack 43 and if it's finished or not, if it's not can you resume from where it left off?", "should_trigger": true },
+  { "query": "Stack 23 was halted because of token limits. Can you pick up where it left off? Tokens have refreshed.", "should_trigger": true },
+  { "query": "Can you take a look at stack 43 and see what's going on? I think something happened, like halted or something. I don't know what the state is or if it finished. Take a look, and if it finished, great; if it didn't, fire up a stack and finish it. If it is finished then go ahead and make a pull request.", "should_trigger": true, "notes": "Compound: status → maybe resume → maybe PR. Leading intent is status check; skill reports state and orchestrator handles PR branch after." },
+  { "query": "Something happened to stack 43, it crashed or something. Take a look and see if it finished what it was supposed to do. If not, fire it back up and finish whatever it was doing, pick up where it left off. Don't tear down the stack, just resume it.", "should_trigger": true },
+
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": false, "notes": "Plural → list-stacks" },
+  { "query": "I'm just curious what the status of everything is. Something weird happened.", "should_trigger": false, "notes": "Plural → list-stacks" },
+  { "query": "The app crashed, I'm not sure if the state listed is correct. Can you verify the state is correct on all of the stacks?", "should_trigger": false, "notes": "Plural → list-stacks" },
+  { "query": "Let's start ticket 151.", "should_trigger": false, "notes": "New-work intent → spec-and-dispatch" },
+  { "query": "Take a look at ticket 144. Looks ready to go. Take a look and see how it looks to you. If it passes all our checks, let's go ahead and work on that.", "should_trigger": false, "notes": "Ticket readiness + new stack → spec-and-dispatch" },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": false, "notes": "PR intent → review-and-pr" },
+  { "query": "Take a pull request out of stack 232.", "should_trigger": false, "notes": "PR intent → review-and-pr" },
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": false, "notes": "Destructive → stack-teardown" },
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not. If not, let's go ahead and flesh out the details.", "should_trigger": false, "notes": "Ticket-only (no stack) → sandstorm-spec" },
+  { "query": "Take a look at stack 275. Seems to be using a ton of tokens, I'm not sure what it's doing.", "should_trigger": false, "notes": "Info-only diagnosis, no resume intent → stack-inspect. Borderline — model may confuse with this skill." }
+]

--- a/docs/skill-evals/list-stacks/trigger-eval.json
+++ b/docs/skill-evals/list-stacks/trigger-eval.json
@@ -1,0 +1,15 @@
+[
+  { "query": "Something happened, our tokens hit the limit and all the stacks got halted. Can you take a look at all the stacks we have and see where the state is and whether or not they finished?", "should_trigger": true },
+  { "query": "I'm just curious what the status of everything is. Something weird happened.", "should_trigger": true },
+  { "query": "The app crashed, I'm not sure if the state listed is correct. Can you verify the state is correct on all of the stacks?", "should_trigger": true },
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": true },
+
+  { "query": "what's the status of stack 243", "should_trigger": false, "notes": "Single stack → check-and-resume-stack" },
+  { "query": "Can you tell me the current state of stack abc?", "should_trigger": false, "notes": "Single stack → check-and-resume-stack" },
+  { "query": "Take a look at stack 42, seems to be running for a while. Stuck in a loop or something?", "should_trigger": false, "notes": "Single stack diagnosis → stack-inspect" },
+  { "query": "Stack 23 was halted. Can you pick up where it left off?", "should_trigger": false, "notes": "Single stack resume → check-and-resume-stack" },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": false, "notes": "PR → review-and-pr" },
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": false, "notes": "Destructive → stack-teardown" },
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not.", "should_trigger": false, "notes": "Spec → sandstorm-spec" },
+  { "query": "Let's start ticket 151.", "should_trigger": false, "notes": "Dispatch → spec-and-dispatch" }
+]

--- a/docs/skill-evals/review-and-pr/trigger-eval.json
+++ b/docs/skill-evals/review-and-pr/trigger-eval.json
@@ -1,0 +1,15 @@
+[
+  { "query": "Stack 43 looks like it's finished. Can you take a look and see how everything is and if everything looks good? Let's go ahead and make a pull request out of that.", "should_trigger": true },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": true },
+  { "query": "Looks like stack user-avatars is finished. Can you take a look and see if it did what it was supposed to do and make a pull request?", "should_trigger": true, "notes": "Named stack, not numeric" },
+  { "query": "Take a pull request out of stack 232.", "should_trigger": true, "notes": "Terse" },
+  { "query": "Ticket 43 is done. Go ahead and make a pull request.", "should_trigger": true, "notes": "User uses 'ticket' for stack here" },
+
+  { "query": "what's the status of stack 243", "should_trigger": false, "notes": "Status only → check-and-resume-stack" },
+  { "query": "Can you tell me the current state of stack abc?", "should_trigger": false, "notes": "Status only → check-and-resume-stack" },
+  { "query": "Take a look at stack 42, seems to be running for a while. I'm not sure what's going on, stuck in a loop or something.", "should_trigger": false, "notes": "Diagnostic info → stack-inspect" },
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": false, "notes": "List → list-stacks" },
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": false, "notes": "Destructive → stack-teardown" },
+  { "query": "Let's start ticket 151.", "should_trigger": false, "notes": "Dispatch new → spec-and-dispatch" },
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not.", "should_trigger": false, "notes": "Spec → sandstorm-spec" }
+]

--- a/docs/skill-evals/sandstorm-spec/trigger-eval.json
+++ b/docs/skill-evals/sandstorm-spec/trigger-eval.json
@@ -1,0 +1,15 @@
+[
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not. If not, let's go ahead and flesh out the details.", "should_trigger": true },
+  { "query": "Take a look at ticket 275. Basically I want to do this stuff and here's some extra context. I want you to help me spec this ticket out a little bit further. We want to make sure it passes our quality checks.", "should_trigger": true },
+  { "query": "Take a look at ticket 159. We have some issues, some extra context. Help me figure out how to shape this idea a little bit better. Here's some rough idea of what I want. Can you help me think through it and make a high quality ticket that passes our spec gates or quality gates?", "should_trigger": true },
+
+  { "query": "Take a look at ticket 144. Looks ready to go. Take a look and see how it looks to you. If it passes all our checks, let's go ahead and work on that.", "should_trigger": false, "notes": "'Work on that' = dispatch → spec-and-dispatch" },
+  { "query": "Let's start ticket 151.", "should_trigger": false, "notes": "Dispatch intent → spec-and-dispatch" },
+  { "query": "Start with an idea: I want to let users pin notes to the top. Make a ticket, make it pass our quality gates, then if everything's good, fire up a stack and get it done.", "should_trigger": false, "notes": "Compound → spec-and-dispatch (stack creation follows)" },
+  { "query": "Take a look at ticket 149. Let's try to flesh out the details. Once it passes our quality checks, let's fire up a stack.", "should_trigger": false, "notes": "Spec + dispatch compound → spec-and-dispatch" },
+  { "query": "what's the status of stack 243", "should_trigger": false, "notes": "Stack status, not ticket spec → check-and-resume-stack" },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": false, "notes": "PR intent → review-and-pr" },
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": false, "notes": "List → list-stacks" },
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": false, "notes": "Destructive → stack-teardown" },
+  { "query": "Take a look at stack 275. Seems to be using a ton of tokens.", "should_trigger": false, "notes": "Stack-level diagnosis → stack-inspect" }
+]

--- a/docs/skill-evals/spec-and-dispatch/trigger-eval.json
+++ b/docs/skill-evals/spec-and-dispatch/trigger-eval.json
@@ -1,0 +1,15 @@
+[
+  { "query": "Start with an idea: I want to let users pin notes to the top. Make a ticket, make it pass our quality gates, then if everything's good, fire up a stack and get it done.", "should_trigger": true, "notes": "Idea-first → spec → dispatch" },
+  { "query": "Take a look at ticket 149. Basically I want this. Let's flesh out the details. Once it passes our quality checks, let's fire up a stack. Start a stack and make it happen.", "should_trigger": true },
+  { "query": "Let's start ticket 151.", "should_trigger": true, "notes": "Terse: implicit spec + new stack" },
+  { "query": "Take a look at ticket 144. Looks ready to go. Take a look and see how it looks to you. If it passes all our checks, let's go ahead and work on that.", "should_trigger": true },
+  { "query": "Take a look at ticket 250. It looks like this is all spec'd out. If that looks good to you, let's go ahead and kick off a stack with it. If not, let's figure out what else we need.", "should_trigger": true },
+
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not. If not, let's flesh out the details.", "should_trigger": false, "notes": "Spec-only, no dispatch → sandstorm-spec" },
+  { "query": "Take a look at ticket 275. I want you to help me spec this ticket out a little bit further. We want to make sure it passes our quality checks.", "should_trigger": false, "notes": "Spec-only → sandstorm-spec" },
+  { "query": "what's the status of stack 243", "should_trigger": false, "notes": "Existing stack status → check-and-resume-stack" },
+  { "query": "Stack 23 was halted because of token limits. Can you pick up where it left off?", "should_trigger": false, "notes": "Resume existing → check-and-resume-stack" },
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": false, "notes": "List → list-stacks" },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": false, "notes": "PR → review-and-pr" },
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": false, "notes": "Destructive → stack-teardown" }
+]

--- a/docs/skill-evals/stack-inspect/trigger-eval.json
+++ b/docs/skill-evals/stack-inspect/trigger-eval.json
@@ -1,0 +1,16 @@
+[
+  { "query": "Take a look at stack 42, seems to be running for a while. I'm not sure what's going on. Stuck in a loop or something? It's been thinking for too long.", "should_trigger": true },
+  { "query": "Take a look at stack 212. Let me know what's going on. Is it something weird going on? Just let me know what the status is.", "should_trigger": true },
+  { "query": "Let me know what the status of 200 is, it seems to be taking longer than I thought.", "should_trigger": true },
+  { "query": "Take a look at stack 275. Seems to be using a ton of tokens, I'm not sure what it's doing.", "should_trigger": true },
+  { "query": "Take a look at stack off-a-branch. We ran out of tokens and I'm not sure where we left off. Can you take a look? I don't know if it's finished or what's going on.", "should_trigger": true, "notes": "Borderline: no explicit resume request, just info" },
+  { "query": "Take a look at stack my-feature. Something crashed, sandstorm I just restarted it, lost context, I want to know where we're at.", "should_trigger": true, "notes": "Info only: 'I want to know where we're at'" },
+
+  { "query": "Stack 23 was halted because of token limits. Can you pick up where it left off?", "should_trigger": false, "notes": "Explicit resume intent → check-and-resume-stack" },
+  { "query": "Can you check the status of stack 43 and if it's finished or not, if it's not can you resume from where it left off?", "should_trigger": false, "notes": "Explicit resume → check-and-resume-stack" },
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": false, "notes": "Plural → list-stacks" },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": false, "notes": "PR → review-and-pr" },
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": false, "notes": "Destructive → stack-teardown" },
+  { "query": "Let's start ticket 151.", "should_trigger": false, "notes": "New stack → spec-and-dispatch" },
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not.", "should_trigger": false, "notes": "Ticket spec, not stack → sandstorm-spec" }
+]

--- a/docs/skill-evals/stack-teardown/trigger-eval.json
+++ b/docs/skill-evals/stack-teardown/trigger-eval.json
@@ -1,0 +1,15 @@
+[
+  { "query": "Let's go ahead and tear down stack 420.", "should_trigger": true, "notes": "User confirmed this is essentially the only way they invoke teardown. Skill's main bar is the negative set — must NEVER over-trigger. Asymmetric cost: false-positives destroy work." },
+
+  { "query": "what's the status of stack 243", "should_trigger": false, "notes": "Status → check-and-resume-stack" },
+  { "query": "Can you tell me the current state of stack abc?", "should_trigger": false, "notes": "Status → check-and-resume-stack" },
+  { "query": "Stack 23 was halted. Can you pick up where it left off?", "should_trigger": false, "notes": "Resume → check-and-resume-stack. Must not interpret 'halted' as teardown-worthy." },
+  { "query": "Take a look at stack 42, seems to be running for a while. Stuck in a loop or something?", "should_trigger": false, "notes": "Diagnosis → stack-inspect. User is NOT asking to kill it." },
+  { "query": "Stack 43 looks like it's finished. Can you take a look and see how everything is and make a pull request out of that.", "should_trigger": false, "notes": "'Finished' → review-and-pr, NOT teardown. Historical failure mode: orchestrator tore down post-push." },
+  { "query": "Stack 123 looks like it's ready for a pull request. Go ahead and make a pull request.", "should_trigger": false, "notes": "PR → review-and-pr" },
+  { "query": "Let me know what the status is of all the stacks.", "should_trigger": false, "notes": "List → list-stacks" },
+  { "query": "Take a look at stack 275. Seems to be using a ton of tokens.", "should_trigger": false, "notes": "Diagnosis → stack-inspect. 'Too many tokens' is NOT a teardown signal." },
+  { "query": "Something happened to stack 43, it crashed. Take a look and fire it back up, pick up where it left off. Don't tear down the stack, just resume it.", "should_trigger": false, "notes": "Explicit anti-signal: user says 'don't tear down'. Must not misfire on the literal word 'tear down'." },
+  { "query": "Let's start ticket 151.", "should_trigger": false, "notes": "New work → spec-and-dispatch" },
+  { "query": "Can you take a look at ticket 43? Let me know if it passes our quality gates or not.", "should_trigger": false, "notes": "Spec → sandstorm-spec" }
+]

--- a/scripts/run-all-skill-evals.sh
+++ b/scripts/run-all-skill-evals.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Run trigger evals for every Sandstorm skill that has an authored
+# eval set under docs/skill-evals/<skill>/trigger-eval.json. Writes one
+# results directory per skill under docs/skill-evals/results/<model>/<skill>/.
+#
+# Usage:
+#   scripts/run-all-skill-evals.sh <model-id> [--max-iterations N]
+#
+# Example:
+#   scripts/run-all-skill-evals.sh claude-opus-4-6
+#   scripts/run-all-skill-evals.sh claude-opus-4-7
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <model-id> [extra args passed through to skill-eval.sh]" >&2
+  exit 2
+fi
+
+MODEL_ID="$1"; shift
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EVALS_DIR="$REPO_ROOT/docs/skill-evals"
+
+SKILLS=()
+while IFS= read -r f; do
+  SKILLS+=("$(basename "$(dirname "$f")")")
+done < <(find "$EVALS_DIR" -mindepth 2 -maxdepth 2 -name 'trigger-eval.json' | sort)
+
+if [[ ${#SKILLS[@]} -eq 0 ]]; then
+  echo "No trigger-eval.json files found under $EVALS_DIR" >&2
+  exit 1
+fi
+
+echo "Model: $MODEL_ID" >&2
+echo "Skills to eval: ${SKILLS[*]}" >&2
+
+FAILED=()
+for skill in "${SKILLS[@]}"; do
+  echo "" >&2
+  echo "===== $skill =====" >&2
+  if ! "$REPO_ROOT/scripts/skill-eval.sh" "$skill" "$MODEL_ID" "$@"; then
+    FAILED+=("$skill")
+  fi
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "" >&2
+  echo "Skills with non-zero exit: ${FAILED[*]}" >&2
+  exit 1
+fi
+echo "" >&2
+echo "All skill evals completed. Results in $EVALS_DIR/results/$MODEL_ID/" >&2

--- a/scripts/skill-eval.sh
+++ b/scripts/skill-eval.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Run the trigger-eval for a single Sandstorm skill and save results.
+#
+# Thin wrapper around skill-creator's run_loop.py. We don't re-implement
+# the eval runner here — the whole point of #285 is to standardize on the
+# official tool so every skill goes through the same code path.
+#
+# Usage:
+#   scripts/skill-eval.sh <skill-name> <model-id> [--max-iterations N]
+#
+# Example:
+#   scripts/skill-eval.sh check-and-resume-stack claude-opus-4-6
+#   scripts/skill-eval.sh check-and-resume-stack claude-opus-4-7 --max-iterations 3
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <skill-name> <model-id> [--max-iterations N] [--runs-per-query N]" >&2
+  exit 2
+fi
+
+SKILL_NAME="$1"; shift
+MODEL_ID="$1"; shift
+
+# Default: one iteration (baseline measurement, no description tuning).
+# Raise to ≥3 to invoke run_loop's improvement pass when a skill is under-triggering.
+MAX_ITER=1
+RUNS_PER_QUERY=3
+HOLDOUT=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-iterations) MAX_ITER="$2"; shift 2 ;;
+    --runs-per-query) RUNS_PER_QUERY="$2"; shift 2 ;;
+    --holdout) HOLDOUT="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_PATH="$REPO_ROOT/sandstorm-cli/skills/$SKILL_NAME"
+EVAL_SET="$REPO_ROOT/docs/skill-evals/$SKILL_NAME/trigger-eval.json"
+
+if [[ ! -f "$SKILL_PATH/SKILL.md" ]]; then
+  echo "ERROR: no SKILL.md at $SKILL_PATH" >&2
+  exit 1
+fi
+if [[ ! -f "$EVAL_SET" ]]; then
+  echo "ERROR: no eval set at $EVAL_SET (see docs/skill-evals/README.md)" >&2
+  exit 1
+fi
+
+# skill-creator is installed as a Claude Code plugin. Both cache and
+# marketplace paths contain the same module tree; prefer cache (used at
+# runtime) with marketplace as fallback.
+SKILL_CREATOR=""
+for candidate in \
+  "$HOME/.claude/plugins/cache/claude-plugins-official/skill-creator/unknown/skills/skill-creator" \
+  "$HOME/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator"; do
+  if [[ -f "$candidate/scripts/run_loop.py" ]]; then
+    SKILL_CREATOR="$candidate"
+    break
+  fi
+done
+if [[ -z "$SKILL_CREATOR" ]]; then
+  echo "ERROR: skill-creator plugin not installed" >&2
+  echo "  run: claude plugin install skill-creator@claude-plugins-official" >&2
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: 'claude' CLI not on PATH" >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not on PATH" >&2
+  exit 1
+fi
+if ! python3 -c 'import anthropic' >/dev/null 2>&1; then
+  echo "ERROR: python3 can't import 'anthropic' (pip install anthropic)" >&2
+  exit 1
+fi
+if [[ "$MAX_ITER" -gt 1 && -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "ERROR: --max-iterations >1 runs description improvement, which needs ANTHROPIC_API_KEY" >&2
+  exit 1
+fi
+
+TIMESTAMP="$(date -u +'%Y-%m-%dT%H%M%SZ')"
+RESULTS_ROOT="$REPO_ROOT/docs/skill-evals/results/$MODEL_ID/$SKILL_NAME"
+mkdir -p "$RESULTS_ROOT"
+
+echo "Running trigger eval: skill=$SKILL_NAME model=$MODEL_ID iterations=$MAX_ITER" >&2
+echo "  eval set:    $EVAL_SET" >&2
+echo "  skill path:  $SKILL_PATH" >&2
+echo "  results dir: $RESULTS_ROOT" >&2
+
+cd "$SKILL_CREATOR"
+python3 -m scripts.run_loop \
+  --eval-set "$EVAL_SET" \
+  --skill-path "$SKILL_PATH" \
+  --model "$MODEL_ID" \
+  --max-iterations "$MAX_ITER" \
+  --runs-per-query "$RUNS_PER_QUERY" \
+  --holdout "$HOLDOUT" \
+  --results-dir "$RESULTS_ROOT" \
+  --report none \
+  --verbose
+
+# Symlink the newest timestamped subdir as 'latest' so downstream tools
+# (CI comment bots, dashboards) always have a stable path to the last run.
+LATEST="$(ls -1dt "$RESULTS_ROOT"/*/ 2>/dev/null | head -1 || true)"
+if [[ -n "$LATEST" ]]; then
+  ln -snf "$(basename "$LATEST")" "$RESULTS_ROOT/latest"
+fi

--- a/tests/unit/skill-evals.test.ts
+++ b/tests/unit/skill-evals.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+// Every authored trigger-eval.json is the contract the skill-eval runner
+// consumes. If the shape or skill-name pairing drifts, the wrapper fails
+// silently or produces meaningless results. These tests pin both.
+
+const repoRoot = resolve(__dirname, '../..')
+const evalsDir = resolve(repoRoot, 'docs/skill-evals')
+const skillsDir = resolve(repoRoot, 'sandstorm-cli/skills')
+
+function listEvalSets(): { skillName: string; path: string }[] {
+  return readdirSync(evalsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && e.name !== 'results')
+    .map((e) => ({
+      skillName: e.name,
+      path: resolve(evalsDir, e.name, 'trigger-eval.json'),
+    }))
+    .filter((e) => existsSync(e.path))
+}
+
+describe('skill trigger-eval sets', () => {
+  const evalSets = listEvalSets()
+
+  it('at least one eval set exists', () => {
+    expect(evalSets.length).toBeGreaterThan(0)
+  })
+
+  it.each(evalSets)('$skillName: pairs with a real bundled skill', ({ skillName }) => {
+    const skillMd = resolve(skillsDir, skillName, 'SKILL.md')
+    expect(existsSync(skillMd), `missing ${skillMd}`).toBe(true)
+  })
+
+  it.each(evalSets)('$skillName: is a well-formed eval array', ({ path }) => {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    expect(Array.isArray(parsed)).toBe(true)
+    const arr = parsed as Array<Record<string, unknown>>
+    expect(arr.length).toBeGreaterThanOrEqual(5)
+    for (const entry of arr) {
+      expect(typeof entry.query).toBe('string')
+      expect((entry.query as string).length).toBeGreaterThan(0)
+      expect(typeof entry.should_trigger).toBe('boolean')
+    }
+  })
+
+  it.each(evalSets)('$skillName: has both positive and negative queries', ({ path }) => {
+    const arr = JSON.parse(readFileSync(path, 'utf-8')) as Array<{ should_trigger: boolean }>
+    const positives = arr.filter((e) => e.should_trigger).length
+    const negatives = arr.filter((e) => !e.should_trigger).length
+    // Per methodology doc: at least 1 positive and 5 negatives. Some skills
+    // (stack-teardown) have only one natural positive phrasing from the user —
+    // the main eval signal for those is the negative set, which must stay
+    // large to prevent over-triggering.
+    expect(positives).toBeGreaterThanOrEqual(1)
+    expect(negatives).toBeGreaterThanOrEqual(5)
+  })
+
+  it.each(evalSets)('$skillName: no duplicate queries', ({ path }) => {
+    const arr = JSON.parse(readFileSync(path, 'utf-8')) as Array<{ query: string }>
+    const seen = new Set<string>()
+    for (const entry of arr) {
+      const key = entry.query.trim().toLowerCase()
+      expect(seen.has(key), `duplicate query: ${entry.query}`).toBe(false)
+      seen.add(key)
+    }
+  })
+})
+
+describe('skill-eval wrapper scripts', () => {
+  const skillEval = resolve(repoRoot, 'scripts/skill-eval.sh')
+  const runAll = resolve(repoRoot, 'scripts/run-all-skill-evals.sh')
+
+  it('both scripts exist and are executable', () => {
+    for (const p of [skillEval, runAll]) {
+      expect(existsSync(p), `missing ${p}`).toBe(true)
+      // eslint-disable-next-line no-bitwise
+      expect(statSync(p).mode & 0o111, `${p} not executable`).not.toBe(0)
+    }
+  })
+
+  it('skill-eval.sh references the pinned skill-creator plugin paths', () => {
+    // If the upstream plugin path layout changes the wrapper will silently
+    // fail to find run_loop.py. Pin both the cache and marketplace paths
+    // so upgrades that rename either show up here first.
+    const body = readFileSync(skillEval, 'utf-8')
+    expect(body).toContain('plugins/cache/claude-plugins-official/skill-creator')
+    expect(body).toContain('plugins/marketplaces/claude-plugins-official/plugins/skill-creator')
+    expect(body).toContain('scripts/run_loop.py')
+  })
+
+  it('run-all-skill-evals.sh delegates to skill-eval.sh', () => {
+    const body = readFileSync(runAll, 'utf-8')
+    expect(body).toContain('scripts/skill-eval.sh')
+  })
+})


### PR DESCRIPTION
## Summary
- Systematic trigger-eval harness for every Sandstorm-bundled skill, replacing ad-hoc interactive probing
- Seven eval sets populated from phrasings the user supplied directly (not invented), with varied entity IDs so the model can't pass by keying on the number
- Wrapper scripts (`scripts/skill-eval.sh`, `scripts/run-all-skill-evals.sh`) standing on top of skill-creator's `run_loop.py` so every skill runs through the same code path and results compare across model releases

## Why
Ad-hoc validation ("try a prompt in an interactive session") was masking real drift. Opus 4.6 → 4.7 could silently change trigger rates and we'd only notice after the regression hit real usage. Now every skill has a committed eval set; re-running on a new model produces a versioned results file under \`docs/skill-evals/results/<model-id>/\`.

## What's authored
| Skill | Positives | Negatives |
|---|---|---|
| check-and-resume-stack | 8 | 11 |
| sandstorm-spec | 3 | 9 |
| spec-and-dispatch | 5 | 7 |
| review-and-pr | 5 | 7 |
| stack-inspect | 6 | 7 |
| list-stacks | 4 | 8 |
| stack-teardown | 1 | 11 |

\`stack-pr\` intentionally has no eval set — user confirmed they'd never invoke it directly; a follow-up will demote or delete that skill.

Negatives are drawn from adjacent skills' positives rather than keyword-adjacent fabrications. That's the disambiguation test that matters.

## How to run
\`\`\`bash
# Single skill
scripts/skill-eval.sh check-and-resume-stack claude-opus-4-6

# All skills
scripts/run-all-skill-evals.sh claude-opus-4-6
\`\`\`

Defaults to \`--max-iterations 1\` (baseline measurement only). Raise to invoke \`run_loop\`'s description-improvement pass; that needs \`ANTHROPIC_API_KEY\`.

## Test plan
- [x] \`npx vitest run tests/unit/skill-evals.test.ts\` — 32 passing (per-skill shape, pairing with real SKILL.md, duplicates, wrapper plumbing)
- [x] \`bash -n\` syntax check on both wrapper scripts
- [x] Smoke-ran \`run-all-skill-evals.sh\` with a bogus model id — wrapper plumbs through to \`run_loop.py\`, returns 0/3 on everything (expected degraded-mode behavior)
- [ ] Follow-up: record opus-4.6 and opus-4.7 baseline pass rates on a real model (next PR)

Closes follow-ups toward #285.