### PR TITLE
add process reuse within refine flow (#370 item 5)

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -22,6 +22,7 @@ import {
   OuterClaudeSessionTokens,
   StackInfo,
   EphemeralStreamEvent,
+  EphemeralSessionHandle,
   zeroSessionTokens,
 } from './types';
 import { appendEphemeralTiming, type EphemeralTimingRecord } from './ephemeral-timing';
@@ -583,6 +584,160 @@ export class ClaudeBackend implements AgentBackend {
 
   runEphemeralAgent(prompt: string, projectDir: string, timeoutMs = 300_000): Promise<string> {
     return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs).promise;
+  }
+
+  /**
+   * Long-lived stream-json process for multi-turn ephemeral flows (#370 item 5).
+   * Mirrors the persistent-session flag set (`--print --input-format stream-json
+   * --output-format stream-json --dangerously-skip-permissions`) and reuses the
+   * same env-trim as `spawnEphemeralAgent` (no global CLAUDE.md, empty plugin
+   * cache). Each `sendFollowUp` writes an NDJSON user message to stdin and
+   * resolves when the next `type:"result"` event arrives.
+   */
+  spawnEphemeralSession(
+    initialPrompt: string,
+    projectDir: string,
+    timeoutMs = 300_000,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+  ): EphemeralSessionHandle {
+    const claudeBin = getClaudeBin();
+    const args = [
+      '--print',
+      '--input-format', 'stream-json',
+      '--output-format', 'stream-json',
+      '--dangerously-skip-permissions',
+    ];
+
+    const child = spawn(claudeBin, args, {
+      cwd: projectDir,
+      env: {
+        ...getClaudeEnv(),
+        CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
+        CLAUDE_CODE_PLUGIN_CACHE_DIR: this.ensureEmptyPluginCacheDir(),
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let outputBuffer = '';
+    let stderrBuffer = '';
+    let currentText = '';
+    let currentResolve: ((value: string) => void) | null = null;
+    let currentReject: ((err: Error) => void) | null = null;
+    let isDisposed = false;
+    let idleTimer: NodeJS.Timeout | null = null;
+
+    const resetIdleTimer = (): void => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        if (currentReject) currentReject(new Error(`Ephemeral session timed out after ${timeoutMs}ms`));
+        dispose();
+      }, timeoutMs);
+    };
+
+    const dispose = (): void => {
+      if (isDisposed) return;
+      isDisposed = true;
+      if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
+      try { child.stdin?.end(); } catch { /* noop */ }
+      try { child.kill('SIGTERM'); } catch { /* noop */ }
+      setTimeout(() => {
+        try { if (child.exitCode === null) child.kill('SIGKILL'); } catch { /* noop */ }
+      }, 5_000);
+      if (currentReject) {
+        const reject = currentReject;
+        currentResolve = null;
+        currentReject = null;
+        reject(new Error('Session disposed'));
+      }
+    };
+
+    child.stdout?.on('data', (data: Buffer) => {
+      outputBuffer += data.toString();
+      const lines = outputBuffer.split('\n');
+      outputBuffer = lines.pop() || '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const parsed = JSON.parse(line);
+          const events = extractStreamEvents(parsed);
+          for (const event of events) {
+            if (event.kind === 'text') currentText += event.delta;
+            onChunk?.(event);
+          }
+          if (parsed.type === 'result' && currentResolve) {
+            const text = currentText;
+            currentText = '';
+            const resolve = currentResolve;
+            currentResolve = null;
+            currentReject = null;
+            if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
+            resolve(text);
+          }
+        } catch {
+          // Skip non-JSON lines
+        }
+      }
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      stderrBuffer += data.toString();
+    });
+
+    child.on('close', (code) => {
+      isDisposed = true;
+      if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
+      if (currentReject) {
+        const reject = currentReject;
+        currentResolve = null;
+        currentReject = null;
+        reject(new Error(
+          `Ephemeral session exited with code ${code}: ${stderrBuffer.trim() || 'unknown error'}`,
+        ));
+      }
+    });
+
+    child.on('error', (err) => {
+      isDisposed = true;
+      if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
+      if (currentReject) {
+        const reject = currentReject;
+        currentResolve = null;
+        currentReject = null;
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+
+    const sendMessage = (text: string): Promise<string> => {
+      if (isDisposed) return Promise.reject(new Error('Session disposed'));
+      if (currentResolve || currentReject) {
+        return Promise.reject(new Error('Previous turn still in flight'));
+      }
+      return new Promise<string>((resolve, reject) => {
+        currentResolve = resolve;
+        currentReject = reject;
+        currentText = '';
+        resetIdleTimer();
+        const ndjson = JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: text },
+        });
+        try {
+          child.stdin?.write(ndjson + '\n');
+        } catch (err) {
+          currentResolve = null;
+          currentReject = null;
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    };
+
+    const initialResult = sendMessage(initialPrompt);
+
+    return {
+      initialResult,
+      sendFollowUp: sendMessage,
+      dispose,
+    };
   }
 
   // --- Auth (AgentBackend interface) ---

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -15,6 +15,21 @@ export type EphemeralStreamEvent =
   | { kind: 'text'; delta: string }
   | { kind: 'tool_use'; name: string; summary: string };
 
+/**
+ * Long-lived stream-json subprocess that can answer follow-up prompts
+ * (#370 item 5). spec_refine spawns one of these for the initial
+ * questions pass, then reuses the same process to feed the user's
+ * answers — keeping the model's exploration context warm across turns.
+ */
+export interface EphemeralSessionHandle {
+  /** Resolves with the assistant's text response to the initial prompt. */
+  initialResult: Promise<string>;
+  /** Send a follow-up prompt on the same process. Resolves with the assistant's text response. */
+  sendFollowUp(prompt: string): Promise<string>;
+  /** Terminate the held subprocess. Idempotent. */
+  dispose(): void;
+}
+
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
@@ -107,6 +122,19 @@ export interface AgentBackend {
     timeoutMs?: number,
     onChunk?: (event: EphemeralStreamEvent) => void,
   ): { promise: Promise<string>; cancel: () => void };
+
+  /**
+   * Spawn a long-lived stream-json agent process that can answer multiple
+   * prompts in sequence (#370 item 5). Used by spec_refine to reuse the
+   * model's exploration context across the initial-questions and
+   * after-answers passes instead of cold-spawning twice.
+   */
+  spawnEphemeralSession(
+    initialPrompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+  ): EphemeralSessionHandle;
 
   // --- Authentication ---
 

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -24,7 +24,7 @@ import type {
   UpdateSchedulePatch,
 } from '../scheduler/schedule-service';
 import { validateProjectDir } from '../validation';
-import type { EphemeralStreamEvent } from '../agent/types';
+import type { EphemeralStreamEvent, EphemeralSessionHandle } from '../agent/types';
 
 export { validateProjectDir };
 
@@ -544,7 +544,46 @@ export function spawnSpecCheck(
 }
 
 /**
- * Cancellable version of spec_refine for the async refinement path.
+ * Pool of held EphemeralSessionHandles for in-flight refine flows (#370 item 5).
+ * Keyed by `<projectDir>|<ticketId>`. The initial-questions pass spawns one and
+ * stashes it here; the after-answers pass picks it up so the second turn reuses
+ * the model's exploration context from the first. Idle sessions are disposed
+ * after 10 minutes to prevent leaked processes if the user walks away.
+ */
+const REFINE_SESSION_IDLE_TTL_MS = 600_000;
+interface PooledRefineSession {
+  handle: EphemeralSessionHandle;
+  idleTimer: NodeJS.Timeout;
+}
+const refineSessionPool = new Map<string, PooledRefineSession>();
+
+function refineSessionKey(projectDir: string, ticketId: string): string {
+  return `${projectDir}|${ticketId}`;
+}
+
+function disposeRefineSession(key: string): void {
+  const pooled = refineSessionPool.get(key);
+  if (!pooled) return;
+  clearTimeout(pooled.idleTimer);
+  try { pooled.handle.dispose(); } catch { /* noop */ }
+  refineSessionPool.delete(key);
+}
+
+function storeRefineSession(key: string, handle: EphemeralSessionHandle): void {
+  // Replace any pre-existing session for the same key.
+  disposeRefineSession(key);
+  const idleTimer = setTimeout(() => disposeRefineSession(key), REFINE_SESSION_IDLE_TTL_MS);
+  refineSessionPool.set(key, { handle, idleTimer });
+}
+
+export function _disposeAllRefineSessionsForTests(): void {
+  for (const key of [...refineSessionPool.keys()]) disposeRefineSession(key);
+}
+
+/**
+ * Cancellable version of spec_refine for the async refinement path. Reuses
+ * one Claude subprocess across the initial-questions and after-answers
+ * passes when both happen within the same refine flow (#370 item 5).
  */
 export function spawnSpecRefine(
   ticketId: string,
@@ -552,11 +591,11 @@ export function spawnSpecRefine(
   userAnswers?: string,
   onChunk?: (event: EphemeralStreamEvent) => void,
 ): { promise: Promise<Record<string, unknown>>; cancel: () => void } {
-  let innerCancel: (() => void) | null = null;
   let cancelled = false;
+  let activeDispose: (() => void) | null = null;
   const cancel = (): void => {
     cancelled = true;
-    innerCancel?.();
+    activeDispose?.();
   };
 
   const promise: Promise<Record<string, unknown>> = (async (): Promise<Record<string, unknown>> => {
@@ -564,19 +603,68 @@ export function spawnSpecRefine(
     if (!res.ok) return res.result;
     if (cancelled) throw new Error('Cancelled');
 
-    const prompt = userAnswers
-      ? buildSpecRefineAnswerPrompt(res.ctx.gate, res.ctx.ticketBody, userAnswers)
-      : buildSpecRefineInitialPrompt(res.ctx.gate, res.ctx.ticketBody);
+    const key = refineSessionKey(projectDir, ticketId);
 
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 300_000, onChunk);
-    innerCancel = epCancel;
-    if (cancelled) { epCancel(); throw new Error('Cancelled'); }
-
-    const result = await ep;
     if (userAnswers) {
+      // After-answers pass. Reuse the held session if we have one; otherwise
+      // cold-start with the full answer prompt.
+      const pooled = refineSessionPool.get(key);
+      const answerPrompt = buildSpecRefineAnswerPrompt(res.ctx.gate, res.ctx.ticketBody, userAnswers);
+
+      if (pooled) {
+        clearTimeout(pooled.idleTimer);
+        activeDispose = () => disposeRefineSession(key);
+        if (cancelled) { disposeRefineSession(key); throw new Error('Cancelled'); }
+        try {
+          const result = await pooled.handle.sendFollowUp(answerPrompt);
+          return applySpecRefineResult(ticketId, projectDir, result, true);
+        } finally {
+          disposeRefineSession(key);
+        }
+      }
+
+      // No pooled session (timed out, app restarted, etc.) — fall back to a
+      // cold ephemeral so the user's answers still produce a result.
+      const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(
+        answerPrompt, projectDir, 300_000, onChunk,
+      );
+      activeDispose = epCancel;
+      if (cancelled) { epCancel(); throw new Error('Cancelled'); }
+      const result = await ep;
       return applySpecRefineResult(ticketId, projectDir, result, true);
     }
+
+    // Initial-questions pass. Spawn a long-lived session so the after-answers
+    // pass can reuse it.
+    const initialPrompt = buildSpecRefineInitialPrompt(res.ctx.gate, res.ctx.ticketBody);
+    const handle = agentBackend.spawnEphemeralSession(initialPrompt, projectDir, 300_000, onChunk);
+    // Cancel during the initial pass must dispose the live handle even though
+    // it isn't pooled yet — otherwise SIGTERM never reaches the held subprocess.
+    activeDispose = (): void => {
+      try { handle.dispose(); } catch { /* noop */ }
+      disposeRefineSession(key);
+    };
+    if (cancelled) { handle.dispose(); throw new Error('Cancelled'); }
+
+    let result: string;
+    try {
+      result = await handle.initialResult;
+    } catch (err) {
+      // Initial pass failed — make sure nothing is held.
+      try { handle.dispose(); } catch { /* noop */ }
+      throw err;
+    }
+
+    if (cancelled) { handle.dispose(); throw new Error('Cancelled'); }
+
+    // Pool the session so the after-answers pass can reuse it. If the gate
+    // already passed without questions, dispose immediately — no follow-up.
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
+    if (passed) {
+      try { handle.dispose(); } catch { /* noop */ }
+    } else {
+      storeRefineSession(key, handle);
+    }
     return { passed, report: result };
   })();
 

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleToolCall, validateProjectDir, _clearTicketBodyCacheForTests } from '../../src/main/claude/tools';
+import { handleToolCall, validateProjectDir, _clearTicketBodyCacheForTests, _disposeAllRefineSessionsForTests, spawnSpecRefine } from '../../src/main/claude/tools';
+import type { EphemeralSessionHandle } from '../../src/main/agent/types';
 
 // Mock the stackManager, agentBackend, and registry imports
 vi.mock('../../src/main/index', () => ({
@@ -10,6 +11,8 @@ vi.mock('../../src/main/index', () => ({
   },
   agentBackend: {
     runEphemeralAgent: vi.fn().mockResolvedValue(''),
+    spawnEphemeralAgent: vi.fn(),
+    spawnEphemeralSession: vi.fn(),
   },
   registry: {
     getProjectTicketConfig: vi.fn().mockReturnValue({ provider: 'github' }),
@@ -790,6 +793,112 @@ describe('MCP tools', () => {
       expect(prompt).toContain('Automated Visual Verification');
       expect(prompt).toContain('All Verification Automatable');
       expect(prompt).toContain('Replace resolved assumptions with verified facts');
+    });
+  });
+
+  describe('spawnSpecRefine — process reuse across initial+answers (#370 item 5)', () => {
+    let fakeHandle: EphemeralSessionHandle & {
+      initialResolve: (text: string) => void;
+      followUpResolve: (text: string) => void;
+      disposeMock: ReturnType<typeof vi.fn>;
+      sendFollowUpMock: ReturnType<typeof vi.fn>;
+    };
+
+    function makeFakeHandle(): typeof fakeHandle {
+      let initialResolve!: (text: string) => void;
+      let followUpResolve: ((text: string) => void) | null = null;
+      const initialResult = new Promise<string>((res) => { initialResolve = res; });
+      const sendFollowUpMock = vi.fn().mockImplementation((_prompt: string): Promise<string> => {
+        return new Promise<string>((res) => { followUpResolve = res; });
+      });
+      const disposeMock = vi.fn();
+      return {
+        initialResult,
+        sendFollowUp: sendFollowUpMock,
+        dispose: disposeMock,
+        initialResolve,
+        followUpResolve: (text: string) => { followUpResolve?.(text); },
+        disposeMock,
+        sendFollowUpMock,
+      };
+    }
+
+    beforeEach(() => {
+      _disposeAllRefineSessionsForTests();
+      _clearTicketBodyCacheForTests();
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: body');
+      vi.mocked(getSpecQualityGate).mockReturnValue('### Problem Statement\nClear?');
+      fakeHandle = makeFakeHandle();
+      vi.mocked(agentBackend.spawnEphemeralSession).mockReturnValue(fakeHandle);
+    });
+
+    it('initial pass with FAIL pools the handle for reuse', async () => {
+      const { promise } = spawnSpecRefine('42', '/proj');
+      fakeHandle.initialResolve(
+        '## Spec Quality Gate: FAIL\n\n### Questions Requiring User Answers\n1. What?',
+      );
+      const result = await promise as { passed: boolean; report: string };
+      expect(result.passed).toBe(false);
+      // Handle is still alive — pooled, not disposed.
+      expect(fakeHandle.disposeMock).not.toHaveBeenCalled();
+    });
+
+    it('after-answers pass reuses the pooled handle via sendFollowUp', async () => {
+      // Pool a session from the initial pass.
+      const { promise: initial } = spawnSpecRefine('42', '/proj');
+      fakeHandle.initialResolve('## Spec Quality Gate: FAIL\n\n### Questions\n1. What?');
+      await initial;
+
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      // After-answers pass — must use the same handle, not spawn a new one.
+      vi.mocked(agentBackend.spawnEphemeralAgent).mockClear();
+      const { promise: followUp } = spawnSpecRefine('42', '/proj', 'Answer text');
+
+      // Wait until sendFollowUp has actually been invoked, then resolve its result.
+      await vi.waitFor(() => expect(fakeHandle.sendFollowUpMock).toHaveBeenCalledTimes(1));
+      fakeHandle.followUpResolve(
+        '## Updated Ticket Body\n\n# Issue: Updated\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+      );
+      await followUp;
+
+      expect(vi.mocked(agentBackend.spawnEphemeralAgent)).not.toHaveBeenCalled();
+      // After-answers pass disposes when done.
+      expect(fakeHandle.disposeMock).toHaveBeenCalled();
+    });
+
+    it('initial pass with PASS disposes immediately (no follow-up expected)', async () => {
+      const { promise } = spawnSpecRefine('42', '/proj');
+      fakeHandle.initialResolve(
+        '## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+      );
+      await promise;
+      expect(fakeHandle.disposeMock).toHaveBeenCalled();
+    });
+
+    it('after-answers cold-starts via spawnEphemeralAgent when no pooled session exists', async () => {
+      // No pool — simulate stale session / app restart by calling directly with answers.
+      const coldEp = { promise: Promise.resolve('## Updated Ticket Body\n\n# Issue: Cold\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |'), cancel: vi.fn() };
+      vi.mocked(agentBackend.spawnEphemeralAgent).mockReturnValue(coldEp);
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      const { promise } = spawnSpecRefine('42', '/proj', 'Answer text');
+      await promise;
+
+      expect(vi.mocked(agentBackend.spawnEphemeralAgent)).toHaveBeenCalledTimes(1);
+      // The pooled session machinery was never touched on this fallback path.
+      expect(fakeHandle.sendFollowUpMock).not.toHaveBeenCalled();
+    });
+
+    it('cancel during the initial pass (after spawn) disposes the held handle', async () => {
+      const { promise, cancel } = spawnSpecRefine('42', '/proj');
+      // Wait until spawnEphemeralSession has actually been invoked.
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralSession).toHaveBeenCalled());
+      cancel();
+      // Unblock the initial await so the cancellation path can finalize.
+      fakeHandle.initialResolve('## Spec Quality Gate: FAIL\n\n### Questions\n1. What?');
+      await expect(promise).rejects.toThrow('Cancelled');
+      expect(fakeHandle.disposeMock).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes the last remaining item from #370 — the only piece that didn't make it into #371. Apologies for the split; #371 merged before I could append this commit to the same branch, so it had to land as a follow-up PR.

## What this does

Items 1–4 of #370 (env trim, drop \`--verbose\`, ticket-body cache, elapsed timer) shipped in #371. This PR adds **item 5**: the initial-questions and after-answers passes within a single refine flow now share one Claude subprocess, so the model's exploration context (file Reads, Greps, typecheck runs) from the first turn stays warm for the second turn.

Before this PR: refine = 2 cold spawns per flow. After: refine = 1 long-lived spawn that gets fed the answer prompt over stdin.

## Architecture

- **New \`EphemeralSessionHandle\`** (\`src/main/agent/types.ts\`) — \`initialResult\` promise, \`sendFollowUp(prompt)\`, \`dispose()\`.
- **\`ClaudeBackend.spawnEphemeralSession()\`** — long-lived \`--print --input-format stream-json --output-format stream-json\` subprocess with a piped stdin. NDJSON user messages on stdin; resolves the current turn on each \`type:"result"\` event. Same env-trim as \`spawnEphemeralAgent\` (\`CLAUDE_CODE_DISABLE_CLAUDE_MDS=1\`, empty plugin cache). 5-min idle watchdog per turn.
- **\`refineSessionPool\`** in \`src/main/claude/tools.ts\` — Map keyed by \`<projectDir>|<ticketId>\` with a 10-min idle TTL to clean up orphaned subprocesses if the user walks away mid-flow.
- **\`spawnSpecRefine\` rewritten** to:
  - Spawn a long-lived session on the initial pass.
  - Pool it if the gate FAILed (questions to follow).
  - Dispose immediately if the gate PASSed (no follow-up expected).
  - Reuse via \`sendFollowUp\` on the after-answers pass, then dispose when done.
- **Fallback**: if the after-answers pass arrives with no pooled session (TTL expired, app restarted, etc.), it cold-spawns via \`spawnEphemeralAgent\` so the user still gets a result.
- **Cancel during the initial pass** disposes the held subprocess via \`activeDispose\` even before pooling (a real bug found while writing the tests — the cancel path used to drop \`handle.dispose()\` because the handle hadn't been pooled yet).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx electron-vite build\` green
- [x] \`npx vitest run\` — 136 tests in the touched files pass

## Tests added (\`tests/unit/tools.test.ts\`)

- initial FAIL pools the handle (not disposed)
- after-answers reuses the pool via \`sendFollowUp\` (no new \`spawnEphemeralAgent\` call)
- initial PASS disposes immediately
- after-answers cold-starts via \`spawnEphemeralAgent\` when pool is empty
- cancel during initial pass (after spawn) disposes the held handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)