### PR TITLE
Add raw API-request capture for orchestrator bloat investigation (#299)

### DIFF
--- a/docs/investigations/orchestrator-delta-runbook.md
+++ b/docs/investigations/orchestrator-delta-runbook.md
@@ -145,3 +145,29 @@ mv ~/.claude/projects/-home-onomojo-Work-sandstorm-desktop/memory.bak \
 ## Experiment 6 — Fresh Claude Code (I run this, no user action)
 
 External baseline via a raw `claude -p` subprocess against the project, parsing the stream-json `type:"result"` usage block. I'll do this in parallel with your runs and merge the result into the analysis table.
+
+---
+
+## Raw API-request capture (#299)
+
+When telemetry is not enough — you want to see exactly what bytes the CLI is sending to `api.anthropic.com` — set this env var on the app launch:
+
+```bash
+SANDSTORM_RAW_REQUEST_CAPTURE=1 \
+"/home/onomojo/Work/sandstorm-desktop/release/sandstorm-desktop-0.1.0-linux.AppImage"
+```
+
+A localhost HTTP proxy is stood up per tab; the child `claude` process is pointed at it via `ANTHROPIC_BASE_URL`. Every outbound request body is dumped (headers redacted) under:
+
+```
+~/.config/sandstorm-desktop/raw-api-capture/<sessionStartIso>/
+```
+
+Analyze with:
+
+```bash
+node scripts/analyze-raw-capture.mjs \
+  ~/.config/sandstorm-desktop/raw-api-capture/<sessionStartIso>
+```
+
+The script prints a per-request summary table, a system-prompt composition breakdown (with the skill-catalog system-reminder flagged explicitly), tool-schema inventory, and net byte deltas between adjacent requests. Clean up the capture dir manually after — no rotation.

--- a/scripts/analyze-raw-capture.mjs
+++ b/scripts/analyze-raw-capture.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * analyze-raw-capture.mjs — summarise a raw-api-capture session dir (#299).
+ *
+ * Usage:
+ *   node scripts/analyze-raw-capture.mjs <path-to-session-dir>
+ *
+ * A session dir is created under:
+ *   <userData>/raw-api-capture/<sessionStartIso>/
+ * with one `index.jsonl` and one `NNNN-<tab>-turnN-subM-req.json` per
+ * outbound API request.
+ *
+ * The script answers: "where is the token bloat coming from?" by breaking
+ * down each request's body into system-prompt chunks, tools schemas, and
+ * messages, then diffing adjacent requests so growth drivers are obvious.
+ *
+ * Pure Node, no deps. Runs outside the app.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const SKILL_CATALOG_MARKER = 'The following skills are available for use with the Skill tool';
+
+function die(msg) {
+  console.error(`analyze-raw-capture: ${msg}`);
+  process.exit(1);
+}
+
+function byteLen(v) {
+  if (v == null) return 0;
+  if (typeof v === 'string') return Buffer.byteLength(v, 'utf-8');
+  return Buffer.byteLength(JSON.stringify(v), 'utf-8');
+}
+
+function formatBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / 1024 / 1024).toFixed(2)}MB`;
+}
+
+function pad(s, w, right = false) {
+  const str = String(s);
+  if (str.length >= w) return str.slice(0, w);
+  const fill = ' '.repeat(w - str.length);
+  return right ? fill + str : str + fill;
+}
+
+function deltaStr(n) {
+  if (n === 0) return '   0';
+  const sign = n > 0 ? '+' : '-';
+  return `${sign}${formatBytes(Math.abs(n))}`;
+}
+
+function loadDumps(dir) {
+  const entries = fs
+    .readdirSync(dir)
+    .filter((f) => /-req\.json$/.test(f))
+    .sort();
+  const dumps = [];
+  for (const f of entries) {
+    const full = path.join(dir, f);
+    try {
+      const parsed = JSON.parse(fs.readFileSync(full, 'utf-8'));
+      dumps.push({ file: f, ...parsed });
+    } catch (e) {
+      console.warn(`warn: could not parse ${f}: ${e.message}`);
+    }
+  }
+  return dumps;
+}
+
+function summarizeBody(body) {
+  // Anthropic /v1/messages request shape:
+  //   { model, max_tokens, system?: string | Array, messages: [], tools?: [] }
+  const out = {
+    model: undefined,
+    systemChunks: [],
+    systemBytes: 0,
+    messageCount: 0,
+    messagesBytes: 0,
+    toolsCount: 0,
+    toolsBytes: 0,
+    firstUserSnippet: '',
+    skillCatalogBytes: 0,
+    skillCatalogPresent: false,
+  };
+  if (!body || typeof body !== 'object') return out;
+  out.model = body.model;
+
+  const sys = body.system;
+  if (Array.isArray(sys)) {
+    for (const entry of sys) {
+      const text = typeof entry === 'string' ? entry : entry?.text;
+      const bytes = byteLen(text ?? entry);
+      out.systemChunks.push({ bytes, head: (text ?? '').slice(0, 80) });
+      out.systemBytes += bytes;
+      if (typeof text === 'string' && text.includes(SKILL_CATALOG_MARKER)) {
+        out.skillCatalogPresent = true;
+        out.skillCatalogBytes += bytes;
+      }
+    }
+  } else if (typeof sys === 'string') {
+    out.systemChunks.push({ bytes: byteLen(sys), head: sys.slice(0, 80) });
+    out.systemBytes = byteLen(sys);
+    if (sys.includes(SKILL_CATALOG_MARKER)) {
+      out.skillCatalogPresent = true;
+      out.skillCatalogBytes = byteLen(sys);
+    }
+  }
+
+  if (Array.isArray(body.messages)) {
+    out.messageCount = body.messages.length;
+    out.messagesBytes = byteLen(body.messages);
+    const firstUser = body.messages.find((m) => m.role === 'user');
+    if (firstUser) {
+      const text = extractFirstText(firstUser.content);
+      out.firstUserSnippet = text.replace(/\s+/g, ' ').slice(0, 60);
+    }
+  }
+
+  if (Array.isArray(body.tools)) {
+    out.toolsCount = body.tools.length;
+    out.toolsBytes = byteLen(body.tools);
+  }
+
+  return out;
+}
+
+function extractFirstText(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  for (const block of content) {
+    if (block?.type === 'text' && typeof block.text === 'string') return block.text;
+    if (typeof block?.text === 'string') return block.text;
+  }
+  return '';
+}
+
+function printTable(rows, columns) {
+  const widths = columns.map((c) =>
+    Math.max(c.header.length, ...rows.map((r) => String(r[c.key] ?? '').length))
+  );
+  const header = columns.map((c, i) => pad(c.header, widths[i], c.right)).join(' │ ');
+  const sep = widths.map((w) => '─'.repeat(w)).join('─┼─');
+  console.log(header);
+  console.log(sep);
+  for (const r of rows) {
+    console.log(
+      columns.map((c, i) => pad(r[c.key] ?? '', widths[i], c.right)).join(' │ ')
+    );
+  }
+}
+
+function main() {
+  const arg = process.argv[2];
+  if (!arg) die('usage: analyze-raw-capture.mjs <session-dir>');
+  const dir = path.resolve(arg);
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    die(`not a directory: ${dir}`);
+  }
+
+  const dumps = loadDumps(dir);
+  if (dumps.length === 0) {
+    console.log(`(no -req.json files in ${dir})`);
+    return;
+  }
+
+  const summaries = dumps.map((d) => ({
+    seq: d.seq,
+    turn: d.turnIndex,
+    sub: d.subTurnSeq,
+    bodyBytes: d.bodyBytes,
+    ...summarizeBody(d.body),
+    tabId: d.tabId,
+  }));
+
+  console.log(`\n=== Summary (${summaries.length} request${summaries.length === 1 ? '' : 's'}) ===\n`);
+  printTable(
+    summaries.map((s) => ({
+      seq: s.seq,
+      turn: s.turn,
+      sub: s.sub,
+      model: s.model ?? '(n/a)',
+      body: formatBytes(s.bodyBytes),
+      msgs: s.messageCount,
+      tools: s.toolsCount,
+      sysChunks: s.systemChunks.length,
+      skillCat: s.skillCatalogPresent ? `YES ${formatBytes(s.skillCatalogBytes)}` : '-',
+      firstUser: s.firstUserSnippet || '-',
+    })),
+    [
+      { header: 'seq', key: 'seq', right: true },
+      { header: 'turn', key: 'turn', right: true },
+      { header: 'sub', key: 'sub', right: true },
+      { header: 'model', key: 'model' },
+      { header: 'body', key: 'body', right: true },
+      { header: 'msgs', key: 'msgs', right: true },
+      { header: 'tools', key: 'tools', right: true },
+      { header: 'sysChunks', key: 'sysChunks', right: true },
+      { header: 'skillCatalog', key: 'skillCat' },
+      { header: 'firstUser', key: 'firstUser' },
+    ]
+  );
+
+  console.log('\n=== Per-request system-prompt composition ===\n');
+  for (const s of summaries) {
+    console.log(`[seq=${s.seq} turn=${s.turn}.${s.sub}] system total=${formatBytes(s.systemBytes)}, ${s.systemChunks.length} chunks`);
+    s.systemChunks
+      .slice()
+      .sort((a, b) => b.bytes - a.bytes)
+      .forEach((c, i) => {
+        const tag = c.head.includes(SKILL_CATALOG_MARKER) ? '  [SKILL CATALOG]' : '';
+        console.log(`    #${i + 1}: ${pad(formatBytes(c.bytes), 8, true)}  ${c.head.replace(/\s+/g, ' ')}${tag}`);
+      });
+  }
+
+  if (summaries.length > 1) {
+    console.log('\n=== Net deltas between adjacent requests ===\n');
+    for (let i = 1; i < summaries.length; i++) {
+      const a = summaries[i - 1];
+      const b = summaries[i];
+      const dBody = b.bodyBytes - a.bodyBytes;
+      const dSys = b.systemBytes - a.systemBytes;
+      const dTools = b.toolsBytes - a.toolsBytes;
+      const dMsgs = b.messagesBytes - a.messagesBytes;
+      const dMsgCount = b.messageCount - a.messageCount;
+      console.log(
+        `seq ${pad(a.seq, 3, true)}→${pad(b.seq, 3, true)}  body ${pad(deltaStr(dBody), 10, true)}` +
+        `  system ${pad(deltaStr(dSys), 10, true)}` +
+        `  tools ${pad(deltaStr(dTools), 10, true)}` +
+        `  messages ${pad(deltaStr(dMsgs), 10, true)} (+${dMsgCount} msgs)`
+      );
+    }
+  }
+
+  // Tool-schema inventory — flag additions / removals across turns.
+  console.log('\n=== Tool inventory ===\n');
+  const toolNamesByReq = dumps.map((d) => {
+    const tools = Array.isArray(d.body?.tools) ? d.body.tools : [];
+    return tools.map((t) => t?.name ?? '?');
+  });
+  for (let i = 0; i < toolNamesByReq.length; i++) {
+    const cur = toolNamesByReq[i];
+    const prev = i > 0 ? toolNamesByReq[i - 1] : null;
+    const added = prev ? cur.filter((t) => !prev.includes(t)) : cur;
+    const removed = prev ? prev.filter((t) => !cur.includes(t)) : [];
+    const tags = [];
+    if (added.length) tags.push(`+${added.join(',')}`);
+    if (removed.length) tags.push(`-${removed.join(',')}`);
+    console.log(`[seq=${dumps[i].seq}] ${cur.length} tools${tags.length ? '  (' + tags.join('; ') + ')' : ''}`);
+  }
+
+  // Observations
+  console.log('\n=== Observations ===');
+  const anyCatalog = summaries.some((s) => s.skillCatalogPresent);
+  if (anyCatalog) {
+    const totalCatalog = summaries.reduce((acc, s) => acc + s.skillCatalogBytes, 0);
+    console.log(`  • Skill catalog system-reminder present in at least one request. Total bytes across captured requests: ${formatBytes(totalCatalog)}.`);
+    console.log(`    Consider disabling Claude Code's plugin auto-advertisement if it's not needed.`);
+  }
+  const maxBody = Math.max(...summaries.map((s) => s.bodyBytes));
+  const maxBodyReq = summaries.find((s) => s.bodyBytes === maxBody);
+  console.log(`  • Largest request: seq=${maxBodyReq.seq} turn=${maxBodyReq.turn}.${maxBodyReq.sub} at ${formatBytes(maxBody)}.`);
+  if (summaries.length > 1) {
+    const growth = summaries[summaries.length - 1].bodyBytes - summaries[0].bodyBytes;
+    console.log(`  • Growth from first to last request: ${deltaStr(growth)}.`);
+  }
+  console.log('');
+}
+
+main();

