### PR TITLE
Deterministic UI for refine → start → make-PR ticket workflow (#310)

### DIFF
--- a/src/main/control-plane/pr-creator.ts
+++ b/src/main/control-plane/pr-creator.ts
@@ -1,0 +1,245 @@
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import fs from 'fs';
+
+const execFileAsync = promisify(execFile);
+
+/** Hard cap on the body the ephemeral drafter is allowed to emit (#310). */
+export const PR_BODY_MAX_BYTES = 8192;
+/** Hard cap on the title (gh truncates anyway, but we surface a clean error). */
+export const PR_TITLE_MAX_CHARS = 70;
+/** Time budget for the draft-body ephemeral call. */
+export const PR_DRAFT_TIMEOUT_MS = 90_000;
+
+export interface DraftedPR {
+  title: string;
+  body: string;
+}
+
+export interface PRCreateResult {
+  url: string;
+  number: number;
+}
+
+/**
+ * Resolve the on-disk workspace directory for a stack. Stacks live under
+ * `<projectDir>/.sandstorm/workspaces/<stackId>/` — see stack-manager.ts:1315.
+ */
+export function workspacePathFor(projectDir: string, stackId: string): string {
+  return path.join(projectDir, '.sandstorm', 'workspaces', stackId);
+}
+
+/** Run `git log <baseBranch>..HEAD --pretty=format:%s%n%b`. */
+async function gitCommits(workspace: string, baseBranch = 'main'): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['log', `${baseBranch}..HEAD`, '--pretty=format:%s%n%b%n---'],
+      { cwd: workspace, timeout: 15000, maxBuffer: 1024 * 1024 }
+    );
+    return stdout.trim();
+  } catch {
+    // Fall back to last 10 commits if base branch is missing.
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['log', '-n', '10', '--pretty=format:%s%n%b%n---'],
+        { cwd: workspace, timeout: 15000, maxBuffer: 1024 * 1024 }
+      );
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  }
+}
+
+/** Run `git diff --stat <baseBranch>..HEAD` for context. */
+async function gitDiffStat(workspace: string, baseBranch = 'main'): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--stat', `${baseBranch}..HEAD`],
+      { cwd: workspace, timeout: 15000, maxBuffer: 1024 * 1024 }
+    );
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Resolve which branch the workspace is on, for error messaging. */
+async function gitCurrentBranch(workspace: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      { cwd: workspace, timeout: 5000 }
+    );
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Strict-JSON draft prompt fed to the ephemeral agent. */
+export function buildDraftPrompt(opts: {
+  ticket: string | null;
+  ticketUrl?: string | null;
+  branch: string;
+  commits: string;
+  diffStat: string;
+  taskOutputTail: string;
+}): string {
+  const ticketLine = opts.ticket
+    ? `Closes #${opts.ticket.replace(/^#/, '')}`
+    : '';
+  return `You are drafting a GitHub pull request body for changes on the branch "${opts.branch}".
+
+Output STRICT JSON only — no prose, no code fences, no preamble. Schema:
+{"title": "<≤70 chars summary>", "body": "<markdown body>"}
+
+Body structure:
+## Summary
+- 1–3 bullets describing what changed and WHY (not what files moved)
+
+## Test plan
+- [ ] checklist of how a reviewer should validate
+
+${ticketLine ? ticketLine + '\n\n' : ''}Hard limits: title ≤ 70 chars, body ≤ ${PR_BODY_MAX_BYTES} bytes.
+Do NOT include "Generated with Claude Code" boilerplate. Do NOT include emojis.
+Match this repo's commit style — lowercase verbs, no marketing.
+
+Commits on this branch:
+${opts.commits || '(no commits found)'}
+
+Diff stat:
+${opts.diffStat || '(no diff stat)'}
+
+Last task output (truncated tail):
+${opts.taskOutputTail || '(no task output)'}
+`;
+}
+
+/**
+ * Parse the strict-JSON draft response. Tolerates a single leading code fence
+ * (```json ... ```) since some Claude responses wrap JSON despite instructions.
+ */
+export function parseDraftResponse(raw: string): DraftedPR {
+  let text = raw.trim();
+  // Strip ```json fences if present
+  text = text.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
+  // Find the first JSON object
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`Draft response did not contain JSON: ${text.slice(0, 200)}`);
+  }
+  const slice = text.slice(start, end + 1);
+  const parsed = JSON.parse(slice) as { title?: unknown; body?: unknown };
+  if (typeof parsed.title !== 'string' || typeof parsed.body !== 'string') {
+    throw new Error('Draft JSON missing title or body');
+  }
+  const title = parsed.title.trim();
+  const body = parsed.body.trim();
+  if (!title) throw new Error('Draft title was empty');
+  if (!body) throw new Error('Draft body was empty');
+  if (Buffer.byteLength(body, 'utf8') > PR_BODY_MAX_BYTES) {
+    throw new Error(
+      `Draft body exceeds ${PR_BODY_MAX_BYTES} bytes (got ${Buffer.byteLength(body, 'utf8')})`
+    );
+  }
+  return {
+    title: title.length > PR_TITLE_MAX_CHARS ? title.slice(0, PR_TITLE_MAX_CHARS) : title,
+    body,
+  };
+}
+
+export interface DraftDeps {
+  /** One-shot Claude call. Returns the agent's full text response. */
+  runEphemeral: (prompt: string, projectDir: string, timeoutMs?: number) => Promise<string>;
+  /** Tail of `/tmp/claude-task.log` from the stack. Empty string when unavailable. */
+  fetchTaskTail?: (stackId: string) => Promise<string>;
+}
+
+export interface DraftPRArgs {
+  stackId: string;
+  workspace: string;
+  ticket: string | null;
+  ticketUrl?: string | null;
+  baseBranch?: string;
+}
+
+/**
+ * Generate a PR title + body for a stack. Pure-ish — only side effect is
+ * the bounded ephemeral Claude call delegated through `deps.runEphemeral`.
+ */
+export async function draftPullRequest(args: DraftPRArgs, deps: DraftDeps): Promise<DraftedPR> {
+  if (!fs.existsSync(args.workspace)) {
+    throw new Error(`Stack workspace not found at ${args.workspace}`);
+  }
+  const baseBranch = args.baseBranch || 'main';
+  const [commits, diffStat, branch, tail] = await Promise.all([
+    gitCommits(args.workspace, baseBranch),
+    gitDiffStat(args.workspace, baseBranch),
+    gitCurrentBranch(args.workspace),
+    deps.fetchTaskTail ? deps.fetchTaskTail(args.stackId).catch(() => '') : Promise.resolve(''),
+  ]);
+  const prompt = buildDraftPrompt({
+    ticket: args.ticket,
+    ticketUrl: args.ticketUrl ?? null,
+    branch: branch || '(unknown)',
+    commits,
+    diffStat,
+    taskOutputTail: tail,
+  });
+  const raw = await deps.runEphemeral(prompt, args.workspace, PR_DRAFT_TIMEOUT_MS);
+  return parseDraftResponse(raw);
+}
+
+/**
+ * Run `gh pr create` in the stack workspace. Returns the parsed URL + number.
+ * `gh` writes the URL to stdout on success: e.g. https://github.com/owner/repo/pull/123
+ */
+export function createPullRequest(args: {
+  workspace: string;
+  title: string;
+  body: string;
+  baseBranch?: string;
+}): Promise<PRCreateResult> {
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(args.workspace)) {
+      reject(new Error(`Stack workspace not found at ${args.workspace}`));
+      return;
+    }
+    const ghArgs = [
+      'pr', 'create',
+      '--title', args.title,
+      '--body', args.body,
+    ];
+    if (args.baseBranch) ghArgs.push('--base', args.baseBranch);
+
+    const child = spawn('gh', ghArgs, {
+      cwd: args.workspace,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || stdout.trim() || `gh pr create exited with code ${code}`));
+        return;
+      }
+      const urlMatch = stdout.match(/https:\/\/github\.com\/[^\s]+\/pull\/(\d+)/);
+      if (!urlMatch) {
+        reject(new Error(`Could not parse PR URL from gh output: ${stdout.trim()}`));
+        return;
+      }
+      resolve({ url: urlMatch[0], number: Number(urlMatch[1]) });
+    });
+  });
+}

