### PR TITLE
add resume button for halted stacks (token limit)

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -301,6 +301,16 @@ while true; do
       rm -f /tmp/claude-task-model.txt
     fi
 
+    # Read resume session id if provided (set by --resume flag in dispatchContinuation)
+    RESUME_ARGS=()
+    if [ -f /tmp/claude-task-resume.txt ]; then
+      RESUME_SESSION_ID=$(cat /tmp/claude-task-resume.txt 2>/dev/null | tr -d '[:space:]')
+      if [ -n "$RESUME_SESSION_ID" ]; then
+        RESUME_ARGS=(--resume "$RESUME_SESSION_ID")
+      fi
+      rm -f /tmp/claude-task-resume.txt
+    fi
+
     echo ""
     echo "=========================================="
     echo "  Task: $LABEL"
@@ -333,8 +343,20 @@ while true; do
 
     log_loop "Starting initial execution pass..."
     echo "execution_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
-    run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}"
+    run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}" "${RESUME_ARGS[@]}"
     EXIT_CODE=${PIPESTATUS[0]}
+
+    # Edge Case 6: if --resume failed, fall back to a fresh dispatch with the original prompt
+    if [ $EXIT_CODE -ne 0 ] && [ ${#RESUME_ARGS[@]} -gt 0 ]; then
+      log_loop "Resume dispatch failed (exit $EXIT_CODE) — session data may be unavailable, falling back to fresh dispatch..."
+      echo "" >> /tmp/claude-task.log
+      echo "⚠️ WARNING: Session resume failed (session data unavailable). Starting fresh dispatch." >> /tmp/claude-task.log
+      > /tmp/claude-raw.log
+      RESUME_ARGS=()
+      run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}"
+      EXIT_CODE=${PIPESTATUS[0]}
+    fi
+
     echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
 
     # Capture execution summary (last 50 lines of task log)

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -407,11 +407,13 @@ case "$COMMAND" in
     SYNC_MODE=false
     TICKET=""
     TASK_MODEL=""
+    TASK_RESUME_SESSION_ID=""
     while true; do
       case "${1:-}" in
         --sync) SYNC_MODE=true; shift ;;
         --ticket) TICKET="$2"; shift 2 ;;
         --model) TASK_MODEL="$2"; shift 2 ;;
+        --resume) TASK_RESUME_SESSION_ID="$2"; shift 2 ;;
         *) break ;;
       esac
     done
@@ -465,6 +467,12 @@ case "$COMMAND" in
       if [ -n "$TASK_MODEL" ]; then
         echo "$TASK_MODEL" | docker exec -i -u claude "$CONTAINER_NAME" \
           bash -c "cat > /tmp/claude-task-model.txt"
+      fi
+
+      # Write resume session id file if specified
+      if [ -n "$TASK_RESUME_SESSION_ID" ]; then
+        echo "$TASK_RESUME_SESSION_ID" | docker exec -i -u claude "$CONTAINER_NAME" \
+          bash -c "cat > /tmp/claude-task-resume.txt"
       fi
 
       # Trigger the task runner (runs as the container's main process, output goes to docker logs)

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -72,6 +72,7 @@ export interface Task {
   verify_finished_at: string | null;
   started_at: string;
   finished_at: string | null;
+  resumed_at: string | null;
 }
 
 export interface TokenUsage {
@@ -479,8 +480,14 @@ export class Registry {
       this.setSchemaVersion(13);
     }
 
+    if (currentVersion < 14) {
+      // Add resumed_at column to tasks for tracking session-pause continuations
+      try { this.db.exec('ALTER TABLE tasks ADD COLUMN resumed_at TEXT'); } catch { /* exists */ }
+      this.setSchemaVersion(14);
+    }
+
     // Future migrations go here:
-    // if (currentVersion < 14) { ... this.setSchemaVersion(14); }
+    // if (currentVersion < 15) { ... this.setSchemaVersion(15); }
   }
 
   // --- Projects ---