--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -26,6 +26,12 @@ import {
 import { resolveOuterClaudeTools } from './tools-allowlist';
 import { composeSystemPromptWithSkills } from './skill-enumeration';
 import { TokenTelemetry, ToolCallRecord, isTelemetryEnabled } from './token-telemetry';
+import {
+  RawCaptureSession,
+  RawCaptureSupervisor,
+  createRawCaptureSupervisor,
+  isRawCaptureEnabled,
+} from './raw-request-capture';
 
 /** In-flight per-cycle tracking; tool_use_id is only retained in memory. */
 interface InFlightToolCall extends ToolCallRecord {
@@ -92,6 +98,8 @@ export class ClaudeBackend implements AgentBackend {
   private timeoutMs: number;
   private modelResolver?: (projectDir: string) => string;
   private telemetry: TokenTelemetry;
+  private rawCapture: RawCaptureSupervisor;
+  private rawCaptureByTab = new Map<string, RawCaptureSession>();
 
   constructor(
     timeoutMs?: number,
@@ -102,6 +110,25 @@ export class ClaudeBackend implements AgentBackend {
     this.modelResolver = modelResolver;
     this.initLogger();
     this.telemetry = this.initTelemetry();
+    this.rawCapture = this.initRawCapture();
+  }
+
+  /**
+   * Opt-in raw API-request capture (#299). Off unless
+   * `SANDSTORM_RAW_REQUEST_CAPTURE=1` is set. Stands up one HTTP proxy per
+   * tab, dumps outbound request bodies to disk next to the telemetry log.
+   */
+  private initRawCapture(): RawCaptureSupervisor {
+    const enabled = isRawCaptureEnabled();
+    let baseDir: string;
+    try {
+      baseDir = typeof app !== 'undefined' && app.getPath ? app.getPath('userData') : os.tmpdir();
+    } catch {
+      baseDir = os.tmpdir();
+    }
+    const sessionId = new Date().toISOString().replace(/[:.]/g, '-');
+    const rootDir = path.join(baseDir, 'raw-api-capture', sessionId);
+    return createRawCaptureSupervisor({ rootDir, enabled });
   }
 
   /**
@@ -256,6 +283,30 @@ export class ClaudeBackend implements AgentBackend {
     // Note: Claude CLI with --input-format stream-json does NOT emit the
     // system init event until it receives input on stdin, so we must write
     // the message first — not wait for init.
+    //
+    // Default (capture off) path stays fully synchronous so no spawn
+    // latency is introduced. Capture on (#299) defers spawn+write until
+    // the loopback proxy has bound an ephemeral port.
+    if (this.rawCapture.enabled) {
+      void this.rawCapture
+        .registerTab(tabId)
+        .then((captureSession) => {
+          const extraEnv: Record<string, string> = {};
+          if (captureSession.baseUrl) {
+            extraEnv.ANTHROPIC_BASE_URL = captureSession.baseUrl;
+            this.rawCaptureByTab.set(tabId, captureSession);
+            this.log(`Raw request capture active for tab=${tabId} at ${captureSession.baseUrl}`);
+          }
+          this.ensureProcess(tabId, extraEnv);
+          this.writeMessage(tabId, message);
+        })
+        .catch((err) => {
+          this.log(`Raw request capture failed to start for tab=${tabId}: ${String(err)}`);
+          this.ensureProcess(tabId);
+          this.writeMessage(tabId, message);
+        });
+      return;
+    }
     this.ensureProcess(tabId);
     this.writeMessage(tabId, message);
   }
@@ -315,6 +366,14 @@ export class ClaudeBackend implements AgentBackend {
       }
     }
     this.sessions.delete(tabId);
+
+    // Tear down the per-tab raw-capture proxy (#299). A fresh one will be
+    // created on the next sendMessage via ensureProcess.
+    const capture = this.rawCaptureByTab.get(tabId);
+    if (capture) {
+      this.rawCaptureByTab.delete(tabId);
+      capture.close().catch(() => { /* best effort */ });
+    }
 
     // Reset token counter to zero for the new session — and push the zero
     // value to the renderer immediately so the UI updates without a poll.
@@ -634,8 +693,12 @@ export class ClaudeBackend implements AgentBackend {
   /**
    * Ensure a persistent Claude process is running for the given tab.
    * Spawns one if none exists. The process stays alive across messages.
+   *
+   * `extraEnv` is merged into the spawn env. Used by the raw-capture
+   * path (#299) to inject `ANTHROPIC_BASE_URL` pointing at the loopback
+   * proxy. When capture is off this is an empty object.
    */
-  private ensureProcess(tabId: string): void {
+  private ensureProcess(tabId: string, extraEnv: Record<string, string> = {}): void {
     const session = this.sessions.get(tabId);
     if (!session || session.process) return;
 
@@ -679,11 +742,12 @@ export class ClaudeBackend implements AgentBackend {
     // SANDSTORM_SKILLS_DIR points at the bundled skills dir so SKILL.md
     // bodies can reference their own `scripts/*.sh` no matter which
     // project is open.
-    const env = {
+    const env: Record<string, string | undefined> = {
       ...getClaudeEnv(),
       SANDSTORM_BRIDGE_URL: `http://127.0.0.1:${this.bridgePort}`,
       SANDSTORM_BRIDGE_TOKEN: this.bridgeToken,
       SANDSTORM_SKILLS_DIR: path.join(cliDir, 'skills'),
+      ...extraEnv,
     };
 
     const child = spawn(claudeBin, args, {
@@ -803,6 +867,10 @@ export class ClaudeBackend implements AgentBackend {
               // Reset per-cycle counters for the next user-message turn.
               session.subTurnCount = 0;
               session.toolCallsInCycle = [];
+              // Advance the raw-capture turn boundary in lock-step with
+              // our internal turn counter. Dumps for the next turn land
+              // in files tagged with the incremented turn index (#299).
+              this.rawCaptureByTab.get(tabId)?.markTurnComplete();
             }
 
             if (session.fullResponse) {
@@ -1004,5 +1072,9 @@ export class ClaudeBackend implements AgentBackend {
     this.logStream?.end();
     this.logStream = null;
     this.telemetry.close();
+    // Close all raw-capture listeners (#299). Fire-and-forget — we don't
+    // block shutdown on proxy drain.
+    this.rawCapture.closeAll().catch(() => { /* ignore */ });
+    this.rawCaptureByTab.clear();
   }
 }

--- a/src/main/agent/raw-request-capture.ts
+++ b/src/main/agent/raw-request-capture.ts
@@ -1,0 +1,318 @@
+/**
+ * Raw Anthropic-API request capture for the outer Claude orchestrator (#299).
+ *
+ * Pure, electron-free module. Stands up one localhost HTTP proxy per tab so
+ * the child `claude` subprocess can be pointed at it via `ANTHROPIC_BASE_URL`.
+ * The proxy dumps every outbound request body to disk (headers redacted),
+ * then forwards to `https://api.anthropic.com` and pipes the SSE response
+ * back unchanged. This gives us ground-truth visibility into what the CLI
+ * actually sends — something telemetry alone cannot reveal.
+ *
+ * Off by default. Opt in with the env var `SANDSTORM_RAW_REQUEST_CAPTURE=1`.
+ *
+ * Redaction contract:
+ *   Authorization, x-api-key, anthropic-api-key, anthropic-auth-token,
+ *   proxy-authorization, cookie, set-cookie, and any header whose name
+ *   matches /token|secret|key/i are replaced with "[REDACTED len=<n>]"
+ *   before writing to disk. The original headers are used in-memory only
+ *   to construct the forwarded request.
+ */
+import {
+  appendFileSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+} from 'fs';
+import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
+import { request as httpsRequest } from 'https';
+import path from 'path';
+
+const REDACT_HEADER_NAMES = new Set([
+  'authorization',
+  'x-api-key',
+  'anthropic-api-key',
+  'anthropic-auth-token',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+]);
+
+const REDACT_HEADER_PATTERN = /token|secret|key/i;
+
+function redactHeaders(
+  headers: Record<string, string | string[] | undefined>
+): Record<string, string | string[] | undefined> {
+  const out: Record<string, string | string[] | undefined> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    const mustRedact =
+      REDACT_HEADER_NAMES.has(lower) || REDACT_HEADER_PATTERN.test(lower);
+    if (!mustRedact) {
+      out[name] = value;
+      continue;
+    }
+    const raw = Array.isArray(value) ? value.join(',') : value ?? '';
+    out[name] = `[REDACTED len=${raw.length}]`;
+  }
+  return out;
+}
+
+function safeFileSegment(segment: string): string {
+  return segment.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64) || 'unknown';
+}
+
+function pad(n: number, width = 4): string {
+  const s = String(n);
+  return s.length >= width ? s : '0'.repeat(width - s.length) + s;
+}
+
+export interface RawCaptureSession {
+  /** URL the child should use as ANTHROPIC_BASE_URL. Empty when disabled. */
+  readonly baseUrl: string;
+  /** Called when a user-message turn completes (outer `type:"result"`). */
+  markTurnComplete(): void;
+  /** Release the listener and stop accepting requests. */
+  close(): Promise<void>;
+}
+
+export interface RawCaptureSupervisor {
+  /**
+   * True when capture is armed. Callers can use this to skip the entire
+   * async registerTab path and keep their code synchronous when capture
+   * is off (the common production case).
+   */
+  readonly enabled: boolean;
+  registerTab(tabId: string): Promise<RawCaptureSession>;
+  closeAll(): Promise<void>;
+}
+
+export interface RawCaptureOptions {
+  /** Absolute path to the session root directory. Will be created lazily. */
+  rootDir: string;
+  /** When false, `registerTab` returns a no-op stub (zero overhead). */
+  enabled: boolean;
+  /** Upstream host to forward to. Overridable for tests. */
+  upstreamHost?: string;
+  /** Upstream port. Overridable for tests (e.g. a local echo http server). */
+  upstreamPort?: number;
+  /** Upstream protocol. 'https' (default, prod) or 'http' (tests only). */
+  upstreamProtocol?: 'http' | 'https';
+}
+
+/**
+ * Reads the opt-in flag. Default off — the flag must be explicitly set to
+ * `1`. Any other value (including `true`, `yes`) is ignored, matching the
+ * contract used by `SANDSTORM_TOKEN_TELEMETRY`.
+ */
+export function isRawCaptureEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.SANDSTORM_RAW_REQUEST_CAPTURE === '1';
+}
+
+const DISABLED_SESSION: RawCaptureSession = {
+  baseUrl: '',
+  markTurnComplete: () => { /* no-op */ },
+  close: async () => { /* no-op */ },
+};
+
+const DISABLED_SUPERVISOR: RawCaptureSupervisor = {
+  enabled: false,
+  registerTab: async () => DISABLED_SESSION,
+  closeAll: async () => { /* no-op */ },
+};
+
+/**
+ * Build a supervisor. When `enabled` is false, returns a stub that never
+ * touches the filesystem or network — the capture path vanishes entirely
+ * so production runs pay no cost.
+ */
+export function createRawCaptureSupervisor(
+  opts: RawCaptureOptions
+): RawCaptureSupervisor {
+  if (!opts.enabled) return DISABLED_SUPERVISOR;
+
+  const upstreamHost = opts.upstreamHost ?? 'api.anthropic.com';
+  const upstreamPort = opts.upstreamPort ?? 443;
+  const upstreamProtocol = opts.upstreamProtocol ?? 'https';
+  const rootDir = opts.rootDir;
+  const indexPath = path.join(rootDir, 'index.jsonl');
+  const sessions = new Set<{ close: () => Promise<void> }>();
+
+  const ensureRootDir = (): void => {
+    if (!existsSync(rootDir)) mkdirSync(rootDir, { recursive: true });
+  };
+
+  function forward(
+    req: IncomingMessage,
+    body: Buffer,
+    res: ServerResponse
+  ): void {
+    if (upstreamProtocol === 'https') {
+      const upstream = httpsRequest(
+        {
+          host: upstreamHost,
+          port: upstreamPort,
+          method: req.method,
+          path: req.url,
+          headers: { ...req.headers, host: upstreamHost },
+        },
+        (upstreamRes) => {
+          res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+          upstreamRes.pipe(res);
+        }
+      );
+      upstream.on('error', (err) => {
+        try {
+          res.writeHead(502);
+          res.end(String(err.message || err));
+        } catch {
+          /* connection already torn down */
+        }
+      });
+      upstream.write(body);
+      upstream.end();
+      return;
+    }
+    // Plain http upstream — only for tests. Use dynamic require to avoid
+    // paying the import cost in production.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const httpRequest = require('http').request;
+    const upstream = httpRequest(
+      {
+        host: upstreamHost,
+        port: upstreamPort,
+        method: req.method,
+        path: req.url,
+        headers: { ...req.headers, host: upstreamHost },
+      },
+      (upstreamRes: IncomingMessage) => {
+        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+        upstreamRes.pipe(res);
+      }
+    );
+    upstream.on('error', (err: Error) => {
+      try {
+        res.writeHead(502);
+        res.end(String(err.message || err));
+      } catch {
+        /* connection already torn down */
+      }
+    });
+    upstream.write(body);
+    upstream.end();
+  }
+
+  async function registerTab(tabId: string): Promise<RawCaptureSession> {
+    ensureRootDir();
+    const tabSafe = safeFileSegment(tabId);
+    let seq = 0;
+    let turnIndex = 0;
+    let subTurnSeq = 0;
+
+    const server: Server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        const body = Buffer.concat(chunks);
+        seq += 1;
+        const thisSeq = seq;
+        const thisSubTurn = subTurnSeq;
+        subTurnSeq += 1;
+
+        const redacted = redactHeaders(req.headers as Record<string, string | string[] | undefined>);
+        const ts = new Date().toISOString();
+
+        let parsedBody: unknown;
+        try {
+          parsedBody = body.length > 0 ? JSON.parse(body.toString('utf-8')) : null;
+        } catch {
+          parsedBody = body.toString('utf-8');
+        }
+
+        const entry = {
+          seq: thisSeq,
+          ts,
+          tabId,
+          turnIndex,
+          subTurnSeq: thisSubTurn,
+          method: req.method ?? 'GET',
+          path: req.url ?? '/',
+          headers: redacted,
+          bodyBytes: body.length,
+          body: parsedBody,
+        };
+
+        const fileName = `${pad(thisSeq)}-${tabSafe}-turn${turnIndex}-sub${thisSubTurn}-req.json`;
+        const filePath = path.join(rootDir, fileName);
+
+        try {
+          writeFileSync(filePath, JSON.stringify(entry, null, 2));
+          const indexLine = JSON.stringify({
+            seq: thisSeq,
+            ts,
+            tabId,
+            turnIndex,
+            subTurnSeq: thisSubTurn,
+            method: entry.method,
+            path: entry.path,
+            bodyBytes: body.length,
+            file: fileName,
+          }) + '\n';
+          appendFileSync(indexPath, indexLine);
+        } catch {
+          // Best-effort: never let disk failures break the orchestrator
+        }
+
+        forward(req, body, res);
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+
+    const address = server.address();
+    const port =
+      address && typeof address === 'object' && 'port' in address
+        ? (address as { port: number }).port
+        : 0;
+    if (!port) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      throw new Error('raw-request-capture: failed to obtain ephemeral port');
+    }
+
+    const handle = {
+      close: async (): Promise<void> => {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      },
+    };
+    sessions.add(handle);
+
+    const session: RawCaptureSession = {
+      baseUrl: `http://127.0.0.1:${port}`,
+      markTurnComplete(): void {
+        turnIndex += 1;
+        subTurnSeq = 0;
+      },
+      async close(): Promise<void> {
+        sessions.delete(handle);
+        await handle.close();
+      },
+    };
+
+    return session;
+  }
+
+  async function closeAll(): Promise<void> {
+    const all = Array.from(sessions);
+    sessions.clear();
+    await Promise.all(all.map((h) => h.close().catch(() => { /* ignore */ })));
+  }
+
+  return { enabled: true, registerTab, closeAll };
+}

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1438,3 +1438,57 @@ describe('Outer-Claude session token accumulation (agent:token-usage IPC)', () =
     expect((bMessages[0].args[0] as { input_tokens: number }).input_tokens).toBe(999);
   });
 });
+
+describe('Raw API-request capture wiring (#299)', () => {
+  let origFlag: string | undefined;
+
+  beforeEach(() => {
+    origFlag = process.env.SANDSTORM_RAW_REQUEST_CAPTURE;
+    spawnedProcesses.length = 0;
+  });
+
+  afterEach(() => {
+    if (origFlag === undefined) delete process.env.SANDSTORM_RAW_REQUEST_CAPTURE;
+    else process.env.SANDSTORM_RAW_REQUEST_CAPTURE = origFlag;
+  });
+
+  it('does NOT set ANTHROPIC_BASE_URL in spawn env when the flag is off', async () => {
+    delete process.env.SANDSTORM_RAW_REQUEST_CAPTURE;
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const mockWindow = { webContents: { send: vi.fn() } };
+    const backend = new ClaudeBackend(1000);
+    backend.setMainWindow(mockWindow as never);
+    await backend.initialize();
+
+    backend.sendMessage('tab-no-cap', 'hi', '/tmp');
+
+    const callArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const spawnOptions = callArgs[2] as { env: Record<string, string | undefined> };
+    expect(spawnOptions.env.ANTHROPIC_BASE_URL).toBeUndefined();
+
+    backend.destroy();
+  });
+
+  it('rawCapture supervisor reports disabled when flag is off', () => {
+    delete process.env.SANDSTORM_RAW_REQUEST_CAPTURE;
+    const backend = new ClaudeBackend(1000);
+    const supervisor = (backend as unknown as {
+      rawCapture: { enabled: boolean };
+    }).rawCapture;
+    expect(supervisor.enabled).toBe(false);
+    backend.destroy();
+  });
+
+  it('rawCapture supervisor reports enabled when flag is set to "1"', () => {
+    process.env.SANDSTORM_RAW_REQUEST_CAPTURE = '1';
+    const backend = new ClaudeBackend(1000);
+    const supervisor = (backend as unknown as {
+      rawCapture: { enabled: boolean };
+    }).rawCapture;
+    expect(supervisor.enabled).toBe(true);
+    backend.destroy();
+  });
+});

--- a/tests/unit/raw-request-capture.test.ts
+++ b/tests/unit/raw-request-capture.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
+import { request as httpRequest } from 'http';
+import {
+  createRawCaptureSupervisor,
+  isRawCaptureEnabled,
+} from '../../src/main/agent/raw-request-capture';
+
+/**
+ * Pure-function tests for #299 raw API-request capture. No mocking — the
+ * module is electron-free, tests target a real temp directory and a real
+ * local echo server in place of api.anthropic.com.
+ */
+
+interface CapturedUpstream {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+function startEchoServer(): Promise<{
+  server: Server;
+  port: number;
+  captured: CapturedUpstream[];
+}> {
+  return new Promise((resolve) => {
+    const captured: CapturedUpstream[] = [];
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        captured.push({
+          method: req.method ?? 'GET',
+          url: req.url ?? '/',
+          headers: { ...req.headers },
+          body: Buffer.concat(chunks).toString('utf-8'),
+        });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, seen: captured.length }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      resolve({ server, port: addr.port, captured });
+    });
+  });
+}
+
+function postJson(
+  baseUrl: string,
+  bodyObj: unknown,
+  extraHeaders: Record<string, string> = {}
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL('/v1/messages', baseUrl);
+    const body = Buffer.from(JSON.stringify(bodyObj), 'utf-8');
+    const req = httpRequest(
+      {
+        host: url.hostname,
+        port: Number(url.port),
+        method: 'POST',
+        path: url.pathname,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': String(body.length),
+          ...extraHeaders,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf-8'),
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function readIndex(rootDir: string): Record<string, unknown>[] {
+  const p = path.join(rootDir, 'index.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe('raw-request-capture (#299)', () => {
+  let tmpDir: string;
+  let rootDir: string;
+  let echo: { server: Server; port: number; captured: CapturedUpstream[] };
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandstorm-raw-capture-'));
+    rootDir = path.join(tmpDir, 'session');
+    echo = await startEchoServer();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => echo.server.close(() => resolve()));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('disabled supervisor returns a stub with empty baseUrl and writes nothing', async () => {
+    const sup = createRawCaptureSupervisor({ rootDir, enabled: false });
+    const session = await sup.registerTab('tab-x');
+    expect(session.baseUrl).toBe('');
+    session.markTurnComplete();
+    await session.close();
+    await sup.closeAll();
+    expect(fs.existsSync(rootDir)).toBe(false);
+  });
+
+  it('enabled supervisor forwards requests to upstream and dumps them to disk', async () => {
+    const sup = createRawCaptureSupervisor({
+      rootDir,
+      enabled: true,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: echo.port,
+      upstreamProtocol: 'http',
+    });
+    const session = await sup.registerTab('tab-1');
+    expect(session.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+    const payload = { model: 'claude-opus-4-7', messages: [{ role: 'user', content: 'hi' }] };
+    const res = await postJson(session.baseUrl, payload);
+    expect(res.status).toBe(200);
+
+    expect(echo.captured).toHaveLength(1);
+    expect(echo.captured[0].method).toBe('POST');
+    expect(echo.captured[0].url).toBe('/v1/messages');
+    expect(JSON.parse(echo.captured[0].body)).toEqual(payload);
+
+    const index = readIndex(rootDir);
+    expect(index).toHaveLength(1);
+    expect(index[0].method).toBe('POST');
+    expect(index[0].path).toBe('/v1/messages');
+    expect(index[0].tabId).toBe('tab-1');
+    expect(index[0].turnIndex).toBe(0);
+    expect(index[0].subTurnSeq).toBe(0);
+
+    const dumpFile = path.join(rootDir, index[0].file as string);
+    const dump = JSON.parse(fs.readFileSync(dumpFile, 'utf-8')) as Record<string, unknown>;
+    expect(dump.tabId).toBe('tab-1');
+    expect(dump.body).toEqual(payload);
+    expect(dump.bodyBytes).toBe(JSON.stringify(payload).length);
+
+    await session.close();
+    await sup.closeAll();
+  });
+
+  it('redacts Authorization/x-api-key headers in dumps (zero secret leakage)', async () => {
+    const sup = createRawCaptureSupervisor({
+      rootDir,
+      enabled: true,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: echo.port,
+      upstreamProtocol: 'http',
+    });
+    const session = await sup.registerTab('tab-r');
+    const secret = 'sk-ant-super-secret-value-12345';
+    await postJson(
+      session.baseUrl,
+      { model: 'x', messages: [] },
+      {
+        Authorization: `Bearer ${secret}`,
+        'x-api-key': secret,
+        'anthropic-api-key': secret,
+        'Set-Cookie': 'session=xyz',
+        'x-stainless-arch': 'x64',
+      }
+    );
+
+    const index = readIndex(rootDir);
+    const dumpFile = path.join(rootDir, index[0].file as string);
+    const rawDump = fs.readFileSync(dumpFile, 'utf-8');
+
+    expect(rawDump).not.toContain('sk-ant-super-secret');
+    expect(rawDump).not.toContain(`Bearer ${secret}`);
+    expect(rawDump).toMatch(/\[REDACTED len=\d+\]/);
+
+    const dump = JSON.parse(rawDump) as Record<string, unknown>;
+    const headers = dump.headers as Record<string, unknown>;
+    const hdr = (name: string): unknown =>
+      headers[name] ?? headers[name.toLowerCase()];
+    expect(String(hdr('authorization'))).toMatch(/^\[REDACTED len=/);
+    expect(String(hdr('x-api-key'))).toMatch(/^\[REDACTED len=/);
+    expect(String(hdr('anthropic-api-key'))).toMatch(/^\[REDACTED len=/);
+    expect(String(hdr('set-cookie'))).toMatch(/^\[REDACTED len=/);
+    // Non-sensitive headers pass through
+    expect(String(hdr('x-stainless-arch'))).toBe('x64');
+
+    // The forwarded request to upstream MUST still carry the un-redacted
+    // headers — otherwise upstream rejects auth.
+    const forwarded = echo.captured[0].headers;
+    expect(String(forwarded['authorization'])).toBe(`Bearer ${secret}`);
+
+    await session.close();
+    await sup.closeAll();
+  });
+
+  it('markTurnComplete increments turn index for subsequent dumps', async () => {
+    const sup = createRawCaptureSupervisor({
+      rootDir,
+      enabled: true,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: echo.port,
+      upstreamProtocol: 'http',
+    });
+    const session = await sup.registerTab('tab-t');
+
+    await postJson(session.baseUrl, { n: 0 });
+    await postJson(session.baseUrl, { n: 1 }); // same turn, next sub-turn
+    session.markTurnComplete();
+    await postJson(session.baseUrl, { n: 2 });
+
+    const index = readIndex(rootDir);
+    expect(index).toHaveLength(3);
+    expect(index[0].turnIndex).toBe(0);
+    expect(index[0].subTurnSeq).toBe(0);
+    expect(index[1].turnIndex).toBe(0);
+    expect(index[1].subTurnSeq).toBe(1);
+    expect(index[2].turnIndex).toBe(1);
+    expect(index[2].subTurnSeq).toBe(0);
+
+    await session.close();
+    await sup.closeAll();
+  });
+
+  it('close() releases the ephemeral port', async () => {
+    const sup = createRawCaptureSupervisor({
+      rootDir,
+      enabled: true,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: echo.port,
+      upstreamProtocol: 'http',
+    });
+    const session = await sup.registerTab('tab-c');
+    const port = Number(new URL(session.baseUrl).port);
+    expect(port).toBeGreaterThan(0);
+
+    await session.close();
+
+    // The port should be free now; a new server can bind to it (race-free
+    // because we wait for the close() promise before asserting).
+    await new Promise<void>((resolve, reject) => {
+      const probe = createServer();
+      probe.once('error', reject);
+      probe.listen(port, '127.0.0.1', () => {
+        probe.close(() => resolve());
+      });
+    });
+
+    await sup.closeAll();
+  });
+
+  it('safely handles non-JSON bodies (stores them as a raw string)', async () => {
+    const sup = createRawCaptureSupervisor({
+      rootDir,
+      enabled: true,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: echo.port,
+      upstreamProtocol: 'http',
+    });
+    const session = await sup.registerTab('tab-n');
+
+    await new Promise<void>((resolve, reject) => {
+      const url = new URL('/v1/anything', session.baseUrl);
+      const body = Buffer.from('not a json payload', 'utf-8');
+      const req = httpRequest(
+        {
+          host: url.hostname,
+          port: Number(url.port),
+          method: 'POST',
+          path: url.pathname,
+          headers: { 'content-length': String(body.length) },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', resolve);
+        }
+      );
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+
+    const index = readIndex(rootDir);
+    expect(index).toHaveLength(1);
+    const dumpFile = path.join(rootDir, index[0].file as string);
+    const dump = JSON.parse(fs.readFileSync(dumpFile, 'utf-8')) as Record<string, unknown>;
+    expect(dump.body).toBe('not a json payload');
+
+    await session.close();
+    await sup.closeAll();
+  });
+
+  it('closeAll shuts every registered tab down', async () => {
+    const sup = createRawCaptureSupervisor({
+      rootDir,
+      enabled: true,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: echo.port,
+      upstreamProtocol: 'http',
+    });
+    const s1 = await sup.registerTab('a');
+    const s2 = await sup.registerTab('b');
+    expect(s1.baseUrl).not.toBe(s2.baseUrl);
+
+    await sup.closeAll();
+
+    // Subsequent requests should fail (ECONNREFUSED) since ports are closed.
+    await expect(postJson(s1.baseUrl, {})).rejects.toBeTruthy();
+    await expect(postJson(s2.baseUrl, {})).rejects.toBeTruthy();
+  });
+});
+
+describe('isRawCaptureEnabled (#299)', () => {
+  it('returns true when the env var is exactly "1"', () => {
+    expect(isRawCaptureEnabled({ SANDSTORM_RAW_REQUEST_CAPTURE: '1' })).toBe(true);
+  });
+
+  it('returns false when the env var is unset', () => {
+    expect(isRawCaptureEnabled({})).toBe(false);
+  });
+
+  it('returns false for truthy-looking but non-"1" values', () => {
+    expect(isRawCaptureEnabled({ SANDSTORM_RAW_REQUEST_CAPTURE: 'true' })).toBe(false);
+    expect(isRawCaptureEnabled({ SANDSTORM_RAW_REQUEST_CAPTURE: 'yes' })).toBe(false);
+    expect(isRawCaptureEnabled({ SANDSTORM_RAW_REQUEST_CAPTURE: 'on' })).toBe(false);
+    expect(isRawCaptureEnabled({ SANDSTORM_RAW_REQUEST_CAPTURE: '0' })).toBe(false);
+    expect(isRawCaptureEnabled({ SANDSTORM_RAW_REQUEST_CAPTURE: '' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Env-flag-gated (`SANDSTORM_RAW_REQUEST_CAPTURE=1`) HTTP proxy that intercepts outbound `POST /v1/messages` requests from the outer Claude subprocess and dumps them to disk so we can diff turn-over-turn growth.
- Telemetry alone hasn't explained the 1M+ tokens in three turns — this captures the exact bytes the CLI sends to Anthropic, with auth headers redacted.
- Approach confirmed by a smoke test against `claude --print` 2.1.116 before implementation. A 4-word "say pineapple" prompt already triggers a 156 KB request to `claude-opus-4-7` carrying a Claude Code plugin-skill catalog as a system-reminder — that's a prime suspect the script flags explicitly.

## What's inside

- `src/main/agent/raw-request-capture.ts` — per-tab loopback proxy, forwards to `api.anthropic.com` via https, redacts `Authorization`, `x-api-key`, cookies, and any header matching `/token|secret|key/i` before writing.
- `src/main/agent/claude-backend.ts` — injects `ANTHROPIC_BASE_URL` into the spawn env when the flag is on; disabled path stays fully synchronous (no added spawn latency and existing tests continue to pass).
- `scripts/analyze-raw-capture.mjs` — per-request summary table, system-prompt composition breakdown (skill-catalog marker flagged), tool-schema inventory, and net byte deltas between adjacent requests.
- Runbook section at `docs/investigations/orchestrator-delta-runbook.md`.

## Test plan

- [x] `npx vitest run tests/unit/raw-request-capture.test.ts` — 10/10 pass (includes redaction verification: `sk-ant-...` never appears in dumps)
- [x] `npx vitest run tests/unit/claude-backend.test.ts` — 55/55 pass (includes 3 new env-wiring tests)
- [x] `npx tsc --noEmit` — clean
- [x] Smoke-tested the analyze script against a fabricated session dir end-to-end
- [ ] End-to-end in packaged app: launch with `SANDSTORM_RAW_REQUEST_CAPTURE=1`, send three messages, confirm dumps appear at `~/.config/sandstorm-desktop/raw-api-capture/<ts>/`, run `node scripts/analyze-raw-capture.mjs <dir>`, confirm UI still streams in real time
- [ ] Flag-off sanity: confirm `~/.config/sandstorm-desktop/raw-api-capture/` is NOT created and child `/proc/<pid>/environ` does NOT contain `ANTHROPIC_BASE_URL`

Closes #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)