### PR TITLE
add refine-to-comments scheduler action

### DIFF
--- a/sandstorm-cli/templates/github/scripts/add-label.sh
+++ b/sandstorm-cli/templates/github/scripts/add-label.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# add-label.sh — Add a label to a GitHub issue.
+#
+# Contract:
+#   Input:  <ticket-id> <label>
+#   Action: adds the label to the issue
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$TICKET_ID" ] || [ -z "$LABEL" ]; then
+  echo "Usage: add-label.sh <ticket-id> <label>" >&2
+  exit 1
+fi
+
+gh issue edit "$TICKET_ID" --add-label "$LABEL" 2>&1 || {
+  echo "Error: Failed to add label '$LABEL' to issue $TICKET_ID. Is 'gh' installed and authenticated?" >&2
+  exit 1
+}

--- a/sandstorm-cli/templates/github/scripts/list-comments.sh
+++ b/sandstorm-cli/templates/github/scripts/list-comments.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# list-comments.sh — List all comments on a GitHub issue.
+#
+# Contract:
+#   Input:  <ticket-id>   (GitHub issue number)
+#   Output: JSON array: [{"author":"<login>","body":"<text>","createdAt":"<iso>"}]
+#           Empty array [] when no comments.
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+
+if [ -z "$TICKET_ID" ]; then
+  echo "Usage: list-comments.sh <ticket-id>" >&2
+  exit 1
+fi
+
+gh issue view "$TICKET_ID" \
+  --json comments \
+  --jq '[.comments[] | {author: .author.login, body: .body, createdAt: .createdAt}]' 2>&1 || {
+  echo "Error: Failed to list comments. Is 'gh' installed and authenticated?" >&2
+  exit 1
+}

--- a/sandstorm-cli/templates/github/scripts/list-tickets.sh
+++ b/sandstorm-cli/templates/github/scripts/list-tickets.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# list-tickets.sh — List open GitHub issues authored by the current user, filtered by label.
+#
+# Contract:
+#   Input:  <label>   (positional — the label to filter by, e.g. "needs-spec")
+#   Output: TSV with one line per issue: <number>\t<title>\t<author-login>
+#           Empty output (no lines) when no matching issues found.
+#   Exit:   0 on success (including empty result), non-zero on failure (error to stderr)
+#
+# Notes:
+#   - Only returns open issues (excludes PRs — gh issue list excludes PRs by default)
+#   - Filtered server-side to issues authored by the current authenticated user (@me)
+#
+set -euo pipefail
+
+LABEL="${1:-}"
+
+if [ -z "$LABEL" ]; then
+  echo "Usage: list-tickets.sh <label>" >&2
+  exit 1
+fi
+
+gh issue list \
+  --label "$LABEL" \
+  --state open \
+  --author @me \
+  --json number,title,author \
+  --jq '.[] | "\(.number)\t\(.title)\t\(.author.login)"' 2>&1 || {
+  echo "Error: Failed to list issues. Is 'gh' installed and authenticated?" >&2
+  exit 1
+}

--- a/sandstorm-cli/templates/github/scripts/post-comment.sh
+++ b/sandstorm-cli/templates/github/scripts/post-comment.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# post-comment.sh — Post a comment on a GitHub issue.
+#
+# Contract:
+#   Input:  <ticket-id> <body>
+#   Action: posts a new comment with the given body
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+BODY="${2:-}"
+
+if [ -z "$TICKET_ID" ] || [ -z "$BODY" ]; then
+  echo "Usage: post-comment.sh <ticket-id> <body>" >&2
+  exit 1
+fi
+
+gh issue comment "$TICKET_ID" --body "$BODY" 2>&1 || {
+  echo "Error: Failed to post comment on issue $TICKET_ID. Is 'gh' installed and authenticated?" >&2
+  exit 1
+}

--- a/sandstorm-cli/templates/github/scripts/remove-label.sh
+++ b/sandstorm-cli/templates/github/scripts/remove-label.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# remove-label.sh — Remove a label from a GitHub issue.
+#
+# Contract:
+#   Input:  <ticket-id> <label>
+#   Action: removes the label from the issue (no-op if label is not present)
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$TICKET_ID" ] || [ -z "$LABEL" ]; then
+  echo "Usage: remove-label.sh <ticket-id> <label>" >&2
+  exit 1
+fi
+
+gh issue edit "$TICKET_ID" --remove-label "$LABEL" 2>&1 || {
+  echo "Error: Failed to remove label '$LABEL' from issue $TICKET_ID. Is 'gh' installed and authenticated?" >&2
+  exit 1
+}

