### PR TITLE
Provider-neutral create-ticket script with Jira support

### DIFF
--- a/sandstorm-cli/templates/github/scripts/create-ticket.sh
+++ b/sandstorm-cli/templates/github/scripts/create-ticket.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# create-ticket.sh — File a new GitHub issue.
+#
+# Contract:
+#   Input:  <title> <body>
+#   Output: URL of the created issue on stdout (final non-empty line)
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TITLE="${1:-}"
+BODY="${2:-}"
+
+if [ -z "$TITLE" ] || [ -z "$BODY" ]; then
+  echo "Usage: create-ticket.sh <title> <body>" >&2
+  exit 1
+fi
+
+gh issue create --title "$TITLE" --body "$BODY" || {
+  echo "Error: Failed to create issue. Is 'gh' installed and authenticated?" >&2
+  exit 1
+}

--- a/sandstorm-cli/templates/github/skills/create-ticket.md
+++ b/sandstorm-cli/templates/github/skills/create-ticket.md
@@ -1,0 +1,24 @@
+# Create Ticket
+
+File a new GitHub issue using the `gh` CLI. Used by the Create Ticket
+dialog and any workflow that needs to open a new ticket programmatically.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth status`).
+
+## Usage
+
+```bash
+.sandstorm/scripts/create-ticket.sh <title> <body>
+```
+
+## Example
+
+```bash
+.sandstorm/scripts/create-ticket.sh "Auth token expiry" "Tokens expire silently after 24h; surface a user-facing error."
+```
+
+On success, the script prints the URL of the created issue on stdout
+(e.g. `https://github.com/owner/repo/issues/123`). Errors go to stderr
+and the script exits non-zero.

