### PR TITLE
Add Dockerfile.sandstorm with jq for token-counter tests (#332)

### DIFF
--- a/Dockerfile.sandstorm
+++ b/Dockerfile.sandstorm
@@ -1,0 +1,44 @@
+FROM node:22
+
+# Electron system dependencies (headless) + jq for token-counter.sh integration tests.
+# This file is used by docker-compose.yml (sandstorm stack) instead of Dockerfile
+# so that jq is available when `npm test` runs token-counter.test.ts inside the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libxshmfence1 \
+    libgtk-3-0 \
+    libdbus-1-3 \
+    xvfb \
+    xauth \
+    jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI — needed by the app to fetch account usage stats
+RUN npm install -g @anthropic-ai/claude-code
+
+ENV DISPLAY=:99
+
+WORKDIR /app
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["xvfb-run", "--auto-servernum", "npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.sandstorm
     ports:
       - "5173:5173"
     volumes:

--- a/tests/unit/project-dockerfile.test.ts
+++ b/tests/unit/project-dockerfile.test.ts
@@ -2,6 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
+describe('Dockerfile.sandstorm (docker-compose app container)', () => {
+  const dockerfilePath = resolve(__dirname, '../../Dockerfile.sandstorm');
+  const dockerfile = readFileSync(dockerfilePath, 'utf-8');
+
+  it('includes jq for token-counter.sh integration tests', () => {
+    expect(dockerfile).toContain('jq');
+  });
+
+  it('includes required Electron dependencies', () => {
+    const electronDeps = ['libnss3', 'libatk1.0-0', 'libgbm1', 'libgtk-3-0', 'xvfb'];
+    for (const dep of electronDeps) {
+      expect(dockerfile).toContain(dep);
+    }
+  });
+
+  it('CMD uses xvfb-run with --auto-servernum', () => {
+    expect(dockerfile).toMatch(/CMD\s.*xvfb-run.*--auto-servernum/);
+  });
+});
+
 describe('Project Dockerfile', () => {
   const dockerfilePath = resolve(__dirname, '../../Dockerfile');
   const dockerfile = readFileSync(dockerfilePath, 'utf-8');
@@ -38,5 +58,9 @@ describe('docker-compose.yml app service', () => {
 
   it('uses xvfb-run in command to support headless Electron', () => {
     expect(compose).toContain('xvfb-run');
+  });
+
+  it('builds from Dockerfile.sandstorm so jq is available for npm test', () => {
+    expect(compose).toContain('Dockerfile.sandstorm');
   });
 });


### PR DESCRIPTION
## Root cause

`tests/unit/token-counter.test.ts` was failing reproducibly inside the sandstorm verify loop (observed on stacks ticket-328, ticket-334, ticket-332). The verify path correctly routes `npm test` to the app container via `sandstorm-exec app npm test`, but that container is built from the top-level `Dockerfile`, which never installs `jq`. `sandstorm-cli/docker/token-counter.sh` shells out to `jq` with `2>/dev/null`, so missing-binary errors are swallowed and assertions fail with confusing "expected [] to have length N" messages instead of pointing at the missing dependency.

## Fix

Introduce a sandstorm-only build of the app image:

- **`Dockerfile.sandstorm`** — mirror of the top-level `Dockerfile` with `jq` added to the apt-get install list. Header comment explains why this exists. Production builds are unaffected.
- **`docker-compose.yml`** — switches the `app` service's build to `dockerfile: Dockerfile.sandstorm` so stacks pick up `jq`.
- **`tests/unit/project-dockerfile.test.ts`** — adds 4 assertions covering the new file (jq present, Electron deps present, correct CMD) and that compose references it.

## Notes

- Production `Dockerfile` is intentionally untouched. `jq` is a sandstorm-test-only need; not worth bloating the shipped image.
- `sandstorm-cli/docker/Dockerfile` already has `jq` (line 15) — that's the claude/workspace image, not the test runtime. Untouched here.
- The bogus app-`Dockerfile` `+ jq` line introduced by ticket-328's earlier diagnosis should be dropped from that PR; this is the correct fix.

## Related

- #333 — dual-loop iteration cap not enforced (this stack ran 5 review iterations chasing other things after the fix landed in iter 1)
- #335 — scope-preservation across iterations + stop-and-ask
- #336 — tests audit for hidden environment assumptions