### PR TITLE
fix build: restore inlined script-status helper + spec-deps third arg

### DIFF
--- a/src/main/control-plane/ticket-comments.ts
+++ b/src/main/control-plane/ticket-comments.ts
@@ -1,6 +1,19 @@
 import { execFile } from 'child_process';
+import fs from 'fs';
 import path from 'path';
-import { getSandstormScriptStatus } from './ticket-updater';
+
+type ScriptStatus = 'ok' | 'missing' | 'not_executable';
+
+function getSandstormScriptStatus(projectDir: string, scriptName: string): ScriptStatus {
+  const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', scriptName);
+  if (!fs.existsSync(scriptPath)) return 'missing';
+  try {
+    fs.accessSync(scriptPath, fs.constants.X_OK);
+    return 'ok';
+  } catch {
+    return 'not_executable';
+  }
+}
 
 export interface TicketComment {
   author: string;

--- a/src/main/control-plane/ticket-labels.ts
+++ b/src/main/control-plane/ticket-labels.ts
@@ -1,6 +1,19 @@
 import { execFile } from 'child_process';
+import fs from 'fs';
 import path from 'path';
-import { getSandstormScriptStatus } from './ticket-updater';
+
+type ScriptStatus = 'ok' | 'missing' | 'not_executable';
+
+function getSandstormScriptStatus(projectDir: string, scriptName: string): ScriptStatus {
+  const scriptPath = path.join(projectDir, '.sandstorm', 'scripts', scriptName);
+  if (!fs.existsSync(scriptPath)) return 'missing';
+  try {
+    fs.accessSync(scriptPath, fs.constants.X_OK);
+    return 'ok';
+  } catch {
+    return 'not_executable';
+  }
+}
 
 function runLabelScript(
   scriptName: string,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -277,6 +277,7 @@ async function initializeApp(): Promise<void> {
                 handleToolCall('spec_check', { ticketId, projectDir }) as Promise<import('./control-plane/ticket-spec').SpecGateReport>,
               (ticketId, projectDir, userAnswers) =>
                 handleToolCall('spec_refine', { ticketId, projectDir, userAnswers }) as Promise<import('./control-plane/ticket-spec').SpecGateReport>,
+              (projectDir) => registry.getProjectTicketConfig(projectDir),
             );
             const deps = buildRefineToCommentsDeps(
               (ticketId, projectDir) => runSpecCheck(ticketId, projectDir, specDeps),


### PR DESCRIPTION
## Summary

`npm run release` was failing on main with two compile errors that landed when #365 ("replace per-project ticket scripts with built-in providers") interacted with #363's `refine-to-comments` scheduler action.

- `ticket-comments.ts` and `ticket-labels.ts` (from #363) still imported `getSandstormScriptStatus` from `ticket-updater.ts` — but #365 gutted `ticket-updater.ts` down to a single re-export.
- `src/main/index.ts:275` called `defaultSpecGateDeps(checkFn, refineFn)` with two arguments, but #365 added a third required `getProviderConfig` parameter.

## Fixes

1. **`src/main/control-plane/ticket-comments.ts`** — inlined the 8-line `getSandstormScriptStatus` helper (`fs.existsSync` + `fs.accessSync(... X_OK)`). Removed the dead import.
2. **`src/main/control-plane/ticket-labels.ts`** — same inline.
3. **`src/main/index.ts`** (refine-to-comments scheduler dispatch) — added the third arg: `(projectDir) => registry.getProjectTicketConfig(projectDir)`.

These are minimal — no behavior change beyond making the existing call shapes line up with the new signatures. The label/comment scripts these modules invoke (`add-label.sh`, `remove-label.sh`, `list-tickets.sh`, `post-comment.sh`, `list-comments.sh`) still exist in `sandstorm-cli/templates/<provider>/scripts/` and were not touched by #365.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx electron-vite build` — green (main / preload / renderer all produce bundles)
- [ ] `npm run release` to completion (the original failing command)
- [ ] Smoke-test the refine-to-comments scheduler action on a project that has the label/comment scripts installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)