### PR TITLE
Hand off ticket id from Create → Refine + auto-run gate (fixes #317)

### DIFF
--- a/src/renderer/components/CreateTicketDialog.tsx
+++ b/src/renderer/components/CreateTicketDialog.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from '../store';
 type Phase = 'input' | 'creating' | 'created';
 
 export function CreateTicketDialog() {
-  const { setShowCreateTicketDialog, setShowRefineTicketDialog, activeProject } = useAppStore();
+  const { setShowCreateTicketDialog, openRefineTicketDialogWith, activeProject } = useAppStore();
   const project = activeProject();
 
   const [title, setTitle] = useState('');
@@ -37,8 +37,11 @@ export function CreateTicketDialog() {
   };
 
   const handleRefineNow = () => {
-    close();
-    setShowRefineTicketDialog(true);
+    if (!created) return;
+    setShowCreateTicketDialog(false);
+    // Hand off the just-filed ticket id so Refine doesn't ask for it again
+    // (#317). The Refine dialog consumes + clears the prefill on mount.
+    openRefineTicketDialogWith(created.ticketId);
   };
 
   return (

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useAppStore, SpecGateResult } from '../store';
 
 type Phase = 'input' | 'running' | 'pass' | 'fail' | 'starting';
@@ -9,7 +9,12 @@ function suggestStackName(ticketId: string): string {
 }
 
 export function RefineTicketDialog() {
-  const { setShowRefineTicketDialog, refreshStacks, activeProject } = useAppStore();
+  const {
+    setShowRefineTicketDialog,
+    refreshStacks,
+    activeProject,
+    consumeRefineTicketPrefill,
+  } = useAppStore();
   const project = activeProject();
 
   const [ticketId, setTicketId] = useState('');
@@ -26,22 +31,25 @@ export function RefineTicketDialog() {
   const cleanTicketId = useMemo(() => ticketId.trim().replace(/^#/, ''), [ticketId]);
   const projectDir = project?.directory ?? '';
 
-  const handleRunGate = async () => {
-    if (!cleanTicketId || !projectDir) {
+  // Take ticketId as an explicit arg so the prefill auto-run effect below
+  // can call it before React has flushed the setTicketId state update.
+  const runGateFor = useCallback(async (id: string) => {
+    const cleanId = id.trim().replace(/^#/, '');
+    if (!cleanId || !projectDir) {
       setError('Ticket ID and an active project are both required');
       return;
     }
     setError(null);
     setPhase('running');
     try {
-      const result = await window.sandstorm.tickets.specCheck(cleanTicketId, projectDir);
+      const result = await window.sandstorm.tickets.specCheck(cleanId, projectDir);
       setGate(result);
       if (result.error) {
         setPhase('fail');
         setError(result.error);
       } else if (result.passed) {
         setPhase('pass');
-        setStackName((s) => s || suggestStackName(cleanTicketId));
+        setStackName((s) => s || suggestStackName(cleanId));
       } else {
         setAnswers(result.questions.map(() => ''));
         setPhase('fail');
@@ -50,7 +58,22 @@ export function RefineTicketDialog() {
       setPhase('fail');
       setError(err instanceof Error ? err.message : String(err));
     }
-  };
+  }, [projectDir]);
+
+  const handleRunGate = () => runGateFor(cleanTicketId);
+
+  // Hand-off from CreateTicketDialog → "Refine #N" (#317). When the dialog
+  // opens with a prefilled id, hydrate the input and kick off the gate
+  // immediately so the user lands on the result instead of an asking-for-id
+  // input they just answered seconds ago in the previous modal.
+  useEffect(() => {
+    const prefill = consumeRefineTicketPrefill();
+    if (!prefill) return;
+    setTicketId(prefill);
+    void runGateFor(prefill);
+    // Run once on mount; consumeRefineTicketPrefill is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSubmitAnswers = async () => {
     if (!cleanTicketId || !projectDir) return;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -335,6 +335,13 @@ interface AppState {
   selectedStackId: string | null;
   showNewStackDialog: boolean;
   showRefineTicketDialog: boolean;
+  /**
+   * Optional ticket id passed when opening the Refine dialog from another
+   * surface (e.g. the Create-Ticket success screen's "Refine #N" hand-off).
+   * The Refine dialog reads + clears it on mount. Null when the user opened
+   * Refine cold from the Tickets strip and should type the id themselves.
+   */
+  refineTicketPrefill: string | null;
   showCreateTicketDialog: boolean;
   showStartTicketDialog: boolean;
   showCreatePRDialog: { stackId: string } | null;
@@ -420,6 +427,9 @@ interface AppState {
   selectStack: (id: string | null) => void;
   setShowNewStackDialog: (show: boolean) => void;
   setShowRefineTicketDialog: (show: boolean) => void;
+  /** Open the Refine dialog with a ticket id already filled in. */
+  openRefineTicketDialogWith: (ticketId: string) => void;
+  consumeRefineTicketPrefill: () => string | null;
   setShowCreateTicketDialog: (show: boolean) => void;
   setShowStartTicketDialog: (show: boolean) => void;
   setShowCreatePRDialog: (state: { stackId: string } | null) => void;
@@ -658,6 +668,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedStackId: null,
   showNewStackDialog: false,
   showRefineTicketDialog: false,
+  refineTicketPrefill: null,
   showCreateTicketDialog: false,
   showStartTicketDialog: false,
   showCreatePRDialog: null,
@@ -845,7 +856,21 @@ export const useAppStore = create<AppState>((set, get) => ({
   setStacks: (stacks) => set({ stacks }),
   selectStack: (id) => set({ selectedStackId: id }),
   setShowNewStackDialog: (show) => set({ showNewStackDialog: show }),
-  setShowRefineTicketDialog: (show) => set({ showRefineTicketDialog: show }),
+  setShowRefineTicketDialog: (show) => set({
+    showRefineTicketDialog: show,
+    // Closing the dialog drops any pending prefill so a later cold-open
+    // doesn't accidentally hydrate from a stale id.
+    refineTicketPrefill: show ? get().refineTicketPrefill : null,
+  }),
+  openRefineTicketDialogWith: (ticketId) => set({
+    showRefineTicketDialog: true,
+    refineTicketPrefill: ticketId,
+  }),
+  consumeRefineTicketPrefill: () => {
+    const value = get().refineTicketPrefill;
+    if (value !== null) set({ refineTicketPrefill: null });
+    return value;
+  },
   setShowCreateTicketDialog: (show) => set({ showCreateTicketDialog: show }),
   setShowStartTicketDialog: (show) => set({ showStartTicketDialog: show }),
   setShowCreatePRDialog: (state) => set({ showCreatePRDialog: state }),

--- a/tests/unit/components/CreateTicketDialog.test.tsx
+++ b/tests/unit/components/CreateTicketDialog.test.tsx
@@ -66,6 +66,9 @@ describe('CreateTicketDialog', () => {
     fireEvent.click(screen.getByTestId('create-ticket-refine-now'));
     expect(useAppStore.getState().showCreateTicketDialog).toBe(false);
     expect(useAppStore.getState().showRefineTicketDialog).toBe(true);
+    // #317 — the just-filed ticket id is handed off so the Refine dialog
+    // doesn't ask for it again.
+    expect(useAppStore.getState().refineTicketPrefill).toBe('77');
   });
 
   it('surfaces an error from tickets.create', async () => {

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -18,6 +18,7 @@ describe('RefineTicketDialog', () => {
       projects: [{ id: 1, name: 'proj', directory: '/proj', added_at: '' }],
       activeProjectId: 1,
       showRefineTicketDialog: true,
+      refineTicketPrefill: null,
       stacks: [],
     });
   });
@@ -172,6 +173,48 @@ describe('RefineTicketDialog', () => {
     fireEvent.click(screen.getByTestId('refine-run-gate'));
     await waitFor(() => {
       expect(screen.getByTestId('refine-error').textContent).toMatch(/gh rate limit/);
+    });
+  });
+
+  // #317 — opening Refine via "Refine #N" hand-off from Create should not
+  // re-prompt for the id; the gate should fire automatically.
+  describe('prefill hand-off (#317)', () => {
+    it('hydrates the ticket id from refineTicketPrefill on mount', () => {
+      useAppStore.setState({ refineTicketPrefill: '77' });
+      api.tickets.specCheck.mockResolvedValue({
+        passed: true, questions: [], gateSummary: '', ticketUrl: null, cached: false,
+      });
+      render(<RefineTicketDialog />);
+      const input = screen.getByTestId('refine-ticket-id') as HTMLInputElement;
+      expect(input.value).toBe('77');
+    });
+
+    it('auto-runs the gate when opened with a prefill', async () => {
+      useAppStore.setState({ refineTicketPrefill: '77' });
+      api.tickets.specCheck.mockResolvedValue({
+        passed: true, questions: [], gateSummary: 'Gate=PASS', ticketUrl: null, cached: false,
+      });
+      render(<RefineTicketDialog />);
+      await waitFor(() => {
+        expect(api.tickets.specCheck).toHaveBeenCalledWith('77', '/proj');
+      });
+      // Lands on the pass state — user goes straight to Start Stack.
+      await waitFor(() => screen.getByTestId('refine-pass'));
+    });
+
+    it('clears the prefill after consuming it (so reopening cold doesn\'t re-fire)', () => {
+      useAppStore.setState({ refineTicketPrefill: '77' });
+      api.tickets.specCheck.mockResolvedValue({
+        passed: false, questions: [], gateSummary: '', ticketUrl: null, cached: false,
+      });
+      render(<RefineTicketDialog />);
+      expect(useAppStore.getState().refineTicketPrefill).toBeNull();
+    });
+
+    it('does NOT auto-run when there is no prefill (user opened Refine cold)', () => {
+      useAppStore.setState({ refineTicketPrefill: null });
+      render(<RefineTicketDialog />);
+      expect(api.tickets.specCheck).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

The "Refine #N" button on the Create-Ticket success screen closed the Create modal and opened the Refine modal — but didn't pass the just-filed ticket id along. The user had to retype the id they'd been shown two seconds earlier on the same dialog. Worse, even after typing they still had to click Run Gate, when the whole point of the hand-off is "you just made this, let's gate it now".

## Fix

- **New \`refineTicketPrefill: string | null\` slot in the store**, with \`openRefineTicketDialogWith(ticketId)\` (set + open in one action) and \`consumeRefineTicketPrefill()\` (read + clear, so a later cold open doesn't hydrate from a stale id). \`setShowRefineTicketDialog(false)\` also clears any pending prefill.
- **CreateTicketDialog** — Refine button now calls \`openRefineTicketDialogWith(created.ticketId)\` instead of just toggling the boolean.
- **RefineTicketDialog** — consumes the prefill on mount, hydrates the input, and immediately fires the gate via a new \`runGateFor(id)\` helper that takes the id explicitly (avoids racing the setTicketId state update). Cold opens (no prefill) keep the old behavior: empty input → user types → clicks Run Gate.

## Tests

- CreateTicketDialog test asserts \`refineTicketPrefill\` is set to the filed ticket id when "Refine #N" is clicked.
- 4 new RefineTicketDialog tests: hydrate from prefill, auto-run the gate, clear the prefill after consuming, no auto-run when opened cold.

## Test plan

- [ ] \`npm run typecheck\` clean
- [ ] All 1651 tests pass
- [ ] In the app: open Create Ticket, fill title + body, File → "Filed issue #N" success state appears → click Refine #N → Refine dialog opens with the id pre-filled and the gate already running, no second click needed.
- [ ] Open Refine cold from the Tickets strip → input is empty, no auto-run.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)