### PR TITLE
speed up refine: trim ephemeral env, add elapsed timer, ticket-body cache

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -436,7 +436,6 @@ export class ClaudeBackend implements AgentBackend {
       '-p', prompt,
       '--output-format', 'stream-json',
       '--dangerously-skip-permissions',
-      '--verbose',
     ];
 
     const spawnedAt = Date.now();
@@ -445,9 +444,19 @@ export class ClaudeBackend implements AgentBackend {
     let isCancelled = false;
     let timingWritten = false;
 
+    // Match the persistent session's env-trim (#302, #303): skip loading
+    // the user's global ~/.claude/CLAUDE.md and point the plugin cache at
+    // an empty dir so globally-installed Claude Code plugins (Gmail/Gcal/
+    // Gdrive MCPs, LSP, skill-creator, etc.) don't register on every refine
+    // spawn. Each tool-call turn would otherwise re-send a bloated system
+    // prompt. #370.
     const child = spawn(claudeBin, args, {
       cwd: projectDir,
-      env: getClaudeEnv(),
+      env: {
+        ...getClaudeEnv(),
+        CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
+        CLAUDE_CODE_PLUGIN_CACHE_DIR: this.ensureEmptyPluginCacheDir(),
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -10,6 +10,7 @@
 import path from 'path';
 import { stackManager, agentBackend, registry } from '../index';
 import { fetchTicketWithConfig, updateTicketWithConfig } from '../control-plane/ticket-config';
+import type { ProjectTicketConfig } from '../control-plane/registry';
 import { getSpecQualityGate } from '../spec-quality-gate';
 import {
   createSchedule,
@@ -184,6 +185,34 @@ interface SpecContext {
   gate: string;
 }
 
+/**
+ * Short-window cache for ticket bodies. The spec gate fetches the same
+ * (projectDir, ticketId) repeatedly within a single refine flow — initial
+ * check, after-answers pass, manual re-runs. Caching for 30s avoids the
+ * provider round-trip without holding stale data. #370.
+ */
+const TICKET_BODY_TTL_MS = 30_000;
+const ticketBodyCache = new Map<string, { body: string; fetchedAt: number }>();
+
+export function _clearTicketBodyCacheForTests(): void {
+  ticketBodyCache.clear();
+}
+
+async function getTicketBodyCached(
+  ticketId: string,
+  config: ProjectTicketConfig,
+  projectDir: string,
+): Promise<string | null> {
+  const key = `${projectDir}|${ticketId}`;
+  const hit = ticketBodyCache.get(key);
+  if (hit && Date.now() - hit.fetchedAt < TICKET_BODY_TTL_MS) {
+    return hit.body;
+  }
+  const body = await fetchTicketWithConfig(ticketId, config, projectDir);
+  if (body) ticketBodyCache.set(key, { body, fetchedAt: Date.now() });
+  return body;
+}
+
 /** Shared pre-checks before calling the LLM. Returns an error result or the resolved context. */
 async function resolveSpecContext(
   ticketId: string,
@@ -205,7 +234,7 @@ async function resolveSpecContext(
     };
   }
 
-  const ticketBody = await fetchTicketWithConfig(ticketId, config, projectDir);
+  const ticketBody = await getTicketBodyCached(ticketId, config, projectDir);
   if (!ticketBody) {
     return {
       ok: false,

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -8,6 +8,27 @@ function suggestStackName(ticketId: string): string {
   return id ? `ticket-${id}` : '';
 }
 
+/** MM:SS elapsed since a startedAt epoch ms. Ticks once per second while mounted. */
+export function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+function ElapsedTimer({ startedAt }: { startedAt: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <span className="font-mono tabular-nums" data-testid="refine-elapsed-timer">
+      {formatElapsed(now - startedAt)}
+    </span>
+  );
+}
+
 export function RefineTicketDialog() {
   const {
     setShowRefineTicketDialog,
@@ -242,7 +263,13 @@ export function RefineTicketDialog() {
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
                   <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
                 </svg>
-                {isStarting ? 'Starting stack…' : 'Running spec gate…'}
+                <span>{isStarting ? 'Starting stack…' : 'Running spec gate…'}</span>
+                {!isStarting && session?.startedAt && (
+                  <>
+                    <span className="text-sandstorm-border">·</span>
+                    <ElapsedTimer startedAt={session.startedAt} />
+                  </>
+                )}
               </div>
               {!isStarting && (
                 <div

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1379,6 +1379,78 @@ describe('ClaudeBackend.spawnEphemeralAgent — onChunk streaming callback', () 
   });
 });
 
+describe('spawnEphemeralAgent — env trim and CLI args (#370)', () => {
+  beforeEach(() => {
+    spawnedProcesses.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT pass --verbose (renderer does not consume verbose chatter)', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000);
+
+    const callArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const spawnedArgs: string[] = callArgs[1];
+    expect(spawnedArgs).not.toContain('--verbose');
+
+    backendUnderTest.destroy();
+  });
+
+  it('still passes the required ephemeral CLI flags', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000);
+
+    const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+    expect(spawnedArgs).toContain('-p');
+    expect(spawnedArgs).toContain('--output-format');
+    expect(spawnedArgs).toContain('stream-json');
+    expect(spawnedArgs).toContain('--dangerously-skip-permissions');
+
+    backendUnderTest.destroy();
+  });
+
+  it('sets CLAUDE_CODE_DISABLE_CLAUDE_MDS=1 in the spawn env', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000);
+
+    const callOpts = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][2];
+    expect(callOpts.env.CLAUDE_CODE_DISABLE_CLAUDE_MDS).toBe('1');
+
+    backendUnderTest.destroy();
+  });
+
+  it('sets CLAUDE_CODE_PLUGIN_CACHE_DIR to a non-empty path', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000);
+
+    const callOpts = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][2];
+    expect(callOpts.env.CLAUDE_CODE_PLUGIN_CACHE_DIR).toBeTruthy();
+    expect(typeof callOpts.env.CLAUDE_CODE_PLUGIN_CACHE_DIR).toBe('string');
+    expect(callOpts.env.CLAUDE_CODE_PLUGIN_CACHE_DIR.length).toBeGreaterThan(0);
+
+    backendUnderTest.destroy();
+  });
+});
+
 describe('Outer-Claude session token accumulation (agent:token-usage IPC)', () => {
   let backend: AgentBackend;
   let mockWindow: { webContents: { send: ReturnType<typeof vi.fn> } };

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { RefineTicketDialog } from '../../../src/renderer/components/RefineTicketDialog';
+import { RefineTicketDialog, formatElapsed } from '../../../src/renderer/components/RefineTicketDialog';
 import { useAppStore } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
 
@@ -319,6 +319,51 @@ describe('RefineTicketDialog', () => {
       useAppStore.setState({ refineTicketPrefill: null });
       render(<RefineTicketDialog />);
       expect(api.tickets.specCheckAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('elapsed timer (#370)', () => {
+    it('formatElapsed formats whole seconds as MM:SS', () => {
+      expect(formatElapsed(0)).toBe('00:00');
+      expect(formatElapsed(999)).toBe('00:00');
+      expect(formatElapsed(1_000)).toBe('00:01');
+      expect(formatElapsed(59_000)).toBe('00:59');
+      expect(formatElapsed(60_000)).toBe('01:00');
+      expect(formatElapsed(125_000)).toBe('02:05');
+      expect(formatElapsed(3_600_000)).toBe('60:00');
+    });
+
+    it('clamps negative inputs to 00:00', () => {
+      expect(formatElapsed(-1)).toBe('00:00');
+      expect(formatElapsed(-99_999)).toBe('00:00');
+    });
+
+    it('renders the elapsed timer next to "Running spec gate…" while running', () => {
+      const start = Date.now() - 7_000; // 7s ago
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'running', phase: 'check', startedAt: start,
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      const timer = screen.getByTestId('refine-elapsed-timer');
+      // Timer should be present and show a MM:SS value.
+      expect(timer.textContent).toMatch(/^\d{2}:\d{2}$/);
+    });
+
+    it('does not render the elapsed timer once the session transitions to ready', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: { passed: true, questions: [], gateSummary: '', ticketUrl: null, cached: false },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.queryByTestId('refine-elapsed-timer')).toBeNull();
     });
   });
 

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleToolCall, validateProjectDir } from '../../src/main/claude/tools';
+import { handleToolCall, validateProjectDir, _clearTicketBodyCacheForTests } from '../../src/main/claude/tools';
 
 // Mock the stackManager, agentBackend, and registry imports
 vi.mock('../../src/main/index', () => ({
@@ -61,6 +61,7 @@ const mockGetProviderConfig = vi.mocked(registry.getProjectTicketConfig);
 describe('MCP tools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _clearTicketBodyCacheForTests();
     // Default: provider is configured as GitHub
     mockGetProviderConfig.mockReturnValue({ provider: 'github' });
   });
@@ -711,6 +712,62 @@ describe('MCP tools', () => {
       expect(prompt).toContain('Dependency Contracts');
       expect(prompt).toContain('Automated Visual Verification');
       expect(prompt).toContain('All Verification Automatable');
+    });
+
+    describe('ticket body cache (#370)', () => {
+      beforeEach(() => {
+        _clearTicketBodyCacheForTests();
+      });
+
+      it('reuses the cached body for repeated calls within the TTL window', async () => {
+        vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: cached body');
+        vi.mocked(getSpecQualityGate).mockReturnValue('### Problem Statement\nClear?');
+        vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+          '## Spec Quality Gate: PASS\n\n### Results\n| C | Result |\n|---|---|\n| X | PASS |',
+        );
+
+        await handleToolCall('spec_check', { ticketId: '42', projectDir: '/proj' });
+        await handleToolCall('spec_check', { ticketId: '42', projectDir: '/proj' });
+
+        expect(vi.mocked(fetchTicketWithConfig)).toHaveBeenCalledTimes(1);
+      });
+
+      it('refetches when the cache key differs (project or ticket)', async () => {
+        vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: body');
+        vi.mocked(getSpecQualityGate).mockReturnValue('### Problem Statement\nClear?');
+        vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+          '## Spec Quality Gate: PASS\n\n### Results\n| C | Result |\n|---|---|\n| X | PASS |',
+        );
+
+        await handleToolCall('spec_check', { ticketId: '42', projectDir: '/proj' });
+        await handleToolCall('spec_check', { ticketId: '43', projectDir: '/proj' });
+        await handleToolCall('spec_check', { ticketId: '42', projectDir: '/other' });
+
+        expect(vi.mocked(fetchTicketWithConfig)).toHaveBeenCalledTimes(3);
+      });
+
+      it('refetches after the TTL expires', async () => {
+        vi.useFakeTimers();
+        try {
+          vi.setSystemTime(new Date('2026-05-28T12:00:00Z'));
+          vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: body');
+          vi.mocked(getSpecQualityGate).mockReturnValue('### Problem Statement\nClear?');
+          vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+            '## Spec Quality Gate: PASS\n\n### Results\n| C | Result |\n|---|---|\n| X | PASS |',
+          );
+
+          await handleToolCall('spec_check', { ticketId: '42', projectDir: '/proj' });
+
+          // Advance past the 30s TTL.
+          vi.setSystemTime(new Date('2026-05-28T12:00:31Z'));
+
+          await handleToolCall('spec_check', { ticketId: '42', projectDir: '/proj' });
+
+          expect(vi.mocked(fetchTicketWithConfig)).toHaveBeenCalledTimes(2);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
 
     it('spec_refine refinement prompt includes enhanced evaluation criteria', async () => {


### PR DESCRIPTION
Implements 4 of the 5 items from #370. The big speed lever (env trim) plus three smaller wins. Process reuse across initial→after-answers (item 5) is deferred — sketched in the issue but more architectural than this PR should swallow.

## What's in

1. **Trim ephemeral env** (#370 item 1 — the highest-payoff fix). \`spawnEphemeralAgent\` now passes \`CLAUDE_CODE_DISABLE_CLAUDE_MDS=1\` and \`CLAUDE_CODE_PLUGIN_CACHE_DIR=<empty>\` just like the persistent orchestrator session at \`claude-backend.ts:~800\`. Stops every refine from cold-loading the user's global \`~/.claude/CLAUDE.md\` plus every globally-installed Claude Code plugin (Gmail/Gcal/Gdrive MCPs, LSP, skill-creator, etc.) on every turn.
2. **Drop \`--verbose\`** (#370 item 2). The renderer parses stream-json events; the verbose chatter was being parsed and discarded. The persistent path doesn't pass it either.
3. **30s ticket-body cache** (#370 item 4). \`resolveSpecContext\` now goes through \`getTicketBodyCached\`, an in-memory \`Map\` keyed by \`<projectDir>|<ticketId>\` with a 30s TTL. Initial check + after-answers pass in the same refine flow now share one provider round-trip instead of two.
4. **Elapsed timer in the dialog** (#370 item 3). \`RefineTicketDialog\` renders \`MM:SS\` next to "Running spec gate…", ticking every second off \`session.startedAt\`. Disappears on transition to ready/errored.

## What's deferred

- **Item 5** (reuse one process for initial→after-answers within a single refine flow). The other four are independently valuable and ship cleanly. Item 5 requires either (a) switching the ephemeral to a long-lived stream-json mode tied to the \`RefinementSession\` lifecycle, or (b) carrying forward a serialized preamble that the second spawn ingests. Both are bigger lifts that deserve their own ticket. Filing as a follow-up.

## Measurement plan (per #370 Definition of Done)

\`ephemeral-timing.ts\` (from #366) already writes a per-run JSONL with \`elapsed_ms\`, \`turn_count\`, etc. To validate this PR's impact:

- [ ] Capture 5 baseline runs on \`main\` against ticket #X — record median \`elapsed_ms\`.
- [ ] Capture 5 runs on this branch against the same ticket — record median \`elapsed_ms\`.
- [ ] Substantial drop (not within noise).
- [ ] Numbers in this PR thread before merge.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx electron-vite build\` green (main / preload / renderer)
- [x] \`npx vitest run\` — 164 tests passing across the touched files (\`claude-backend.test.ts\`, \`tools.test.ts\`, \`RefineTicketDialog.test.tsx\`)
- [ ] Manual: trigger a refine on a real ticket and confirm the dialog shows a ticking \`MM:SS\` next to "Running spec gate…"
- [ ] Manual: trigger two refines on the same ticket within 30s and confirm only one GitHub API call in the logs (cache hit)

## Tests added

- **\`claude-backend.test.ts\`** — ephemeral spawn no longer passes \`--verbose\`; \`CLAUDE_CODE_DISABLE_CLAUDE_MDS\` and \`CLAUDE_CODE_PLUGIN_CACHE_DIR\` are set on the spawn env; required flags (\`-p\`, \`--output-format stream-json\`, \`--dangerously-skip-permissions\`) still present.
- **\`tools.test.ts\`** — ticket-body cache hits within TTL (1 fetch for 2 calls), refetches across different ticket/project keys (3 fetches for 3 distinct keys), refetches after the 30s TTL expires.
- **\`RefineTicketDialog.test.tsx\`** — \`formatElapsed\` boundary cases (0, 999, 1000, 59000, 60000, 125000, 3600000, negatives); the timer renders while running, disappears once the session is ready.

Closes #370 (with item 5 carried forward as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)