--- a/src/main/control-plane/ticket-spec.ts
+++ b/src/main/control-plane/ticket-spec.ts
@@ -1,0 +1,372 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { fetchTicketContext, getScriptStatus } from './ticket-fetcher';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Trimmed result returned to the renderer for spec check / refine. Mirrors
+ * the JSON shape that `sandstorm-spec.sh` emits when invoked from a skill —
+ * but routed in-process so we don't pay for an HTTP-bridge round-trip when
+ * the orchestrator isn't even involved.
+ */
+export interface SpecGateResult {
+  passed: boolean;
+  questions: string[];
+  gateSummary: string;
+  ticketUrl: string | null;
+  cached: boolean;
+  /** Set when the ticket can't be evaluated (missing fetch script, etc.). */
+  error?: string;
+}
+
+/** Raw spec-gate report payload coming back from the ephemeral agent. */
+export interface SpecGateReport {
+  passed: boolean;
+  report?: string;
+  reason?: string;
+  error?: string;
+  updatedBody?: string | null;
+}
+
+/** Pull the gate verdict + question count out of the verbose report. */
+export function extractGateSummary(report: string): string {
+  if (!report) return '';
+  let verdict = '';
+  if (/##\s+Spec Quality Gate:\s*PASS/i.test(report)) verdict = 'PASS';
+  else if (/##\s+Spec Quality Gate:\s*FAIL/i.test(report)) verdict = 'FAIL';
+  if (!verdict) return 'Gate verdict not parsed';
+  const qcount = (report.match(/^[0-9]+\.\s/gm) || []).length;
+  return `Gate=${verdict}, questions=${qcount}`;
+}
+
+/**
+ * Mirrors the awk parser in sandstorm-spec.sh: only pulls numbered items
+ * sitting under a `### Questions` or `### Gaps` heading, stopping at the
+ * next `## ` boundary. Returns an empty array when nothing matches.
+ */
+export function extractQuestions(report: string): string[] {
+  if (!report) return [];
+  const lines = report.split('\n');
+  let capture = false;
+  const out: string[] = [];
+  for (const line of lines) {
+    if (/^### (Questions|Gaps)/i.test(line)) {
+      capture = true;
+      continue;
+    }
+    if (/^## /.test(line)) {
+      capture = false;
+      continue;
+    }
+    if (!capture) continue;
+    const m = line.match(/^[0-9]+\.\s*(.*)$/);
+    if (m && m[1].trim()) out.push(m[1].trim());
+  }
+  return out;
+}
+
+/**
+ * Look up `spec-ready:sha-<hash>` labels on the issue and return the hash
+ * suffix if any. Empty string when `gh` isn't available or the call fails.
+ */
+async function readSpecReadyHash(ticketId: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['issue', 'view', ticketId, '--json', 'labels', '-q', '.labels[].name'],
+      { timeout: 15000 }
+    );
+    const m = stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.startsWith('spec-ready:sha-'));
+    return m ? m.replace('spec-ready:sha-', '') : '';
+  } catch {
+    return '';
+  }
+}
+
+/** Fetch the issue URL via gh; empty string when unavailable. */
+async function readTicketUrl(ticketId: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['issue', 'view', ticketId, '--json', 'url', '-q', '.url'],
+      { timeout: 15000 }
+    );
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Compute the short body hash used by sandstorm-spec.sh for idempotency. */
+export function shortBodyHash(body: string): string {
+  // Match `sha256sum | cut -c1-12` shape.
+  // We avoid pulling node:crypto here — keeps this module test-friendly.
+  // The hash is opaque; consistency with the shell script is not required
+  // because this module is the only producer/consumer of the in-process value.
+  let h = 0;
+  for (let i = 0; i < body.length; i++) {
+    h = ((h << 5) - h + body.charCodeAt(i)) | 0;
+  }
+  // Pack as 12-char hex — pad/wrap so collisions are still rare for short bodies.
+  const u = h >>> 0;
+  return u.toString(16).padStart(8, '0').repeat(2).slice(0, 12);
+}
+
+/**
+ * Replace existing `spec-ready:sha-*` labels with a fresh one tracking the
+ * current body. Best-effort — failures (no gh, no perms, network) are swallowed.
+ */
+async function markSpecReady(ticketId: string, hash: string): Promise<void> {
+  if (!hash) return;
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['issue', 'view', ticketId, '--json', 'labels', '-q', '.labels[].name'],
+      { timeout: 15000 }
+    );
+    const stale = stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith('spec-ready:sha-'));
+    for (const lab of stale) {
+      try {
+        await execFileAsync('gh', ['issue', 'edit', ticketId, '--remove-label', lab], { timeout: 15000 });
+      } catch {
+        // ignore
+      }
+    }
+    await execFileAsync('gh', ['issue', 'edit', ticketId, '--add-label', `spec-ready:sha-${hash}`], { timeout: 15000 });
+  } catch {
+    // ignore
+  }
+}
+
+export interface SpecGateDeps {
+  fetchTicket: (ticketId: string, projectDir: string) => Promise<string | null>;
+  scriptStatus: (projectDir: string) => 'ok' | 'missing' | 'not_executable';
+  runCheck: (ticketId: string, projectDir: string) => Promise<SpecGateReport>;
+  runRefine: (
+    ticketId: string,
+    projectDir: string,
+    userAnswers?: string
+  ) => Promise<SpecGateReport>;
+  readSpecReadyHash: (ticketId: string) => Promise<string>;
+  readTicketUrl: (ticketId: string) => Promise<string>;
+  markSpecReady: (ticketId: string, hash: string) => Promise<void>;
+}
+
+/**
+ * Run the spec quality gate for a ticket. When the ticket already carries
+ * a `spec-ready:sha-<hash>` label whose hash matches the current body, we
+ * return `cached: true` without invoking the LLM. Otherwise we call the
+ * provided `runCheck` (typically the existing `handleSpecCheck`) and trim
+ * its verbose report down to the renderer-facing shape.
+ */
+export async function runSpecCheck(
+  ticketId: string,
+  projectDir: string,
+  deps: SpecGateDeps
+): Promise<SpecGateResult> {
+  const status = deps.scriptStatus(projectDir);
+  if (status !== 'ok') {
+    return {
+      passed: false,
+      questions: [],
+      gateSummary: `fetch-ticket.sh ${status}`,
+      ticketUrl: null,
+      cached: false,
+      error:
+        status === 'missing'
+          ? 'fetch-ticket.sh is missing — run `sandstorm init` to generate it.'
+          : 'fetch-ticket.sh exists but is not executable. Run `chmod +x .sandstorm/scripts/fetch-ticket.sh`.',
+    };
+  }
+
+  const body = await deps.fetchTicket(ticketId, projectDir);
+  if (!body) {
+    return {
+      passed: false,
+      questions: [],
+      gateSummary: 'fetch-ticket.sh returned no output',
+      ticketUrl: null,
+      cached: false,
+      error: `fetch-ticket.sh ran but returned no output for ticket "${ticketId}".`,
+    };
+  }
+
+  const url = await deps.readTicketUrl(ticketId);
+  const curHash = shortBodyHash(body);
+  const cachedHash = await deps.readSpecReadyHash(ticketId);
+
+  if (cachedHash && cachedHash === curHash) {
+    return {
+      passed: true,
+      questions: [],
+      gateSummary: 'cached (body unchanged since last PASS)',
+      ticketUrl: url || null,
+      cached: true,
+    };
+  }
+
+  const report = await deps.runCheck(ticketId, projectDir);
+  if (report.error) {
+    return {
+      passed: false,
+      questions: [],
+      gateSummary: '',
+      ticketUrl: url || null,
+      cached: false,
+      error: report.error,
+    };
+  }
+  if (report.reason && !report.report) {
+    return {
+      passed: report.passed,
+      questions: [],
+      gateSummary: '',
+      ticketUrl: url || null,
+      cached: false,
+      error: report.reason,
+    };
+  }
+
+  const passed = !!report.passed;
+  const reportText = report.report || '';
+  if (passed && curHash) {
+    await deps.markSpecReady(ticketId, curHash);
+  }
+
+  return {
+    passed,
+    questions: passed ? [] : extractQuestions(reportText),
+    gateSummary: extractGateSummary(reportText),
+    ticketUrl: url || null,
+    cached: false,
+  };
+}
+
+/**
+ * Run a refinement step — pipes the user's answers to the spec-refine
+ * handler, then trims the response. The MCP handler writes the updated
+ * ticket body back to GitHub itself, so we only need to surface the
+ * verdict + any remaining questions.
+ */
+export async function runSpecRefine(
+  ticketId: string,
+  projectDir: string,
+  userAnswers: string,
+  deps: SpecGateDeps
+): Promise<SpecGateResult> {
+  const status = deps.scriptStatus(projectDir);
+  if (status !== 'ok') {
+    return {
+      passed: false,
+      questions: [],
+      gateSummary: `fetch-ticket.sh ${status}`,
+      ticketUrl: null,
+      cached: false,
+      error:
+        status === 'missing'
+          ? 'fetch-ticket.sh is missing — run `sandstorm init` to generate it.'
+          : 'fetch-ticket.sh exists but is not executable.',
+    };
+  }
+
+  const url = await deps.readTicketUrl(ticketId);
+  const report = await deps.runRefine(ticketId, projectDir, userAnswers);
+  if (report.error) {
+    return {
+      passed: false,
+      questions: [],
+      gateSummary: '',
+      ticketUrl: url || null,
+      cached: false,
+      error: report.error,
+    };
+  }
+  if (report.reason && !report.report) {
+    return {
+      passed: report.passed,
+      questions: [],
+      gateSummary: '',
+      ticketUrl: url || null,
+      cached: false,
+      error: report.reason,
+    };
+  }
+
+  const passed = !!report.passed;
+  const reportText = report.report || '';
+
+  if (passed) {
+    // Refine just rewrote the ticket body — re-fetch + re-hash before tagging.
+    const fresh = await deps.fetchTicket(ticketId, projectDir);
+    if (fresh) {
+      await deps.markSpecReady(ticketId, shortBodyHash(fresh));
+    }
+  }
+
+  return {
+    passed,
+    questions: passed ? [] : extractQuestions(reportText),
+    gateSummary: extractGateSummary(reportText),
+    ticketUrl: url || null,
+    cached: false,
+  };
+}
+
+/**
+ * Default deps wired to the real ticket-fetcher + tools.ts handlers.
+ * Exposed so the IPC layer doesn't have to know how to wire the graph.
+ */
+export function defaultSpecGateDeps(
+  runCheck: (ticketId: string, projectDir: string) => Promise<SpecGateReport>,
+  runRefine: (
+    ticketId: string,
+    projectDir: string,
+    userAnswers?: string
+  ) => Promise<SpecGateReport>
+): SpecGateDeps {
+  return {
+    fetchTicket: fetchTicketContext,
+    scriptStatus: getScriptStatus,
+    runCheck,
+    runRefine,
+    readSpecReadyHash,
+    readTicketUrl,
+    markSpecReady,
+  };
+}
+
+export interface FetchTicketResult {
+  body: string;
+  url: string | null;
+}
+
+/**
+ * Fetch the rendered ticket body for the renderer. Returns the body and
+ * (best-effort) the GitHub URL.
+ */
+export async function fetchTicketForRenderer(
+  ticketId: string,
+  projectDir: string
+): Promise<FetchTicketResult> {
+  const status = getScriptStatus(projectDir);
+  if (status !== 'ok') {
+    throw new Error(
+      status === 'missing'
+        ? 'fetch-ticket.sh is missing — run `sandstorm init` to generate it.'
+        : 'fetch-ticket.sh exists but is not executable.'
+    );
+  }
+  const body = await fetchTicketContext(ticketId, projectDir);
+  if (!body) {
+    throw new Error(`fetch-ticket.sh returned no output for ticket "${ticketId}".`);
+  }
+  const url = await readTicketUrl(ticketId);
+  return { body, url: url || null };
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -50,6 +50,19 @@ import {
   ensureReviewPrompt,
   isReviewPromptMissing,
 } from './review-prompt';
+import {
+  defaultSpecGateDeps,
+  fetchTicketForRenderer,
+  runSpecCheck,
+  runSpecRefine,
+  type SpecGateReport,
+} from './control-plane/ticket-spec';
+import {
+  draftPullRequest,
+  createPullRequest,
+  workspacePathFor,
+} from './control-plane/pr-creator';
+import { handleToolCall } from './claude/tools';
 
 /**
  * Copy bundled sandstorm skill files into a project's .claude/skills/ directory.
@@ -885,5 +898,66 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
     return result;
   });
+
+  // --- Tickets (deterministic UI for refine workflow, #310) ---
+  // These IPC handlers route the renderer straight to the same ticket-fetcher
+  // and spec-gate primitives that the `sandstorm-spec` skill uses, but in
+  // process — no orchestrator round-trip, no skill catalog.
+
+  const specDeps = defaultSpecGateDeps(
+    (ticketId, projectDir) =>
+      handleToolCall('spec_check', { ticketId, projectDir }) as Promise<SpecGateReport>,
+    (ticketId, projectDir, userAnswers) =>
+      handleToolCall('spec_refine', { ticketId, projectDir, userAnswers }) as Promise<SpecGateReport>,
+  );
+
+  ipcMain.handle('tickets:fetch', async (_event, ticketId: string, projectDir: string) => {
+    return fetchTicketForRenderer(ticketId, projectDir);
+  });
+
+  ipcMain.handle('tickets:specCheck', async (_event, ticketId: string, projectDir: string) => {
+    return runSpecCheck(ticketId, projectDir, specDeps);
+  });
+
+  ipcMain.handle(
+    'tickets:specRefine',
+    async (_event, ticketId: string, projectDir: string, userAnswers: string) => {
+      return runSpecRefine(ticketId, projectDir, userAnswers, specDeps);
+    },
+  );
+
+  // --- PR creation (deterministic UI for make-PR workflow, #310) ---
+
+  ipcMain.handle('pr:draftBody', async (_event, stackId: string) => {
+    const stack = await stackManager.getStackWithServices(stackId);
+    if (!stack) throw new Error(`Stack "${stackId}" not found`);
+    return draftPullRequest(
+      {
+        stackId,
+        workspace: workspacePathFor(stack.project_dir, stackId),
+        ticket: stack.ticket,
+      },
+      {
+        runEphemeral: (prompt, projectDir, timeoutMs) =>
+          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs),
+        fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
+      },
+    );
+  });
+
+  ipcMain.handle(
+    'pr:create',
+    async (_event, stackId: string, title: string, body: string) => {
+      const stack = await stackManager.getStackWithServices(stackId);
+      if (!stack) throw new Error(`Stack "${stackId}" not found`);
+      const result = await createPullRequest({
+        workspace: workspacePathFor(stack.project_dir, stackId),
+        title,
+        body,
+      });
+      stackManager.setPullRequest(stackId, result.url, result.number);
+      return result;
+    },
+  );
 
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -145,6 +145,15 @@ export interface SandstormAPI {
   docker: {
     status: () => Promise<{ connected: boolean }>;
   };
+  tickets: {
+    fetch: (ticketId: string, projectDir: string) => Promise<{ body: string; url: string | null }>;
+    specCheck: (ticketId: string, projectDir: string) => Promise<unknown>;
+    specRefine: (ticketId: string, projectDir: string, userAnswers: string) => Promise<unknown>;
+  };
+  pr: {
+    draftBody: (stackId: string) => Promise<{ title: string; body: string }>;
+    create: (stackId: string, title: string, body: string) => Promise<{ url: string; number: number }>;
+  };
   on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
 }
 
@@ -282,6 +291,19 @@ const api: SandstormAPI = {
   },
   docker: {
     status: () => ipcRenderer.invoke('docker:status'),
+  },
+  tickets: {
+    fetch: (ticketId, projectDir) =>
+      ipcRenderer.invoke('tickets:fetch', ticketId, projectDir),
+    specCheck: (ticketId, projectDir) =>
+      ipcRenderer.invoke('tickets:specCheck', ticketId, projectDir),
+    specRefine: (ticketId, projectDir, userAnswers) =>
+      ipcRenderer.invoke('tickets:specRefine', ticketId, projectDir, userAnswers),
+  },
+  pr: {
+    draftBody: (stackId) => ipcRenderer.invoke('pr:draftBody', stackId),
+    create: (stackId, title, body) =>
+      ipcRenderer.invoke('pr:create', stackId, title, body),
   },
   on: (channel, callback) => {
     const handler = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,6 +3,8 @@ import { useAppStore, ThresholdLevel } from './store';
 import { Dashboard } from './components/Dashboard';
 import { StackDetail } from './components/StackDetail';
 import { NewStackDialog } from './components/NewStackDialog';
+import { RefineTicketDialog } from './components/RefineTicketDialog';
+import { CreatePRDialog } from './components/CreatePRDialog';
 import { ProjectTabs } from './components/ProjectTabs';
 import { OpenProjectDialog } from './components/OpenProjectDialog';
 import { AccountUsageBar } from './components/AccountUsageBar';
@@ -23,6 +25,8 @@ export default function App() {
   const {
     selectedStackId,
     showNewStackDialog,
+    showRefineTicketDialog,
+    showCreatePRDialog,
     showOpenProjectDialog,
     dockerConnected,
     refreshStacks,
@@ -231,6 +235,8 @@ export default function App() {
 
       {/* Dialogs */}
       {showNewStackDialog && <NewStackDialog />}
