### PR TITLE
Pin actions column + always-show Teardown + suppress popover (fixes #316)

### DIFF
--- a/src/renderer/components/Dashboard.tsx
+++ b/src/renderer/components/Dashboard.tsx
@@ -26,13 +26,16 @@ import { formatTokenCount } from '../utils/format';
 // Trimmed table layout (#315). Dropped columns: description, services bubbles,
 // resources — all moved into the row hover popover. Storage key bumped to v2
 // so saved widths from the old layout don't wreck the new one.
-const TABLE_COLUMNS: (ColumnDef & { label: string; align?: 'left' | 'right' })[] = [
+//
+// `actions` is sticky-right + has no resize handle (it's last) so the buttons
+// stay visible regardless of horizontal scroll or other column widths (#316).
+const TABLE_COLUMNS: (ColumnDef & { label: string; align?: 'left' | 'right'; stickyRight?: boolean })[] = [
   { key: 'status', label: 'Status', minWidth: 60, defaultWidth: 90 },
   { key: 'name', label: 'Name', minWidth: 100, defaultWidth: 200 },
   { key: 'model', label: 'Model', minWidth: 50, defaultWidth: 80 },
   { key: 'services', label: 'Svcs', minWidth: 50, defaultWidth: 70 },
   { key: 'duration', label: 'Duration', minWidth: 50, defaultWidth: 90 },
-  { key: 'actions', label: '', minWidth: 80, defaultWidth: 120, align: 'right' as const },
+  { key: 'actions', label: '', minWidth: 160, defaultWidth: 160, align: 'right' as const, stickyRight: true },
 ];
 
 const STACK_TABLE_STORAGE_KEY = 'stack-table-v2';
@@ -794,6 +797,10 @@ export function Dashboard() {
                 ))}
               </div>
             ) : (
+              // Wrap in overflow-x-auto so the actions sticky-right cell
+              // has a horizontal scroll context to anchor against on
+              // narrow viewports (#316).
+              <div className="overflow-x-auto">
               <table className="w-full text-xs" style={{ tableLayout: 'fixed' }} data-testid="stack-table">
                 <ResizableTableHeader
                   columns={TABLE_COLUMNS}
@@ -806,6 +813,7 @@ export function Dashboard() {
                   ))}
                 </tbody>
               </table>