--- a/sandstorm-cli/templates/jira/scripts/create-ticket.sh
+++ b/sandstorm-cli/templates/jira/scripts/create-ticket.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# create-ticket.sh — File a new Jira issue via the Jira Cloud REST API v2.
+#
+# Prerequisites (export in shell before launching the app):
+#   JIRA_URL          Site root, e.g. https://yourorg.atlassian.net
+#   JIRA_USERNAME     Atlassian account email
+#   JIRA_API_TOKEN    API token from https://id.atlassian.com/manage-profile/security/api-tokens
+#   JIRA_PROJECT_KEY  Project key the issue is filed under (e.g. PROJ)
+#
+# Optional:
+#   JIRA_ISSUE_TYPE   Issue type name (default: "Task")
+#
+# Contract:
+#   Input:  <title> <body>
+#   Output: URL of the created issue on stdout (final non-empty line)
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TITLE="${1:-}"
+BODY="${2:-}"
+
+if [ -z "$TITLE" ] || [ -z "$BODY" ]; then
+  echo "Usage: create-ticket.sh <title> <body>" >&2
+  exit 1
+fi
+
+missing_deps=()
+command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
+command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
+if [ ${#missing_deps[@]} -gt 0 ]; then
+  echo "Error: missing required tools: ${missing_deps[*]}" >&2
+  echo "Install them and try again." >&2
+  exit 1
+fi
+
+missing_vars=()
+[ -z "${JIRA_URL:-}" ] && missing_vars+=("JIRA_URL")
+[ -z "${JIRA_USERNAME:-}" ] && missing_vars+=("JIRA_USERNAME")
+[ -z "${JIRA_API_TOKEN:-}" ] && missing_vars+=("JIRA_API_TOKEN")
+[ -z "${JIRA_PROJECT_KEY:-}" ] && missing_vars+=("JIRA_PROJECT_KEY")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "Error: missing required environment variables: ${missing_vars[*]}" >&2
+  echo "Export them in your shell environment and restart the desktop app." >&2
+  exit 1
+fi
+
+ISSUE_TYPE="${JIRA_ISSUE_TYPE:-Task}"
+
+BASE_URL="${JIRA_URL%/}"
+if echo "$BASE_URL" | grep -qE '^https?://[^/]+/.+'; then
+  echo "Error: JIRA_URL must be the site root (e.g. https://yourorg.atlassian.net), not a REST path." >&2
+  exit 1
+fi
+
+PAYLOAD=$(jq -n \
+  --arg key "$JIRA_PROJECT_KEY" \
+  --arg summary "$TITLE" \
+  --arg description "$BODY" \
+  --arg issuetype "$ISSUE_TYPE" \
+  '{"fields":{"project":{"key":$key},"summary":$summary,"description":$description,"issuetype":{"name":$issuetype}}}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "$PAYLOAD" \
+  "$BASE_URL/rest/api/2/issue")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+RESP_BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error: Jira API returned HTTP $HTTP_CODE" >&2
+  echo "$RESP_BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
+  echo "$RESP_BODY" | jq -r '.errors // {} | to_entries[]? | "  " + .key + ": " + (.value|tostring)' >&2 2>/dev/null || true
+  exit 1
+fi
+
+ISSUE_KEY=$(echo "$RESP_BODY" | jq -r '.key // empty')
+if [ -z "$ISSUE_KEY" ]; then
+  echo "Error: Jira API response did not include an issue key." >&2
+  exit 1
+fi
+
+echo "${BASE_URL}/browse/${ISSUE_KEY}"

--- a/sandstorm-cli/templates/jira/scripts/fetch-ticket.sh
+++ b/sandstorm-cli/templates/jira/scripts/fetch-ticket.sh
@@ -52,7 +52,7 @@ RESPONSE=$(curl -s -w "\n%{http_code}" \
   "$BASE_URL/rest/api/2/issue/$TICKET_ID?fields=summary,description,status,labels,reporter,created,comment")
 
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | head -n -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
 
 if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
   echo "Error: Jira API returned HTTP $HTTP_CODE" >&2

--- a/sandstorm-cli/templates/jira/scripts/start-ticket.sh
+++ b/sandstorm-cli/templates/jira/scripts/start-ticket.sh
@@ -53,7 +53,7 @@ TRANS_RESPONSE=$(curl -s -w "\n%{http_code}" \
   "$BASE_URL/rest/api/2/issue/$TICKET_ID/transitions")
 
 HTTP_CODE=$(echo "$TRANS_RESPONSE" | tail -1)
-TRANS_BODY=$(echo "$TRANS_RESPONSE" | head -n -1)
+TRANS_BODY=$(echo "$TRANS_RESPONSE" | sed '$d')
 
 if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
   echo "Error: failed to fetch transitions (HTTP $HTTP_CODE)" >&2
@@ -99,7 +99,7 @@ MYSELF_RESPONSE=$(curl -s -w "\n%{http_code}" \
   "$BASE_URL/rest/api/2/myself")
 
 HTTP_CODE=$(echo "$MYSELF_RESPONSE" | tail -1)
-MYSELF_BODY=$(echo "$MYSELF_RESPONSE" | head -n -1)
+MYSELF_BODY=$(echo "$MYSELF_RESPONSE" | sed '$d')
 
 if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
   echo "Warning: could not retrieve account info (HTTP $HTTP_CODE) — skipping assignment." >&2

--- a/sandstorm-cli/templates/jira/scripts/update-ticket.sh
+++ b/sandstorm-cli/templates/jira/scripts/update-ticket.sh
@@ -60,7 +60,7 @@ RESPONSE=$(curl -s -w "\n%{http_code}" \
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
   echo "Error: update failed (HTTP $HTTP_CODE)" >&2
-  RESP_BODY=$(echo "$RESPONSE" | head -n -1)
+  RESP_BODY=$(echo "$RESPONSE" | sed '$d')
   echo "$RESP_BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
   exit 1
 fi

--- a/sandstorm-cli/templates/jira/skills/create-ticket.md
+++ b/sandstorm-cli/templates/jira/skills/create-ticket.md
@@ -1,0 +1,33 @@
+# Create Ticket
+
+File a new Jira issue. Used by the Create Ticket dialog and any workflow
+that needs to open a new ticket programmatically.
+
+## Prerequisites
+
+Export these in your shell environment before launching the app:
+
+- `JIRA_URL` — site root, e.g. `https://yourorg.atlassian.net`
+- `JIRA_USERNAME` — your Atlassian account email
+- `JIRA_API_TOKEN` — from https://id.atlassian.com/manage-profile/security/api-tokens
+- `JIRA_PROJECT_KEY` — project key the issue is filed under (e.g. `PROJ`)
+
+Optional:
+
+- `JIRA_ISSUE_TYPE` — issue type name (default: `Task`)
+
+## Usage
+
+```bash
+.sandstorm/scripts/create-ticket.sh <title> <body>
+```
+
+## Example
+
+```bash
+.sandstorm/scripts/create-ticket.sh "Auth token expiry" "Tokens expire silently after 24h; surface a user-facing error."
+```
+
+On success, the script prints the URL of the created ticket on stdout
+(e.g. `https://yourorg.atlassian.net/browse/PROJ-123`). Errors go to
+stderr and the script exits non-zero.

--- a/sandstorm-cli/templates/skeleton/scripts/create-ticket.sh
+++ b/sandstorm-cli/templates/skeleton/scripts/create-ticket.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# create-ticket.sh — File a new ticket.
+#
+# CONTRACT:
+#   Input:  <title> <body>
+#   Output: URL of the created ticket on stdout (final non-empty line)
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+# Replace the body of this script with your ticket system's API call.
+# If your ticket system doesn't support programmatic creation, this script
+# can print a message telling the user to file the ticket manually and
+# exit non-zero so the UI surfaces the limitation.
+#
+set -euo pipefail
+
+TITLE="${1:-}"
+BODY="${2:-}"
+
+if [ -z "$TITLE" ] || [ -z "$BODY" ]; then
+  echo "Usage: create-ticket.sh <title> <body>" >&2
+  exit 1
+fi
+
+echo "Error: create-ticket.sh is not configured." >&2
+echo "Edit .sandstorm/scripts/create-ticket.sh to connect to your ticket system." >&2
+exit 1

--- a/sandstorm-cli/templates/skeleton/skills/create-ticket.md
+++ b/sandstorm-cli/templates/skeleton/skills/create-ticket.md
@@ -1,0 +1,24 @@
+# Create Ticket
+
+File a new ticket in your project's ticket system. Used by the Create
+Ticket dialog and any workflow that needs to open a new ticket
+programmatically.
+
+The skeleton template ships a stub script that exits non-zero with a
+message. Replace `.sandstorm/scripts/create-ticket.sh` with a real
+implementation for your ticket provider.
+
+## Contract
+
+Input:  `<title> <body>` as two positional arguments.
+
+Output: the URL of the created ticket on stdout (last non-empty line).
+Sandstorm parses this line to record the new ticket in the UI.
+
+Exit:   0 on success, non-zero on failure (error to stderr).
+
+## Usage
+
+```bash
+.sandstorm/scripts/create-ticket.sh <title> <body>
+```

--- a/src/main/control-plane/ticket-creator.ts
+++ b/src/main/control-plane/ticket-creator.ts
@@ -1,18 +1,24 @@
-import { spawn } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs';
+import path from 'path';
+import { getSandstormScriptStatus, type ScriptStatus } from './ticket-updater';
 
 export interface CreatedTicket {
   url: string;
-  number: number;
   ticketId: string;
 }
 
+/** Status check for create-ticket.sh, mirrors the other script helpers. */
+export function getCreateTicketScriptStatus(projectDir: string): ScriptStatus {
+  return getSandstormScriptStatus(projectDir, 'create-ticket.sh');
+}
+
 /**
- * File a new GitHub issue via `gh issue create`. Returns the URL + number
- * parsed from gh's stdout (e.g. https://github.com/owner/repo/issues/315).
- *
- * Pure-ish — only effect is the gh subprocess. No Electron deps, fully
- * test-injectable via the optional `runner` arg (not used in production).
+ * File a new ticket by running `.sandstorm/scripts/create-ticket.sh <title> <body>`.
+ * Provider-neutral — GitHub, Jira, or any custom backend — so long as the
+ * project's script implements the `<title> <body>` contract and prints the
+ * created ticket's URL on stdout. The ticket id is taken from the URL's
+ * last path segment (works for `/issues/123` and `/browse/PROJ-123`).
  */
 export function createTicket(opts: {
   projectDir: string;
@@ -35,28 +41,61 @@ export function createTicket(opts: {
       return;
     }
 
-    const child = spawn('gh', ['issue', 'create', '--title', title, '--body', body], {
-      cwd: opts.projectDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (d: Buffer) => { stdout += d.toString(); });
-    child.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
-    child.on('error', (err) => reject(err));
-    child.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error(stderr.trim() || stdout.trim() || `gh issue create exited with code ${code}`));
-        return;
-      }
-      const match = stdout.match(/https:\/\/github\.com\/[^\s]+\/issues\/(\d+)/);
-      if (!match) {
-        reject(new Error(`Could not parse issue URL from gh output: ${stdout.trim()}`));
-        return;
-      }
-      resolve({ url: match[0], number: Number(match[1]), ticketId: match[1] });
-    });
+    const scriptPath = path.join(opts.projectDir, '.sandstorm', 'scripts', 'create-ticket.sh');
+    const status = getCreateTicketScriptStatus(opts.projectDir);
+    if (status === 'missing') {
+      reject(new Error(
+        `create-ticket.sh is missing at ${scriptPath}. ` +
+        'The Create Ticket dialog can\'t file a new ticket until you install it. ' +
+        'Re-run `sandstorm init` or install the script via the project migration prompt.',
+      ));
+      return;
+    }
+    if (status === 'not_executable') {
+      reject(new Error(
+        `create-ticket.sh exists but is not executable. Run: chmod +x ${scriptPath}`,
+      ));
+      return;
+    }
+
+    execFile(
+      scriptPath,
+      [title, body],
+      { cwd: opts.projectDir, timeout: 30000, maxBuffer: 2 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message;
+          reject(new Error(`create-ticket.sh failed: ${msg}`));
+          return;
+        }
+        const parsed = parseTicketUrl(stdout);
+        if (!parsed) {
+          reject(new Error(
+            `Could not parse a ticket URL from create-ticket.sh output. ` +
+            `Expected an http(s) URL on the final line of stdout. Got: ${stdout.trim()}`,
+          ));
+          return;
+        }
+        resolve(parsed);
+      },
+    );
   });
 }
 