--- a/sandstorm-cli/templates/jira/scripts/add-label.sh
+++ b/sandstorm-cli/templates/jira/scripts/add-label.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# add-label.sh — Add a label to a Jira issue.
+#
+# Prerequisites (export in shell before launching the app):
+#   JIRA_URL        Site root, e.g. https://yourorg.atlassian.net
+#   JIRA_USERNAME   Atlassian account email
+#   JIRA_API_TOKEN  API token from https://id.atlassian.com/manage-profile/security/api-tokens
+#
+# Contract:
+#   Input:  <ticket-id> <label>
+#   Action: adds the label to the issue
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$TICKET_ID" ] || [ -z "$LABEL" ]; then
+  echo "Usage: add-label.sh <ticket-id> <label>" >&2
+  exit 1
+fi
+
+missing_deps=()
+command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
+command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
+if [ ${#missing_deps[@]} -gt 0 ]; then
+  echo "Error: missing required tools: ${missing_deps[*]}" >&2
+  exit 1
+fi
+
+missing_vars=()
+[ -z "${JIRA_URL:-}" ] && missing_vars+=("JIRA_URL")
+[ -z "${JIRA_USERNAME:-}" ] && missing_vars+=("JIRA_USERNAME")
+[ -z "${JIRA_API_TOKEN:-}" ] && missing_vars+=("JIRA_API_TOKEN")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "Error: missing required environment variables: ${missing_vars[*]}" >&2
+  exit 1
+fi
+
+BASE_URL="${JIRA_URL%/}"
+PAYLOAD=$(jq -n --arg label "$LABEL" '{"update":{"labels":[{"add":$label}]}}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X PUT \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "$PAYLOAD" \
+  "${BASE_URL}/rest/api/2/issue/${TICKET_ID}")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error: add-label failed (HTTP $HTTP_CODE)" >&2
+  RESP_BODY=$(echo "$RESPONSE" | sed '$d')
+  echo "$RESP_BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "Added label '$LABEL' to $TICKET_ID."

--- a/sandstorm-cli/templates/jira/scripts/list-comments.sh
+++ b/sandstorm-cli/templates/jira/scripts/list-comments.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# list-comments.sh — List all comments on a Jira issue.
+#
+# Prerequisites (export in shell before launching the app):
+#   JIRA_URL        Site root, e.g. https://yourorg.atlassian.net
+#   JIRA_USERNAME   Atlassian account email
+#   JIRA_API_TOKEN  API token from https://id.atlassian.com/manage-profile/security/api-tokens
+#
+# Contract:
+#   Input:  <ticket-id>   (Jira key, e.g. PROJ-123)
+#   Output: JSON array: [{"author":"<accountId>","body":"<text>","createdAt":"<iso>"}]
+#           Empty array [] when no comments.
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+# Note: author field emits accountId (stable, privacy-safe Jira Cloud identifier)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+
+if [ -z "$TICKET_ID" ]; then
+  echo "Usage: list-comments.sh <ticket-id>" >&2
+  exit 1
+fi
+
+missing_deps=()
+command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
+command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
+if [ ${#missing_deps[@]} -gt 0 ]; then
+  echo "Error: missing required tools: ${missing_deps[*]}" >&2
+  exit 1
+fi
+
+missing_vars=()
+[ -z "${JIRA_URL:-}" ] && missing_vars+=("JIRA_URL")
+[ -z "${JIRA_USERNAME:-}" ] && missing_vars+=("JIRA_USERNAME")
+[ -z "${JIRA_API_TOKEN:-}" ] && missing_vars+=("JIRA_API_TOKEN")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "Error: missing required environment variables: ${missing_vars[*]}" >&2
+  exit 1
+fi
+
+BASE_URL="${JIRA_URL%/}"
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+  -H "Accept: application/json" \
+  "${BASE_URL}/rest/api/2/issue/${TICKET_ID}?fields=comment")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error: Jira API returned HTTP $HTTP_CODE" >&2
+  echo "$BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "$BODY" | jq '[.fields.comment.comments[] | {author: .author.accountId, body: .body, createdAt: .created}]'

--- a/sandstorm-cli/templates/jira/scripts/list-tickets.sh
+++ b/sandstorm-cli/templates/jira/scripts/list-tickets.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# list-tickets.sh — List open Jira issues reported by the current user, filtered by label.
+#
+# Prerequisites (export in shell before launching the app):
+#   JIRA_URL        Site root, e.g. https://yourorg.atlassian.net
+#   JIRA_USERNAME   Atlassian account email
+#   JIRA_API_TOKEN  API token from https://id.atlassian.com/manage-profile/security/api-tokens
+#
+# Contract:
+#   Input:  <label>   (positional — the label to filter by, e.g. "needs-spec")
+#   Output: TSV with one line per issue: <key>\t<summary>\t<reporter-accountId>
+#           Empty output (no lines) when no matching issues found.
+#   Exit:   0 on success (including empty result), non-zero on failure (error to stderr)
+#
+# Notes:
+#   - Uses reporter = currentUser() JQL — filters server-side to the authenticated user
+#   - accountId is used as identity (stable, always present on Jira Cloud)
+#
+set -euo pipefail
+
+LABEL="${1:-}"
+
+if [ -z "$LABEL" ]; then
+  echo "Usage: list-tickets.sh <label>" >&2
+  exit 1
+fi
+
+missing_deps=()
+command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
+command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
+if [ ${#missing_deps[@]} -gt 0 ]; then
+  echo "Error: missing required tools: ${missing_deps[*]}" >&2
+  exit 1
+fi
+
+missing_vars=()
+[ -z "${JIRA_URL:-}" ] && missing_vars+=("JIRA_URL")
+[ -z "${JIRA_USERNAME:-}" ] && missing_vars+=("JIRA_USERNAME")
+[ -z "${JIRA_API_TOKEN:-}" ] && missing_vars+=("JIRA_API_TOKEN")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "Error: missing required environment variables: ${missing_vars[*]}" >&2
+  exit 1
+fi
+
+BASE_URL="${JIRA_URL%/}"
+JQL="reporter = currentUser() AND labels = \"${LABEL}\" AND statusCategory != Done"
+ENCODED_JQL=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$JQL")
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+  -H "Accept: application/json" \
+  "${BASE_URL}/rest/api/2/search?jql=${ENCODED_JQL}&fields=summary,reporter&maxResults=50")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error: Jira API returned HTTP $HTTP_CODE" >&2
+  echo "$BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "$BODY" | jq -r '.issues[] | "\(.key)\t\(.fields.summary)\t\(.fields.reporter.accountId // "")"'

--- a/sandstorm-cli/templates/jira/scripts/post-comment.sh
+++ b/sandstorm-cli/templates/jira/scripts/post-comment.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# post-comment.sh — Post a comment on a Jira issue.
+#
+# Prerequisites (export in shell before launching the app):
+#   JIRA_URL        Site root, e.g. https://yourorg.atlassian.net
+#   JIRA_USERNAME   Atlassian account email
+#   JIRA_API_TOKEN  API token from https://id.atlassian.com/manage-profile/security/api-tokens
+#
+# Contract:
+#   Input:  <ticket-id> <body>
+#   Action: posts a new comment with the given body
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+BODY="${2:-}"
+
+if [ -z "$TICKET_ID" ] || [ -z "$BODY" ]; then
+  echo "Usage: post-comment.sh <ticket-id> <body>" >&2
+  exit 1
+fi
+
+missing_deps=()
+command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
+command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
+if [ ${#missing_deps[@]} -gt 0 ]; then
+  echo "Error: missing required tools: ${missing_deps[*]}" >&2
+  exit 1
+fi
+
+missing_vars=()
+[ -z "${JIRA_URL:-}" ] && missing_vars+=("JIRA_URL")
+[ -z "${JIRA_USERNAME:-}" ] && missing_vars+=("JIRA_USERNAME")
+[ -z "${JIRA_API_TOKEN:-}" ] && missing_vars+=("JIRA_API_TOKEN")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "Error: missing required environment variables: ${missing_vars[*]}" >&2
+  exit 1
+fi
+
+BASE_URL="${JIRA_URL%/}"
+PAYLOAD=$(jq -n --arg body "$BODY" '{"body":$body}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "$PAYLOAD" \
+  "${BASE_URL}/rest/api/2/issue/${TICKET_ID}/comment")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error: post-comment failed (HTTP $HTTP_CODE)" >&2
+  RESP_BODY=$(echo "$RESPONSE" | sed '$d')
+  echo "$RESP_BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "Posted comment on $TICKET_ID."

--- a/sandstorm-cli/templates/jira/scripts/remove-label.sh
+++ b/sandstorm-cli/templates/jira/scripts/remove-label.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# remove-label.sh — Remove a label from a Jira issue.
+#
+# Prerequisites (export in shell before launching the app):
+#   JIRA_URL        Site root, e.g. https://yourorg.atlassian.net
+#   JIRA_USERNAME   Atlassian account email
+#   JIRA_API_TOKEN  API token from https://id.atlassian.com/manage-profile/security/api-tokens
+#
+# Contract:
+#   Input:  <ticket-id> <label>
+#   Action: removes the label from the issue (no-op if label is not present)
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+set -euo pipefail
+
+TICKET_ID="${1:-}"
+LABEL="${2:-}"
+
+if [ -z "$TICKET_ID" ] || [ -z "$LABEL" ]; then
+  echo "Usage: remove-label.sh <ticket-id> <label>" >&2
+  exit 1
+fi
+
+missing_deps=()
+command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
+command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
+if [ ${#missing_deps[@]} -gt 0 ]; then
+  echo "Error: missing required tools: ${missing_deps[*]}" >&2
+  exit 1
+fi
+
+missing_vars=()
+[ -z "${JIRA_URL:-}" ] && missing_vars+=("JIRA_URL")
+[ -z "${JIRA_USERNAME:-}" ] && missing_vars+=("JIRA_USERNAME")
+[ -z "${JIRA_API_TOKEN:-}" ] && missing_vars+=("JIRA_API_TOKEN")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  echo "Error: missing required environment variables: ${missing_vars[*]}" >&2
+  exit 1
+fi
+
+BASE_URL="${JIRA_URL%/}"
+PAYLOAD=$(jq -n --arg label "$LABEL" '{"update":{"labels":[{"remove":$label}]}}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X PUT \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "$PAYLOAD" \
+  "${BASE_URL}/rest/api/2/issue/${TICKET_ID}")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error: remove-label failed (HTTP $HTTP_CODE)" >&2
+  RESP_BODY=$(echo "$RESPONSE" | sed '$d')
+  echo "$RESP_BODY" | jq -r '.errorMessages[]? // empty' >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "Removed label '$LABEL' from $TICKET_ID."

--- a/sandstorm-cli/templates/skeleton/scripts/add-label.sh
+++ b/sandstorm-cli/templates/skeleton/scripts/add-label.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# add-label.sh — Add a label to a ticket.
+#
+# CONTRACT:
+#   Input:  <ticket-id> <label>
+#   Action: adds the label to the ticket
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+# This stub is a no-op. Replace with your ticket system's API call.
+#
+set -euo pipefail
+
+exit 0

--- a/sandstorm-cli/templates/skeleton/scripts/list-comments.sh
+++ b/sandstorm-cli/templates/skeleton/scripts/list-comments.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# list-comments.sh — List all comments on a ticket.
+#
+# CONTRACT:
+#   Input:  <ticket-id>
+#   Output: JSON array: [{"author":"<identity>","body":"<text>","createdAt":"<iso>"}]
+#           Empty array [] when no comments.
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+# This stub returns an empty array. Replace with your ticket system's API call.
+#
+set -euo pipefail
+
+echo "[]"
+exit 0

--- a/sandstorm-cli/templates/skeleton/scripts/list-tickets.sh
+++ b/sandstorm-cli/templates/skeleton/scripts/list-tickets.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# list-tickets.sh — List open tickets for the current user with a given label.
+#
+# CONTRACT:
+#   Input:  <label>   (positional — the label to filter by, e.g. "needs-spec")
+#   Output: TSV with one line per ticket: <id>\t<title>\t<author-identity>
+#           Empty output (no lines) when no matching tickets found.
+#   Exit:   0 on success (including empty result), non-zero on failure (error to stderr)
+#
+# This stub is a clean no-op. Replace with your ticket system's API call.
+# The output format above is what Sandstorm expects.
+#
+set -euo pipefail
+
+# Intentionally empty — no tickets to process from an unconfigured system.
+exit 0

--- a/sandstorm-cli/templates/skeleton/scripts/post-comment.sh
+++ b/sandstorm-cli/templates/skeleton/scripts/post-comment.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# post-comment.sh — Post a comment on a ticket.
+#
+# CONTRACT:
+#   Input:  <ticket-id> <body>
+#   Action: posts a new comment with the given body
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+# This stub is a no-op. Replace with your ticket system's API call.
+#
+set -euo pipefail
+
+exit 0

--- a/sandstorm-cli/templates/skeleton/scripts/remove-label.sh
+++ b/sandstorm-cli/templates/skeleton/scripts/remove-label.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# remove-label.sh — Remove a label from a ticket.
+#
+# CONTRACT:
+#   Input:  <ticket-id> <label>
+#   Action: removes the label from the ticket (no-op if label is not present)
+#   Exit:   0 on success, non-zero on failure (error to stderr)
+#
+# This stub is a no-op. Replace with your ticket system's API call.
+#
+set -euo pipefail
+
+exit 0

--- a/src/main/control-plane/ticket-comments.ts
+++ b/src/main/control-plane/ticket-comments.ts
@@ -1,0 +1,139 @@
+import { execFile } from 'child_process';
+import path from 'path';
+import { getSandstormScriptStatus } from './ticket-updater';
+
+export interface TicketComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface TicketEntry {
+  id: string;
+  title: string;
+  author: string;
+}
+
+function runScript(
+  scriptName: string,
+  projectDir: string,
+  args: string[],
+  timeoutMs = 30000,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', scriptName);
+    const status = getSandstormScriptStatus(projectDir, scriptName);
+    if (status === 'missing') {
+      reject(new Error(`${scriptName} is missing at ${scriptPath}.`));
+      return;
+    }
+    if (status === 'not_executable') {
+      reject(new Error(`${scriptName} exists but is not executable. Run: chmod +x ${scriptPath}`));
+      return;
+    }
+    execFile(
+      scriptPath,
+      args,
+      { cwd: projectDir, timeout: timeoutMs, maxBuffer: 2 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message;
+          reject(new Error(`${scriptName} failed: ${msg}`));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * List open tickets for the current auth user carrying the given label.
+ * Runs `list-tickets.sh <label>` and parses its TSV output.
+ */
+export async function listTickets(
+  label: string,
+  projectDir: string,
+): Promise<TicketEntry[]> {
+  const stdout = await runScript('list-tickets.sh', projectDir, [label]);
+  const lines = stdout.split('\n').filter((l) => l.trim());
+  return lines.map((line) => {
+    const parts = line.split('\t');
+    return {
+      id: parts[0]?.trim() ?? '',
+      title: parts[1]?.trim() ?? '',
+      author: parts[2]?.trim() ?? '',
+    };
+  }).filter((e) => e.id);
+}
+
+/**
+ * List all comments on a ticket. Runs `list-comments.sh <ticket-id>` and
+ * parses its JSON array output.
+ */
+export async function listTicketComments(
+  ticketId: string,
+  projectDir: string,
+): Promise<TicketComment[]> {
+  const stdout = await runScript('list-comments.sh', projectDir, [ticketId]);
+  const trimmed = stdout.trim();
+  if (!trimmed || trimmed === '[]') return [];
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((item: unknown) => {
+      const c = item as Record<string, unknown>;
+      return {
+        author: String(c['author'] ?? ''),
+        body: String(c['body'] ?? ''),
+        createdAt: String(c['createdAt'] ?? ''),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Post a comment on a ticket. Runs `post-comment.sh <ticket-id> <body>`.
+ */
+export function postComment(
+  ticketId: string,
+  projectDir: string,
+  body: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const scriptName = 'post-comment.sh';
+    const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', scriptName);
+    const status = getSandstormScriptStatus(projectDir, scriptName);
+    if (status === 'missing') {
+      reject(new Error(`${scriptName} is missing at ${scriptPath}.`));
+      return;
+    }
+    if (status === 'not_executable') {
+      reject(new Error(`${scriptName} exists but is not executable. Run: chmod +x ${scriptPath}`));
+      return;
+    }
+    if (!ticketId.trim()) {
+      reject(new Error('Ticket ID is required'));
+      return;
+    }
+    if (!body.trim()) {
+      reject(new Error('Comment body cannot be empty'));
+      return;
+    }
+    execFile(
+      scriptPath,
+      [ticketId, body],
+      { cwd: projectDir, timeout: 30000, maxBuffer: 2 * 1024 * 1024 },
+      (err, _stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message;
+          reject(new Error(`${scriptName} failed: ${msg}`));
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+}

--- a/src/main/control-plane/ticket-labels.ts
+++ b/src/main/control-plane/ticket-labels.ts
@@ -1,0 +1,68 @@
+import { execFile } from 'child_process';
+import path from 'path';
+import { getSandstormScriptStatus } from './ticket-updater';
+
+function runLabelScript(
+  scriptName: string,
+  ticketId: string,
+  label: string,
+  projectDir: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', scriptName);
+    const status = getSandstormScriptStatus(projectDir, scriptName);
+    if (status === 'missing') {
+      reject(new Error(`${scriptName} is missing at ${scriptPath}.`));
+      return;
+    }
+    if (status === 'not_executable') {
+      reject(new Error(`${scriptName} exists but is not executable. Run: chmod +x ${scriptPath}`));
+      return;
+    }
+    if (!ticketId.trim()) {
+      reject(new Error('Ticket ID is required'));
+      return;
+    }
+    if (!label.trim()) {
+      reject(new Error('Label is required'));
+      return;
+    }
+    execFile(
+      scriptPath,
+      [ticketId, label],
+      { cwd: projectDir, timeout: 30000, maxBuffer: 512 * 1024 },
+      (err, _stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message;
+          reject(new Error(`${scriptName} failed: ${msg}`));
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+}
+
+/**
+ * Add a label to a ticket. Runs `add-label.sh <ticket-id> <label>`.
+ * Provider-neutral — GitHub, Jira, or any custom backend.
+ */
+export function addLabel(
+  ticketId: string,
+  projectDir: string,
+  label: string,
+): Promise<void> {
+  return runLabelScript('add-label.sh', ticketId, label, projectDir);
+}
+
+/**
+ * Remove a label from a ticket. Runs `remove-label.sh <ticket-id> <label>`.
+ * Provider-neutral — GitHub, Jira, or any custom backend.
+ */
+export function removeLabel(
+  ticketId: string,
+  projectDir: string,
+  label: string,
+): Promise<void> {
+  return runLabelScript('remove-label.sh', ticketId, label, projectDir);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -268,6 +268,28 @@ async function initializeApp(): Promise<void> {
             );
             return response;
           }
+          case 'refine-to-comments': {
+            const { runRefineToComments, buildRefineToCommentsDeps } = await import('./scheduler/refine-to-comments');
+            const { handleToolCall } = await import('./claude/tools');
+            const { defaultSpecGateDeps, runSpecCheck, runSpecRefine } = await import('./control-plane/ticket-spec');
+            const specDeps = defaultSpecGateDeps(
+              (ticketId, projectDir) =>
+                handleToolCall('spec_check', { ticketId, projectDir }) as Promise<import('./control-plane/ticket-spec').SpecGateReport>,
+              (ticketId, projectDir, userAnswers) =>
+                handleToolCall('spec_refine', { ticketId, projectDir, userAnswers }) as Promise<import('./control-plane/ticket-spec').SpecGateReport>,
+            );
+            const deps = buildRefineToCommentsDeps(
+              (ticketId, projectDir) => runSpecCheck(ticketId, projectDir, specDeps),
+              (ticketId, projectDir, userAnswers) => runSpecRefine(ticketId, projectDir, userAnswers, specDeps),
+            );
+            const label = schedule.action.ticketLabel ?? 'needs-spec';
+            const result = await runRefineToComments(project.directory, label, deps);
+            console.log(
+              `[scheduler] refine-to-comments: processed=${result.processed} passed=${result.passed} failed=${result.failed}`,
+            );
+            const dispatchId = `dispatch_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+            return { ok: true, dispatchId };
+          }
           default: {
             const unknownKind = (schedule.action as { kind?: string }).kind;
             return {

--- a/src/main/scheduler/built-in-actions.ts
+++ b/src/main/scheduler/built-in-actions.ts
@@ -7,5 +7,17 @@ export interface BuiltInAction {
   defaultAction: ScheduleAction;
 }
 
-// Populated as #325 / #326 / #327 land.
-export const BUILT_IN_ACTIONS: BuiltInAction[] = [];
+export const BUILT_IN_ACTIONS: BuiltInAction[] = [
+  {
+    kind: 'refine-to-comments',
+    label: 'Refine `needs-spec` tickets',
+    description:
+      'Runs the spec quality gate against open tickets labelled `needs-spec` (or a custom label). ' +
+      'Posts questions as comments; when answers are provided, refines the ticket and — once the gate passes — ' +
+      'swaps `needs-spec` → `spec-ready`.',
+    defaultAction: {
+      kind: 'refine-to-comments',
+      ticketLabel: 'needs-spec',
+    },
+  },
+];

--- a/src/main/scheduler/refine-to-comments.ts
+++ b/src/main/scheduler/refine-to-comments.ts
@@ -1,0 +1,206 @@
+/**
+ * refine-to-comments — scheduled action that closes the loop on rough tickets.
+ *
+ * Per-fire flow (comment-driven model — maintainer answer 2026-05-27 round 2):
+ *
+ * For each open ticket labelled `ticketLabel` and authored by the current user:
+ *
+ *   First pass (no prior bot comment):
+ *     1. Run spec check.
+ *     2. If passes → add `spec-ready`, remove `ticketLabel`.
+ *     3. If fails → post a question comment with the gate's questions.
+ *
+ *   Subsequent fires (bot comment already posted):
+ *     1. Fetch comments. Filter to user comments newer than the last bot comment.
+ *     2. If no new user comments → no-op (unanswered; avoid comment spam).
+ *     3. If user comments exist → run spec refine with those answers as userAnswers.
+ *        The refiner writes the refined description back to the ticket itself.
+ *     4. If gate passes → add `spec-ready`, remove `ticketLabel`.
+ *     5. If gate fails → post a new question comment with remaining questions.
+ *
+ * Never touches the outer-Claude chat session. The spec check/refine calls are
+ * bounded ephemeral LLM subprocesses via agentBackend.runEphemeralAgent.
+ *
+ * Label swap order (Gap B): add `spec-ready` first, then remove `ticketLabel`.
+ * If the remove fails, the ticket retains both labels and stays in the candidate
+ * set on the next fire — the add is idempotent so it just succeeds again.
+ */
+
+import {
+  listTickets as realListTickets,
+  listTicketComments as realListComments,
+  postComment as realPostComment,
+  type TicketComment,
+  type TicketEntry,
+} from '../control-plane/ticket-comments';
+import {
+  addLabel as realAddLabel,
+  removeLabel as realRemoveLabel,
+} from '../control-plane/ticket-labels';
+import type { SpecGateResult } from '../control-plane/ticket-spec';
+
+/** Marker that identifies comments posted by this bot. */
+export const BOT_COMMENT_MARKER = '<!-- sandstorm:bot-question -->';
+
+export interface RefineToCommentsDeps {
+  listTickets: (label: string, projectDir: string) => Promise<TicketEntry[]>;
+  listComments: (ticketId: string, projectDir: string) => Promise<TicketComment[]>;
+  postComment: (ticketId: string, projectDir: string, body: string) => Promise<void>;
+  addLabel: (ticketId: string, projectDir: string, label: string) => Promise<void>;
+  removeLabel: (ticketId: string, projectDir: string, label: string) => Promise<void>;
+  specCheck: (ticketId: string, projectDir: string) => Promise<SpecGateResult>;
+  specRefine: (ticketId: string, projectDir: string, userAnswers: string) => Promise<SpecGateResult>;
+}
+
+export interface RefineToCommentsResult {
+  processed: number;
+  passed: number;
+  failed: number;
+}
+
+export function isBotComment(comment: TicketComment): boolean {
+  return comment.body.includes(BOT_COMMENT_MARKER);
+}
+
+export function getLastBotComment(comments: TicketComment[]): TicketComment | null {
+  for (let i = comments.length - 1; i >= 0; i--) {
+    if (isBotComment(comments[i])) return comments[i];
+  }
+  return null;
+}
+
+export function getUserAnswersAfterBot(
+  comments: TicketComment[],
+  ticketAuthor: string,
+  lastBotComment: TicketComment | null,
+): string {
+  const afterTimestamp = lastBotComment?.createdAt ?? null;
+  const answers = comments.filter(
+    (c) =>
+      c.author === ticketAuthor &&
+      !isBotComment(c) &&
+      (afterTimestamp === null || c.createdAt > afterTimestamp),
+  );
+  return answers.map((c) => c.body).join('\n\n');
+}
+
+export function formatQuestionComment(questions: string[], gateSummary: string): string {
+  const lines = [
+    BOT_COMMENT_MARKER,
+    '',
+    '## Spec Review',
+    '',
+    "I've reviewed this ticket and have a few questions before it can move to `spec-ready`:",
+    '',
+    ...questions.map((q, i) => `${i + 1}. ${q}`),
+  ];
+  if (gateSummary) {
+    lines.push('', `_Sandstorm spec gate: ${gateSummary}_`);
+  }
+  return lines.join('\n');
+}
+
+async function processTicket(
+  ticket: TicketEntry,
+  projectDir: string,
+  ticketLabel: string,
+  deps: RefineToCommentsDeps,
+): Promise<'passed' | 'failed' | 'skipped'> {
+  const { id: ticketId, author: ticketAuthor } = ticket;
+
+  const comments = await deps.listComments(ticketId, projectDir);
+  const lastBotComment = getLastBotComment(comments);
+  const userAnswers = getUserAnswersAfterBot(comments, ticketAuthor, lastBotComment);
+
+  if (lastBotComment && !userAnswers) {
+    // Bot already asked questions; user hasn't answered yet — no-op.
+    return 'skipped';
+  }
+
+  let result: SpecGateResult;
+
+  if (userAnswers) {
+    // Fold-in: run refiner with the user's answers. The refiner writes the
+    // updated description body back to the ticket itself.
+    result = await deps.specRefine(ticketId, projectDir, userAnswers);
+  } else {
+    // First pass: no bot comment, no user answers — run the check.
+    result = await deps.specCheck(ticketId, projectDir);
+  }
+
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  if (result.passed) {
+    // add spec-ready first, then remove ticketLabel (Gap B swap order).
+    await deps.addLabel(ticketId, projectDir, 'spec-ready');
+    await deps.removeLabel(ticketId, projectDir, ticketLabel);
+    return 'passed';
+  }
+
+  // Gate failed — post a question comment (or re-ask with updated questions).
+  if (result.questions.length > 0) {
+    const commentBody = formatQuestionComment(result.questions, result.gateSummary);
+    await deps.postComment(ticketId, projectDir, commentBody);
+  }
+  return 'failed';
+}
+
+/**
+ * Run the refine-to-comments action for all candidate tickets.
+ * Per-ticket errors are caught and logged; the fire continues with the next candidate.
+ */
+export async function runRefineToComments(
+  projectDir: string,
+  ticketLabel: string,
+  deps: RefineToCommentsDeps,
+): Promise<RefineToCommentsResult> {
+  const result: RefineToCommentsResult = { processed: 0, passed: 0, failed: 0 };
+
+  let tickets: TicketEntry[];
+  try {
+    tickets = await deps.listTickets(ticketLabel, projectDir);
+  } catch (err) {
+    console.error('[refine-to-comments] Failed to list tickets:', err);
+    return result;
+  }
+
+  for (const ticket of tickets) {
+    result.processed++;
+    try {
+      const outcome = await processTicket(ticket, projectDir, ticketLabel, deps);
+      if (outcome === 'passed') {
+        result.passed++;
+      } else if (outcome === 'failed') {
+        result.failed++;
+      }
+      // 'skipped' counts as processed but neither passed nor failed
+    } catch (err) {
+      console.error(`[refine-to-comments] Error processing ticket ${ticket.id}:`, err);
+      result.failed++;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Wire up the real deps for production use.
+ * Accepts pre-wired specCheck/specRefine so the caller (index.ts) controls
+ * how the ephemeral LLM is invoked (mirrors the ipc.ts specDeps pattern).
+ */
+export function buildRefineToCommentsDeps(
+  specCheck: (ticketId: string, projectDir: string) => Promise<SpecGateResult>,
+  specRefine: (ticketId: string, projectDir: string, userAnswers: string) => Promise<SpecGateResult>,
+): RefineToCommentsDeps {
+  return {
+    listTickets: realListTickets,
+    listComments: realListComments,
+    postComment: realPostComment,
+    addLabel: realAddLabel,
+    removeLabel: realRemoveLabel,
+    specCheck,
+    specRefine,
+  };
+}

--- a/src/main/scheduler/schedule-service.ts
+++ b/src/main/scheduler/schedule-service.ts
@@ -26,6 +26,9 @@ function isValidAction(a: unknown): a is ScheduleAction {
   if (obj.kind === 'run-script') {
     return typeof obj.scriptName === 'string' && obj.scriptName.trim().length > 0;
   }
+  if (obj.kind === 'refine-to-comments') {
+    return obj.ticketLabel === undefined || (typeof obj.ticketLabel === 'string' && obj.ticketLabel.trim().length > 0);
+  }
   return false;
 }
 
@@ -114,7 +117,7 @@ export function createSchedule(input: CreateScheduleInput): Schedule {
   }
 
   if (!isValidAction(action)) {
-    throw new Error('Invalid schedule action: expected { kind: "run-script", scriptName: string }');
+    throw new Error('Invalid schedule action: unsupported kind or missing required fields');
   }
 
   const now = new Date().toISOString();
@@ -169,7 +172,7 @@ export function updateSchedule(
 
   if (patch.action !== undefined) {
     if (!isValidAction(patch.action)) {
-      throw new Error('Invalid schedule action: expected { kind: "run-script", scriptName: string }');
+      throw new Error('Invalid schedule action: unsupported kind or missing required fields');
     }
     store.schedules[idx].action = patch.action;
   }

--- a/src/main/scheduler/types.ts
+++ b/src/main/scheduler/types.ts
@@ -23,6 +23,15 @@ export type ScheduleAction =
        * segment or absolute path) is rejected.
        */
       scriptName: string;
+    }
+  | {
+      kind: 'refine-to-comments';
+      /**
+       * Label used to find candidate tickets (default: "needs-spec").
+       * Tickets with this label authored by the current user are processed.
+       * On gate-pass the label is swapped to "spec-ready".
+       */
+      ticketLabel?: string;
     };
 
 export interface Schedule {

--- a/src/renderer/components/scheduler/RefineToCommentsConfig.tsx
+++ b/src/renderer/components/scheduler/RefineToCommentsConfig.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface RefineToCommentsConfigProps {
+  ticketLabel?: string;
+  onChange?: (ticketLabel: string) => void;
+}
+
+export function RefineToCommentsConfig({ ticketLabel, onChange }: RefineToCommentsConfigProps) {
+  const value = ticketLabel ?? 'needs-spec';
+
+  return (
+    <div className="space-y-2" data-testid="refine-to-comments-config">
+      <div>
+        <label className="block text-[10px] text-sandstorm-muted mb-1">
+          Ticket label to process
+        </label>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange?.(e.target.value)}
+          placeholder="needs-spec"
+          className="w-full bg-sandstorm-surface border border-sandstorm-border rounded px-2 py-1 text-xs text-sandstorm-text-primary focus:outline-none focus:border-sandstorm-accent"
+          data-testid="refine-to-comments-label-input"
+        />
+      </div>
+      <p className="text-[10px] text-sandstorm-muted">
+        On each fire, open tickets with this label authored by you are checked against the spec
+        quality gate. Questions are posted as comments; once answered and the gate passes, the label
+        swaps to{' '}
+        <span className="font-mono text-sandstorm-text-secondary">spec-ready</span>.
+      </p>
+    </div>
+  );
+}

--- a/tests/unit/components/RefineToCommentsConfig.test.tsx
+++ b/tests/unit/components/RefineToCommentsConfig.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+afterEach(() => cleanup());
+import { RefineToCommentsConfig } from '../../../src/renderer/components/scheduler/RefineToCommentsConfig';
+
+describe('RefineToCommentsConfig', () => {
+  it('renders with default label when ticketLabel is not provided', () => {
+    render(<RefineToCommentsConfig />);
+
+    const input = screen.getByTestId('refine-to-comments-label-input') as HTMLInputElement;
+    expect(input.value).toBe('needs-spec');
+  });
+
+  it('renders with a custom label when ticketLabel is provided', () => {
+    render(<RefineToCommentsConfig ticketLabel="my-custom-label" />);
+
+    const input = screen.getByTestId('refine-to-comments-label-input') as HTMLInputElement;
+    expect(input.value).toBe('my-custom-label');
+  });
+
+  it('invokes onChange when the input value changes', () => {
+    const onChange = vi.fn();
+    render(<RefineToCommentsConfig ticketLabel="needs-spec" onChange={onChange} />);
+
+    const input = screen.getByTestId('refine-to-comments-label-input');
+    fireEvent.change(input, { target: { value: 'ready-for-spec' } });
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('ready-for-spec');
+  });
+
+  it('does not throw when onChange is not provided and input changes', () => {
+    render(<RefineToCommentsConfig ticketLabel="needs-spec" />);
+
+    const input = screen.getByTestId('refine-to-comments-label-input');
+    expect(() => fireEvent.change(input, { target: { value: 'new-label' } })).not.toThrow();
+  });
+
+  it('renders the container with description text about spec-ready', () => {
+    render(<RefineToCommentsConfig />);
+
+    expect(screen.getByTestId('refine-to-comments-config')).toBeTruthy();
+    const container = screen.getByTestId('refine-to-comments-config');
+    expect(container.textContent).toContain('spec-ready');
+  });
+});

--- a/tests/unit/main/control-plane/ticket-comments.test.ts
+++ b/tests/unit/main/control-plane/ticket-comments.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { listTickets, listTicketComments, postComment } from '../../../../src/main/control-plane/ticket-comments';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ticket-comments-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.sandstorm', 'scripts'), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function installScript(name: string, body: string): void {
+  fs.writeFileSync(path.join(tmpDir, '.sandstorm', 'scripts', name), body, { mode: 0o755 });
+}
+
+describe('listTickets', () => {
+  it('rejects when list-tickets.sh is missing', async () => {
+    await expect(listTickets('needs-spec', tmpDir)).rejects.toThrow(/list-tickets\.sh is missing/);
+  });
+
+  it('returns empty array when script outputs nothing', async () => {
+    installScript('list-tickets.sh', '#!/bin/bash\nexit 0\n');
+    const result = await listTickets('needs-spec', tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('parses TSV output into TicketEntry array', async () => {
+    const sideChannel = path.join(tmpDir, 'label');
+    installScript(
+      'list-tickets.sh',
+      `#!/bin/bash\nprintf "%s\\n" "$1" > "${sideChannel}"\nprintf "42\\tFix the bug\\tmonkeyuser\\n123\\tAnother ticket\\tmonkeyuser\\n"\n`,
+    );
+    const result = await listTickets('needs-spec', tmpDir);
+    expect(fs.readFileSync(sideChannel, 'utf-8').trim()).toBe('needs-spec');
+    expect(result).toEqual([
+      { id: '42', title: 'Fix the bug', author: 'monkeyuser' },
+      { id: '123', title: 'Another ticket', author: 'monkeyuser' },
+    ]);
+  });
+
+  it('filters out rows with empty id', async () => {
+    installScript('list-tickets.sh', '#!/bin/bash\nprintf "\\t\\t\\n"\n');
+    const result = await listTickets('needs-spec', tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('rejects when script exits non-zero', async () => {
+    installScript('list-tickets.sh', '#!/bin/bash\necho "auth error" >&2\nexit 1\n');
+    await expect(listTickets('needs-spec', tmpDir)).rejects.toThrow(/auth error/);
+  });
+});
+
+describe('listTicketComments', () => {
+  it('rejects when list-comments.sh is missing', async () => {
+    await expect(listTicketComments('42', tmpDir)).rejects.toThrow(/list-comments\.sh is missing/);
+  });
+
+  it('returns empty array when script outputs empty array', async () => {
+    installScript('list-comments.sh', '#!/bin/bash\necho "[]"\n');
+    const result = await listTicketComments('42', tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('parses JSON array of comments', async () => {
+    const comments = [
+      { author: 'monkeyuser', body: 'This is my answer', createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    installScript(
+      'list-comments.sh',
+      `#!/bin/bash\necho '${JSON.stringify(comments)}'\n`,
+    );
+    const result = await listTicketComments('42', tmpDir);
+    expect(result).toEqual(comments);
+  });
+
+  it('returns empty array on invalid JSON', async () => {
+    installScript('list-comments.sh', '#!/bin/bash\necho "not json"\n');
+    const result = await listTicketComments('42', tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('passes ticket id to the script', async () => {
+    const sideChannel = path.join(tmpDir, 'args');
+    installScript(
+      'list-comments.sh',
+      `#!/bin/bash\necho "$1" > "${sideChannel}"\necho "[]"\n`,
+    );
+    await listTicketComments('PROJ-123', tmpDir);
+    expect(fs.readFileSync(sideChannel, 'utf-8').trim()).toBe('PROJ-123');
+  });
+});
+
+describe('postComment', () => {
+  it('rejects when post-comment.sh is missing', async () => {
+    await expect(postComment('42', tmpDir, 'hello')).rejects.toThrow(/post-comment\.sh is missing/);
+  });
+
+  it('rejects when ticketId is empty', async () => {
+    installScript('post-comment.sh', '#!/bin/bash\nexit 0\n');
+    await expect(postComment('  ', tmpDir, 'hello')).rejects.toThrow(/Ticket ID is required/);
+  });
+
+  it('rejects when body is empty', async () => {
+    installScript('post-comment.sh', '#!/bin/bash\nexit 0\n');
+    await expect(postComment('42', tmpDir, '  ')).rejects.toThrow(/body cannot be empty/);
+  });
+
+  it('passes ticket id and body as positional args', async () => {
+    const sideChannel = path.join(tmpDir, 'args');
+    installScript(
+      'post-comment.sh',
+      `#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "${sideChannel}"\nexit 0\n`,
+    );
+    await postComment('42', tmpDir, 'My comment body');
+    const args = fs.readFileSync(sideChannel, 'utf-8').split('\n').filter(Boolean);
+    expect(args).toEqual(['42', 'My comment body']);
+  });
+
+  it('rejects with script stderr on failure', async () => {
+    installScript('post-comment.sh', '#!/bin/bash\necho "401 Unauthorized" >&2\nexit 1\n');
+    await expect(postComment('42', tmpDir, 'body')).rejects.toThrow(/401 Unauthorized/);
+  });
+
+  it('resolves on success', async () => {
+    installScript('post-comment.sh', '#!/bin/bash\nexit 0\n');
+    await expect(postComment('42', tmpDir, 'body')).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/main/control-plane/ticket-labels.test.ts
+++ b/tests/unit/main/control-plane/ticket-labels.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { addLabel, removeLabel } from '../../../../src/main/control-plane/ticket-labels';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ticket-labels-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.sandstorm', 'scripts'), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function installScript(name: string, body: string): void {
+  fs.writeFileSync(path.join(tmpDir, '.sandstorm', 'scripts', name), body, { mode: 0o755 });
+}
+
+describe('addLabel', () => {
+  it('rejects when add-label.sh is missing', async () => {
+    await expect(addLabel('42', tmpDir, 'spec-ready')).rejects.toThrow(/add-label\.sh is missing/);
+  });
+
+  it('rejects when ticketId is empty', async () => {
+    installScript('add-label.sh', '#!/bin/bash\nexit 0\n');
+    await expect(addLabel('  ', tmpDir, 'spec-ready')).rejects.toThrow(/Ticket ID is required/);
+  });
+
+  it('rejects when label is empty', async () => {
+    installScript('add-label.sh', '#!/bin/bash\nexit 0\n');
+    await expect(addLabel('42', tmpDir, '  ')).rejects.toThrow(/Label is required/);
+  });
+
+  it('passes ticket id and label as positional args', async () => {
+    const sideChannel = path.join(tmpDir, 'args');
+    installScript(
+      'add-label.sh',
+      `#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "${sideChannel}"\nexit 0\n`,
+    );
+    await addLabel('42', tmpDir, 'spec-ready');
+    const args = fs.readFileSync(sideChannel, 'utf-8').split('\n').filter(Boolean);
+    expect(args).toEqual(['42', 'spec-ready']);
+  });
+
+  it('rejects with script stderr on failure', async () => {
+    installScript('add-label.sh', '#!/bin/bash\necho "label not found" >&2\nexit 1\n');
+    await expect(addLabel('42', tmpDir, 'spec-ready')).rejects.toThrow(/label not found/);
+  });
+
+  it('resolves on success', async () => {
+    installScript('add-label.sh', '#!/bin/bash\nexit 0\n');
+    await expect(addLabel('42', tmpDir, 'spec-ready')).resolves.toBeUndefined();
+  });
+});
+
+describe('removeLabel', () => {
+  it('rejects when remove-label.sh is missing', async () => {
+    await expect(removeLabel('42', tmpDir, 'needs-spec')).rejects.toThrow(/remove-label\.sh is missing/);
+  });
+
+  it('passes ticket id and label as positional args', async () => {
+    const sideChannel = path.join(tmpDir, 'args');
+    installScript(
+      'remove-label.sh',
+      `#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "${sideChannel}"\nexit 0\n`,
+    );
+    await removeLabel('42', tmpDir, 'needs-spec');
+    const args = fs.readFileSync(sideChannel, 'utf-8').split('\n').filter(Boolean);
+    expect(args).toEqual(['42', 'needs-spec']);
+  });
+
+  it('resolves on success', async () => {
+    installScript('remove-label.sh', '#!/bin/bash\nexit 0\n');
+    await expect(removeLabel('42', tmpDir, 'needs-spec')).resolves.toBeUndefined();
+  });
+
+  it('rejects with script stderr on failure', async () => {
+    installScript('remove-label.sh', '#!/bin/bash\necho "permission denied" >&2\nexit 1\n');
+    await expect(removeLabel('42', tmpDir, 'needs-spec')).rejects.toThrow(/permission denied/);
+  });
+});
+
+describe('label swap order (Gap B)', () => {
+  it('add-label resolves before remove-label is called', async () => {
+    const calls: string[] = [];
+    const sideChannel = path.join(tmpDir, 'calls');
+
+    installScript('add-label.sh', `#!/bin/bash\necho "add $2" >> "${sideChannel}"\nexit 0\n`);
+    installScript('remove-label.sh', `#!/bin/bash\necho "remove $2" >> "${sideChannel}"\nexit 0\n`);
+
+    await addLabel('42', tmpDir, 'spec-ready');
+    await removeLabel('42', tmpDir, 'needs-spec');
+
+    const lines = fs.readFileSync(sideChannel, 'utf-8').trim().split('\n');
+    expect(lines[0]).toBe('add spec-ready');
+    expect(lines[1]).toBe('remove needs-spec');
+    void calls;
+  });
+});

--- a/tests/unit/main/scheduler/refine-to-comments.test.ts
+++ b/tests/unit/main/scheduler/refine-to-comments.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runRefineToComments,
+  formatQuestionComment,
+  isBotComment,
+  getLastBotComment,
+  getUserAnswersAfterBot,
+  BOT_COMMENT_MARKER,
+  type RefineToCommentsDeps,
+} from '../../../../src/main/scheduler/refine-to-comments';
+import type { TicketEntry, TicketComment } from '../../../../src/main/control-plane/ticket-comments';
+import type { SpecGateResult } from '../../../../src/main/control-plane/ticket-spec';
+
+const PASS_RESULT: SpecGateResult = {
+  passed: true,
+  questions: [],
+  gateSummary: 'Gate=PASS, questions=0',
+  ticketUrl: null,
+  cached: false,
+};
+
+const FAIL_RESULT: SpecGateResult = {
+  passed: false,
+  questions: ['What does "fast" mean?', 'Which provider handles auth?'],
+  gateSummary: 'Gate=FAIL, questions=2',
+  ticketUrl: null,
+  cached: false,
+};
+
+const TICKET: TicketEntry = { id: '42', title: 'My rough ticket', author: 'devuser' };
+
+function makeDeps(overrides: Partial<RefineToCommentsDeps> = {}): RefineToCommentsDeps {
+  return {
+    listTickets: vi.fn().mockResolvedValue([TICKET]),
+    listComments: vi.fn().mockResolvedValue([]),
+    postComment: vi.fn().mockResolvedValue(undefined),
+    addLabel: vi.fn().mockResolvedValue(undefined),
+    removeLabel: vi.fn().mockResolvedValue(undefined),
+    specCheck: vi.fn().mockResolvedValue(PASS_RESULT),
+    specRefine: vi.fn().mockResolvedValue(PASS_RESULT),
+    ...overrides,
+  };
+}
+
+// ── Helper unit tests ────────────────────────────────────────────────────────
+
+describe('isBotComment', () => {
+  it('returns true when body contains the marker', () => {
+    expect(isBotComment({ author: 'bot', body: `${BOT_COMMENT_MARKER}\nHello`, createdAt: '' })).toBe(true);
+  });
+
+  it('returns false for a regular user comment', () => {
+    expect(isBotComment({ author: 'user', body: 'My answer is X', createdAt: '' })).toBe(false);
+  });
+});
+
+describe('getLastBotComment', () => {
+  it('returns null when no bot comments exist', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: 'Hello', createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    expect(getLastBotComment(comments)).toBeNull();
+  });
+
+  it('returns the last bot comment in chronological order', () => {
+    const first: TicketComment = { author: 'bot', body: `${BOT_COMMENT_MARKER}\nQ1`, createdAt: '2026-05-01T10:00:00Z' };
+    const second: TicketComment = { author: 'bot', body: `${BOT_COMMENT_MARKER}\nQ2`, createdAt: '2026-05-02T10:00:00Z' };
+    const user: TicketComment = { author: 'devuser', body: 'My answer', createdAt: '2026-05-01T12:00:00Z' };
+    expect(getLastBotComment([first, user, second])).toBe(second);
+  });
+});
+
+describe('getUserAnswersAfterBot', () => {
+  it('returns empty string when no user comments exist', () => {
+    const botComment: TicketComment = { author: 'bot', body: `${BOT_COMMENT_MARKER}\nQ?`, createdAt: '2026-05-01T10:00:00Z' };
+    expect(getUserAnswersAfterBot([], 'devuser', botComment)).toBe('');
+  });
+
+  it('returns empty string when user comment precedes bot comment', () => {
+    const botComment: TicketComment = { author: 'bot', body: `${BOT_COMMENT_MARKER}\nQ?`, createdAt: '2026-05-02T10:00:00Z' };
+    const userBefore: TicketComment = { author: 'devuser', body: 'Old note', createdAt: '2026-05-01T10:00:00Z' };
+    expect(getUserAnswersAfterBot([userBefore, botComment], 'devuser', botComment)).toBe('');
+  });
+
+  it('returns concatenated answers from user comments after bot comment', () => {
+    const botComment: TicketComment = { author: 'bot', body: `${BOT_COMMENT_MARKER}\nQ?`, createdAt: '2026-05-01T10:00:00Z' };
+    const ans1: TicketComment = { author: 'devuser', body: 'Answer one', createdAt: '2026-05-02T10:00:00Z' };
+    const ans2: TicketComment = { author: 'devuser', body: 'Answer two', createdAt: '2026-05-03T10:00:00Z' };
+    const result = getUserAnswersAfterBot([botComment, ans1, ans2], 'devuser', botComment);
+    expect(result).toBe('Answer one\n\nAnswer two');
+  });
+
+  it('ignores comments from other users', () => {
+    const botComment: TicketComment = { author: 'bot', body: `${BOT_COMMENT_MARKER}\nQ?`, createdAt: '2026-05-01T10:00:00Z' };
+    const other: TicketComment = { author: 'otheruser', body: 'Other person comment', createdAt: '2026-05-02T10:00:00Z' };
+    expect(getUserAnswersAfterBot([botComment, other], 'devuser', botComment)).toBe('');
+  });
+
+  it('includes all user comments when no bot comment exists (first pass)', () => {
+    const userComment: TicketComment = { author: 'devuser', body: 'Initial clarification', createdAt: '2026-05-01T10:00:00Z' };
+    expect(getUserAnswersAfterBot([userComment], 'devuser', null)).toBe('Initial clarification');
+  });
+});
+
+describe('formatQuestionComment', () => {
+  it('includes the bot marker', () => {
+    const result = formatQuestionComment(['Q1', 'Q2'], 'Gate=FAIL, questions=2');
+    expect(result).toContain(BOT_COMMENT_MARKER);
+  });
+
+  it('formats questions as numbered list', () => {
+    const result = formatQuestionComment(['What is X?', 'Why Y?'], '');
+    expect(result).toContain('1. What is X?');
+    expect(result).toContain('2. Why Y?');
+  });
+
+  it('includes gate summary when provided', () => {
+    const result = formatQuestionComment(['Q'], 'Gate=FAIL, questions=1');
+    expect(result).toContain('Gate=FAIL, questions=1');
+  });
+});
+
+// ── Integration tests ────────────────────────────────────────────────────────
+
+describe('runRefineToComments — first pass, no comments', () => {
+  it('runs spec check and posts questions when gate fails', async () => {
+    const deps = makeDeps({
+      specCheck: vi.fn().mockResolvedValue(FAIL_RESULT),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(deps.specCheck).toHaveBeenCalledWith('42', '/proj');
+    expect(deps.postComment).toHaveBeenCalledOnce();
+    const [id, , body] = (deps.postComment as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(id).toBe('42');
+    expect(body).toContain(BOT_COMMENT_MARKER);
+    expect(body).toContain('What does "fast" mean?');
+    expect(result).toEqual({ processed: 1, passed: 0, failed: 1 });
+  });
+
+  it('swaps labels when gate passes on first check', async () => {
+    const deps = makeDeps({ specCheck: vi.fn().mockResolvedValue(PASS_RESULT) });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(deps.addLabel).toHaveBeenCalledWith('42', '/proj', 'spec-ready');
+    expect(deps.removeLabel).toHaveBeenCalledWith('42', '/proj', 'needs-spec');
+    expect(deps.postComment).not.toHaveBeenCalled();
+    expect(result).toEqual({ processed: 1, passed: 1, failed: 0 });
+  });
+
+  it('adds spec-ready before removing needs-spec (Gap B swap order)', async () => {
+    const calls: string[] = [];
+    const deps = makeDeps({
+      specCheck: vi.fn().mockResolvedValue(PASS_RESULT),
+      addLabel: vi.fn().mockImplementation(async () => { calls.push('add'); }),
+      removeLabel: vi.fn().mockImplementation(async () => { calls.push('remove'); }),
+    });
+    await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(calls).toEqual(['add', 'remove']);
+  });
+});
+
+describe('runRefineToComments — subsequent fire, unanswered', () => {
+  it('is a no-op when bot has posted but user has not answered', async () => {
+    const botComment: TicketComment = {
+      author: 'bot',
+      body: `${BOT_COMMENT_MARKER}\n## Spec Review\n1. What does X mean?`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const deps = makeDeps({
+      listComments: vi.fn().mockResolvedValue([botComment]),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(deps.specCheck).not.toHaveBeenCalled();
+    expect(deps.specRefine).not.toHaveBeenCalled();
+    expect(deps.postComment).not.toHaveBeenCalled();
+    expect(deps.addLabel).not.toHaveBeenCalled();
+    // processed=1, but neither passed nor failed
+    expect(result).toEqual({ processed: 1, passed: 0, failed: 0 });
+  });
+});
+
+describe('runRefineToComments — fold-in with user answer', () => {
+  it('runs refiner with user answers and swaps labels when gate passes', async () => {
+    const botComment: TicketComment = {
+      author: 'bot',
+      body: `${BOT_COMMENT_MARKER}\n1. Q?`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const userAnswer: TicketComment = {
+      author: 'devuser',
+      body: 'My answer to Q',
+      createdAt: '2026-05-02T10:00:00Z',
+    };
+    const deps = makeDeps({
+      listComments: vi.fn().mockResolvedValue([botComment, userAnswer]),
+      specRefine: vi.fn().mockResolvedValue(PASS_RESULT),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(deps.specRefine).toHaveBeenCalledWith('42', '/proj', 'My answer to Q');
+    expect(deps.addLabel).toHaveBeenCalledWith('42', '/proj', 'spec-ready');
+    expect(deps.removeLabel).toHaveBeenCalledWith('42', '/proj', 'needs-spec');
+    expect(result).toEqual({ processed: 1, passed: 1, failed: 0 });
+  });
+
+  it('posts new question comment when refiner still fails', async () => {
+    const botComment: TicketComment = {
+      author: 'bot',
+      body: `${BOT_COMMENT_MARKER}\n1. Q?`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const userAnswer: TicketComment = {
+      author: 'devuser',
+      body: 'Partial answer',
+      createdAt: '2026-05-02T10:00:00Z',
+    };
+    const deps = makeDeps({
+      listComments: vi.fn().mockResolvedValue([botComment, userAnswer]),
+      specRefine: vi.fn().mockResolvedValue(FAIL_RESULT),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(deps.postComment).toHaveBeenCalledOnce();
+    const body = (deps.postComment as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    expect(body).toContain(BOT_COMMENT_MARKER);
+    expect(result).toEqual({ processed: 1, passed: 0, failed: 1 });
+  });
+});
+
+describe('runRefineToComments — error handling', () => {
+  it('returns empty result when listTickets fails', async () => {
+    const deps = makeDeps({
+      listTickets: vi.fn().mockRejectedValue(new Error('gh: not authenticated')),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(result).toEqual({ processed: 0, passed: 0, failed: 0 });
+  });
+
+  it('counts per-ticket error as failed and continues to next ticket', async () => {
+    const ticket2: TicketEntry = { id: '99', title: 'Second', author: 'devuser' };
+    const deps = makeDeps({
+      listTickets: vi.fn().mockResolvedValue([TICKET, ticket2]),
+      specCheck: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('LLM timeout'))
+        .mockResolvedValueOnce(PASS_RESULT),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(result.processed).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.passed).toBe(1);
+  });
+
+  it('counts spec result with error field as thrown error (failed)', async () => {
+    const errorResult: SpecGateResult = {
+      passed: false,
+      questions: [],
+      gateSummary: '',
+      ticketUrl: null,
+      cached: false,
+      error: 'fetch-ticket.sh is missing',
+    };
+    const deps = makeDeps({ specCheck: vi.fn().mockResolvedValue(errorResult) });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(result.failed).toBe(1);
+    expect(deps.postComment).not.toHaveBeenCalled();
+  });
+
+  it('non-author comments are ignored when filtering answers', async () => {
+    const botComment: TicketComment = {
+      author: 'bot',
+      body: `${BOT_COMMENT_MARKER}\n1. Q?`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const otherUser: TicketComment = {
+      author: 'nottheauthor',
+      body: 'I can answer this!',
+      createdAt: '2026-05-02T10:00:00Z',
+    };
+    const deps = makeDeps({
+      listComments: vi.fn().mockResolvedValue([botComment, otherUser]),
+    });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    // otherUser's comment doesn't count — treated as unanswered → no-op
+    expect(deps.specRefine).not.toHaveBeenCalled();
+    expect(deps.specCheck).not.toHaveBeenCalled();
+    expect(result).toEqual({ processed: 1, passed: 0, failed: 0 });
+  });
+
+  it('returns empty result when no tickets match the label', async () => {
+    const deps = makeDeps({ listTickets: vi.fn().mockResolvedValue([]) });
+    const result = await runRefineToComments('/proj', 'needs-spec', deps);
+    expect(result).toEqual({ processed: 0, passed: 0, failed: 0 });
+  });
+});

--- a/tests/unit/schedule-service.test.ts
+++ b/tests/unit/schedule-service.test.ts
@@ -13,6 +13,8 @@ import {
 import type { ScheduleAction } from '../../src/main/scheduler/types';
 
 const runScript = (scriptName: string): ScheduleAction => ({ kind: 'run-script', scriptName });
+const refineToComments = (ticketLabel?: string): ScheduleAction =>
+  ticketLabel !== undefined ? { kind: 'refine-to-comments', ticketLabel } : { kind: 'refine-to-comments' };
 
 let tmpDir: string;
 
@@ -82,6 +84,34 @@ describe('schedule-service', () => {
           cronExpression: '0 * * * *',
           // Cast through unknown to simulate a bad payload crossing the IPC boundary.
           action: { kind: 'legacy-prompt' } as unknown as ScheduleAction,
+        })
+      ).toThrow('Invalid schedule action');
+    });
+
+    it('creates refine-to-comments action without ticketLabel (uses default)', () => {
+      const schedule = createSchedule({
+        projectDir: tmpDir,
+        cronExpression: '0 * * * *',
+        action: refineToComments(),
+      });
+      expect(schedule.action).toEqual({ kind: 'refine-to-comments' });
+    });
+
+    it('creates refine-to-comments action with a custom ticketLabel', () => {
+      const schedule = createSchedule({
+        projectDir: tmpDir,
+        cronExpression: '0 * * * *',
+        action: refineToComments('my-label'),
+      });
+      expect(schedule.action).toEqual({ kind: 'refine-to-comments', ticketLabel: 'my-label' });
+    });
+
+    it('rejects refine-to-comments action with empty ticketLabel', () => {
+      expect(() =>
+        createSchedule({
+          projectDir: tmpDir,
+          cronExpression: '0 * * * *',
+          action: refineToComments(''),
         })
       ).toThrow('Invalid schedule action');
     });
@@ -256,6 +286,40 @@ describe('schedule-service', () => {
         updateSchedule(tmpDir, created.id, {
           action: { kind: 'run-script', scriptName: '' },
         }),
+      ).toThrow('Invalid schedule action');
+    });
+
+    it('accepts refine-to-comments action patch without ticketLabel', () => {
+      const created = createSchedule({
+        projectDir: tmpDir,
+        cronExpression: '0 * * * *',
+        action: runScript('test.sh'),
+      });
+
+      const updated = updateSchedule(tmpDir, created.id, { action: refineToComments() });
+      expect(updated.action).toEqual({ kind: 'refine-to-comments' });
+    });
+
+    it('accepts refine-to-comments action patch with custom ticketLabel', () => {
+      const created = createSchedule({
+        projectDir: tmpDir,
+        cronExpression: '0 * * * *',
+        action: runScript('test.sh'),
+      });
+
+      const updated = updateSchedule(tmpDir, created.id, { action: refineToComments('custom-label') });
+      expect(updated.action).toEqual({ kind: 'refine-to-comments', ticketLabel: 'custom-label' });
+    });
+
+    it('rejects refine-to-comments action patch with empty ticketLabel', () => {
+      const created = createSchedule({
+        projectDir: tmpDir,
+        cronExpression: '0 * * * *',
+        action: runScript('test.sh'),
+      });
+
+      expect(() =>
+        updateSchedule(tmpDir, created.id, { action: refineToComments('') }),
       ).toThrow('Invalid schedule action');
     });
 


### PR DESCRIPTION
## Summary
- add `refine-to-comments` scheduler action that scans tickets carrying a configurable label and refines them from their comment threads via a deterministic control-plane module
- ship provider-neutral `list-tickets`, `list-comments`, `post-comment`, `add-label`, `remove-label` scripts for github / jira / skeleton so the new action and future label/comment workflows are pluggable
- validate the action's `ticketLabel` (reject empty/whitespace) in `schedule-service.isValidAction` and cover create/update paths with unit tests

## Test plan
- [ ] `npm test` passes (2072 tests, including the 6 new refine-to-comments validation cases)
- [ ] create a schedule with kind `refine-to-comments` and no `ticketLabel` — accepted
- [ ] create a schedule with `ticketLabel: "needs-refinement"` — accepted
- [ ] create a schedule with `ticketLabel: ""` or whitespace — rejected
- [ ] run the scheduled action against a project with the configured label and confirm matching tickets are refined from comments without touching the outer chat session
- [ ] verify the new `list-tickets` / `list-comments` / `post-comment` / `add-label` / `remove-label` scripts are copied into a freshly initialized project for each provider template

Closes #325