+              </div>
             )
           ) : (
             history.length === 0 ? (

--- a/src/renderer/components/ResizableTableHeader.tsx
+++ b/src/renderer/components/ResizableTableHeader.tsx
@@ -2,22 +2,28 @@ import React from 'react';
 import { ColumnDef } from '../hooks/useResizableColumns';
 
 interface ResizableTableHeaderProps {
-  columns: (ColumnDef & { label: string; align?: 'left' | 'right' })[];
+  columns: (ColumnDef & { label: string; align?: 'left' | 'right'; stickyRight?: boolean })[];
   columnWidths: Record<string, number>;
   onResizeStart: (columnKey: string, startX: number) => void;
 }
 
 export function ResizableTableHeader({ columns, columnWidths, onResizeStart }: ResizableTableHeaderProps) {
   return (
-    <thead>
+    <thead className="bg-sandstorm-bg">
       <tr className="border-b border-sandstorm-border text-sandstorm-muted">
         {columns.map((col, i) => {
           const isLast = i === columns.length - 1;
           const width = columnWidths[col.key] ?? col.defaultWidth;
+          // Sticky-right keeps the actions header pinned to the viewport
+          // edge during horizontal scroll so it stays aligned with its
+          // sticky-right cells below (#316).
+          const stickyClasses = col.stickyRight
+            ? 'sticky right-0 z-[2] bg-sandstorm-bg border-l border-sandstorm-border'
+            : '';
           return (
             <th
               key={col.key}
-              className={`${col.align === 'right' ? 'text-right' : 'text-left'} font-medium px-3 py-2 relative select-none`}
+              className={`${col.align === 'right' ? 'text-right' : 'text-left'} font-medium px-3 py-2 relative select-none ${stickyClasses}`}
               style={{ width: `${width}px`, minWidth: `${col.minWidth}px` }}
               data-testid={`col-header-${col.key}`}
             >

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -86,6 +86,19 @@ export function StackTableRow({
     setPopoverRect(null);
   };
 
+  // #316 — the popover is anchored to the row's right edge and overlaps
+  // the action buttons in narrow viewports, blocking clicks. Suppress it
+  // entirely when the cursor enters the actions cell so buttons stay
+  // clickable. We don't auto-reopen on leave; the user can mouse off and
+  // back on if they want details again.
+  const handleActionsEnter = () => {
+    if (enterTimer.current) {
+      clearTimeout(enterTimer.current);
+      enterTimer.current = null;
+    }
+    setPopoverRect(null);
+  };
+
   const runningCount = stack.services.filter((s) => s.status === 'running').length;
   const totalCount = stack.services.length;
   const statusColor = STATUS_COLORS[stack.status] ?? 'bg-gray-500';
@@ -118,7 +131,7 @@ export function StackTableRow({
     <>
       <tr
         ref={rowRef}
-        className="border-b border-sandstorm-border hover:bg-sandstorm-surface-hover cursor-pointer transition-colors group"
+        className="border-b border-sandstorm-border bg-sandstorm-bg hover:bg-sandstorm-surface-hover cursor-pointer transition-colors group"
         onClick={() => selectStack(stack.id)}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
@@ -182,8 +195,13 @@ export function StackTableRow({
           {duration}
         </td>
         <td
-          className="px-3 py-2 whitespace-nowrap text-right overflow-hidden"
+          className="px-3 py-2 whitespace-nowrap text-right overflow-hidden sticky right-0 z-[1] bg-sandstorm-bg group-hover:bg-sandstorm-surface-hover border-l border-sandstorm-border"
+          // Width is fixed by `actions.defaultWidth` in TABLE_COLUMNS — the
+          // column has no resize handle (it's last in the row), so the
+          // user can't drag it shrunk and lose the buttons (#316).
           style={columnWidths?.actions ? { width: `${columnWidths.actions}px` } : undefined}
+          data-testid={`row-actions-${stack.id}`}
+          onMouseEnter={handleActionsEnter}
         >
           <div className="flex items-center gap-1 justify-end">
             {/* Persistent primary action — always visible when applicable */}
@@ -197,30 +215,30 @@ export function StackTableRow({
                 🆕 Make PR
               </button>
             )}
-            {/* Secondary actions — hover-gated */}
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              {stack.status !== 'running' && (
-                <button
-                  onClick={handleTeardown}
-                  className="text-[10px] px-1.5 py-0.5 rounded text-red-400 hover:bg-red-500/10 transition-colors"
-                >
-                  Teardown
-                </button>
-              )}
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-sandstorm-muted"
+            {/* Teardown — always visible (#316). Was opacity-0 group-hover
+                but the user couldn't reach it without the popover blocking. */}
+            {stack.status !== 'running' && (
+              <button
+                onClick={handleTeardown}
+                className="text-[10px] px-1.5 py-0.5 rounded text-red-400 hover:bg-red-500/10 transition-colors"
+                data-testid={`row-teardown-${stack.id}`}
               >
-                <path d="M9 18l6-6-6-6" />
-              </svg>
-            </div>
+                Teardown
+              </button>
+            )}
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-sandstorm-muted"
+            >
+              <path d="M9 18l6-6-6-6" />
+            </svg>
           </div>
         </td>
       </tr>

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { StackTableRow } from '../../../src/renderer/components/StackTableRow';
 import { useAppStore, Stack } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
@@ -227,5 +227,89 @@ describe('StackTableRow primary-action chip (#315)', () => {
     const link = screen.getByTestId('row-pr-link-open');
     expect(link).toBeDefined();
     expect(link.textContent).toMatch(/#312/);
+  });
+});
+
+describe('StackTableRow action button visibility (#316)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSandstormApi();
+    useAppStore.setState({ stacks: [], selectedStackId: null, stackMetrics: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('Teardown is visible without hovering the row (no opacity-0 wrapper)', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'foo', status: 'completed' }));
+    const teardown = screen.getByTestId('row-teardown-foo');
+    // Walk the parent chain — none should carry opacity-0 / group-hover.
+    let el: HTMLElement | null = teardown;
+    while (el) {
+      expect(el.className).not.toMatch(/opacity-0/);
+      expect(el.className).not.toMatch(/group-hover:opacity-100/);
+      el = el.parentElement;
+    }
+  });
+
+  it('Teardown is hidden while a task is running (destructive guard, unchanged)', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'busy', status: 'running' }));
+    expect(screen.queryByTestId('row-teardown-busy')).toBeNull();
+  });
+
+  it('actions cell is sticky to the right edge so it stays visible during scroll', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'foo', status: 'completed' }));
+    const cell = screen.getByTestId('row-actions-foo');
+    // Tailwind's `sticky right-0` on a <td> — verify the classes survived.
+    expect(cell.className).toMatch(/\bsticky\b/);
+    expect(cell.className).toMatch(/right-0/);
+  });
+});
+
+describe('StackTableRow popover suppression on actions hover (#316)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSandstormApi();
+    useAppStore.setState({ stacks: [], selectedStackId: null, stackMetrics: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('cancels the pending popover when the cursor enters the actions cell', async () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'foo', status: 'completed' }));
+
+    // Hover the row — popover would normally appear after the open delay.
+    const row = screen.getByTestId('row-actions-foo').closest('tr')!;
+    fireEvent.mouseEnter(row);
+
+    // Cursor moves to the actions cell BEFORE the delay elapses.
+    const actions = screen.getByTestId('row-actions-foo');
+    fireEvent.mouseEnter(actions);
+
+    // Run timers; popover should NOT have opened.
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(screen.queryByTestId(/stack-row-popover-/)).toBeNull();
+  });
+
+  it('hides an already-open popover when the cursor enters the actions cell', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'foo', status: 'completed' }));
+
+    const row = screen.getByTestId('row-actions-foo').closest('tr')!;
+    fireEvent.mouseEnter(row);
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(screen.queryByTestId('stack-row-popover-foo')).not.toBeNull();
+
+    // Now move cursor to actions — popover should disappear.
+    const actions = screen.getByTestId('row-actions-foo');
+    fireEvent.mouseEnter(actions);
+    expect(screen.queryByTestId('stack-row-popover-foo')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Three issues with the trimmed table view shipped in #315 — all on the actions column:

1. **Popover overlapped action buttons.** The hover popover is anchored to the row's right edge; on narrow viewports it covered Teardown / Make PR and blocked clicks.
2. **Teardown only visible on hover.** It was wrapped in \`opacity-0 group-hover:opacity-100\`, so it appeared on hover — but the popover that ALSO appeared on hover was visually in the way.
3. **Actions column scrolled off-screen** on narrow windows because there was no horizontal-scroll anchor, so the buttons were completely hidden until the user scrolled.

## Fixes

- **Sticky-right actions cell + header** with bg matching the row hover state. They stay pinned to the viewport's right edge regardless of horizontal scroll. The table wrapper got \`overflow-x-auto\` so the sticky cells have a defined scroll context.
- **No resize / no shrink on actions column.** It was already last in the header (so the existing header already skipped its resize handle), but I also bumped \`minWidth\` to equal \`defaultWidth\` (160px) so stale localStorage values can't make it narrower than the buttons need.
- **Dropped the \`opacity-0 group-hover\` wrapper around Teardown.** Always visible now. (Still hidden while a task is running — that destructive-action guard is unchanged.)
- **\`onMouseEnter\` on the actions cell cancels the popover.** Cancels any pending popover-open timer AND closes any already-open popover. The user can now move the cursor from row → action buttons without the tooltip blocking. No auto-reopen on actions-leave; mousing off the row + back on still triggers the popover for users who want details again.

## Tests

5 new tests in \`StackTableRow.test.tsx\`:
- Teardown has no \`opacity-0\` / \`group-hover:opacity-100\` ancestor
- Teardown still hidden while a task is running (destructive-action guard unchanged)
- Actions cell carries the \`sticky right-0\` classes
- Pending popover cancelled when cursor enters actions before the open delay
- Already-open popover closes immediately on actions hover

## Test plan

- [ ] \`npm run typecheck\` clean
- [ ] All 1656 tests pass
- [ ] In the app: shrink the window narrow enough that the table would normally scroll → actions column stays pinned to the right edge, all buttons visible
- [ ] Hover a row → popover appears → move cursor toward Teardown → popover disappears, button is clickable
- [ ] Teardown visible on every non-running stack row without any hover

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)