+function parseTicketUrl(stdout: string): CreatedTicket | null {
+  const lines = stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const match = lines[i].match(/https?:\/\/\S+/);
+    if (!match) continue;
+    const url = match[0].replace(/[.,;:)\]]+$/, '');
+    try {
+      const segments = new URL(url).pathname.split('/').filter(Boolean);
+      const ticketId = segments[segments.length - 1];
+      if (!ticketId) continue;
+      return { url, ticketId };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -211,7 +211,7 @@ export interface SandstormAPI {
     specRefineAsync: (sessionId: string, ticketId: string, projectDir: string, userAnswers: string) => Promise<void>;
     cancelRefinement: (sessionId: string) => Promise<void>;
     listRefinements: () => Promise<unknown[]>;
-    create: (projectDir: string, title: string, body: string) => Promise<{ url: string; number: number; ticketId: string }>;
+    create: (projectDir: string, title: string, body: string) => Promise<{ url: string; ticketId: string }>;
   };
   pr: {
     draftBody: (stackId: string) => Promise<{ title: string; body: string }>;

--- a/src/renderer/components/CreateTicketDialog.tsx
+++ b/src/renderer/components/CreateTicketDialog.tsx
@@ -55,7 +55,7 @@ export function CreateTicketDialog() {
           <div>
             <h2 className="text-base font-semibold text-sandstorm-text">Create Ticket</h2>
             <p className="text-[11px] text-sandstorm-muted mt-0.5">
-              Files a new GitHub issue in this project
+              Files a new ticket in this project's ticket system
             </p>
           </div>
           <button
@@ -94,7 +94,7 @@ export function CreateTicketDialog() {
                   onClick={(e) => { e.preventDefault(); window.open(created.url, '_blank'); }}
                   className="ml-auto underline"
                 >
-                  Open on GitHub
+                  Open ticket
                 </a>
               </div>
               <p className="text-xs text-sandstorm-text-secondary">

--- a/tests/unit/components/CreateTicketDialog.test.tsx
+++ b/tests/unit/components/CreateTicketDialog.test.tsx
@@ -37,7 +37,7 @@ describe('CreateTicketDialog', () => {
   it('files the ticket via tickets.create with the project dir + trimmed values', async () => {
     const user = userEvent.setup();
     api.tickets.create.mockResolvedValue({
-      url: 'https://github.com/o/r/issues/77', number: 77, ticketId: '77',
+      url: 'https://github.com/o/r/issues/77', ticketId: '77',
     });
     render(<CreateTicketDialog />);
 
@@ -55,7 +55,7 @@ describe('CreateTicketDialog', () => {
   it('shows the Refine button after success and hands off via store', async () => {
     const user = userEvent.setup();
     api.tickets.create.mockResolvedValue({
-      url: 'https://github.com/o/r/issues/77', number: 77, ticketId: '77',
+      url: 'https://github.com/o/r/issues/77', ticketId: '77',
     });
     render(<CreateTicketDialog />);
     await user.type(screen.getByTestId('create-ticket-title'), 't');

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -169,7 +169,7 @@ export function mockSandstormApi() {
       cancelRefinement: vi.fn().mockResolvedValue(undefined),
       listRefinements: vi.fn().mockResolvedValue([]),
       create: vi.fn().mockResolvedValue({
-        url: 'https://github.com/o/r/issues/42', number: 42, ticketId: '42',
+        url: 'https://github.com/o/r/issues/42', ticketId: '42',
       }),
     },
     pr: {

--- a/tests/unit/jira-scripts.test.ts
+++ b/tests/unit/jira-scripts.test.ts
@@ -527,3 +527,121 @@ describe('update-ticket.sh', () => {
     expect(result.stderr).toContain('400');
   });
 });
+
+// ---------------------------------------------------------------------------
+// create-ticket.sh
+// ---------------------------------------------------------------------------
+
+describe('create-ticket.sh', () => {
+  const CREATE_ENV = { ...VALID_ENV, JIRA_PROJECT_KEY: 'PROJ' };
+  const CREATED_RESPONSE = JSON.stringify({
+    id: '10001',
+    key: 'PROJ-456',
+    self: 'https://test.atlassian.net/rest/api/2/issue/10001',
+  });
+
+  it('exits 1 with usage when title is missing', async () => {
+    const result = await runScript('create-ticket.sh', [], CREATE_ENV, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Usage:');
+  });
+
+  it('exits 1 with usage when body is missing', async () => {
+    const result = await runScript('create-ticket.sh', ['title only'], CREATE_ENV, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Usage:');
+  });
+
+  it('exits 1 and names all missing env vars (including JIRA_PROJECT_KEY)', async () => {
+    const result = await runScript('create-ticket.sh', ['t', 'b'], {}, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('JIRA_URL');
+    expect(result.stderr).toContain('JIRA_USERNAME');
+    expect(result.stderr).toContain('JIRA_API_TOKEN');
+    expect(result.stderr).toContain('JIRA_PROJECT_KEY');
+    expect(result.stderr).toContain('restart the desktop app');
+  });
+
+  it('exits 1 when only JIRA_PROJECT_KEY is missing', async () => {
+    const { JIRA_PROJECT_KEY: _, ...env } = CREATE_ENV;
+    const result = await runScript('create-ticket.sh', ['t', 'b'], env, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('JIRA_PROJECT_KEY');
+  });
+
+  it('rejects JIRA_URL with REST path', async () => {
+    const env = { ...CREATE_ENV, JIRA_URL: 'https://test.atlassian.net/rest/api/2' };
+    const result = await runScript('create-ticket.sh', ['t', 'b'], env, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('site root');
+  });
+
+  it('POSTs to /rest/api/2/issue and prints the browse URL on success', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 201, body: CREATED_RESPONSE }]);
+    const result = await runScript('create-ticket.sh', ['Title', 'Body'], { ...CREATE_ENV, ...stub.env() }, tmpDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('https://test.atlassian.net/browse/PROJ-456');
+
+    const log = stub.getLog();
+    expect(log[0]).toMatchObject({ method: 'POST', url: expect.stringContaining('/rest/api/2/issue') });
+  });
+
+  it('sends the expected fields in the POST payload', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 201, body: CREATED_RESPONSE }]);
+    await runScript('create-ticket.sh', ['My Title', 'My Body'], { ...CREATE_ENV, ...stub.env() }, tmpDir);
+
+    const log = stub.getLog();
+    const parsed = JSON.parse(log[0].data) as { fields: Record<string, unknown> };
+    expect(parsed.fields).toMatchObject({
+      project: { key: 'PROJ' },
+      summary: 'My Title',
+      description: 'My Body',
+      issuetype: { name: 'Task' },
+    });
+  });
+
+  it('honors JIRA_ISSUE_TYPE override', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 201, body: CREATED_RESPONSE }]);
+    const env = { ...CREATE_ENV, ...stub.env(), JIRA_ISSUE_TYPE: 'Story' };
+    await runScript('create-ticket.sh', ['Title', 'Body'], env, tmpDir);
+
+    const log = stub.getLog();
+    const parsed = JSON.parse(log[0].data) as { fields: { issuetype: { name: string } } };
+    expect(parsed.fields.issuetype.name).toBe('Story');
+  });
+
+  it('round-trips multi-line body with quotes and backslashes', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 201, body: CREATED_RESPONSE }]);
+    const body = 'Line 1\nLine 2 with "quotes"\nLine 3 with \\backslash\\';
+    await runScript('create-ticket.sh', ['Title', body], { ...CREATE_ENV, ...stub.env() }, tmpDir);
+
+    const log = stub.getLog();
+    const parsed = JSON.parse(log[0].data) as { fields: { description: string } };
+    expect(parsed.fields.description).toBe(body);
+  });
+
+  it('exits 1 and reports HTTP error on non-2xx response', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 400, body: '{"errorMessages":["Field required: priority"]}' }]);
+    const result = await runScript('create-ticket.sh', ['t', 'b'], { ...CREATE_ENV, ...stub.env() }, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('400');
+  });
+
+  it('exits 1 when API responds with no issue key', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 201, body: '{"id":"10001"}' }]);
+    const result = await runScript('create-ticket.sh', ['t', 'b'], { ...CREATE_ENV, ...stub.env() }, tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('issue key');
+  });
+
+  it('normalises JIRA_URL trailing slash (no double-slashes in the request)', async () => {
+    stub.setRoutes([{ method: 'POST', urlContains: '/rest/api/2/issue', status: 201, body: CREATED_RESPONSE }]);
+    const env = { ...CREATE_ENV, ...stub.env(), JIRA_URL: 'https://test.atlassian.net/' };
+    const result = await runScript('create-ticket.sh', ['t', 'b'], env, tmpDir);
+    expect(result.exitCode).toBe(0);
+    const log = stub.getLog();
+    expect(log[0].url).not.toContain('//rest');
+    // And the browse URL should also be slash-clean
+    expect(result.stdout.trim()).toBe('https://test.atlassian.net/browse/PROJ-456');
+  });
+});

