### PR TITLE
stream live refinement progress to the refine ticket dialog

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -415,6 +415,7 @@ export class ClaudeBackend implements AgentBackend {
     prompt: string,
     projectDir: string,
     timeoutMs = 300_000,
+    onChunk?: (delta: string) => void,
   ): { promise: Promise<string>; cancel: () => void } {
     const claudeBin = getClaudeBin();
     const args = [
@@ -468,7 +469,10 @@ export class ClaudeBackend implements AgentBackend {
         try {
           const parsed = JSON.parse(line);
           const text = this.extractText(parsed);
-          if (text) fullText += text;
+          if (text) {
+            fullText += text;
+            if (!settled) onChunk?.(text);
+          }
         } catch {
           // Skip non-JSON lines
         }

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -95,7 +95,8 @@ export interface AgentBackend {
   spawnEphemeralAgent(
     prompt: string,
     projectDir: string,
-    timeoutMs?: number
+    timeoutMs?: number,
+    onChunk?: (delta: string) => void,
   ): { promise: Promise<string>; cancel: () => void };
 
   // --- Authentication ---

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -487,6 +487,7 @@ async function handleSpecRefine(
 export function spawnSpecCheck(
   ticketId: string,
   projectDir: string,
+  onChunk?: (delta: string) => void,
 ): { promise: Promise<Record<string, unknown>>; cancel: () => void } {
   let innerCancel: (() => void) | null = null;
   let cancelled = false;
@@ -501,7 +502,7 @@ export function spawnSpecCheck(
     if (cancelled) throw new Error('Cancelled');
 
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir);
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 300_000, onChunk);
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 
@@ -520,6 +521,7 @@ export function spawnSpecRefine(
   ticketId: string,
   projectDir: string,
   userAnswers?: string,
+  onChunk?: (delta: string) => void,
 ): { promise: Promise<Record<string, unknown>>; cancel: () => void } {
   let innerCancel: (() => void) | null = null;
   let cancelled = false;
@@ -537,7 +539,7 @@ export function spawnSpecRefine(
       ? buildSpecRefineAnswerPrompt(res.ctx.gate, res.ctx.ticketBody, userAnswers)
       : buildSpecRefineInitialPrompt(res.ctx.gate, res.ctx.ticketBody);
 
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir);
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 300_000, onChunk);
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1191,9 +1191,13 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     persistRefinement(session);
     emitRefinementUpdate(session);
 
+    const onChunk = (delta: string): void => {
+      mainWindow?.webContents.send('refinement:progress', { sessionId: id, delta });
+    };
+
     const { promise, cancel } = phase === 'check'
-      ? spawnSpecCheck(ticketId, projectDir)
-      : spawnSpecRefine(ticketId, projectDir, userAnswers);
+      ? spawnSpecCheck(ticketId, projectDir, onChunk)
+      : spawnSpecRefine(ticketId, projectDir, userAnswers, onChunk);
 
     activeRefinements.set(id, { session, cancel });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -47,6 +47,7 @@ export default function App() {
     showSessionWarningModal,
     setShowSessionWarningModal,
     upsertRefinementSession,
+    appendRefinementStreamChunk,
     error,
   } = useAppStore();
 
@@ -106,7 +107,15 @@ export default function App() {
       upsertRefinementSession(data as Parameters<typeof upsertRefinementSession>[0]);
     });
 
-    return () => { unsubRefinement(); };
+    const unsubProgress = window.sandstorm.on('refinement:progress', (data: unknown) => {
+      const { sessionId, delta } = data as { sessionId: string; delta: string };
+      appendRefinementStreamChunk(sessionId, delta);
+    });
+
+    return () => {
+      unsubRefinement();
+      unsubProgress();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useAppStore, SpecGateResult, RefinementSession } from '../store';
 
 type LocalPhase = 'input' | 'starting';
@@ -149,6 +149,15 @@ export function RefineTicketDialog() {
     setShowRefineTicketDialog(false);
   };
 
+  const streamingOutput = session?.streamingOutput ?? '';
+  const streamPanelRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll the streaming panel to the bottom as new content arrives.
+  useEffect(() => {
+    const el = streamPanelRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [streamingOutput]);
+
   const isRunning = session?.status === 'running' || localPhase === 'starting';
   const isStarting = localPhase === 'starting';
   const noSession = !session;
@@ -228,11 +237,22 @@ export function RefineTicketDialog() {
           )}
 
           {isRunning && (
-            <div className="text-xs text-sandstorm-muted flex items-center gap-2" data-testid="refine-running">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
-                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
-              </svg>
-              {isStarting ? 'Starting stack…' : 'Running spec gate…'}
+            <div className="space-y-2" data-testid="refine-running">
+              <div className="text-xs text-sandstorm-muted flex items-center gap-2">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+                </svg>
+                {isStarting ? 'Starting stack…' : 'Running spec gate…'}
+              </div>
+              {!isStarting && (
+                <div
+                  ref={streamPanelRef}
+                  className="h-32 overflow-y-auto bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 font-mono text-[11px] text-sandstorm-muted whitespace-pre-wrap"
+                  data-testid="refine-stream-panel"
+                >
+                  {streamingOutput || <span className="opacity-50">Waiting for output…</span>}
+                </div>
+              )}
             </div>
           )}
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -475,6 +475,8 @@ interface AppState {
   openRefinementSession: (sessionId: string) => void;
   /** Add or update a refinement session (called on refinement:update events). */
   upsertRefinementSession: (session: RefinementSession) => void;
+  /** Append a streaming text chunk to a running session's output. */
+  appendRefinementStreamChunk: (sessionId: string, delta: string) => void;
   /** Remove a refinement session (after cancel or dismiss). */
   removeRefinementSession: (sessionId: string) => void;
   /** Set which session id is shown in the refine dialog. */
@@ -720,6 +722,8 @@ export interface RefinementSession {
   result?: SpecGateResult;
   error?: string;
   startedAt: number;
+  /** Live streamed output from the ephemeral gate subprocess while running. */
+  streamingOutput?: string;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -1018,13 +1022,26 @@ export const useAppStore = create<AppState>((set, get) => ({
     if ((session as { status?: string }).status === 'cancelled') {
       return { refinementSessions: state.refinementSessions.filter((s) => s.id !== session.id) };
     }
+    // Clear streamingOutput when the session leaves the running state.
+    const normalized = session.status !== 'running'
+      ? { ...session, streamingOutput: undefined }
+      : session;
     const idx = state.refinementSessions.findIndex((s) => s.id === session.id);
     if (idx >= 0) {
       const next = [...state.refinementSessions];
-      next[idx] = session;
+      next[idx] = normalized;
       return { refinementSessions: next };
     }
-    return { refinementSessions: [...state.refinementSessions, session] };
+    return { refinementSessions: [...state.refinementSessions, normalized] };
+  }),
+  appendRefinementStreamChunk: (sessionId, delta) => set((state) => {
+    const idx = state.refinementSessions.findIndex((s) => s.id === sessionId);
+    if (idx < 0) return {};
+    const session = state.refinementSessions[idx];
+    if (session.status !== 'running') return {};
+    const next = [...state.refinementSessions];
+    next[idx] = { ...session, streamingOutput: (session.streamingOutput ?? '') + delta };
+    return { refinementSessions: next };
   }),
   removeRefinementSession: (sessionId) => set((state) => ({
     refinementSessions: state.refinementSessions.filter((s) => s.id !== sessionId),

--- a/tests/integration/refinement-streaming.spec.ts
+++ b/tests/integration/refinement-streaming.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from './fixtures';
+
+test.describe('Refinement streaming panel', () => {
+  test('refine-stream-panel shows live streamed text mid-run', async ({ electronApp, mainWindow }) => {
+    // Wait for the app to be fully rendered
+    await mainWindow.waitForSelector('text=Sandstorm', { timeout: 15000 });
+
+    const sessionId = 'int-test-refine-stream-1';
+
+    // Inject a fake running session from the main process by sending the same
+    // IPC events that startRefinementAsync() in ipc.ts emits when a real
+    // ephemeral subprocess is running. This exercises the full renderer-side
+    // chain without spawning the real claude CLI.
+    await electronApp.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (electron: any, args: { sid: string; ts: number }) => {
+        const win = electron.BrowserWindow.getAllWindows()[0];
+        win.webContents.send('refinement:update', {
+          id: args.sid,
+          ticketId: '999',
+          projectDir: '/tmp/integration-test',
+          status: 'running',
+          phase: 'check',
+          startedAt: args.ts,
+        });
+      },
+      { sid: sessionId, ts: Date.now() },
+    );
+
+    // Wait for the RefinementIndicator pill to appear in the title bar —
+    // it becomes visible as soon as the store has at least one session.
+    await mainWindow.waitForSelector('[data-testid="refinement-indicator-pill"]', { timeout: 5000 });
+
+    // Send streaming progress deltas, mirroring the onChunk callbacks that
+    // spawnEphemeralAgent fires for each parsed text delta from the subprocess.
+    await electronApp.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (electron: any, sid: string) => {
+        const win = electron.BrowserWindow.getAllWindows()[0];
+        win.webContents.send('refinement:progress', {
+          sessionId: sid,
+          delta: 'Analyzing spec quality...',
+        });
+        win.webContents.send('refinement:progress', {
+          sessionId: sid,
+          delta: '\nChecking problem statement...',
+        });
+      },
+      sessionId,
+    );
+
+    // Expand the refinement indicator dropdown and click the session to open
+    // RefineTicketDialog. This mirrors the normal user flow for reopening a
+    // running session.
+    await mainWindow.click('[data-testid="refinement-indicator-pill"]');
+    await mainWindow.waitForSelector(`[data-testid="refinement-session-${sessionId}"]`, { timeout: 5000 });
+    await mainWindow.click(`[data-testid="refinement-session-${sessionId}"]`);
+
+    // The dialog must be open and the running state must include the stream panel.
+    await mainWindow.waitForSelector('[data-testid="refine-ticket-dialog"]', { timeout: 5000 });
+    await mainWindow.waitForSelector('[data-testid="refine-stream-panel"]', { timeout: 5000 });
+
+    // Wait until the panel contains the streamed text rather than the empty
+    // placeholder ("Waiting for output…"). The IPC events travel through the
+    // preload bridge and the Zustand store, so there may be a brief render lag.
+    await mainWindow.waitForFunction(
+      () => {
+        const panel = document.querySelector('[data-testid="refine-stream-panel"]');
+        return (
+          panel !== null &&
+          panel.textContent !== null &&
+          !panel.textContent.includes('Waiting for output')
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    // Assert the stream panel is visible and populated with the injected delta.
+    const streamPanel = mainWindow.locator('[data-testid="refine-stream-panel"]');
+    await expect(streamPanel).toBeVisible();
+    const panelText = await streamPanel.textContent();
+    expect(panelText).toBeTruthy();
+    expect(panelText).toContain('Analyzing spec quality');
+
+    // Capture a screenshot showing the dialog mid-run with the live-streaming
+    // panel populated (not the static spinner alone).
+    const screenshot = await mainWindow.screenshot();
+    expect(screenshot.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1262,6 +1262,94 @@ describe('ClaudeBackend.runEphemeralAgent — promise settlement', () => {
   });
 });
 
+describe('ClaudeBackend.spawnEphemeralAgent — onChunk streaming callback', () => {
+  beforeEach(() => {
+    spawnedProcesses.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function getEphemeralProcess(): MockChildProcess {
+    return spawnedProcesses[spawnedProcesses.length - 1];
+  }
+
+  it('invokes onChunk for each extracted text delta', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    const chunks: string[] = [];
+    const { promise } = backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000, (d) => chunks.push(d));
+    const proc = getEphemeralProcess();
+
+    const line1 = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'hello ' }] } });
+    const line2 = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'world' }] } });
+    proc.stdout.emit('data', Buffer.from(line1 + '\n' + line2 + '\n'));
+    proc.exitCode = 0;
+    proc.emit('close', 0);
+
+    const result = await promise;
+    expect(result).toBe('hello world');
+    expect(chunks).toEqual(['hello ', 'world']);
+
+    backendUnderTest.destroy();
+  });
+
+  it('does not invoke onChunk for malformed / non-JSON lines', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    const chunks: string[] = [];
+    const { promise } = backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000, (d) => chunks.push(d));
+    const proc = getEphemeralProcess();
+
+    proc.stdout.emit('data', Buffer.from('not json\n'));
+    const line = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } });
+    proc.stdout.emit('data', Buffer.from(line + '\n'));
+    proc.exitCode = 0;
+    proc.emit('close', 0);
+
+    await promise;
+    expect(chunks).toEqual(['ok']);
+
+    backendUnderTest.destroy();
+  });
+
+  it('does not invoke onChunk after cancel', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    const chunks: string[] = [];
+    const { promise, cancel } = backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000, (d) => chunks.push(d));
+    const proc = getEphemeralProcess();
+
+    cancel();
+    // Emit text after cancel — should not fire onChunk
+    const line = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'late' }] } });
+    proc.stdout.emit('data', Buffer.from(line + '\n'));
+
+    await expect(promise).rejects.toThrow('Cancelled');
+    expect(chunks).toEqual([]);
+
+    backendUnderTest.destroy();
+  });
+
+  it('still resolves with the full concatenated text when onChunk is provided', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    const { promise } = backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000, () => {});
+    const proc = getEphemeralProcess();
+
+    const line1 = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'part1 ' }] } });
+    const line2 = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'part2' }] } });
+    proc.stdout.emit('data', Buffer.from(line1 + '\n'));
+    proc.stdout.emit('data', Buffer.from(line2 + '\n'));
+    proc.exitCode = 0;
+    proc.emit('close', 0);
+
+    const result = await promise;
+    expect(result).toBe('part1 part2');
+
+    backendUnderTest.destroy();
+  });
+});
+
 describe('Outer-Claude session token accumulation (agent:token-usage IPC)', () => {
   let backend: AgentBackend;
   let mockWindow: { webContents: { send: ReturnType<typeof vi.fn> } };

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -321,4 +321,126 @@ describe('RefineTicketDialog', () => {
       expect(api.tickets.specCheckAsync).not.toHaveBeenCalled();
     });
   });