+      {showRefineTicketDialog && <RefineTicketDialog />}
+      {showCreatePRDialog && <CreatePRDialog stackId={showCreatePRDialog.stackId} />}
       {showOpenProjectDialog && <OpenProjectDialog />}
 
       {/* Session warning modal (blocking, at 95% and 100% thresholds) */}

--- a/src/renderer/components/CreatePRDialog.tsx
+++ b/src/renderer/components/CreatePRDialog.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import { useAppStore } from '../store';
+
+export function CreatePRDialog({ stackId }: { stackId: string }) {
+  const { setShowCreatePRDialog, refreshStacks } = useAppStore();
+
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [drafting, setDrafting] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDrafting(true);
+    setError(null);
+    window.sandstorm.pr
+      .draftBody(stackId)
+      .then((drafted) => {
+        if (cancelled) return;
+        setTitle(drafted.title);
+        setBody(drafted.body);
+        setDrafting(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setDrafting(false);
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => { cancelled = true; };
+  }, [stackId]);
+
+  const close = () => setShowCreatePRDialog(null);
+
+  const handleCreate = async () => {
+    if (!title.trim() || !body.trim()) {
+      setError('Title and body are both required');
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    try {
+      const result = await window.sandstorm.pr.create(stackId, title.trim(), body.trim());
+      await refreshStacks();
+      window.open(result.url, '_blank');
+      close();
+    } catch (err) {
+      setCreating(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in"
+      onClick={(e) => { if (e.target === e.currentTarget) close(); }}
+      data-testid="create-pr-dialog"
+    >
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[640px] max-h-[90vh] overflow-y-auto shadow-dialog animate-slide-up">
+        <div className="px-6 py-4 border-b border-sandstorm-border flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-sandstorm-text">Create Pull Request</h2>
+            <p className="text-[11px] text-sandstorm-muted mt-0.5">
+              Stack <span className="font-mono">{stackId}</span> — drafted by one ephemeral Claude call
+            </p>
+          </div>
+          <button
+            onClick={close}
+            className="text-sandstorm-muted hover:text-sandstorm-text transition-colors p-1.5 rounded-md hover:bg-sandstorm-surface-hover"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          {error && (
+            <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2.5" data-testid="pr-error">
+              {error}
+            </div>
+          )}
+
+          {drafting ? (
+            <div className="text-xs text-sandstorm-muted flex items-center gap-2 py-8 justify-center" data-testid="pr-drafting">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+              </svg>
+              Drafting PR title and body…
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="block text-xs font-medium text-sandstorm-text-secondary mb-1.5">
+                  Title
+                </label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-[13px] text-sandstorm-text outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+                  data-testid="pr-title"
+                />
+                <p className={`text-[10px] mt-1 ${title.length > 70 ? 'text-amber-400' : 'text-sandstorm-muted'}`}>
+                  {title.length}/70 chars
+                </p>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-sandstorm-text-secondary mb-1.5">
+                  Body
+                </label>
+                <textarea
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  rows={14}
+                  className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-xs font-mono text-sandstorm-text resize-y outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+                  data-testid="pr-body"
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="px-6 py-4 border-t border-sandstorm-border flex justify-end gap-2">
+          <button
+            onClick={close}
+            className="px-4 py-2 text-xs font-medium text-sandstorm-muted hover:text-sandstorm-text transition-colors rounded-lg hover:bg-sandstorm-surface-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={drafting || creating || !title.trim() || !body.trim()}
+            className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
+            data-testid="pr-create"
+          >
+            {creating ? 'Creating…' : 'Create PR'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/Dashboard.tsx
+++ b/src/renderer/components/Dashboard.tsx
@@ -353,7 +353,7 @@ function TokenUsageSummary({ usage }: { usage: GlobalTokenUsage }) {
 }
 
 export function Dashboard() {
-  const { setShowNewStackDialog, setShowModelSettings, showModelSettings, filteredStacks, filteredStackHistory, activeProject, globalTokenUsage } = useAppStore();
+  const { setShowNewStackDialog, setShowRefineTicketDialog, setShowModelSettings, showModelSettings, filteredStacks, filteredStackHistory, activeProject, globalTokenUsage } = useAppStore();
   const stacks = filteredStacks();
   const history = filteredStackHistory();
   const project = activeProject();
@@ -541,6 +541,20 @@ export function Dashboard() {
                 <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
               </svg>
               Context
+            </button>
+          )}
+          {project && (
+            <button
+              onClick={() => setShowRefineTicketDialog(true)}
+              className="flex items-center gap-1.5 px-3 py-2 bg-sandstorm-surface-hover hover:bg-sandstorm-border text-sandstorm-text-secondary rounded-lg transition-all text-sm font-medium active:scale-[0.98]"
+              data-testid="refine-ticket-btn"
+              title="Run the spec gate on a ticket and start a stack"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 11l3 3L22 4"/>
+                <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
+              </svg>
+              Refine Ticket
             </button>
           )}
           <button

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -1,0 +1,284 @@
+import React, { useState, useMemo } from 'react';
+import { useAppStore, SpecGateResult } from '../store';
+
+type Phase = 'input' | 'running' | 'pass' | 'fail' | 'starting';
+
+function suggestStackName(ticketId: string): string {
+  const id = ticketId.replace(/^#/, '').replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase();
+  return id ? `ticket-${id}` : '';
+}
+
+export function RefineTicketDialog() {
+  const { setShowRefineTicketDialog, refreshStacks, activeProject } = useAppStore();
+  const project = activeProject();
+
+  const [ticketId, setTicketId] = useState('');
+  const [phase, setPhase] = useState<Phase>('input');
+  const [gate, setGate] = useState<SpecGateResult | null>(null);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [stackName, setStackName] = useState('');
+
+  const close = () => {
+    setShowRefineTicketDialog(false);
+  };
+
+  const cleanTicketId = useMemo(() => ticketId.trim().replace(/^#/, ''), [ticketId]);
+  const projectDir = project?.directory ?? '';
+
+  const handleRunGate = async () => {
+    if (!cleanTicketId || !projectDir) {
+      setError('Ticket ID and an active project are both required');
+      return;
+    }
+    setError(null);
+    setPhase('running');
+    try {
+      const result = await window.sandstorm.tickets.specCheck(cleanTicketId, projectDir);
+      setGate(result);
+      if (result.error) {
+        setPhase('fail');
+        setError(result.error);
+      } else if (result.passed) {
+        setPhase('pass');
+        setStackName((s) => s || suggestStackName(cleanTicketId));
+      } else {
+        setAnswers(result.questions.map(() => ''));
+        setPhase('fail');
+      }
+    } catch (err) {
+      setPhase('fail');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleSubmitAnswers = async () => {
+    if (!cleanTicketId || !projectDir) return;
+    const combined = (gate?.questions ?? [])
+      .map((q, i) => `Q${i + 1}: ${q}\nA: ${answers[i]?.trim() || '(no answer)'}`)
+      .join('\n\n');
+    setError(null);
+    setPhase('running');
+    try {
+      const result = await window.sandstorm.tickets.specRefine(cleanTicketId, projectDir, combined);
+      setGate(result);
+      if (result.error) {
+        setPhase('fail');
+        setError(result.error);
+      } else if (result.passed) {
+        setPhase('pass');
+        setStackName((s) => s || suggestStackName(cleanTicketId));
+      } else {
+        setAnswers(result.questions.map(() => ''));
+        setPhase('fail');
+      }
+    } catch (err) {
+      setPhase('fail');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleStartStack = async () => {
+    if (!cleanTicketId || !projectDir) return;
+    const name = stackName.trim();
+    if (!name) {
+      setError('Stack name is required');
+      return;
+    }
+    setError(null);
+    setPhase('starting');
+    try {
+      const fetched = await window.sandstorm.tickets.fetch(cleanTicketId, projectDir);
+      await window.sandstorm.stacks.create({
+        name,
+        projectDir,
+        ticket: cleanTicketId,
+        branch: `feat/${cleanTicketId}-${name}`,
+        description: fetched.body.split('\n').find((l) => l.trim())?.replace(/^#\s*/, '').slice(0, 120) ?? null,
+        runtime: 'docker',
+        task: fetched.body,
+        gateApproved: true,
+      });
+      await refreshStacks();
+      close();
+    } catch (err) {
+      setPhase('pass');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in"
+      onClick={(e) => { if (e.target === e.currentTarget) close(); }}
+      data-testid="refine-ticket-dialog"
+    >
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[560px] max-h-[90vh] overflow-y-auto shadow-dialog animate-slide-up">
+        <div className="px-6 py-4 border-b border-sandstorm-border flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-sandstorm-text">Refine Ticket</h2>
+            <p className="text-[11px] text-sandstorm-muted mt-0.5">
+              Run the spec quality gate, refine, and start a stack — all in-process
+            </p>
+          </div>
+          <button
+            onClick={close}
+            className="text-sandstorm-muted hover:text-sandstorm-text transition-colors p-1.5 rounded-md hover:bg-sandstorm-surface-hover"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          {!project && (
+            <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
+              Select a project tab first — the spec gate runs against the project's `.sandstorm/spec-quality-gate.md`.
+            </div>
+          )}
+
+          {error && (
+            <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2.5" data-testid="refine-error">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-xs font-medium text-sandstorm-text-secondary mb-1.5">
+              Ticket ID <span className="text-sandstorm-accent">*</span>
+            </label>
+            <input
+              type="text"
+              value={ticketId}
+              onChange={(e) => setTicketId(e.target.value)}
+              placeholder="310"
+              disabled={phase === 'running' || phase === 'starting'}
+              className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-[13px] font-mono text-sandstorm-text placeholder-sandstorm-muted/50 outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+              data-testid="refine-ticket-id"
+              autoFocus
+            />
+          </div>
+
+          {phase === 'running' && (
+            <div className="text-xs text-sandstorm-muted flex items-center gap-2" data-testid="refine-running">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+              </svg>
+              Running spec gate…
+            </div>
+          )}
+
+          {phase === 'starting' && (
+            <div className="text-xs text-sandstorm-muted flex items-center gap-2">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+              </svg>
+              Starting stack…
+            </div>
+          )}
+
+          {gate && phase === 'pass' && (
+            <div className="space-y-3" data-testid="refine-pass">
+              <div className="text-xs text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2.5 flex items-center gap-2">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                  <path d="M20 6L9 17l-5-5"/>
+                </svg>
+                {gate.cached
+                  ? 'Ticket already passed — body unchanged since last gate run.'
+                  : 'Spec quality gate passed. Ready to start a stack.'}
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-sandstorm-text-secondary mb-1.5">
+                  Stack Name <span className="text-sandstorm-accent">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={stackName}
+                  onChange={(e) => setStackName(e.target.value)}
+                  className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-[13px] font-mono text-sandstorm-text outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+                  data-testid="refine-stack-name"
+                />
+              </div>
+            </div>
+          )}
+
+          {gate && phase === 'fail' && !gate.error && (
+            <div className="space-y-3" data-testid="refine-fail">
+              <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
+                Spec gate failed. {gate.gateSummary}
+              </div>
+              {gate.questions.length === 0 ? (
+                <div className="text-xs text-sandstorm-muted">
+                  No structured questions parsed. The full report was committed to the ticket — open it on GitHub to read it.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {gate.questions.map((q, i) => (
+                    <div key={i}>
+                      <p className="text-xs text-sandstorm-text-secondary mb-1">
+                        <span className="text-sandstorm-muted">{i + 1}.</span> {q}
+                      </p>
+                      <textarea
+                        value={answers[i] ?? ''}
+                        onChange={(e) => {
+                          const next = [...answers];
+                          next[i] = e.target.value;
+                          setAnswers(next);
+                        }}
+                        rows={2}
+                        placeholder="Your answer…"
+                        className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-xs text-sandstorm-text resize-none outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+                        data-testid={`refine-answer-${i}`}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="px-6 py-4 border-t border-sandstorm-border flex justify-end gap-2">
+          <button
+            onClick={close}
+            className="px-4 py-2 text-xs font-medium text-sandstorm-muted hover:text-sandstorm-text transition-colors rounded-lg hover:bg-sandstorm-surface-hover"
+          >
+            Cancel
+          </button>
+          {(phase === 'input' || (phase === 'fail' && (gate?.questions.length ?? 0) === 0)) && (
+            <button
+              onClick={handleRunGate}
+              disabled={!cleanTicketId || !projectDir}
+              className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
+              data-testid="refine-run-gate"
+            >
+              Run Gate
+            </button>
+          )}
+          {phase === 'fail' && gate && gate.questions.length > 0 && (
+            <button
+              onClick={handleSubmitAnswers}
+              disabled={answers.some((a) => !a.trim())}
+              className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
+              data-testid="refine-submit-answers"
+            >
+              Submit Answers
+            </button>
+          )}
+          {phase === 'pass' && (
+            <button
+              onClick={handleStartStack}
+              disabled={!stackName.trim()}
+              className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
+              data-testid="refine-start-stack"
+            >
+              Start Stack
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/StackCard.tsx
+++ b/src/renderer/components/StackCard.tsx
@@ -74,7 +74,7 @@ function formatMs(ms: number): string {
 }
 
 export function StackCard({ stack, showProject }: { stack: Stack; showProject?: boolean }) {
-  const { selectStack, refreshStacks, stackMetrics } = useAppStore();
+  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog } = useAppStore();
   const metrics: StackMetrics | undefined = stackMetrics[stack.id];
 
   const runningCount = stack.services.filter(
@@ -291,6 +291,13 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
             <ActionButton label="View Diff" onClick={(e) => { e.stopPropagation(); selectStack(stack.id); }} />
             <ActionButton label="Push" onClick={(e) => { e.stopPropagation(); window.sandstorm.push.execute(stack.id); }} primary />
           </>
+        )}
+        {(stack.status === 'completed' || stack.status === 'pushed') && !stack.pr_url && (
+          <ActionButton
+            label="Make PR"
+            onClick={(e) => { e.stopPropagation(); setShowCreatePRDialog({ stackId: stack.id }); }}
+            primary
+          />
         )}
         {stack.status === 'running' && (
           <ActionButton label="View Output" onClick={(e) => { e.stopPropagation(); selectStack(stack.id); }} />

--- a/src/renderer/components/StackDetail.tsx
+++ b/src/renderer/components/StackDetail.tsx
@@ -23,7 +23,7 @@ export function StackDetail({
   stackId: string;
   onBack: () => void;
 }) {
-  const { stacks, refreshStacks, stackMetrics } = useAppStore();
+  const { stacks, refreshStacks, stackMetrics, setShowCreatePRDialog } = useAppStore();
   const stack = stacks.find((s) => s.id === stackId);
   const metrics: StackMetrics | undefined = stackMetrics[stackId];
 
@@ -451,6 +451,11 @@ export function StackDetail({
           <FooterButton onClick={handlePush}>
             Push
           </FooterButton>
+          {(stack.status === 'completed' || stack.status === 'pushed') && !stack.pr_url && (
+            <FooterButton onClick={() => setShowCreatePRDialog({ stackId })}>
+              Make PR
+            </FooterButton>
+          )}
           <FooterButton onClick={handleTeardown} danger>
             Tear Down
           </FooterButton>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -334,6 +334,8 @@ interface AppState {
   stackHistory: StackHistoryRecord[];
   selectedStackId: string | null;
   showNewStackDialog: boolean;
+  showRefineTicketDialog: boolean;
+  showCreatePRDialog: { stackId: string } | null;
   stackMetrics: Record<string, StackMetrics>;
   loading: boolean;
   error: string | null;
@@ -409,6 +411,8 @@ interface AppState {
   setStacks: (stacks: Stack[]) => void;
   selectStack: (id: string | null) => void;
   setShowNewStackDialog: (show: boolean) => void;
+  setShowRefineTicketDialog: (show: boolean) => void;
+  setShowCreatePRDialog: (state: { stackId: string } | null) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   refreshStacks: () => Promise<void>;
@@ -566,9 +570,28 @@ declare global {
       docker: {
         status: () => Promise<{ connected: boolean }>;
       };
+      tickets: {
+        fetch: (ticketId: string, projectDir: string) => Promise<{ body: string; url: string | null }>;
+        specCheck: (ticketId: string, projectDir: string) => Promise<SpecGateResult>;
+        specRefine: (ticketId: string, projectDir: string, userAnswers: string) => Promise<SpecGateResult>;
+      };
+      pr: {
+        draftBody: (stackId: string) => Promise<{ title: string; body: string }>;
+        create: (stackId: string, title: string, body: string) => Promise<{ url: string; number: number }>;
+      };
       on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
     };
   }
+}
+
+/** Renderer-side mirror of `SpecGateResult` from main/control-plane/ticket-spec.ts. */
+export interface SpecGateResult {
+  passed: boolean;
+  questions: string[];
+  gateSummary: string;
+  ticketUrl: string | null;
+  cached: boolean;
+  error?: string;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -612,6 +635,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   stackMetrics: {},
   selectedStackId: null,
   showNewStackDialog: false,
+  showRefineTicketDialog: false,
+  showCreatePRDialog: null,
   loading: false,
   error: null,
 
@@ -795,6 +820,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   setStacks: (stacks) => set({ stacks }),
   selectStack: (id) => set({ selectedStackId: id }),
   setShowNewStackDialog: (show) => set({ showNewStackDialog: show }),
+  setShowRefineTicketDialog: (show) => set({ showRefineTicketDialog: show }),
+  setShowCreatePRDialog: (state) => set({ showCreatePRDialog: state }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
 

--- a/tests/unit/components/CreatePRDialog.test.tsx
+++ b/tests/unit/components/CreatePRDialog.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CreatePRDialog } from '../../../src/renderer/components/CreatePRDialog';
+import { useAppStore } from '../../../src/renderer/store';
+import { mockSandstormApi } from './setup';
+
+describe('CreatePRDialog', () => {
+  let api: ReturnType<typeof mockSandstormApi>;
+  let originalOpen: typeof window.open;
+
+  beforeEach(() => {
+    api = mockSandstormApi();
+    useAppStore.setState({
+      showCreatePRDialog: { stackId: 'foo' },
+      stacks: [],
+    });
+    originalOpen = window.open;
+    window.open = vi.fn() as unknown as typeof window.open;
+  });
+
+  it('shows the drafting state while the title/body are loading', async () => {
+    let resolve!: (v: { title: string; body: string }) => void;
+    api.pr.draftBody.mockReturnValue(new Promise<{ title: string; body: string }>((r) => { resolve = r; }));
+    render(<CreatePRDialog stackId="foo" />);
+    expect(screen.getByTestId('pr-drafting')).toBeDefined();
+    resolve({ title: 'feat: x', body: '## Summary\n- y' });
+    await waitFor(() => screen.getByTestId('pr-title'));
+  });
+
+  it('renders the drafted title and body for editing', async () => {
+    api.pr.draftBody.mockResolvedValue({
+      title: 'feat: drafted title',
+      body: '## Summary\n- drafted bullet\n\n## Test plan\n- [ ] thing',
+    });
+    render(<CreatePRDialog stackId="foo" />);
+    await waitFor(() => {
+      const titleInput = screen.getByTestId('pr-title') as HTMLInputElement;
+      expect(titleInput.value).toBe('feat: drafted title');
+    });
+    const bodyInput = screen.getByTestId('pr-body') as HTMLTextAreaElement;
+    expect(bodyInput.value).toContain('drafted bullet');
+  });
+
+  it('calls draftBody with the stack id on mount', () => {
+    render(<CreatePRDialog stackId="my-stack" />);
+    expect(api.pr.draftBody).toHaveBeenCalledWith('my-stack');
+  });
+
+  it('disables Create until both title and body have content', async () => {
+    api.pr.draftBody.mockResolvedValue({ title: '', body: '' });
+    render(<CreatePRDialog stackId="foo" />);
+    await waitFor(() => screen.getByTestId('pr-title'));
+    const create = screen.getByTestId('pr-create');
+    expect(create.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('calls pr.create with the edited title/body and closes on success', async () => {
+    const user = userEvent.setup();
+    api.pr.draftBody.mockResolvedValue({ title: 'orig', body: 'orig body' });
+    api.pr.create.mockResolvedValue({ url: 'https://github.com/o/r/pull/9', number: 9 });
+    render(<CreatePRDialog stackId="foo" />);
+    await waitFor(() => screen.getByTestId('pr-title'));
+
+    const title = screen.getByTestId('pr-title') as HTMLInputElement;
+    await user.clear(title);
+    await user.type(title, 'edited title');
+
+    fireEvent.click(screen.getByTestId('pr-create'));
+    await waitFor(() => {
+      expect(api.pr.create).toHaveBeenCalledWith('foo', 'edited title', 'orig body');
+    });
+    await waitFor(() => {
+      expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    });
+    expect(window.open).toHaveBeenCalledWith('https://github.com/o/r/pull/9', '_blank');
+  });
+
+  it('surfaces an error from draftBody', async () => {
+    api.pr.draftBody.mockRejectedValue(new Error('runaway draft'));
+    render(<CreatePRDialog stackId="foo" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pr-error').textContent).toMatch(/runaway draft/);
+    });
+  });
+
+  it('surfaces an error from pr.create and stays open', async () => {
+    const user = userEvent.setup();
+    api.pr.draftBody.mockResolvedValue({ title: 't', body: 'b' });
+    api.pr.create.mockRejectedValue(new Error('gh failed'));
+    render(<CreatePRDialog stackId="foo" />);
+    await waitFor(() => screen.getByTestId('pr-create'));
+    fireEvent.click(screen.getByTestId('pr-create'));
+    await waitFor(() => {
+      expect(screen.getByTestId('pr-error').textContent).toMatch(/gh failed/);
+    });
+    expect(useAppStore.getState().showCreatePRDialog).not.toBeNull();
+  });
+
+  it('warns when the title exceeds 70 characters', async () => {
+    const user = userEvent.setup();
+    api.pr.draftBody.mockResolvedValue({ title: 't', body: 'b' });
+    render(<CreatePRDialog stackId="foo" />);
+    await waitFor(() => screen.getByTestId('pr-title'));
+    const title = screen.getByTestId('pr-title') as HTMLInputElement;
+    await user.clear(title);
+    await user.type(title, 'x'.repeat(75));
+    expect(screen.getByText(/75\/70/)).toBeDefined();
+  });
+});

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RefineTicketDialog } from '../../../src/renderer/components/RefineTicketDialog';
+import { useAppStore } from '../../../src/renderer/store';
+import { mockSandstormApi } from './setup';
+
+describe('RefineTicketDialog', () => {
+  let api: ReturnType<typeof mockSandstormApi>;
+
+  beforeEach(() => {
+    api = mockSandstormApi();
+    useAppStore.setState({
+      projects: [{ id: 1, name: 'proj', directory: '/proj', added_at: '' }],
+      activeProjectId: 1,
+      showRefineTicketDialog: true,
+      stacks: [],
+    });
+  });
+
+  it('renders the dialog with the ticket id input', () => {
+    render(<RefineTicketDialog />);
+    expect(screen.getByText('Refine Ticket')).toBeDefined();
+    expect(screen.getByTestId('refine-ticket-id')).toBeDefined();
+  });
+
+  it('Run Gate is disabled until a ticket id is entered', () => {
+    render(<RefineTicketDialog />);
+    const btn = screen.getByTestId('refine-run-gate');
+    expect(btn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('closes when Cancel is clicked', () => {
+    render(<RefineTicketDialog />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+  });
+
+  it('renders the pass state and a Start Stack button when the gate passes', async () => {
+    const user = userEvent.setup();
+    api.tickets.specCheck.mockResolvedValue({
+      passed: true, questions: [], gateSummary: 'Gate=PASS, questions=0',
+      ticketUrl: 'https://github.com/o/r/issues/310', cached: false,
+    });
+    render(<RefineTicketDialog />);
+    await user.type(screen.getByTestId('refine-ticket-id'), '310');
+    fireEvent.click(screen.getByTestId('refine-run-gate'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refine-pass')).toBeDefined();
+    });
+    expect(api.tickets.specCheck).toHaveBeenCalledWith('310', '/proj');
+    expect(screen.getByTestId('refine-start-stack')).toBeDefined();
+    const nameInput = screen.getByTestId('refine-stack-name') as HTMLInputElement;
+    expect(nameInput.value).toBe('ticket-310');
+  });
+
+  it('renders the fail state with a per-question form', async () => {
+    const user = userEvent.setup();
+    api.tickets.specCheck.mockResolvedValue({
+      passed: false,
+      questions: ['What is X?', 'What is Y?'],
+      gateSummary: 'Gate=FAIL, questions=2',
+      ticketUrl: null,
+      cached: false,
+    });
+    render(<RefineTicketDialog />);
+    await user.type(screen.getByTestId('refine-ticket-id'), '310');
+    fireEvent.click(screen.getByTestId('refine-run-gate'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refine-fail')).toBeDefined();
+    });
+    expect(screen.getByText('What is X?')).toBeDefined();
+    expect(screen.getByTestId('refine-answer-0')).toBeDefined();
+    expect(screen.getByTestId('refine-answer-1')).toBeDefined();
+
+    // Submit answers should be disabled until all are filled.
+    const submit = screen.getByTestId('refine-submit-answers');
+    expect(submit.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('calls specRefine with the formatted Q/A payload when answers are submitted', async () => {
+    const user = userEvent.setup();
+    api.tickets.specCheck.mockResolvedValue({
+      passed: false,
+      questions: ['What is X?'],
+      gateSummary: 'Gate=FAIL, questions=1',
+      ticketUrl: null,
+      cached: false,
+    });
+    api.tickets.specRefine.mockResolvedValue({
+      passed: true, questions: [], gateSummary: 'Gate=PASS, questions=0',
+      ticketUrl: null, cached: false,
+    });
+    render(<RefineTicketDialog />);
+    await user.type(screen.getByTestId('refine-ticket-id'), '310');
+    fireEvent.click(screen.getByTestId('refine-run-gate'));
+    await waitFor(() => screen.getByTestId('refine-fail'));
+
+    await user.type(screen.getByTestId('refine-answer-0'), 'X is foo');
+    fireEvent.click(screen.getByTestId('refine-submit-answers'));
+
+    await waitFor(() => {
+      expect(api.tickets.specRefine).toHaveBeenCalledWith(
+        '310',
+        '/proj',
+        expect.stringContaining('Q1: What is X?\nA: X is foo'),
+      );
+    });
+
+    // Should land on the pass state after the refine succeeds.
+    await waitFor(() => screen.getByTestId('refine-pass'));
+  });
+
+  it('calls stacks.create with verbatim ticket body when Start Stack is clicked', async () => {
+    const user = userEvent.setup();
+    api.tickets.specCheck.mockResolvedValue({
+      passed: true, questions: [], gateSummary: 'Gate=PASS', ticketUrl: null, cached: false,
+    });
+    api.tickets.fetch.mockResolvedValue({
+      body: '# Issue: Refine ticket\n\nbody text', url: null,
+    });
+    api.stacks.create.mockResolvedValue({
+      id: 'ticket-310', project: 'proj', status: 'building', services: [],
+    });
+
+    render(<RefineTicketDialog />);
+    await user.type(screen.getByTestId('refine-ticket-id'), '310');
+    fireEvent.click(screen.getByTestId('refine-run-gate'));
+    await waitFor(() => screen.getByTestId('refine-start-stack'));
+
+    fireEvent.click(screen.getByTestId('refine-start-stack'));
+
+    await waitFor(() => {
+      expect(api.stacks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'ticket-310',
+          projectDir: '/proj',
+          ticket: '310',
+          task: '# Issue: Refine ticket\n\nbody text',
+          gateApproved: true,
+        }),
+      );
+    });
+
+    // Dialog should close after success
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+  });
+
+  it('shows the cached banner copy when the gate result is cached', async () => {
+    const user = userEvent.setup();
+    api.tickets.specCheck.mockResolvedValue({
+      passed: true, questions: [], gateSummary: 'cached', ticketUrl: null, cached: true,
+    });
+    render(<RefineTicketDialog />);
+    await user.type(screen.getByTestId('refine-ticket-id'), '310');
+    fireEvent.click(screen.getByTestId('refine-run-gate'));
+    await waitFor(() => screen.getByTestId('refine-pass'));
+    expect(screen.getByText(/already passed/i)).toBeDefined();
+  });
+
+  it('surfaces an error when specCheck rejects', async () => {
+    const user = userEvent.setup();
+    api.tickets.specCheck.mockRejectedValue(new Error('gh rate limit'));
+    render(<RefineTicketDialog />);
+    await user.type(screen.getByTestId('refine-ticket-id'), '310');
+    fireEvent.click(screen.getByTestId('refine-run-gate'));
+    await waitFor(() => {
+      expect(screen.getByTestId('refine-error').textContent).toMatch(/gh rate limit/);
+    });
+  });
+});

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -139,6 +139,21 @@ export function mockSandstormApi() {
       status: vi.fn().mockResolvedValue({ loggedIn: false, expired: false }),
       login: vi.fn().mockResolvedValue({ success: true }),
     },
+    tickets: {
+      fetch: vi.fn().mockResolvedValue({ body: '# Issue: test\n\nbody', url: 'https://github.com/o/r/issues/1' }),
+      specCheck: vi.fn().mockResolvedValue({
+        passed: true, questions: [], gateSummary: 'Gate=PASS, questions=0',
+        ticketUrl: 'https://github.com/o/r/issues/1', cached: false,
+      }),
+      specRefine: vi.fn().mockResolvedValue({
+        passed: true, questions: [], gateSummary: 'Gate=PASS, questions=0',
+        ticketUrl: 'https://github.com/o/r/issues/1', cached: false,
+      }),
+    },
+    pr: {
+      draftBody: vi.fn().mockResolvedValue({ title: 'Test PR', body: '## Summary\n- thing\n\n## Test plan\n- [ ] check' }),
+      create: vi.fn().mockResolvedValue({ url: 'https://github.com/o/r/pull/1', number: 1 }),
+    },
     on: vi.fn().mockReturnValue(() => {}),
   };
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -145,6 +145,10 @@ vi.mock('../../src/main/control-plane/account-usage', () => ({
 
 vi.mock('child_process', () => ({
   spawn: mockSpawn,
+  // ticket-spec / pr-creator use execFile via promisify; promisify only needs
+  // the function to exist + be callable, so a no-op stub is enough for the
+  // existing IPC handler tests (none of them exercise the new tickets/pr paths).
+  execFile: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1048,6 +1052,11 @@ describe('IPC Handlers', () => {
       'docker:status',
       'auth:status',
       'auth:login',
+      'tickets:fetch',
+      'tickets:specCheck',
+      'tickets:specRefine',
+      'pr:draftBody',
+      'pr:create',
     ];
 
     it('registers all expected IPC channels', () => {

--- a/tests/unit/pr-creator.test.ts
+++ b/tests/unit/pr-creator.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import {
+  buildDraftPrompt,
+  parseDraftResponse,
+  workspacePathFor,
+  draftPullRequest,
+  PR_BODY_MAX_BYTES,
+  PR_TITLE_MAX_CHARS,
+} from '../../src/main/control-plane/pr-creator';
+
+describe('workspacePathFor', () => {
+  it('joins projectDir + .sandstorm/workspaces + stackId', () => {
+    expect(workspacePathFor('/p', 'foo')).toBe('/p/.sandstorm/workspaces/foo');
+  });
+});
+
+describe('buildDraftPrompt', () => {
+  it('includes the branch, commits, diff stat, and task tail', () => {
+    const out = buildDraftPrompt({
+      ticket: '42',
+      branch: 'feat/something',
+      commits: 'commit message text',
+      diffStat: ' src/foo.ts | 10 +-',
+      taskOutputTail: 'last log lines',
+    });
+    expect(out).toContain('"feat/something"');
+    expect(out).toContain('commit message text');
+    expect(out).toContain('src/foo.ts');
+    expect(out).toContain('last log lines');
+    expect(out).toContain('Closes #42');
+  });
+
+  it('strips a leading # from the ticket id', () => {
+    const out = buildDraftPrompt({
+      ticket: '#310',
+      branch: 'b',
+      commits: '',
+      diffStat: '',
+      taskOutputTail: '',
+    });
+    expect(out).toContain('Closes #310');
+    expect(out).not.toContain('Closes ##310');
+  });
+
+  it('omits the Closes line when no ticket is given', () => {
+    const out = buildDraftPrompt({
+      ticket: null,
+      branch: 'b',
+      commits: '',
+      diffStat: '',
+      taskOutputTail: '',
+    });
+    expect(out).not.toMatch(/Closes #/);
+  });
+
+  it('mentions the body byte cap', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).toContain(`${PR_BODY_MAX_BYTES} bytes`);
+  });
+});
+
+describe('parseDraftResponse', () => {
+  it('parses a clean JSON response', () => {
+    const r = parseDraftResponse('{"title":"hi","body":"## Summary\\n- ok"}');
+    expect(r.title).toBe('hi');
+    expect(r.body).toBe('## Summary\n- ok');
+  });
+
+  it('strips ```json fences', () => {
+    const r = parseDraftResponse('```json\n{"title":"x","body":"y"}\n```');
+    expect(r.title).toBe('x');
+  });
+
+  it('extracts JSON from surrounding prose', () => {
+    const r = parseDraftResponse('Sure!\n{"title":"a","body":"b"}\n');
+    expect(r.title).toBe('a');
+    expect(r.body).toBe('b');
+  });
+
+  it('throws when no JSON is found', () => {
+    expect(() => parseDraftResponse('not json')).toThrow(/did not contain JSON/);
+  });
+
+  it('throws when title or body is missing', () => {
+    expect(() => parseDraftResponse('{"title":"x"}')).toThrow(/missing title or body/);
+  });
+
+  it('throws when title is empty', () => {
+    expect(() => parseDraftResponse('{"title":"","body":"b"}')).toThrow(/title was empty/);
+  });
+
+  it('throws when body exceeds the byte cap', () => {
+    const big = 'a'.repeat(PR_BODY_MAX_BYTES + 100);
+    expect(() => parseDraftResponse(JSON.stringify({ title: 'x', body: big }))).toThrow(/exceeds.*bytes/);
+  });
+
+  it('truncates titles longer than the char cap', () => {
+    const long = 'x'.repeat(PR_TITLE_MAX_CHARS + 10);
+    const r = parseDraftResponse(JSON.stringify({ title: long, body: 'b' }));
+    expect(r.title.length).toBe(PR_TITLE_MAX_CHARS);
+  });
+});
+
+describe('draftPullRequest', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-draft-'));
+    // Init a tiny git repo with one commit on a branch off main.
+    execFileSync('git', ['-c', 'init.defaultBranch=main', 'init', '-q'], { cwd: workspace });
+    execFileSync('git', ['config', 'user.email', 't@t'], { cwd: workspace });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: workspace });
+    fs.writeFileSync(path.join(workspace, 'a'), 'a');
+    execFileSync('git', ['add', 'a'], { cwd: workspace });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: workspace });
+    execFileSync('git', ['checkout', '-q', '-b', 'feat/x'], { cwd: workspace });
+    fs.writeFileSync(path.join(workspace, 'b'), 'b');
+    execFileSync('git', ['add', 'b'], { cwd: workspace });
+    execFileSync('git', ['commit', '-q', '-m', 'feat: add b'], { cwd: workspace });
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('rejects when the workspace directory is missing', async () => {
+    await expect(
+      draftPullRequest(
+        { stackId: 's', workspace: '/nope', ticket: null },
+        { runEphemeral: vi.fn() },
+      ),
+    ).rejects.toThrow(/workspace not found/);
+  });
+
+  it('calls the ephemeral agent with a prompt that mentions the branch and commit', async () => {
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"feat: add b","body":"## Summary\\n- adds b\\n\\n## Test plan\\n- [ ] verify"}');
+    const drafted = await draftPullRequest(
+      { stackId: 's', workspace, ticket: '42' },
+      { runEphemeral },
+    );
+    expect(drafted.title).toBe('feat: add b');
+    expect(drafted.body).toContain('Summary');
+    expect(runEphemeral).toHaveBeenCalledTimes(1);
+    const promptArg = runEphemeral.mock.calls[0][0] as string;
+    expect(promptArg).toContain('feat/x');
+    expect(promptArg).toContain('feat: add b');
+    expect(promptArg).toContain('Closes #42');
+  });
+
+  it('reuses the workspace as cwd for the ephemeral call', async () => {
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"x","body":"## Summary\\n- y"}');
+    await draftPullRequest({ stackId: 's', workspace, ticket: null }, { runEphemeral });
+    expect(runEphemeral).toHaveBeenCalledWith(expect.any(String), workspace, expect.any(Number));
+  });
+
+  it('passes the task tail through when fetchTaskTail is provided', async () => {
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"x","body":"## Summary\\n- y"}');
+    const fetchTaskTail = vi.fn().mockResolvedValue('important task log');
+    await draftPullRequest(
+      { stackId: 's', workspace, ticket: null },
+      { runEphemeral, fetchTaskTail },
+    );
+    expect(fetchTaskTail).toHaveBeenCalledWith('s');
+    expect(runEphemeral.mock.calls[0][0]).toContain('important task log');
+  });
+});

--- a/tests/unit/ticket-spec.test.ts
+++ b/tests/unit/ticket-spec.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  extractGateSummary,
+  extractQuestions,
+  shortBodyHash,
+  runSpecCheck,
+  runSpecRefine,
+  type SpecGateDeps,
+} from '../../src/main/control-plane/ticket-spec';
+
+const PASS_REPORT = `## Spec Quality Gate: PASS
+
+### Results
+| Criterion | Result | Notes |
+|-----------|--------|-------|
+| One | PASS | |
+`;
+
+const FAIL_REPORT = `## Spec Quality Gate: FAIL
+
+### Questions
+1. What does "fast" mean here in concrete numbers?
+2. Should we cache the full body or just the hash?
+
+### Results
+| Criterion | Result |
+|-----------|--------|
+| Specificity | FAIL |
+`;
+
+function makeDeps(overrides: Partial<SpecGateDeps> = {}): SpecGateDeps {
+  return {
+    fetchTicket: vi.fn().mockResolvedValue('a body'),
+    scriptStatus: vi.fn().mockReturnValue('ok'),
+    runCheck: vi.fn().mockResolvedValue({ passed: true, report: PASS_REPORT }),
+    runRefine: vi.fn().mockResolvedValue({ passed: true, report: PASS_REPORT }),
+    readSpecReadyHash: vi.fn().mockResolvedValue(''),
+    readTicketUrl: vi.fn().mockResolvedValue('https://github.com/o/r/issues/1'),
+    markSpecReady: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('extractGateSummary', () => {
+  it('parses PASS verdict and zero questions', () => {
+    expect(extractGateSummary(PASS_REPORT)).toBe('Gate=PASS, questions=0');
+  });
+
+  it('parses FAIL verdict and counts numbered questions', () => {
+    expect(extractGateSummary(FAIL_REPORT)).toBe('Gate=FAIL, questions=2');
+  });
+
+  it('returns empty string when report is empty', () => {
+    expect(extractGateSummary('')).toBe('');
+  });
+
+  it('returns "not parsed" when verdict header is missing', () => {
+    expect(extractGateSummary('## Some other section')).toBe('Gate verdict not parsed');
+  });
+});
+
+describe('extractQuestions', () => {
+  it('pulls numbered items under a Questions heading', () => {
+    expect(extractQuestions(FAIL_REPORT)).toEqual([
+      'What does "fast" mean here in concrete numbers?',
+      'Should we cache the full body or just the hash?',
+    ]);
+  });
+
+  it('also captures items under a Gaps heading', () => {
+    const r = `### Gaps\n1. First gap\n2. Second gap\n## Next\n3. Outside`;
+    expect(extractQuestions(r)).toEqual(['First gap', 'Second gap']);
+  });
+
+  it('returns empty array when no Questions/Gaps heading exists', () => {
+    expect(extractQuestions(PASS_REPORT)).toEqual([]);
+  });
+
+  it('stops capturing at the next ## heading boundary', () => {
+    const r = `### Questions\n1. Inside\n## Other\n2. Outside`;
+    expect(extractQuestions(r)).toEqual(['Inside']);
+  });
+});
+
+describe('shortBodyHash', () => {
+  it('produces a 12-char hex string', () => {
+    const h = shortBodyHash('hello world');
+    expect(h).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(shortBodyHash('foo')).toBe(shortBodyHash('foo'));
+  });
+
+  it('changes when the body changes', () => {
+    expect(shortBodyHash('foo')).not.toBe(shortBodyHash('foo!'));
+  });
+});
+
+describe('runSpecCheck', () => {
+  it('returns an error when fetch-ticket.sh is missing', async () => {
+    const deps = makeDeps({ scriptStatus: vi.fn().mockReturnValue('missing') });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(false);
+    expect(result.error).toMatch(/fetch-ticket\.sh is missing/);
+    expect(deps.runCheck).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the fetched body is empty', async () => {
+    const deps = makeDeps({ fetchTicket: vi.fn().mockResolvedValue('') });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(false);
+    expect(result.error).toMatch(/returned no output/);
+    expect(deps.runCheck).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits when the spec-ready label hash matches the current body', async () => {
+    const body = '# Ticket body';
+    const hash = shortBodyHash(body);
+    const deps = makeDeps({
+      fetchTicket: vi.fn().mockResolvedValue(body),
+      readSpecReadyHash: vi.fn().mockResolvedValue(hash),
+    });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(true);
+    expect(result.cached).toBe(true);
+    expect(result.gateSummary).toMatch(/cached/);
+    expect(deps.runCheck).not.toHaveBeenCalled();
+    expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+
+  it('runs the check when there is no cached hash and tags the ticket on PASS', async () => {
+    const body = '# Ticket body';
+    const deps = makeDeps({ fetchTicket: vi.fn().mockResolvedValue(body) });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(true);
+    expect(result.cached).toBe(false);
+    expect(deps.runCheck).toHaveBeenCalledWith('1', '/proj');
+    expect(deps.markSpecReady).toHaveBeenCalledWith('1', shortBodyHash(body));
+  });
+
+  it('parses gate failures into structured questions and skips the label', async () => {
+    const deps = makeDeps({
+      runCheck: vi.fn().mockResolvedValue({ passed: false, report: FAIL_REPORT }),
+    });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(false);
+    expect(result.questions.length).toBe(2);
+    expect(result.gateSummary).toBe('Gate=FAIL, questions=2');
+    expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+
+  it('surfaces handler errors verbatim', async () => {
+    const deps = makeDeps({
+      runCheck: vi.fn().mockResolvedValue({ passed: false, error: 'No quality gate configured' }),
+    });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(false);
+    expect(result.error).toBe('No quality gate configured');
+  });
+});
+
+describe('runSpecRefine', () => {
+  it('passes user answers to the refine handler', async () => {
+    const deps = makeDeps({
+      runRefine: vi.fn().mockResolvedValue({ passed: true, report: PASS_REPORT }),
+    });
+    await runSpecRefine('1', '/proj', 'Q1: foo\nA: bar', deps);
+    expect(deps.runRefine).toHaveBeenCalledWith('1', '/proj', 'Q1: foo\nA: bar');
+  });
+
+  it('re-fetches the body and tags spec-ready on PASS', async () => {
+    const fresh = '# updated body';
+    const fetch = vi.fn()
+      // First call (none in refine path) — but post-PASS we re-fetch
+      .mockResolvedValue(fresh);
+    const deps = makeDeps({
+      fetchTicket: fetch,
+      runRefine: vi.fn().mockResolvedValue({ passed: true, report: PASS_REPORT }),
+    });
+    const result = await runSpecRefine('1', '/proj', 'answers', deps);
+    expect(result.passed).toBe(true);
+    expect(fetch).toHaveBeenCalledWith('1', '/proj');
+    expect(deps.markSpecReady).toHaveBeenCalledWith('1', shortBodyHash(fresh));
+  });
+
+  it('returns parsed questions on FAIL', async () => {
+    const deps = makeDeps({
+      runRefine: vi.fn().mockResolvedValue({ passed: false, report: FAIL_REPORT }),
+    });
+    const result = await runSpecRefine('1', '/proj', 'answers', deps);
+    expect(result.passed).toBe(false);
+    expect(result.questions.length).toBe(2);
+    expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Routes the ticket-to-PR arc through clickable UI actions backed by the existing ticket-fetcher and spec-gate primitives. The outer Claude orchestrator stops being the default path for ticket workflows; only bounded one-shot subprocesses make API calls.

## What landed

**Refine Ticket dialog** (Dashboard header button, project tabs only)
- input → run gate → pass / fail
- Pass: green banner + Start Stack button. Cached banner when `spec-ready:sha-<hash>` already matches.
- Fail: per-question form rendered from the report's `### Questions` / `### Gaps` block. Submit Answers re-evaluates via the same in-process path.
- Each click fires one ephemeral Claude call. No session state.

**Start Stack** — zero-LLM dispatch
- Fetches the (possibly refined) ticket body verbatim via `tickets:fetch`
- Calls `stacks.create` with `gateApproved: true` and the body as `task` — inner Claude picks it up unmodified

**Make PR dialog** (StackCard button + StackDetail footer when `status in {completed,pushed}` and `pr_url` is null)
- `pr:draftBody` collects commits / diff stat / last task-output tail and runs one ephemeral Claude call with a strict-JSON prompt
- Hard caps: 8 KB body, 70-char title, 90 s timeout — title is truncated, body throws if oversized
- User edits in editable textareas, click Create → deterministic `gh pr create` in the stack workspace
- Records the URL via the existing `stackManager.setPullRequest`

## New main-process modules (pure, dep-injectable)

- `src/main/control-plane/ticket-spec.ts` — orchestrates check/refine, mirrors `sandstorm-spec.sh`'s output trim and `spec-ready:sha-<hash>` idempotency cache.
- `src/main/control-plane/pr-creator.ts` — gathers commits/diff/task-tail, builds the strict-JSON drafter prompt, parses with caps, shells `gh pr create`.

## New IPC channels

`tickets:fetch`, `tickets:specCheck`, `tickets:specRefine`, `pr:draftBody`, `pr:create`. Exposed in preload as `window.sandstorm.tickets.*` and `window.sandstorm.pr.*`.

## Tests

54 new unit tests, all green:
- `tests/unit/ticket-spec.test.ts` (20) — gate summary/question parsing, body-hash idempotency cache, error pass-through, refine handler wiring
- `tests/unit/pr-creator.test.ts` (17) — draft prompt structure, JSON parsing tolerance + caps, real-git-repo end-to-end for `draftPullRequest`
- `tests/unit/components/RefineTicketDialog.test.tsx` (9) — pass/fail/cached states, Q/A submission shape, Start-Stack call args
- `tests/unit/components/CreatePRDialog.test.tsx` (8) — drafting state, edit + create, error surfaces, title-cap warning

Pure modules avoid Electron mocks per the project's no-electron-mocks rule.

## What's NOT changing

- Outer Claude chat panel stays for novel / exploratory work and PR review (see #310 out-of-scope).
- `sandstorm-spec` skill stays. Chat-driven `/spec-check` and `/spec-refine` keep working — both paths converge on the same `handleSpecCheck` / `handleSpecRefine` handlers.
- Legacy `spec_check` / `spec_refine` MCP tool handlers stay (separate cleanup ticket if/when dead).

## Test plan

- [ ] `npm run typecheck` — passes
- [ ] `npm test` — all 1601 tests pass
- [ ] `npm run build` — clean
- [ ] Open the app on a project with `.sandstorm/` configured, click Refine Ticket, enter a passing ticket → green banner + Start Stack
- [ ] Repeat with a failing ticket → questions form appears, answer them, Submit → re-evaluates
- [ ] On a stack with `status in {completed,pushed}` and no PR, click Make PR → modal opens within ~10s with drafted title/body, edit, Create → PR appears on GitHub and StackCard updates
- [ ] Run with `SANDSTORM_RAW_REQUEST_CAPTURE=1` across the full arc → confirm the orchestrator tab's capture dir has zero new dump files (only ephemeral subprocesses produce API calls)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)