### PR TITLE
Strip auto-CLAUDE.md and global plugins from outer-Claude spawn (#302, #303)

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -114,6 +114,29 @@ export class ClaudeBackend implements AgentBackend {
   }
 
   /**
+   * Per-process empty directory used as `CLAUDE_CODE_PLUGIN_CACHE_DIR` for
+   * outer Claude subprocess spawns (#303). Pointing the CLI's plugin cache
+   * at a pristine empty dir prevents globally-installed Claude Code plugins
+   * (Gmail/Gcal/Gdrive MCPs, LSP, skill-creator, etc.) from registering
+   * themselves in the subprocess while our Sandstorm skills continue to
+   * load via `--plugin-dir`. Created lazily on first `ensureProcess` call.
+   */
+  private emptyPluginCacheDir: string | null = null;
+
+  private ensureEmptyPluginCacheDir(): string {
+    if (this.emptyPluginCacheDir) return this.emptyPluginCacheDir;
+    const dir = path.join(os.tmpdir(), `sandstorm-empty-plugins-${process.pid}`);
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+    } catch {
+      // If the mkdir fails we still return the path — the CLI will just
+      // see a missing dir and treat it as empty, which is fine.
+    }
+    this.emptyPluginCacheDir = dir;
+    return dir;
+  }
+
+  /**
    * Opt-in raw API-request capture (#299). Off unless
    * `SANDSTORM_RAW_REQUEST_CAPTURE=1` is set. Stands up one HTTP proxy per
    * tab, dumps outbound request bodies to disk next to the telemetry log.
@@ -742,11 +765,29 @@ export class ClaudeBackend implements AgentBackend {
     // SANDSTORM_SKILLS_DIR points at the bundled skills dir so SKILL.md
     // bodies can reference their own `scripts/*.sh` no matter which
     // project is open.
+    //
+    // `CLAUDE_CODE_DISABLE_CLAUDE_MDS=1` (#302) — stops Claude Code from
+    // auto-injecting the project's CLAUDE.md into every user message as
+    // a `<system-reminder>`. The outer orchestrator already gets its
+    // instructions from SANDSTORM_OUTER.md; the per-project CLAUDE.md is
+    // for the inner stack Claude, not the outer. Without this flag every
+    // outbound API request carries ~10 KB of redundant context per turn.
+    //
+    // `CLAUDE_CODE_PLUGIN_CACHE_DIR` (#303) — points the CLI's plugin
+    // discovery at an empty sandbox dir so globally-installed Claude
+    // Code plugins (frontend-design, skill-creator, Gmail/Gcal/Gdrive
+    // MCPs, LSP, etc.) don't register themselves. Our Sandstorm skills
+    // still load via `--plugin-dir`. Saves several KB of tool schemas
+    // on every API request and prevents unrelated MCP tools from
+    // advertising auth flows to the orchestrator model.
+    const emptyPluginDir = this.ensureEmptyPluginCacheDir();
     const env: Record<string, string | undefined> = {
       ...getClaudeEnv(),
       SANDSTORM_BRIDGE_URL: `http://127.0.0.1:${this.bridgePort}`,
       SANDSTORM_BRIDGE_TOKEN: this.bridgeToken,
       SANDSTORM_SKILLS_DIR: path.join(cliDir, 'skills'),
+      CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
+      CLAUDE_CODE_PLUGIN_CACHE_DIR: emptyPluginDir,
       ...extraEnv,
     };
 

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1492,3 +1492,69 @@ describe('Raw API-request capture wiring (#299)', () => {
     backend.destroy();
   });
 });
+
+describe('Outer Claude context-bloat suppression (#302, #303)', () => {
+  beforeEach(() => {
+    spawnedProcesses.length = 0;
+  });
+
+  it('spawns with CLAUDE_CODE_DISABLE_CLAUDE_MDS=1 (#302 — suppress project CLAUDE.md auto-injection)', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backend = new ClaudeBackend(1000);
+    backend.setMainWindow({ webContents: { send: vi.fn() } } as never);
+    await backend.initialize();
+
+    backend.sendMessage('tab-claudemd', 'hi', '/tmp');
+
+    const callArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const env = (callArgs[2] as { env: Record<string, string | undefined> }).env;
+    expect(env.CLAUDE_CODE_DISABLE_CLAUDE_MDS).toBe('1');
+
+    backend.destroy();
+  });
+
+  it('spawns with CLAUDE_CODE_PLUGIN_CACHE_DIR pointing at a sandbox empty dir (#303 — suppress global MCP/LSP)', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backend = new ClaudeBackend(1000);
+    backend.setMainWindow({ webContents: { send: vi.fn() } } as never);
+    await backend.initialize();
+
+    backend.sendMessage('tab-plugincache', 'hi', '/tmp');
+
+    const callArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const env = (callArgs[2] as { env: Record<string, string | undefined> }).env;
+    expect(env.CLAUDE_CODE_PLUGIN_CACHE_DIR).toBeDefined();
+    expect(env.CLAUDE_CODE_PLUGIN_CACHE_DIR).toContain('sandstorm-empty-plugins');
+    // Must not be the user's real Claude plugin dir
+    expect(env.CLAUDE_CODE_PLUGIN_CACHE_DIR).not.toContain('.claude/plugins');
+
+    backend.destroy();
+  });
+
+  it('plugin cache dir is stable across multiple sendMessage calls in the same backend', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backend = new ClaudeBackend(1000);
+    backend.setMainWindow({ webContents: { send: vi.fn() } } as never);
+    await backend.initialize();
+
+    backend.sendMessage('tab-a', 'hi', '/tmp');
+    backend.sendMessage('tab-b', 'hi', '/tmp');
+
+    const callA = spawnMock.mock.calls[spawnMock.mock.calls.length - 2];
+    const callB = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const envA = (callA[2] as { env: Record<string, string | undefined> }).env;
+    const envB = (callB[2] as { env: Record<string, string | undefined> }).env;
+    expect(envA.CLAUDE_CODE_PLUGIN_CACHE_DIR).toBe(envB.CLAUDE_CODE_PLUGIN_CACHE_DIR);
+
+    backend.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Two env-var-driven suppressions on the outer-Claude subprocess spawn, removing ~15.6 KB of per-request noise that the orchestrator has no use for:

- `CLAUDE_CODE_DISABLE_CLAUDE_MDS=1` (#302) — stops Claude Code from auto-injecting the project's `CLAUDE.md` into every user message. The outer gets its rules from `SANDSTORM_OUTER.md`; the project `CLAUDE.md` is for inner stack Claudes.
- `CLAUDE_CODE_PLUGIN_CACHE_DIR=<sandbox empty dir>` (#303) — redirects plugin discovery to an empty dir so globally-installed Claude Code plugins (Gmail/Gcal/Gdrive auth, LSP, frontend-design, skill-creator, etc.) don't register their tool schemas. Sandstorm skills continue to load via `--plugin-dir cliDir`.

Verified empirically against claude 2.1.116 via the raw-capture proxy from PR #300 before writing the fix. Not attempting #301 (~14.6 KB skill catalog) here — that requires a scope refactor (remove Skill from `--tools` + migrate compound skill invocation to Bash scripts); filing that as follow-up.

## Test plan

- [x] `npx vitest run tests/unit/claude-backend.test.ts` — 58/58 pass (3 new)
- [x] `npx tsc --noEmit` — clean
- [x] Empirical verification with the capture proxy: CLAUDE.md block absent, Google MCP schemas absent, `--tools` allowlist respected (our Sandstorm skills still load)
- [ ] Rebuild the app, launch with `SANDSTORM_RAW_REQUEST_CAPTURE=1`, send a real message, confirm:
  - Request body no longer contains `# claudeMd` or `Contents of .../CLAUDE.md`
  - Request `tools[]` no longer lists any `mcp__claude_ai_Gmail__*`, `mcp__claude_ai_Google_Calendar__*`, `mcp__claude_ai_Google_Drive__*`, or `LSP`
  - Sandstorm-bundled skills (sandstorm, check-and-resume-stack, stack-failure-diagnostic, etc.) are still visible and callable

## Closes

- #302 — CLAUDE.md auto-injection
- #303 — Global MCP / LSP schemas

## Remaining

- #301 — Skill catalog system-reminder (deferred, requires scope refactor)
- #304 — Compound skill for stack spin-up (builds on these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)