### PR TITLE
Fix Make PR: persist draft + commit/push before gh (fixes #320)

### DIFF
--- a/src/main/control-plane/pr-creator.ts
+++ b/src/main/control-plane/pr-creator.ts
@@ -198,6 +198,71 @@ export async function draftPullRequest(args: DraftPRArgs, deps: DraftDeps): Prom
 }
 
 /**
+ * Commit any uncommitted changes in the workspace, then push the current
+ * branch to origin with upstream tracking. Fixes #320: `gh pr create` used
+ * to fail because inner-Claude's changes sat uncommitted in the workspace
+ * and the branch had never been pushed. "Make PR" is supposed to be one
+ * button — commit + push + create.
+ *
+ * No-op commit when there's nothing staged (idempotent if the user
+ * already pushed via the Push button). `git push -u origin HEAD` is
+ * idempotent too — safe if the branch is already on remote.
+ */
+export function commitAndPush(args: {
+  workspace: string;
+  commitMessage: string;
+}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(args.workspace)) {
+      reject(new Error(`Stack workspace not found at ${args.workspace}`));
+      return;
+    }
+    const message = args.commitMessage.trim() || 'Changes from Sandstorm stack';
+
+    runGit(args.workspace, ['add', '-A'])
+      .then(() => runGit(args.workspace, ['diff', '--cached', '--quiet']).then(
+        // Exit 0 from `diff --cached --quiet` means no staged changes → skip commit.
+        () => 'no-changes',
+        // Non-zero exit means there are staged changes → commit them.
+        () => 'has-changes',
+      ))
+      .then(async (state) => {
+        if (state === 'has-changes') {
+          await runGit(args.workspace, ['commit', '-m', message]);
+        }
+      })
+      .then(() => runGit(args.workspace, ['push', '-u', 'origin', 'HEAD']))
+      .then(() => resolve())
+      .catch((err) => reject(err));
+  });
+}
+
+function runGit(workspace: string, gitArgs: string[]): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', gitArgs, {
+      cwd: workspace,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => reject(err));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        const tag = `git ${gitArgs[0]}`;
+        reject(new Error(
+          `${tag} failed (exit ${code}): ${stderr.trim() || stdout.trim() || '(no output)'}`,
+        ));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+/**
  * Run `gh pr create` in the stack workspace. Returns the parsed URL + number.
  * `gh` writes the URL to stdout on success: e.g. https://github.com/owner/repo/pull/123
  */

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -60,6 +60,7 @@ import {
 import {
   draftPullRequest,
   createPullRequest,
+  commitAndPush,
   workspacePathFor,
 } from './control-plane/pr-creator';
 import { createTicket } from './control-plane/ticket-creator';
@@ -994,11 +995,12 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     async (_event, stackId: string, title: string, body: string) => {
       const stack = await stackManager.getStackWithServices(stackId);
       if (!stack) throw new Error(`Stack "${stackId}" not found`);
-      const result = await createPullRequest({
-        workspace: workspacePathFor(stack.project_dir, stackId),
-        title,
-        body,
-      });
+      const workspace = workspacePathFor(stack.project_dir, stackId);
+      // Make PR is one button — commit any dirty workspace + push the
+      // branch before gh pr create. Without this, gh fails with
+      // "uncommitted changes" / "must first push the branch" (#320).
+      await commitAndPush({ workspace, commitMessage: title });
+      const result = await createPullRequest({ workspace, title, body });
       stackManager.setPullRequest(stackId, result.url, result.number);
       return result;
     },

--- a/src/renderer/components/CreatePRDialog.tsx
+++ b/src/renderer/components/CreatePRDialog.tsx
@@ -1,16 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useAppStore } from '../store';
 
 export function CreatePRDialog({ stackId }: { stackId: string }) {
-  const { setShowCreatePRDialog, refreshStacks } = useAppStore();
+  const { setShowCreatePRDialog, refreshStacks, prDraftCache, setPrDraft, clearPrDraft } = useAppStore();
+  const cached = prDraftCache[stackId];
 
-  const [title, setTitle] = useState('');
-  const [body, setBody] = useState('');
-  const [drafting, setDrafting] = useState(true);
+  const [title, setTitle] = useState(cached?.title ?? '');
+  const [body, setBody] = useState(cached?.body ?? '');
+  const [drafting, setDrafting] = useState(!cached);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Don't re-draft on reopen — hydrate from the store-level cache instead.
+  // Only call draftBody when nothing is cached for this stack yet (#320).
   useEffect(() => {
+    if (cached) return;
     let cancelled = false;
     setDrafting(true);
     setError(null);
@@ -20,6 +24,7 @@ export function CreatePRDialog({ stackId }: { stackId: string }) {
         if (cancelled) return;
         setTitle(drafted.title);
         setBody(drafted.body);
+        setPrDraft(stackId, drafted);
         setDrafting(false);
       })
       .catch((err) => {
@@ -28,7 +33,25 @@ export function CreatePRDialog({ stackId }: { stackId: string }) {
         setError(err instanceof Error ? err.message : String(err));
       });
     return () => { cancelled = true; };
+    // `cached` is intentionally omitted — we only want to kick off a draft
+    // once per mount when the cache was empty at mount time. Later edits
+    // shouldn't retrigger the LLM call.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stackId]);
+
+  // Persist edits to the store-level cache so closing + reopening the
+  // dialog restores the in-progress draft (#320). Skip the very first
+  // render when we're still drafting and `title`/`body` are empty strings.
+  const firstPersistRef = useRef(true);
+  useEffect(() => {
+    if (drafting) return;
+    if (!title && !body) return;
+    if (firstPersistRef.current) {
+      firstPersistRef.current = false;
+      return;
+    }
+    setPrDraft(stackId, { title, body });
+  }, [title, body, drafting, stackId, setPrDraft]);
 
   const close = () => setShowCreatePRDialog(null);
 
@@ -41,6 +64,7 @@ export function CreatePRDialog({ stackId }: { stackId: string }) {
     setError(null);
     try {
       const result = await window.sandstorm.pr.create(stackId, title.trim(), body.trim());
+      clearPrDraft(stackId);
       await refreshStacks();
       window.open(result.url, '_blank');
       close();
@@ -61,7 +85,8 @@ export function CreatePRDialog({ stackId }: { stackId: string }) {
           <div>
             <h2 className="text-base font-semibold text-sandstorm-text">Create Pull Request</h2>
             <p className="text-[11px] text-sandstorm-muted mt-0.5">
-              Stack <span className="font-mono">{stackId}</span> — drafted by one ephemeral Claude call
+              Stack <span className="font-mono">{stackId}</span>
+              {cached && !drafting ? ' — draft restored' : ' — drafted by one ephemeral Claude call'}
             </p>
           </div>
           <button
@@ -118,6 +143,9 @@ export function CreatePRDialog({ stackId }: { stackId: string }) {
                   data-testid="pr-body"
                 />
               </div>
+              <p className="text-[10px] text-sandstorm-muted">
+                Creating the PR also commits and pushes any uncommitted work in this stack's branch.
+              </p>
             </>
           )}
         </div>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -338,6 +338,12 @@ interface AppState {
   showCreateTicketDialog: boolean;
   showStartTicketDialog: boolean;
   showCreatePRDialog: { stackId: string } | null;
+  /**
+   * Drafted PR title/body keyed by stackId — survives the dialog being
+   * closed/reopened so the user doesn't pay for another ephemeral Claude
+   * call to redraft (#320). Cleared after a successful PR creation.
+   */
+  prDraftCache: Record<string, { title: string; body: string }>;
   stackMetrics: Record<string, StackMetrics>;
   loading: boolean;
   error: string | null;
@@ -417,6 +423,8 @@ interface AppState {
   setShowCreateTicketDialog: (show: boolean) => void;
   setShowStartTicketDialog: (show: boolean) => void;
   setShowCreatePRDialog: (state: { stackId: string } | null) => void;
+  setPrDraft: (stackId: string, draft: { title: string; body: string }) => void;
+  clearPrDraft: (stackId: string) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   refreshStacks: () => Promise<void>;
@@ -653,6 +661,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   showCreateTicketDialog: false,
   showStartTicketDialog: false,
   showCreatePRDialog: null,
+  prDraftCache: {},
   loading: false,
   error: null,
 
@@ -840,6 +849,16 @@ export const useAppStore = create<AppState>((set, get) => ({
   setShowCreateTicketDialog: (show) => set({ showCreateTicketDialog: show }),
   setShowStartTicketDialog: (show) => set({ showStartTicketDialog: show }),
   setShowCreatePRDialog: (state) => set({ showCreatePRDialog: state }),
+  setPrDraft: (stackId, draft) =>
+    set((state) => ({
+      prDraftCache: { ...state.prDraftCache, [stackId]: draft },
+    })),
+  clearPrDraft: (stackId) =>
+    set((state) => {
+      const next = { ...state.prDraftCache };
+      delete next[stackId];
+      return { prDraftCache: next };
+    }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
 

--- a/tests/unit/components/CreatePRDialog.test.tsx
+++ b/tests/unit/components/CreatePRDialog.test.tsx
@@ -18,6 +18,7 @@ describe('CreatePRDialog', () => {
     useAppStore.setState({
       showCreatePRDialog: { stackId: 'foo' },
       stacks: [],
+      prDraftCache: {},
     });
     originalOpen = window.open;
     window.open = vi.fn() as unknown as typeof window.open;
@@ -110,5 +111,89 @@ describe('CreatePRDialog', () => {
     await user.clear(title);
     await user.type(title, 'x'.repeat(75));
     expect(screen.getByText(/75\/70/)).toBeDefined();
+  });
+
+  // #320 — reopening the dialog must not re-run the draft LLM call.
+  describe('draft cache (#320)', () => {
+    it('hydrates title/body from prDraftCache and skips the LLM call', async () => {
+      useAppStore.setState({
+        prDraftCache: { foo: { title: 'cached title', body: 'cached body' } },
+      });
+      render(<CreatePRDialog stackId="foo" />);
+
+      // Editor is immediately visible (no drafting spinner) because we
+      // had a cached draft — no LLM call needed.
+      expect(screen.queryByTestId('pr-drafting')).toBeNull();
+      expect(api.pr.draftBody).not.toHaveBeenCalled();
+
+      const titleInput = screen.getByTestId('pr-title') as HTMLInputElement;
+      expect(titleInput.value).toBe('cached title');
+      const bodyInput = screen.getByTestId('pr-body') as HTMLTextAreaElement;
+      expect(bodyInput.value).toBe('cached body');
+    });
+
+    it('persists the drafted title/body to the cache after the first draft', async () => {
+      api.pr.draftBody.mockResolvedValue({ title: 'fresh title', body: 'fresh body' });
+      render(<CreatePRDialog stackId="foo" />);
+      await waitFor(() => screen.getByTestId('pr-title'));
+      // Wait for the persistence effect to flush.
+      await waitFor(() => {
+        expect(useAppStore.getState().prDraftCache.foo).toEqual({
+          title: 'fresh title',
+          body: 'fresh body',
+        });
+      });
+    });
+
+    it('writes edits to the cache so they survive a close + reopen', async () => {
+      const user = userEvent.setup();
+      api.pr.draftBody.mockResolvedValue({ title: 'orig', body: 'orig body' });
+      render(<CreatePRDialog stackId="foo" />);
+      await waitFor(() => screen.getByTestId('pr-title'));
+
+      const title = screen.getByTestId('pr-title') as HTMLInputElement;
+      await user.clear(title);
+      await user.type(title, 'user-edited title');
+
+      await waitFor(() => {
+        expect(useAppStore.getState().prDraftCache.foo?.title).toBe('user-edited title');
+      });
+    });
+
+    it('clears the cache after a successful pr.create', async () => {
+      useAppStore.setState({
+        prDraftCache: { foo: { title: 'cached', body: 'cached body' } },
+      });
+      api.pr.create.mockResolvedValue({ url: 'https://github.com/o/r/pull/1', number: 1 });
+      render(<CreatePRDialog stackId="foo" />);
+      fireEvent.click(screen.getByTestId('pr-create'));
+      await waitFor(() => {
+        expect(useAppStore.getState().prDraftCache.foo).toBeUndefined();
+      });
+    });
+
+    it('does NOT clear the cache when pr.create fails', async () => {
+      useAppStore.setState({
+        prDraftCache: { foo: { title: 'cached', body: 'cached body' } },
+      });
+      api.pr.create.mockRejectedValue(new Error('network down'));
+      render(<CreatePRDialog stackId="foo" />);
+      fireEvent.click(screen.getByTestId('pr-create'));
+      await waitFor(() => {
+        expect(screen.getByTestId('pr-error').textContent).toMatch(/network down/);
+      });
+      expect(useAppStore.getState().prDraftCache.foo).toEqual({
+        title: 'cached',
+        body: 'cached body',
+      });
+    });
+
+    it('shows the "draft restored" hint when hydrating from cache', () => {
+      useAppStore.setState({
+        prDraftCache: { foo: { title: 'cached', body: 'cached body' } },
+      });
+      render(<CreatePRDialog stackId="foo" />);
+      expect(screen.getByText(/draft restored/i)).toBeDefined();
+    });
   });
 });

--- a/tests/unit/pr-creator.test.ts
+++ b/tests/unit/pr-creator.test.ts
@@ -8,6 +8,7 @@ import {
   parseDraftResponse,
   workspacePathFor,
   draftPullRequest,
+  commitAndPush,
   PR_BODY_MAX_BYTES,
   PR_TITLE_MAX_CHARS,
 } from '../../src/main/control-plane/pr-creator';
@@ -166,5 +167,109 @@ describe('draftPullRequest', () => {
     );
     expect(fetchTaskTail).toHaveBeenCalledWith('s');
     expect(runEphemeral.mock.calls[0][0]).toContain('important task log');
+  });
+});
+
+describe('commitAndPush (#320)', () => {
+  let originDir: string;
+  let workspace: string;
+
+  beforeEach(() => {
+    // Stand up a bare "origin" repo + a cloned workspace on a feature branch
+    // so we can exercise commit + push without hitting the network. We force
+    // HEAD to `main` via symbolic-ref because older gits don't honor the
+    // `-c init.defaultBranch=main` flag (or -b on init).
+    originDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-origin-'));
+    execFileSync('git', ['init', '--bare', '-q'], { cwd: originDir });
+    execFileSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], { cwd: originDir });
+
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-ws-'));
+    execFileSync('git', ['init', '-q'], { cwd: workspace });
+    execFileSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], { cwd: workspace });
+    execFileSync('git', ['config', 'user.email', 't@t'], { cwd: workspace });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: workspace });
+    execFileSync('git', ['remote', 'add', 'origin', originDir], { cwd: workspace });
+    fs.writeFileSync(path.join(workspace, 'README'), 'hi');
+    execFileSync('git', ['add', 'README'], { cwd: workspace });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: workspace });
+    execFileSync('git', ['push', '-q', '-u', 'origin', 'main'], { cwd: workspace });
+    execFileSync('git', ['checkout', '-q', '-b', 'feat/x'], { cwd: workspace });
+  });
+
+  afterEach(() => {
+    fs.rmSync(originDir, { recursive: true, force: true });
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('rejects when the workspace is missing', async () => {
+    await expect(
+      commitAndPush({ workspace: '/nope', commitMessage: 'x' }),
+    ).rejects.toThrow(/workspace not found/);
+  });
+
+  it('commits dirty files and pushes the branch to origin', async () => {
+    fs.writeFileSync(path.join(workspace, 'new-file'), 'hello');
+    await commitAndPush({ workspace, commitMessage: 'feat: add new-file' });
+
+    // Commit landed locally.
+    const log = execFileSync('git', ['log', '-1', '--pretty=format:%s'], { cwd: workspace, encoding: 'utf-8' });
+    expect(log).toBe('feat: add new-file');
+
+    // Branch exists on origin.
+    const remoteBranches = execFileSync('git', ['branch', '-a'], { cwd: workspace, encoding: 'utf-8' });
+    expect(remoteBranches).toContain('remotes/origin/feat/x');
+  });
+
+  it('skips the commit when nothing is dirty but still pushes', async () => {
+    // Make one commit on the feature branch so there is something to push,
+    // but leave the working tree clean at call time.
+    fs.writeFileSync(path.join(workspace, 'already-committed'), 'a');
+    execFileSync('git', ['add', 'already-committed'], { cwd: workspace });
+    execFileSync('git', ['commit', '-q', '-m', 'pre-existing'], { cwd: workspace });
+
+    await commitAndPush({ workspace, commitMessage: 'ignored — no dirty files' });
+
+    // Commit count unchanged — nothing added on top of pre-existing.
+    const commits = execFileSync('git', ['rev-list', '--count', 'HEAD'], { cwd: workspace, encoding: 'utf-8' }).trim();
+    expect(commits).toBe('2');
+
+    // But the pre-existing commit did reach origin.
+    const originHead = execFileSync(
+      'git', ['ls-remote', 'origin', 'refs/heads/feat/x'],
+      { cwd: workspace, encoding: 'utf-8' },
+    ).trim();
+    expect(originHead).not.toBe('');
+  });
+
+  it('is idempotent when the branch is already pushed', async () => {
+    fs.writeFileSync(path.join(workspace, 'a'), 'a');
+    await commitAndPush({ workspace, commitMessage: 'first' });
+    // Run a second time with no new changes — should not throw.
+    await expect(
+      commitAndPush({ workspace, commitMessage: 'second' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('uses the provided commit message', async () => {
+    fs.writeFileSync(path.join(workspace, 'file'), 'x');
+    await commitAndPush({ workspace, commitMessage: 'Deterministic UI polish #320' });
+    const subject = execFileSync('git', ['log', '-1', '--pretty=format:%s'], { cwd: workspace, encoding: 'utf-8' });
+    expect(subject).toBe('Deterministic UI polish #320');
+  });
+
+  it('falls back to a default message when the provided one is empty', async () => {
+    fs.writeFileSync(path.join(workspace, 'file'), 'x');
+    await commitAndPush({ workspace, commitMessage: '   ' });
+    const subject = execFileSync('git', ['log', '-1', '--pretty=format:%s'], { cwd: workspace, encoding: 'utf-8' });
+    expect(subject).toMatch(/Changes from Sandstorm stack/);
+  });
+
+  it('surfaces git errors with which command failed', async () => {
+    // Point at a non-existent remote to force push to fail.
+    execFileSync('git', ['remote', 'set-url', 'origin', '/does-not-exist'], { cwd: workspace });
+    fs.writeFileSync(path.join(workspace, 'file'), 'x');
+    await expect(
+      commitAndPush({ workspace, commitMessage: 'x' }),
+    ).rejects.toThrow(/git push failed/);
   });
 });


### PR DESCRIPTION
## Summary

Two distinct bugs in the Make PR flow:

1. **Closing the modal threw away the LLM-drafted title/body.** Reopening paid for another ephemeral Claude call to redraft from scratch.
2. **\`gh pr create\` failed** with \`Warning: 1 uncommitted change. aborted: You must first push the current branch...\` because the inner Claude's work sat uncommitted in the workspace and the branch had never been pushed. Make PR is supposed to be one button — commit + push + create.

## Fix 1 — store-level draft cache

- New \`prDraftCache: Record<stackId, {title, body}>\` in zustand + \`setPrDraft\` / \`clearPrDraft\` actions.
- \`CreatePRDialog\` hydrates from cache on mount (no LLM call when present), writes back on user edits, clears on successful create.
- Failed creates leave the cache in place so the user doesn't lose their work.
- Header subtitle reads "draft restored" when hydrating from cache.

## Fix 2 — commit + push integrated into pr:create

- New \`commitAndPush()\` helper in \`pr-creator.ts\`: \`git add -A\` → optional commit (skip if nothing staged) → \`git push -u origin HEAD\`. Idempotent — works whether the branch is fresh or already tracked.
- \`pr:create\` IPC handler runs \`commitAndPush(workspace, title)\` before \`createPullRequest\`. The PR title doubles as the commit message so history reads cleanly.
- New copy under the body editor: "Creating the PR also commits and pushes any uncommitted work in this stack's branch."

## Tests

- \`pr-creator.test.ts\`: 7 new \`commitAndPush\` tests against a real bare origin + cloned workspace — dirty-tree commit, clean-tree skip, idempotent re-runs, custom + default commit messages, surfaced git errors, missing-workspace rejection.
- \`CreatePRDialog.test.tsx\`: 6 new draft-cache tests — hydrate-from-cache skips draftBody, persists drafts to cache, persists user edits, clears on success, preserves on failure, "draft restored" hint.

## Test plan

- [ ] \`npm run typecheck\` clean
- [ ] All 1647 tests pass
- [ ] In the app: click Make PR, wait for draft, close the modal → reopen → editor opens immediately with no LLM call, "draft restored" subtitle appears
- [ ] Click Create PR on a stack with uncommitted changes + unpushed branch → PR opens on GitHub without the "you must first push" error
- [ ] Click Create PR on a stack that's already pushed (no dirty files) → idempotent, PR still opens

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)