@@ -841,6 +848,12 @@ export class Registry {
     this.db.prepare(
       "UPDATE tasks SET status = 'interrupted', finished_at = datetime('now') WHERE id = ? AND status = 'running'"
     ).run(taskId);
+  }
+
+  setTaskResumedAt(taskId: number, ts: string): void {
+    this.db.prepare(
+      'UPDATE tasks SET resumed_at = ? WHERE id = ?'
+    ).run(ts, taskId);
   }
 
   getStackTokenUsage(stackId: string): TokenUsage {

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -570,6 +570,113 @@ export class StackManager {
     return resumed;
   }
 
+  /**
+   * Resume a session_paused stack and continue the in-flight task.
+   * Cases:
+   *   A — running task with session_id  → resume Claude session with --resume
+   *   B — running task, no session_id   → interrupt old task, dispatch fresh
+   *   C — no running task               → containers come up, status → idle
+   * Throws if the stack is not found or containers cannot be started.
+   */
+  async resumeStackWithContinuation(
+    stackId: string,
+    isHalted: () => boolean = () => false
+  ): Promise<{
+    outcome: 'resuming_with_session' | 'resumed_fresh' | 'idle';
+  }> {
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    // Pre-flight: block resume if session token limit hasn't refreshed yet
+    if (isHalted()) {
+      throw new SandstormError(ErrorCode.SESSION_HALTED, 'Session token limit has not refreshed yet');
+    }
+
+    // Guard: only act on session_paused stacks
+    if (stack.status !== 'session_paused') {
+      return { outcome: 'idle' };
+    }
+
+    // Bring containers up synchronously
+    this.registry.updateStackStatus(stackId, 'building');
+    this.notifyUpdate();
+    try {
+      await this.ensureStackContainersRunning(stack, stackId);
+    } catch (err) {
+      // Revert to session_paused on container failure so the user can retry
+      this.registry.updateStackStatus(stackId, 'session_paused');
+      this.notifyUpdate();
+      throw err;
+    }
+
+    const runningTask = this.registry.getRunningTask(stackId);
+
+    if (!runningTask) {
+      // Case C: no in-flight task — leave stack idle
+      this.registry.updateStackStatus(stackId, 'idle');
+      this.notifyUpdate();
+      return { outcome: 'idle' };
+    }
+
+    if (runningTask.session_id) {
+      // Case A: resume with existing Claude session
+      await this.dispatchContinuation(stack, stackId, runningTask);
+      return { outcome: 'resuming_with_session' };
+    } else {
+      // Case B: session not yet logged — interrupt and redispatch fresh
+      this.registry.interruptTask(runningTask.id);
+      await this.dispatchTask(stackId, runningTask.prompt, runningTask.model ?? undefined, {
+        skipTicketFetch: true,
+      });
+      return { outcome: 'resumed_fresh' };
+    }
+  }
+
+  /**
+   * Re-dispatch an existing running task using `--resume <session_id>`.
+   * Does NOT create a new task row — the caller's existing task is reused and
+   * `resumed_at` is stamped so the UI can distinguish continuations.
+   */
+  private async dispatchContinuation(
+    stack: Stack,
+    stackId: string,
+    task: Task
+  ): Promise<void> {
+    const runtime = this.getRuntimeForStack(stack);
+    let claudeContainer = await this.findClaudeContainer(stack, runtime);
+
+    if (claudeContainer.status !== 'running') {
+      await this.ensureStackContainersRunning(stack, stackId);
+      claudeContainer = await this.findClaudeContainer(stack, runtime);
+    }
+
+    await this.waitForClaudeReady(claudeContainer.id, runtime);
+
+    this.registry.setTaskResumedAt(task.id, new Date().toISOString());
+    this.registry.updateStackStatus(stackId, 'running');
+    this.notifyUpdate();
+
+    const continuationPrompt =
+      'Continue the work that was halted by token limits. Keep going from where you left off.';
+
+    const cliArgs = ['task', stackId, '--resume', task.session_id!];
+    if (task.model) cliArgs.push('--model', task.model);
+    cliArgs.push(continuationPrompt);
+
+    const result = await this.runCli(stack.project_dir, cliArgs);
+    if (result.exitCode !== 0) {
+      this.registry.updateStackStatus(stackId, 'session_paused');
+      this.notifyUpdate();
+      throw new SandstormError(
+        ErrorCode.TASK_DISPATCH_FAILED,
+        result.stderr.trim() || result.stdout.trim() || 'Resume dispatch failed'
+      );
+    }
+
+    this.taskWatcher.watch(stackId, claudeContainer.id);
+    this.taskWatcher.streamOutput(stackId, claudeContainer.id, () => {}).catch(() => {});
+  }
+
   async teardownStack(stackId: string): Promise<void> {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
@@ -673,7 +780,7 @@ export class StackManager {
     stackId: string,
     prompt: string,
     model?: string,
-    opts?: { gateApproved?: boolean; forceBypass?: boolean }
+    opts?: { gateApproved?: boolean; forceBypass?: boolean; skipTicketFetch?: boolean }
   ): Promise<DispatchTaskResult> {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
@@ -706,8 +813,10 @@ export class StackManager {
     }
 
     // If the stack has a ticket number, fetch the full ticket context
-    // via the project's fetch-ticket script and prepend it to the prompt
-    if (stack.ticket) {
+    // via the project's fetch-ticket script and prepend it to the prompt.
+    // Skipped when the caller has already embedded ticket context in the prompt
+    // (e.g. re-dispatch of an interrupted task whose stored prompt includes it).
+    if (stack.ticket && !opts?.skipTicketFetch) {
       const ticketContext = await fetchTicketContext(stack.ticket, stack.project_dir);
       if (ticketContext) {
         prompt = `${ticketContext}\n\n---\n\n## Task\n\n${prompt}`;

--- a/src/main/errors.ts
+++ b/src/main/errors.ts
@@ -17,6 +17,7 @@ export enum ErrorCode {
   INVALID_INPUT = 'INVALID_INPUT',
   INTERNAL_ERROR = 'INTERNAL_ERROR',
   GATE_CHECK_REQUIRED = 'GATE_CHECK_REQUIRED',
+  SESSION_HALTED = 'SESSION_HALTED',
 }
 
 export class SandstormError extends Error {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,6 +23,7 @@ import {
 import type { ScheduleAction } from './scheduler/types';
 import { BUILT_IN_ACTIONS } from './scheduler/built-in-actions';
 import { validateProjectDir } from './validation';
+import { SandstormError, ErrorCode } from './errors';
 import { syncAllProjectsCrontab, projectIdFromDir } from './scheduler/scheduler-manager';
 import { StackManager } from './control-plane/stack-manager';
 import { CreateStackOpts } from './control-plane/stack-manager';
@@ -954,6 +955,22 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   ipcMain.handle('session:resumeStack', (_event, stackId: string) => {
     stackManager.sessionResumeStack(stackId);
+  });
+
+  ipcMain.handle('session:resumeStackWithContinuation', async (_event, stackId: string) => {
+    try {
+      const result = await stackManager.resumeStackWithContinuation(
+        stackId,
+        () => sessionMonitor.getState().halted
+      );
+      return { halted: false, ...result };
+    } catch (err) {
+      if (err instanceof SandstormError && err.code === ErrorCode.SESSION_HALTED) {
+        const resetAt = sessionMonitor.getState().usage?.session?.resetsAt ?? null;
+        return { halted: true, resetAt };
+      }
+      throw err;
+    }
   });
 
   ipcMain.handle('session:forcePoll', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -169,6 +169,11 @@ export interface SandstormAPI {
     haltAll: () => Promise<string[]>;
     resumeAll: () => Promise<string[]>;
     resumeStack: (stackId: string) => Promise<void>;
+    resumeStackWithContinuation: (stackId: string) => Promise<{
+      halted: boolean;
+      resetAt?: string | null;
+      outcome?: 'resuming_with_session' | 'resumed_fresh' | 'idle';
+    }>;
     forcePoll: () => Promise<unknown>;
     reportActivity: () => void;
   };
@@ -332,6 +337,8 @@ const api: SandstormAPI = {
     haltAll: () => ipcRenderer.invoke('session:haltAll'),
     resumeAll: () => ipcRenderer.invoke('session:resumeAll'),
     resumeStack: (stackId) => ipcRenderer.invoke('session:resumeStack', stackId),
+    resumeStackWithContinuation: (stackId) =>
+      ipcRenderer.invoke('session:resumeStackWithContinuation', stackId),
     forcePoll: () => ipcRenderer.invoke('session:forcePoll'),
     reportActivity: () => { ipcRenderer.send('session:activity'); },
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { ProjectTabs } from './components/ProjectTabs';
 import { OpenProjectDialog } from './components/OpenProjectDialog';
 import { AccountUsageBar } from './components/AccountUsageBar';
 import { SessionWarningModal } from './components/SessionWarningModal';
+import { SessionTokenLimitModal } from './components/SessionTokenLimitModal';
 import trayIcon from './tray-icon.png';
 import buildVersion from './build-version.txt?raw';
 
@@ -260,6 +261,9 @@ export default function App() {
           onClose={() => setShowSessionWarningModal(false)}
         />
       )}
+
+      {/* Token-limit-not-refreshed modal — shown when user clicks Resume too early */}
+      <SessionTokenLimitModal />
     </div>
   );
 }

--- a/src/renderer/components/SessionTokenLimitModal.tsx
+++ b/src/renderer/components/SessionTokenLimitModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useAppStore } from '../store';
+
+export function SessionTokenLimitModal() {
+  const { sessionTokenLimitModal, setSessionTokenLimitModal } = useAppStore();
+
+  if (!sessionTokenLimitModal) return null;
+
+  const { resetAt } = sessionTokenLimitModal;
+
+  let resetLabel = 'later';
+  if (resetAt) {
+    try {
+      resetLabel = new Date(resetAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      // invalid date — keep default
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      data-testid="session-token-limit-modal"
+    >
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl p-6 max-w-sm w-full mx-4 shadow-xl">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="w-8 h-8 rounded-full bg-orange-500/20 flex items-center justify-center shrink-0">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-orange-400">
+              <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+            </svg>
+          </div>
+          <h2 className="text-[15px] font-semibold text-sandstorm-text">Token limit not yet refreshed</h2>
+        </div>
+        <p className="text-[13px] text-sandstorm-text-secondary mb-4">
+          The account's usage window hasn't reset yet.{' '}
+          {resetAt
+            ? <>Resume will be available at <span className="font-medium text-sandstorm-text">{resetLabel}</span>.</>
+            : 'Resume will be available once the limit refreshes.'}
+        </p>
+        <button
+          onClick={() => setSessionTokenLimitModal(null)}
+          className="w-full text-[13px] font-medium px-4 py-2 rounded-lg bg-sandstorm-accent/10 text-sandstorm-accent border border-sandstorm-accent/30 hover:bg-sandstorm-accent/20 transition-colors"
+          data-testid="session-token-limit-modal-dismiss"
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/StackCard.tsx
+++ b/src/renderer/components/StackCard.tsx
@@ -15,6 +15,7 @@ const STATUS_COLORS: Record<string, string> = {
   pushed: 'bg-violet-400',
   pr_created: 'bg-violet-400',
   rate_limited: 'bg-orange-400 animate-pulse',
+  session_paused: 'bg-orange-400',
 };
 
 const STATUS_BADGE: Record<string, { bg: string; text: string }> = {
@@ -29,6 +30,7 @@ const STATUS_BADGE: Record<string, { bg: string; text: string }> = {
   pushed: { bg: 'bg-violet-500/10 border-violet-500/20', text: 'text-violet-400' },
   pr_created: { bg: 'bg-violet-500/10 border-violet-500/20', text: 'text-violet-400' },
   rate_limited: { bg: 'bg-orange-500/10 border-orange-500/20', text: 'text-orange-400' },
+  session_paused: { bg: 'bg-orange-500/10 border-orange-500/20', text: 'text-orange-400' },
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -43,6 +45,7 @@ const STATUS_LABELS: Record<string, string> = {
   pushed: 'Pushed',
   pr_created: 'PR Open',
   rate_limited: 'Rate Limited',
+  session_paused: 'Halted',
 };
 
 function timeAgo(dateStr: string): string {
@@ -74,7 +77,7 @@ function formatMs(ms: number): string {
 }
 
 export function StackCard({ stack, showProject }: { stack: Stack; showProject?: boolean }) {
-  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog } = useAppStore();
+  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation } = useAppStore();
   const metrics: StackMetrics | undefined = stackMetrics[stack.id];
 
   const runningCount = stack.services.filter(
@@ -111,6 +114,15 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
       refreshStacks();
     } catch (err) {
       alert(`Failed to start: ${err}`);
+    }
+  };
+
+  const handleResume = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await resumeStackWithContinuation(stack.id);
+    } catch (err) {
+      alert(`Failed to resume: ${err}`);
     }
   };
 
@@ -281,6 +293,22 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
             </svg>
             PR #{stack.pr_number}
           </a>
+        </div>
+      )}
+
+      {/* Resume callout — persistent, always visible for halted stacks */}
+      {stack.status === 'session_paused' && (
+        <div className="mt-3 ml-5">
+          <button
+            onClick={handleResume}
+            className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/20 transition-colors active:scale-[0.98]"
+            data-testid={`card-resume-${stack.id}`}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="5 3 19 12 5 21 5 3"/>
+            </svg>
+            Resume
+          </button>
         </div>
       )}
 

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -15,6 +15,7 @@ const STATUS_COLORS: Record<string, string> = {
   pushed: 'bg-violet-400',
   pr_created: 'bg-violet-400',
   rate_limited: 'bg-orange-400 animate-pulse',
+  session_paused: 'bg-orange-400',
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -29,6 +30,7 @@ const STATUS_LABELS: Record<string, string> = {
   pushed: 'Pushed',
   pr_created: 'PR Open',
   rate_limited: 'Limited',
+  session_paused: 'Halted',
 };
 
 const POPOVER_OPEN_DELAY_MS = 150;
@@ -46,7 +48,7 @@ export function StackTableRow({
   showProject?: boolean;
   columnWidths?: Record<string, number>;
 }) {
-  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog } = useAppStore();
+  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation } = useAppStore();
   const metrics: StackMetrics | undefined = stackMetrics[stack.id];
   const [duration, setDuration] = useState(() =>
     getStackDuration(stack.created_at, stack.updated_at, stack.status),
@@ -118,6 +120,15 @@ export function StackTableRow({
   const handleMakePr = (e: React.MouseEvent) => {
     e.stopPropagation();
     setShowCreatePRDialog({ stackId: stack.id });
+  };
+
+  const handleResume = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await resumeStackWithContinuation(stack.id);
+    } catch (err) {
+      alert(`Failed to resume: ${err}`);
+    }
   };
 
   const handlePrLink = (e: React.MouseEvent) => {
@@ -205,6 +216,16 @@ export function StackTableRow({
         >
           <div className="flex items-center gap-1 justify-end">
             {/* Persistent primary action — always visible when applicable */}
+            {stack.status === 'session_paused' && (
+              <button
+                onClick={handleResume}
+                className="text-[10px] font-medium px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/20 transition-colors"
+                data-testid={`row-resume-${stack.id}`}
+                title="Resume this halted stack and continue the in-flight task"
+              >
+                ▶ Resume
+              </button>
+            )}
             {makePrEligible(stack) && (
               <button
                 onClick={handleMakePr}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -425,12 +425,16 @@ interface AppState {
   /** Whether to show the session warning modal */
   showSessionWarningModal: boolean;
   setShowSessionWarningModal: (show: boolean) => void;
+  /** Non-dismissive modal shown when user tries to resume but token limit hasn't refreshed */
+  sessionTokenLimitModal: { resetAt: string | null } | null;
+  setSessionTokenLimitModal: (state: { resetAt: string | null } | null) => void;
   refreshSessionState: () => Promise<void>;
   refreshSessionSettings: () => Promise<void>;
   updateSessionSettings: (settings: Partial<SessionMonitorSettings>) => Promise<void>;
   sessionAcknowledgeCritical: () => Promise<void>;
   sessionHaltAll: () => Promise<string[]>;
   sessionResumeAll: () => Promise<string[]>;
+  resumeStackWithContinuation: (stackId: string) => Promise<void>;
 
   // Schedules (per-project)
   schedules: ScheduleEntry[];
@@ -629,6 +633,11 @@ declare global {
         haltAll: () => Promise<string[]>;
         resumeAll: () => Promise<string[]>;
         resumeStack: (stackId: string) => Promise<void>;
+        resumeStackWithContinuation: (stackId: string) => Promise<{
+          halted: boolean;
+          resetAt?: string | null;
+          outcome?: 'resuming_with_session' | 'resumed_fresh' | 'idle';
+        }>;
         forcePoll: () => Promise<SessionMonitorState>;
         reportActivity: () => void;
       };
@@ -818,6 +827,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   sessionWarningLevel: null,
   showSessionWarningModal: false,
   setShowSessionWarningModal: (show) => set({ showSessionWarningModal: show }),
+  sessionTokenLimitModal: null,
+  setSessionTokenLimitModal: (state) => set({ sessionTokenLimitModal: state }),
 
   refreshSessionState: async () => {
     try {
@@ -856,6 +867,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     const resumed = await window.sandstorm.session.resumeAll();
     await get().refreshStacks();
     return resumed;
+  },
+
+  resumeStackWithContinuation: async (stackId: string) => {
+    const result = await window.sandstorm.session.resumeStackWithContinuation(stackId);
+    if (result.halted) {
+      get().setSessionTokenLimitModal({ resetAt: result.resetAt ?? null });
+      return;
+    }
+    await get().refreshStacks();
   },
 
   // Schedules

--- a/tests/unit/components/SessionTokenLimitModal.test.tsx
+++ b/tests/unit/components/SessionTokenLimitModal.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionTokenLimitModal } from '../../../src/renderer/components/SessionTokenLimitModal';
+import { useAppStore } from '../../../src/renderer/store';
+import { mockSandstormApi } from './setup';
+
+describe('SessionTokenLimitModal', () => {
+  beforeEach(() => {
+    mockSandstormApi();
+    useAppStore.setState({ sessionTokenLimitModal: null });
+  });
+
+  it('renders nothing when sessionTokenLimitModal is null', () => {
+    const { container } = render(<SessionTokenLimitModal />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the modal when state is set', () => {
+    useAppStore.setState({ sessionTokenLimitModal: { resetAt: null } });
+    render(<SessionTokenLimitModal />);
+    expect(screen.getByTestId('session-token-limit-modal')).toBeDefined();
+    expect(screen.getByText('Token limit not yet refreshed')).toBeDefined();
+  });
+
+  it('shows formatted reset time when resetAt is provided', () => {
+    useAppStore.setState({
+      sessionTokenLimitModal: { resetAt: '2026-05-04T15:30:00.000Z' },
+    });
+    render(<SessionTokenLimitModal />);
+    // The modal renders the time via toLocaleTimeString — just check it's present
+    expect(screen.getByTestId('session-token-limit-modal').textContent).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it('shows fallback text when resetAt is null', () => {
+    useAppStore.setState({ sessionTokenLimitModal: { resetAt: null } });
+    render(<SessionTokenLimitModal />);
+    expect(screen.getByTestId('session-token-limit-modal').textContent).toContain(
+      'Resume will be available once the limit refreshes.'
+    );
+  });
+
+  it('dismisses modal when OK button is clicked', () => {
+    useAppStore.setState({ sessionTokenLimitModal: { resetAt: null } });
+    render(<SessionTokenLimitModal />);
+    fireEvent.click(screen.getByTestId('session-token-limit-modal-dismiss'));
+    expect(useAppStore.getState().sessionTokenLimitModal).toBeNull();
+  });
+});

--- a/tests/unit/components/StackCard.test.tsx
+++ b/tests/unit/components/StackCard.test.tsx
@@ -94,6 +94,7 @@ describe('StackCard', () => {
       ['stopped', 'Stopped'],
       ['pushed', 'Pushed'],
       ['pr_created', 'PR Open'],
+      ['session_paused', 'Halted'],
     ];
 
     for (const [status, label] of statuses) {
@@ -203,5 +204,26 @@ describe('StackCard', () => {
   it('does not show model label when current_model is null', () => {
     render(<StackCard stack={makeStack({ id: 'no-model', current_model: null })} />);
     expect(screen.queryByTestId('stack-model-no-model')).toBeNull();
+  });
+
+  it('shows Resume button only for session_paused stacks', () => {
+    const { unmount } = render(
+      <StackCard stack={makeStack({ id: 'paused', status: 'session_paused' })} />
+    );
+    expect(screen.getByTestId('card-resume-paused')).toBeDefined();
+    unmount();
+
+    render(<StackCard stack={makeStack({ id: 'running', status: 'running' })} />);
+    expect(screen.queryByTestId('card-resume-running')).toBeNull();
+  });
+
+  it('calls resumeStackWithContinuation when Resume button is clicked', () => {
+    const resumeFn = vi.fn().mockResolvedValue({ halted: false, outcome: 'resuming_with_session' });
+    useAppStore.setState({ resumeStackWithContinuation: resumeFn } as any);
+
+    render(<StackCard stack={makeStack({ id: 'paused2', status: 'session_paused' })} />);
+    fireEvent.click(screen.getByTestId('card-resume-paused2'));
+
+    expect(resumeFn).toHaveBeenCalledWith('paused2');
   });
 });

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -270,6 +270,47 @@ describe('StackTableRow action button visibility (#316)', () => {
   });
 });
 
+describe('StackTableRow session_paused Resume button', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSandstormApi();
+    useAppStore.setState({ stacks: [], selectedStackId: null, stackMetrics: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows Resume button only for session_paused stacks', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'paused', status: 'session_paused' }));
+    expect(screen.getByTestId('row-resume-paused')).toBeDefined();
+  });
+
+  it('does not show Resume button for running stacks', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'busy', status: 'running' }));
+    expect(screen.queryByTestId('row-resume-busy')).toBeNull();
+  });
+
+  it('shows Halted label for session_paused status', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'halted', status: 'session_paused' }));
+    expect(screen.getByText('Halted')).toBeDefined();
+  });
+
+  it('calls resumeStackWithContinuation when Resume is clicked', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    const resumeFn = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ resumeStackWithContinuation: resumeFn } as any);
+
+    renderRow(makeStack({ id: 'paused2', status: 'session_paused' }));
+    fireEvent.click(screen.getByTestId('row-resume-paused2'));
+
+    expect(resumeFn).toHaveBeenCalledWith('paused2');
+  });
+});
+
 describe('StackTableRow popover suppression on actions hover (#316)', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -128,6 +128,7 @@ export function mockSandstormApi() {
       haltAll: vi.fn().mockResolvedValue([]),
       resumeAll: vi.fn().mockResolvedValue([]),
       resumeStack: vi.fn().mockResolvedValue(undefined),
+      resumeStackWithContinuation: vi.fn().mockResolvedValue({ halted: false, outcome: 'idle' }),
       forcePoll: vi.fn().mockResolvedValue({
         usage: null, level: 'normal', stale: false, halted: false,
         lastPollAt: null, consecutiveFailures: 0,

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { SandstormError, ErrorCode } from '../../src/main/errors';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — vi.mock factories are hoisted above all imports, so any
@@ -20,6 +21,7 @@ const {
   mockSpawn,
   mockFetchAccountUsage,
   mockRemoveProjectFromCrontab,
+  mockSessionMonitor,
 } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
 
@@ -54,6 +56,7 @@ const {
     getGlobalTokenUsage: vi.fn(),
     getRateLimitState: vi.fn(),
     getWorkflowProgress: vi.fn(),
+    resumeStackWithContinuation: vi.fn(),
   };
 
   const mockDockerRuntime = {
@@ -95,6 +98,14 @@ const {
   const mockFetchAccountUsage = vi.fn();
   const mockRemoveProjectFromCrontab = vi.fn();
 
+  const mockSessionMonitor = {
+    getState: vi.fn(),
+    acknowledgeCritical: vi.fn(),
+    markResumed: vi.fn(),
+    updateSettings: vi.fn(),
+    forcePoll: vi.fn(),
+  };
+
   return {
     registeredHandlers,
     mockRegistry,
@@ -107,6 +118,7 @@ const {
     mockSpawn,
     mockFetchAccountUsage,
     mockRemoveProjectFromCrontab,
+    mockSessionMonitor,
   };
 });
 
@@ -138,6 +150,7 @@ vi.mock('../../src/main/index', () => ({
   podmanRuntime: mockPodmanRuntime,
   agentBackend: mockAgentBackend,
   dockerConnectionManager: mockDockerConnectionManager,
+  sessionMonitor: mockSessionMonitor,
   cliDir: '/tmp/sandstorm-cli',
 }));
 
@@ -818,6 +831,48 @@ describe('IPC Handlers', () => {
   });
 
   // =========================================================================
+  // Session Resume With Continuation
+  // =========================================================================
+  describe('session:resumeStackWithContinuation', () => {
+    it('returns halted=true when resumeStackWithContinuation throws SESSION_HALTED', async () => {
+      mockSessionMonitor.getState.mockReturnValue({
+        halted: true,
+        usage: { session: { resetsAt: '2026-05-04T15:00:00Z' } },
+      });
+      mockStackManager.resumeStackWithContinuation.mockRejectedValue(
+        new SandstormError(ErrorCode.SESSION_HALTED, 'Session token limit has not refreshed yet')
+      );
+
+      const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1');
+
+      expect(result).toEqual({ halted: true, resetAt: '2026-05-04T15:00:00Z' });
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function));
+    });
+
+    it('returns halted=true with null resetAt when usage is absent', async () => {
+      mockSessionMonitor.getState.mockReturnValue({ halted: true, usage: null });
+      mockStackManager.resumeStackWithContinuation.mockRejectedValue(
+        new SandstormError(ErrorCode.SESSION_HALTED, 'Session token limit has not refreshed yet')
+      );
+
+      const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1');
+
+      expect(result).toEqual({ halted: true, resetAt: null });
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function));
+    });
+
+    it('calls resumeStackWithContinuation with isHalted callback when monitor is not halted', async () => {
+      mockSessionMonitor.getState.mockReturnValue({ halted: false });
+      mockStackManager.resumeStackWithContinuation.mockResolvedValue({ status: 'running' });
+
+      const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1');
+
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function));
+      expect(result).toEqual({ halted: false, status: 'running' });
+    });
+  });
+
+  // =========================================================================
   // Auth
   // =========================================================================
   describe('auth', () => {
@@ -1218,6 +1273,7 @@ describe('IPC Handlers', () => {
       'session:haltAll',
       'session:resumeAll',
       'session:resumeStack',
+      'session:resumeStackWithContinuation',
       'session:forcePoll',
       'docker:status',
       'schedules:list',

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -1832,6 +1832,124 @@ describe('StackManager', () => {
     });
   });
 
+  describe('resumeStackWithContinuation', () => {
+    it('Case A: dispatches with --resume flag when running task has session_id', async () => {
+      registry.createStack(makeStack('resume-a'));
+      const task = registry.createTask('resume-a', 'do work', 'sonnet');
+      registry.setTaskSessionId(task.id, 'sess-abc123');
+      // Must set session_paused AFTER createTask — createTask calls updateStackStatus('running')
+      registry.updateStackStatus('resume-a', 'session_paused');
+
+      vi.spyOn(manager, 'waitForClaudeReady').mockResolvedValue(undefined);
+      vi.spyOn(taskWatcher, 'watch').mockImplementation(() => {});
+      vi.spyOn(taskWatcher, 'streamOutput').mockResolvedValue(undefined);
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: '', stderr: '', exitCode: 0,
+      });
+
+      const result = await manager.resumeStackWithContinuation('resume-a');
+      expect(result.outcome).toBe('resuming_with_session');
+
+      // CLI should include --resume and the session ID
+      const resumeCall = runCliSpy.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args.includes('--resume')
+      );
+      expect(resumeCall).toBeDefined();
+      expect(resumeCall![1]).toContain('sess-abc123');
+
+      // resumed_at should be stamped on the task
+      const tasks = registry.getTasksForStack('resume-a');
+      expect(tasks[0].resumed_at).toBeTruthy();
+
+      expect(registry.getStack('resume-a')!.status).toBe('running');
+    });
+
+    it('Case B: interrupts old task and redispatches fresh when session_id is null', async () => {
+      registry.createStack(makeStack('resume-b'));
+      const task = registry.createTask('resume-b', 'original prompt', 'sonnet');
+      // session_id is null by default; set session_paused after createTask
+      registry.updateStackStatus('resume-b', 'session_paused');
+
+      vi.spyOn(manager, 'waitForClaudeReady').mockResolvedValue(undefined);
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: '', stderr: '', exitCode: 0,
+      });
+
+      const result = await manager.resumeStackWithContinuation('resume-b');
+      expect(result.outcome).toBe('resumed_fresh');
+
+      // Old task must be interrupted
+      const allTasks = registry.getTasksForStack('resume-b');
+      const oldTask = allTasks.find(t => t.id === task.id);
+      expect(oldTask!.status).toBe('interrupted');
+
+      // A new task was created for the fresh dispatch
+      expect(allTasks.length).toBeGreaterThan(1);
+
+      // CLI task call must NOT carry --resume
+      const taskCall = runCliSpy.mock.calls.find(
+        ([, args]) => Array.isArray(args) && args[0] === 'task'
+      );
+      expect(taskCall).toBeDefined();
+      expect(taskCall![1]).not.toContain('--resume');
+    });
+
+    it('Case C: marks stack idle when no running task exists', async () => {
+      registry.createStack(makeStack('resume-c'));
+      // Stack has no tasks; set session_paused directly
+      registry.updateStackStatus('resume-c', 'session_paused');
+
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      const result = await manager.resumeStackWithContinuation('resume-c');
+      expect(result.outcome).toBe('idle');
+      expect(registry.getStack('resume-c')!.status).toBe('idle');
+    });
+
+    it('returns idle immediately and skips CLI when stack is not session_paused', async () => {
+      registry.createStack(makeStack('resume-up'));
+      // default status is 'up'
+
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: '', stderr: '', exitCode: 0,
+      });
+
+      const result = await manager.resumeStackWithContinuation('resume-up');
+      expect(result.outcome).toBe('idle');
+      expect(runCliSpy).not.toHaveBeenCalled();
+      expect(registry.getStack('resume-up')!.status).toBe('up');
+    });
+
+    it('Pre-flight: throws without touching containers when isHalted returns true', async () => {
+      registry.createStack(makeStack('resume-halted'));
+      registry.updateStackStatus('resume-halted', 'session_paused');
+
+      const runCliSpy = vi.spyOn(manager, 'runCli');
+
+      await expect(
+        manager.resumeStackWithContinuation('resume-halted', () => true)
+      ).rejects.toThrow('Session token limit has not refreshed yet');
+
+      expect(runCliSpy).not.toHaveBeenCalled();
+      expect(registry.getStack('resume-halted')!.status).toBe('session_paused');
+    });
+
+    it('reverts to session_paused when container start fails', async () => {
+      registry.createStack(makeStack('resume-fail'));
+      registry.updateStackStatus('resume-fail', 'session_paused');
+
+      vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: '', stderr: 'docker daemon unavailable', exitCode: 1,
+      });
+
+      await expect(
+        manager.resumeStackWithContinuation('resume-fail')
+      ).rejects.toThrow();
+
+      expect(registry.getStack('resume-fail')!.status).toBe('session_paused');
+    });
+  });
+
   describe('getRuntimeForStack (per-stack runtime resolution)', () => {
     it('returns docker runtime for stacks with runtime=docker', () => {
       const dockerRt = createMockRuntime();


### PR DESCRIPTION
## Summary
- adds a Resume affordance on `session_paused` stacks that brings containers back up and continues the in-flight task — resumes the existing Claude session via `--resume <session_id>` when one was logged, otherwise interrupts and re-dispatches the stored prompt fresh
- gates resume on the session token limit having actually refreshed: `resumeStackWithContinuation` takes an `isHalted` callback and throws `SESSION_HALTED`, which the IPC handler maps to a non-dismissive modal showing the reset time so users can't click through into another immediate halt
- skips the per-task `fetch-ticket` prepend on re-dispatch (`skipTicketFetch`) since the stored prompt already embeds ticket context — avoids double-prepending on the Case B redispatch path

## Test plan
- [ ] `npm test` passes (covers the new pre-flight halt check, all three resume outcomes, and the StackCard / StackTableRow / SessionTokenLimitModal renders)
- [ ] put a stack into `session_paused` with a running task that has a `session_id`, click Resume → containers come up, status flips to `running`, Claude resumes with `--resume`
- [ ] same as above but with a running task that has no `session_id` → old task is interrupted, fresh dispatch runs without re-prepending ticket context
- [ ] put a stack into `session_paused` with no running task, click Resume → containers come up and status settles to `idle`
- [ ] click Resume while the session token limit is still halted → `SessionTokenLimitModal` appears with the reset time and no container action is taken
- [ ] verify the Resume button shows on both card and table views and is hidden for non-`session_paused` stacks

Closes #344