+
+  describe('streaming output panel', () => {
+    it('shows the stream panel when session is running', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'running', phase: 'check', startedAt: Date.now(),
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByTestId('refine-stream-panel')).toBeDefined();
+    });
+
+    it('renders streamed text in the panel', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'running', phase: 'check', startedAt: Date.now(),
+          streamingOutput: 'Evaluating spec quality…\nChecking scope…',
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      const panel = screen.getByTestId('refine-stream-panel');
+      expect(panel.textContent).toContain('Evaluating spec quality');
+    });
+
+    it('shows placeholder when streamingOutput is empty', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'running', phase: 'check', startedAt: Date.now(),
+          streamingOutput: '',
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByText('Waiting for output…')).toBeDefined();
+    });
+
+    it('does not show the stream panel when session is ready (pass)', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: { passed: true, questions: [], gateSummary: '', ticketUrl: null, cached: false },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.queryByTestId('refine-stream-panel')).toBeNull();
+    });
+  });
+
+  describe('appendRefinementStreamChunk store action', () => {
+    it('appends delta to streamingOutput for a running session', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'sess', ticketId: '1', projectDir: '/p',
+          status: 'running', phase: 'check', startedAt: 0,
+          streamingOutput: 'hello ',
+        }],
+      });
+      useAppStore.getState().appendRefinementStreamChunk('sess', 'world');
+      const s = useAppStore.getState().refinementSessions[0];
+      expect(s.streamingOutput).toBe('hello world');
+    });
+
+    it('ignores delta for a non-running session', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'sess', ticketId: '1', projectDir: '/p',
+          status: 'ready', phase: 'check', startedAt: 0,
+        }],
+      });
+      useAppStore.getState().appendRefinementStreamChunk('sess', 'ignored');
+      const s = useAppStore.getState().refinementSessions[0];
+      expect(s.streamingOutput).toBeUndefined();
+    });
+
+    it('ignores delta for unknown session id', () => {
+      useAppStore.setState({ refinementSessions: [] });
+      expect(() => useAppStore.getState().appendRefinementStreamChunk('unknown', 'x')).not.toThrow();
+    });
+  });
+
+  describe('upsertRefinementSession clears streamingOutput on completion', () => {
+    it('clears streamingOutput when status transitions to ready', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'sess', ticketId: '1', projectDir: '/p',
+          status: 'running', phase: 'check', startedAt: 0,
+          streamingOutput: 'some output',
+        }],
+      });
+      useAppStore.getState().upsertRefinementSession({
+        id: 'sess', ticketId: '1', projectDir: '/p',
+        status: 'ready', phase: 'check', startedAt: 0,
+        result: { passed: true, questions: [], gateSummary: '', ticketUrl: null, cached: false },
+      });
+      const s = useAppStore.getState().refinementSessions[0];
+      expect(s.streamingOutput).toBeUndefined();
+    });
+
+    it('clears streamingOutput when status transitions to errored', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'sess', ticketId: '1', projectDir: '/p',
+          status: 'running', phase: 'check', startedAt: 0,
+          streamingOutput: 'partial',
+        }],
+      });
+      useAppStore.getState().upsertRefinementSession({
+        id: 'sess', ticketId: '1', projectDir: '/p',
+        status: 'errored', phase: 'check', startedAt: 0,
+        error: 'something failed',
+      });
+      const s = useAppStore.getState().refinementSessions[0];
+      expect(s.streamingOutput).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/refinement-streaming.test.ts
+++ b/tests/unit/refinement-streaming.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Integration test for the refinement streaming chain:
+ * startRefinementAsync → spawnSpecCheck(onChunk) → webContents.send('refinement:progress')
+ *
+ * This drives the real startRefinementAsync IPC handler with a mocked subprocess
+ * (via a controlled spawnSpecCheck) and asserts that refinement:progress events
+ * reach the renderer with the correct {sessionId, delta} payload.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.mock factories are hoisted above all imports, so any
+// variables they reference must also be hoisted via vi.hoisted().
+// ---------------------------------------------------------------------------
+const { registeredHandlers, mockSpawnSpecCheck, mockSpawnSpecRefine } = vi.hoisted(() => {
+  const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
+  const mockSpawnSpecCheck = vi.fn();
+  const mockSpawnSpecRefine = vi.fn();
+  return { registeredHandlers, mockSpawnSpecCheck, mockSpawnSpecRefine };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks (same pattern as ipc-handlers.test.ts)
+// ---------------------------------------------------------------------------
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      registeredHandlers[channel] = handler;
+    }),
+    on: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  BrowserWindow: {
+    fromWebContents: vi.fn(),
+  },
+  app: {
+    getPath: () => '/tmp',
+  },
+}));
+
+vi.mock('../../src/main/index', () => ({
+  registry: {
+    listProjects: vi.fn(),
+    addProject: vi.fn(),
+    removeProject: vi.fn(),
+    getProject: vi.fn(),
+    getPorts: vi.fn(),
+  },
+  stackManager: {
+    setOnStackUpdate: vi.fn(),
+    listStacksWithServices: vi.fn(),
+    getStackWithServices: vi.fn(),
+    createStack: vi.fn(),
+    teardownStack: vi.fn(),
+    stopStack: vi.fn(),
+    startStack: vi.fn(),
+    listStackHistory: vi.fn(),
+    detectStaleWorkspaces: vi.fn(),
+    cleanupStaleWorkspaces: vi.fn(),
+    dispatchTask: vi.fn(),
+    getTasksForStack: vi.fn(),
+    getDiff: vi.fn(),
+    push: vi.fn(),
+    setPullRequest: vi.fn(),
+    getStackMemoryUsage: vi.fn(),
+    getStackDetailedStats: vi.fn(),
+    getStackTaskMetrics: vi.fn(),
+    getStackTokenUsage: vi.fn(),
+    getGlobalTokenUsage: vi.fn(),
+    getRateLimitState: vi.fn(),
+    getWorkflowProgress: vi.fn(),
+    resumeStackWithContinuation: vi.fn(),
+  },
+  dockerRuntime: {
+    isAvailable: vi.fn(),
+    logs: vi.fn(),
+  },
+  podmanRuntime: {
+    isAvailable: vi.fn(),
+    logs: vi.fn(),
+  },
+  agentBackend: {
+    sendMessage: vi.fn(),
+    cancelSession: vi.fn(),
+    resetSession: vi.fn(),
+    getHistory: vi.fn(),
+    getAuthStatus: vi.fn(),
+    login: vi.fn(),
+    syncCredentials: vi.fn(),
+  },
+  dockerConnectionManager: {
+    isConnected: false,
+  },
+  sessionMonitor: {
+    getState: vi.fn(),
+    acknowledgeCritical: vi.fn(),
+    markResumed: vi.fn(),
+    updateSettings: vi.fn(),
+    forcePoll: vi.fn(),
+  },
+  cliDir: '/tmp/sandstorm-cli',
+}));
+
+// Mock tools so spawnSpecCheck is controllable — the key seam under test.
+vi.mock('../../src/main/claude/tools', () => ({
+  handleToolCall: vi.fn(),
+  spawnSpecCheck: mockSpawnSpecCheck,
+  spawnSpecRefine: mockSpawnSpecRefine,
+  validateProjectDir: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/main/custom-context', () => ({
+  getCustomContext: vi.fn(),
+  saveCustomInstructions: vi.fn(),
+  listCustomSkills: vi.fn(),
+  getCustomSkill: vi.fn(),
+  saveCustomSkill: vi.fn(),
+  deleteCustomSkill: vi.fn(),
+  getCustomSettings: vi.fn(),
+  saveCustomSettings: vi.fn(),
+}));
+
+vi.mock('../../src/main/control-plane/account-usage', () => ({
+  fetchAccountUsage: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execFile: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 1, stdout: '', stderr: '' })),
+}));
+
+vi.mock('../../src/main/scheduler', () => ({
+  createSchedule: vi.fn(),
+  listSchedules: vi.fn().mockReturnValue([]),
+  updateSchedule: vi.fn(),
+  deleteSchedule: vi.fn(),
+  isCronRunning: vi.fn().mockReturnValue(true),
+  removeProjectFromCrontab: vi.fn(),
+}));
+
+vi.mock('../../src/main/scheduler/scheduler-manager', () => ({
+  syncAllProjectsCrontab: vi.fn().mockResolvedValue(undefined),
+  projectIdFromDir: vi.fn().mockImplementation((dir: string) => {
+    const parts = dir.split('/');
+    return parts[parts.length - 1].toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+import { registerIpcHandlers } from '../../src/main/ipc';
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+async function invokeHandler(channel: string, ...args: unknown[]): Promise<unknown> {
+  const handler = registeredHandlers[channel];
+  if (!handler) throw new Error(`No handler registered for channel "${channel}"`);
+  const fakeEvent = { sender: { id: 1 } };
+  return handler(fakeEvent, ...args);
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+describe('refinement streaming — IPC chain', () => {
+  let mockMainWindow: { webContents: { send: Mock } };
+
+  beforeEach(() => {
+    for (const key of Object.keys(registeredHandlers)) {
+      delete registeredHandlers[key];
+    }
+    vi.clearAllMocks();
+
+    mockMainWindow = { webContents: { send: vi.fn() } };
+    registerIpcHandlers(mockMainWindow as unknown as import('electron').BrowserWindow);
+  });
+
+  it('forwards onChunk deltas to the renderer via refinement:progress', async () => {
+    let capturedOnChunk: ((delta: string) => void) | undefined;
+
+    // Simulate a subprocess that is still running (promise never resolves here).
+    // We capture the onChunk callback so we can fire it manually.
+    mockSpawnSpecCheck.mockImplementation(
+      (_ticketId: unknown, _projectDir: unknown, onChunk: (delta: string) => void) => {
+        capturedOnChunk = onChunk;
+        return {
+          promise: new Promise<Record<string, unknown>>(() => {}),
+          cancel: vi.fn(),
+        };
+      },
+    );
+
+    // Invoke the async handler — returns {sessionId} immediately while the
+    // ephemeral subprocess runs in the background.
+    const result = (await invokeHandler(
+      'tickets:specCheckAsync',
+      'TICKET-123',
+      '/tmp/my-project',
+    )) as { sessionId: string };
+
+    expect(result).toHaveProperty('sessionId');
+    expect(typeof result.sessionId).toBe('string');
+    const { sessionId } = result;
+
+    // The IPC handler must have called spawnSpecCheck and wired up onChunk.
+    expect(capturedOnChunk).toBeDefined();
+
+    // Fire two scripted stream-json text chunks, just as the real Claude CLI
+    // subprocess would emit them from its stdout parse loop.
+    capturedOnChunk!('Evaluating Problem Statement...');
+    capturedOnChunk!(' Checking Scope Boundaries...');
+
+    // Both deltas must have been forwarded to the renderer on the correct channel
+    // with the session's ID so the store can route them to the right session.
+    expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(
+      'refinement:progress',
+      { sessionId, delta: 'Evaluating Problem Statement...' },
+    );
+    expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(
+      'refinement:progress',
+      { sessionId, delta: ' Checking Scope Boundaries...' },
+    );
+  });
+
+  it('scopes refinement:progress events to the originating session ID', async () => {
+    const onChunks: Array<(delta: string) => void> = [];
+
+    mockSpawnSpecCheck.mockImplementation(
+      (_ticketId: unknown, _projectDir: unknown, onChunk: (delta: string) => void) => {
+        onChunks.push(onChunk);
+        return {
+          promise: new Promise<Record<string, unknown>>(() => {}),
+          cancel: vi.fn(),
+        };
+      },
+    );
+
+    const r1 = (await invokeHandler('tickets:specCheckAsync', 'T-1', '/tmp/proj1')) as {
+      sessionId: string;
+    };
+    const r2 = (await invokeHandler('tickets:specCheckAsync', 'T-2', '/tmp/proj2')) as {
+      sessionId: string;
+    };
+
+    expect(onChunks).toHaveLength(2);
+    expect(r1.sessionId).not.toBe(r2.sessionId);
+
+    onChunks[0]('delta for session 1');
+    onChunks[1]('delta for session 2');
+
+    const progressCalls = mockMainWindow.webContents.send.mock.calls.filter(
+      ([channel]) => channel === 'refinement:progress',
+    );
+
+    const s1Calls = progressCalls.filter(([, payload]) => (payload as { sessionId: string }).sessionId === r1.sessionId);
+    const s2Calls = progressCalls.filter(([, payload]) => (payload as { sessionId: string }).sessionId === r2.sessionId);
+
+    expect(s1Calls).toHaveLength(1);
+    expect(s1Calls[0][1]).toEqual({ sessionId: r1.sessionId, delta: 'delta for session 1' });
+
+    expect(s2Calls).toHaveLength(1);
+    expect(s2Calls[0][1]).toEqual({ sessionId: r2.sessionId, delta: 'delta for session 2' });
+  });
+
+  it('sends a refinement:update event when the session starts', async () => {
+    mockSpawnSpecCheck.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+
+    await invokeHandler('tickets:specCheckAsync', 'TICKET-1', '/tmp/proj');
+
+    expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(
+      'refinement:update',
+      expect.objectContaining({ status: 'running', ticketId: 'TICKET-1' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Stream the inner agent's refinement output live to the Refine Ticket dialog so users can watch spec analysis happen instead of staring at a static "running" state
- Wire a `refinement:progress` IPC channel from the claude backend through the preload bridge into the Zustand store (`appendRefinementStreamChunk`), and render the accumulated text in a stream panel that replaces the "Waiting for output…" placeholder once chunks arrive
- Add the streaming types/plumbing in the agent backend (`claude-backend.ts`, `types.ts`, `tools.ts`) so progress deltas are emitted alongside the existing `refinement:update` session events

## Test plan
- [ ] `npm test` — unit suite passes, including the new `tests/unit/refinement-streaming.test.ts` and updated `claude-backend` / `RefineTicketDialog` tests
- [ ] `npm run typecheck` — clean
- [ ] Run the app, trigger a ticket refinement, and confirm the dialog's stream panel populates with output mid-run rather than showing the waiting placeholder
- [ ] Optionally run the integration spec `tests/integration/refinement-streaming.spec.ts`, which injects a fake running session and streaming deltas and asserts the panel renders the streamed text

Closes #360