--- a/tests/unit/ticket-creator.test.ts
+++ b/tests/unit/ticket-creator.test.ts
@@ -2,39 +2,69 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { createTicket } from '../../src/main/control-plane/ticket-creator';
+import {
+  createTicket,
+  getCreateTicketScriptStatus,
+} from '../../src/main/control-plane/ticket-creator';
 
 /**
- * createTicket spawns `gh` directly. We test it by stubbing `gh` via a temp
- * PATH dir that contains a fake binary echoing canned stdout. No vi.mock —
- * matches the no-electron-mocks rule + ipc-tickets style.
+ * Mirrors tests/unit/ticket-updater.test.ts — install a real stub script in
+ * .sandstorm/scripts/create-ticket.sh inside a temp project dir and invoke
+ * it directly. No vi.mock — matches the no-electron-mocks pattern.
  */
-describe('createTicket', () => {
+
+describe('getCreateTicketScriptStatus', () => {
   let tmpDir: string;
-  let originalPath: string | undefined;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ticket-create-'));
-    originalPath = process.env.PATH;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-status-'));
   });
 
   afterEach(() => {
-    process.env.PATH = originalPath;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function stubGh(script: string): string {
-    const binDir = path.join(tmpDir, 'bin');
-    fs.mkdirSync(binDir, { recursive: true });
-    const ghPath = path.join(binDir, 'gh');
-    fs.writeFileSync(ghPath, script, { mode: 0o755 });
-    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`;
-    return ghPath;
+  it('returns "missing" when create-ticket.sh does not exist', () => {
+    expect(getCreateTicketScriptStatus(tmpDir)).toBe('missing');
+  });
+
+  it('returns "not_executable" when script exists but lacks execute permission', () => {
+    const scriptsDir = path.join(tmpDir, '.sandstorm', 'scripts');
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(scriptsDir, 'create-ticket.sh'), '#!/bin/bash\nexit 0', { mode: 0o644 });
+    expect(getCreateTicketScriptStatus(tmpDir)).toBe('not_executable');
+  });
+
+  it('returns "ok" when script exists and is executable', () => {
+    const scriptsDir = path.join(tmpDir, '.sandstorm', 'scripts');
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(scriptsDir, 'create-ticket.sh'), '#!/bin/bash\nexit 0', { mode: 0o755 });
+    expect(getCreateTicketScriptStatus(tmpDir)).toBe('ok');
+  });
+});
+
+describe('createTicket', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-ticket-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function installStubScript(body: string): string {
+    const scriptsDir = path.join(tmpDir, '.sandstorm', 'scripts');
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, 'create-ticket.sh');
+    fs.writeFileSync(scriptPath, body, { mode: 0o755 });
+    return scriptPath;
   }
 
   it('rejects when the project directory does not exist', async () => {
     await expect(
-      createTicket({ projectDir: '/nope-dir', title: 't', body: 'b' }),
+      createTicket({ projectDir: '/nope-dir-xyz', title: 't', body: 'b' }),
     ).rejects.toThrow(/not found/);
   });
 
@@ -50,38 +80,95 @@ describe('createTicket', () => {
     ).rejects.toThrow(/body is required/);
   });
 
-  it('parses the issue URL and number on success', async () => {
-    stubGh('#!/usr/bin/env bash\necho "https://github.com/onomojo/sandstorm-desktop/issues/315"');
+  it('rejects with a clear error when create-ticket.sh is missing', async () => {
+    await expect(
+      createTicket({ projectDir: tmpDir, title: 't', body: 'b' }),
+    ).rejects.toThrow(/create-ticket\.sh is missing/);
+  });
+
+  it('rejects with a clear error when the script is not executable', async () => {
+    const scriptsDir = path.join(tmpDir, '.sandstorm', 'scripts');
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(scriptsDir, 'create-ticket.sh'), '#!/bin/bash', { mode: 0o644 });
+    await expect(
+      createTicket({ projectDir: tmpDir, title: 't', body: 'b' }),
+    ).rejects.toThrow(/not executable/);
+  });
+
+  it('passes title and body as positional args to the script', async () => {
+    const sideChannel = path.join(tmpDir, 'args');
+    installStubScript(
+      `#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "${sideChannel}"\necho "https://github.com/o/r/issues/9"\n`,
+    );
+    await createTicket({ projectDir: tmpDir, title: 'My Title', body: 'My Body' });
+    const args = fs.readFileSync(sideChannel, 'utf-8').split('\n').filter(Boolean);
+    expect(args).toEqual(['My Title', 'My Body']);
+  });
+
+  it('runs the script with cwd set to the project directory', async () => {
+    const sideChannel = path.join(tmpDir, 'cwd');
+    installStubScript(
+      `#!/usr/bin/env bash\npwd > "${sideChannel}"\necho "https://github.com/o/r/issues/1"\n`,
+    );
+    await createTicket({ projectDir: tmpDir, title: 't', body: 'b' });
+    const cwd = fs.readFileSync(sideChannel, 'utf-8').trim();
+    expect(cwd === tmpDir || cwd === fs.realpathSync(tmpDir)).toBe(true);
+  });
+
+  it('parses a GitHub issue URL — numeric ticketId from /issues/N', async () => {
+    installStubScript(
+      '#!/usr/bin/env bash\necho "https://github.com/onomojo/sandstorm-desktop/issues/315"\n',
+    );
     const result = await createTicket({ projectDir: tmpDir, title: 'Title', body: 'Body' });
     expect(result.url).toBe('https://github.com/onomojo/sandstorm-desktop/issues/315');
-    expect(result.number).toBe(315);
     expect(result.ticketId).toBe('315');
   });
 
-  it('rejects when gh exits non-zero with stderr', async () => {
-    stubGh('#!/usr/bin/env bash\necho "auth required" 1>&2\nexit 1');
+  it('parses a Jira browse URL — alphanumeric key from /browse/PROJ-N', async () => {
+    installStubScript(
+      '#!/usr/bin/env bash\necho "https://acme.atlassian.net/browse/PROJ-123"\n',
+    );
+    const result = await createTicket({ projectDir: tmpDir, title: 'Title', body: 'Body' });
+    expect(result.url).toBe('https://acme.atlassian.net/browse/PROJ-123');
+    expect(result.ticketId).toBe('PROJ-123');
+  });
+
+  it('uses the LAST URL-bearing line of stdout — ignores preamble', async () => {
+    installStubScript(
+      '#!/usr/bin/env bash\n' +
+      'echo "Some chatter"\n' +
+      'echo "Created issue at the URL below:"\n' +
+      'echo "https://acme.atlassian.net/browse/PROJ-77"\n',
+    );
+    const result = await createTicket({ projectDir: tmpDir, title: 'Title', body: 'Body' });
+    expect(result.url).toBe('https://acme.atlassian.net/browse/PROJ-77');
+    expect(result.ticketId).toBe('PROJ-77');
+  });
+
+  it('strips trailing punctuation that might cling to the URL', async () => {
+    installStubScript(
+      '#!/usr/bin/env bash\necho "Filed: https://github.com/o/r/issues/42."\n',
+    );
+    const result = await createTicket({ projectDir: tmpDir, title: 't', body: 'b' });
+    expect(result.url).toBe('https://github.com/o/r/issues/42');
+    expect(result.ticketId).toBe('42');
+  });
+
+  it('rejects when script exits non-zero, surfacing stderr', async () => {
+    installStubScript(
+      '#!/usr/bin/env bash\necho "auth required" >&2\nexit 1\n',
+    );
     await expect(
       createTicket({ projectDir: tmpDir, title: 't', body: 'b' }),
     ).rejects.toThrow(/auth required/);
   });
 
-  it('rejects when gh stdout has no parseable URL', async () => {
-    stubGh('#!/usr/bin/env bash\necho "draft only — not opened"');
+  it('rejects when stdout has no parseable URL', async () => {
+    installStubScript(
+      '#!/usr/bin/env bash\necho "draft only — not opened"\n',
+    );
     await expect(
       createTicket({ projectDir: tmpDir, title: 't', body: 'b' }),
-    ).rejects.toThrow(/parse issue URL/);
-  });
-
-  it('passes the title and body as gh CLI args (workspace = projectDir)', async () => {
-    // Capture args by writing them to a side-channel file.
-    const sideChannel = path.join(tmpDir, 'gh-args');
-    stubGh(
-      `#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "${sideChannel}"\n` +
-      'echo "https://github.com/o/r/issues/9"\n',
-    );
-    await createTicket({ projectDir: tmpDir, title: 'My Title', body: 'My Body' });
-    const args = fs.readFileSync(sideChannel, 'utf-8').split('\n').filter(Boolean);
-    expect(args).toEqual(['issue', 'create', '--title', 'My Title', '--body', 'My Body']);
+    ).rejects.toThrow(/Could not parse a ticket URL/);
   });
 });
-


### PR DESCRIPTION
## Summary

- Create Ticket dialog now works for Jira projects, not just GitHub. The TS wrapper shells out to `.sandstorm/scripts/create-ticket.sh` instead of hardcoding `gh issue create`, matching the existing `fetch-ticket` / `update-ticket` / `start-ticket` script pattern.
- New `create-ticket.sh` ships in all three provider templates (github / jira / skeleton) with a shared contract: `<title> <body>` args, ticket URL on stdout. Jira variant POSTs to `/rest/api/2/issue` and requires `JIRA_PROJECT_KEY` (plus the existing `JIRA_URL` / `JIRA_USERNAME` / `JIRA_API_TOKEN`).
- Fixed a BSD-vs-GNU portability bug in the existing Jira fetch / update / start scripts: `head -n -1` is GNU-only and silently errors on macOS host shells. Replaced with `sed '$d'`. (Scripts ran fine inside Linux Sandstorm containers — the bug only surfaced when invoking them directly on a macOS shell.)
- Dropped the unused `number` field from `CreatedTicket` (and the preload type). It was GitHub-specific and not meaningful for Jira keys.
- Provider-neutralized the Create Ticket dialog copy ("Files a new ticket in this project's ticket system", "Open ticket").

## Verified

- `sandstorm-cli/templates/jira/scripts/create-ticket.sh` was run end-to-end against a live Jira instance (servus / NVMD project). The POST succeeded and a real ticket was filed. Reported URL printout was hit after the portability fix.

## Follow-ups (not in this PR)

- Migration handler (`projects:installCreateTicketScript`) so existing projects can pick up the new script without re-running `sandstorm init`. Skipped here to keep the diff focused — new projects pick it up automatically from `init.sh` because it copies `*.sh` wholesale.

## Test plan

- [ ] CI: `npm test` passes (new `tests/unit/jira-scripts.test.ts > create-ticket.sh` block, rewritten `tests/unit/ticket-creator.test.ts`, updated `CreateTicketDialog.test.tsx` mocks).
- [ ] CI: typecheck passes (preload return type updated; `number` field removed).
- [ ] Manual: Create Ticket dialog in the desktop app against a Jira-configured project produces a real ticket and the "Refine" handoff works.
- [ ] Manual: Same flow against a GitHub-configured project still produces an issue (unchanged behavior — `gh issue create` is now invoked through the script instead of directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)