### PR TITLE
feat: structured multiple-choice questions for ticket refinement

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -313,8 +313,22 @@ Respond in EXACTLY this format (no other text before or after):
 ...
 
 ### Questions Requiring User Answers (if any)
-1. <specific question from unresolvable assumptions or ambiguities>
-...`;
+
+Every question MUST be phrased as an actionable multiple-choice question — never a statement. Provide 2 or more options when reasonable choices exist.
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "<specific actionable question>",
+    "options": [
+      { "id": "a", "label": "<option A>" },
+      { "id": "b", "label": "<option B>" }
+    ]
+  }
+]
+\`\`\`
+`;
 }
 
 async function handleSpecCheck(
@@ -381,9 +395,22 @@ Respond in EXACTLY this format:
 ...
 
 ### Questions to Resolve Gaps
-1. <specific question>
-2. <specific question>
-...`;
+
+Every question MUST be phrased as an actionable multiple-choice question — never a statement. Provide 2 or more options when reasonable choices exist.
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "<specific actionable question>",
+    "options": [
+      { "id": "a", "label": "<option A>" },
+      { "id": "b", "label": "<option B>" }
+    ]
+  }
+]
+\`\`\`
+`;
 }
 
 function buildSpecRefineAnswerPrompt(gate: string, ticketBody: string, userAnswers: string): string {
@@ -433,8 +460,22 @@ Respond in EXACTLY this format:
 ...
 
 ### Questions to Resolve Remaining Gaps (if any)
-1. <specific question>
-...`;
+
+Every question MUST be phrased as an actionable multiple-choice question — never a statement. Provide 2 or more options when reasonable choices exist.
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "<specific actionable question>",
+    "options": [
+      { "id": "a", "label": "<option A>" },
+      { "id": "b", "label": "<option B>" }
+    ]
+  }
+]
+\`\`\`
+`;
 }
 
 async function applySpecRefineResult(

--- a/src/main/control-plane/ticket-spec.ts
+++ b/src/main/control-plane/ticket-spec.ts
@@ -5,6 +5,17 @@ import type { ProjectTicketConfig } from './registry';
 
 const execFileAsync = promisify(execFile);
 
+export interface RefineQuestionOption {
+  id: string;
+  label: string;
+}
+
+export interface RefineQuestion {
+  id: string;
+  question: string;
+  options: RefineQuestionOption[];
+}
+
 /**
  * Trimmed result returned to the renderer for spec check / refine. Mirrors
  * the JSON shape that `sandstorm-spec.sh` emits when invoked from a skill —
@@ -13,7 +24,7 @@ const execFileAsync = promisify(execFile);
  */
 export interface SpecGateResult {
   passed: boolean;
-  questions: string[];
+  questions: RefineQuestion[];
   gateSummary: string;
   ticketUrl: string | null;
   cached: boolean;
@@ -37,20 +48,28 @@ export function extractGateSummary(report: string): string {
   if (/##\s+Spec Quality Gate:\s*PASS/i.test(report)) verdict = 'PASS';
   else if (/##\s+Spec Quality Gate:\s*FAIL/i.test(report)) verdict = 'FAIL';
   if (!verdict) return 'Gate verdict not parsed';
-  const qcount = (report.match(/^[0-9]+\.\s/gm) || []).length;
+  const qcount = extractQuestions(report).length;
   return `Gate=${verdict}, questions=${qcount}`;
 }
 
 /**
- * Mirrors the awk parser in sandstorm-spec.sh: only pulls numbered items
- * sitting under a `### Questions` or `### Gaps` heading, stopping at the
- * next `## ` boundary. Returns an empty array when nothing matches.
+ * Parses structured questions from a spec gate report. Looks for a ```json
+ * fence under a `### Questions` or `### Gaps` heading and parses it as
+ * RefineQuestion[]. Falls back to the legacy numbered-list parser (coercing
+ * each line to a RefineQuestion with no options) when no valid JSON block is found.
  */
-export function extractQuestions(report: string): string[] {
+export function extractQuestions(report: string): RefineQuestion[] {
   if (!report) return [];
+
+  // Try JSON block parser first.
+  const jsonResult = tryParseJsonBlock(report);
+  if (jsonResult !== null) return jsonResult;
+
+  // Fallback: legacy numbered-item parser.
   const lines = report.split('\n');
   let capture = false;
-  const out: string[] = [];
+  const out: RefineQuestion[] = [];
+  let idx = 0;
   for (const line of lines) {
     if (/^### (Questions|Gaps)/i.test(line)) {
       capture = true;
@@ -62,9 +81,73 @@ export function extractQuestions(report: string): string[] {
     }
     if (!capture) continue;
     const m = line.match(/^[0-9]+\.\s*(.*)$/);
-    if (m && m[1].trim()) out.push(m[1].trim());
+    if (m && m[1].trim()) {
+      out.push({ id: `q${idx + 1}`, question: m[1].trim(), options: [] });
+      idx++;
+    }
   }
   return out;
+}
+
+/**
+ * Locate the first ```json fence following a ### Questions/Gaps heading and
+ * parse it as RefineQuestion[]. Returns null on missing block, parse error,
+ * or invalid shape.
+ */
+function tryParseJsonBlock(report: string): RefineQuestion[] | null {
+  const lines = report.split('\n');
+  let inSection = false;
+  let inFence = false;
+  const fenceLines: string[] = [];
+
+  for (const line of lines) {
+    if (/^### (Questions|Gaps)/i.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^## /.test(line)) {
+      break;
+    }
+    if (!inSection) continue;
+
+    if (!inFence && line.trim() === '```json') {
+      inFence = true;
+      continue;
+    }
+    if (inFence) {
+      if (line.trim() === '```') break;
+      fenceLines.push(line);
+    }
+  }
+
+  if (fenceLines.length === 0) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(fenceLines.join('\n'));
+    if (!Array.isArray(parsed)) return null;
+    const result: RefineQuestion[] = [];
+    for (const item of parsed) {
+      if (typeof item !== 'object' || item === null) return null;
+      const obj = item as Record<string, unknown>;
+      if (typeof obj.question !== 'string') return null;
+      const id = typeof obj.id === 'string' ? obj.id : `q${result.length + 1}`;
+      const options: RefineQuestionOption[] = [];
+      if (Array.isArray(obj.options)) {
+        for (const opt of obj.options) {
+          if (typeof opt === 'object' && opt !== null) {
+            const o = opt as Record<string, unknown>;
+            if (typeof o.id === 'string' && typeof o.label === 'string') {
+              options.push({ id: o.id, label: o.label });
+            }
+          }
+        }
+      }
+      result.push({ id, question: obj.question, options });
+    }
+    return result;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/main/scheduler/refine-to-comments.ts
+++ b/src/main/scheduler/refine-to-comments.ts
@@ -37,7 +37,7 @@ import {
   addLabel as realAddLabel,
   removeLabel as realRemoveLabel,
 } from '../control-plane/ticket-labels';
-import type { SpecGateResult } from '../control-plane/ticket-spec';
+import type { SpecGateResult, RefineQuestion } from '../control-plane/ticket-spec';
 
 /** Marker that identifies comments posted by this bot. */
 export const BOT_COMMENT_MARKER = '<!-- sandstorm:bot-question -->';
@@ -84,7 +84,16 @@ export function getUserAnswersAfterBot(
   return answers.map((c) => c.body).join('\n\n');
 }
 
-export function formatQuestionComment(questions: string[], gateSummary: string): string {
+export function formatQuestionComment(questions: RefineQuestion[], gateSummary: string): string {
+  const questionLines: string[] = [];
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i];
+    questionLines.push(`${i + 1}. ${q.question}`);
+    for (let j = 0; j < q.options.length; j++) {
+      const letter = String.fromCharCode(65 + j); // A, B, C, ...
+      questionLines.push(`   - ${letter}) ${q.options[j].label}`);
+    }
+  }
   const lines = [
     BOT_COMMENT_MARKER,
     '',
@@ -92,7 +101,7 @@ export function formatQuestionComment(questions: string[], gateSummary: string):
     '',
     "I've reviewed this ticket and have a few questions before it can move to `spec-ready`:",
     '',
-    ...questions.map((q, i) => `${i + 1}. ${q}`),
+    ...questionLines,
   ];
   if (gateSummary) {
     lines.push('', `_Sandstorm spec gate: ${gateSummary}_`);

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useAppStore, SpecGateResult, RefinementSession } from '../store';
+import { useAppStore, SpecGateResult, RefinementSession, RefineQuestion } from '../store';
 
 type LocalPhase = 'input' | 'starting';
 
@@ -45,7 +45,7 @@ export function RefineTicketDialog() {
 
   const [ticketId, setTicketId] = useState('');
   const [localPhase, setLocalPhase] = useState<LocalPhase>('input');
-  const [answers, setAnswers] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<{ optionId: string | null; text: string }[]>([]);
   const [localError, setLocalError] = useState<string | null>(null);
   const [stackName, setStackName] = useState('');
   const [confirmingCancel, setConfirmingCancel] = useState(false);
@@ -61,10 +61,16 @@ export function RefineTicketDialog() {
   const gate: SpecGateResult | null = session?.result ?? null;
   const sessionError = session?.error ?? null;
 
-  // Initialise answers when gate questions change
+  // Initialise answers when gate questions change.
+  // Defensively coerce legacy string[] items (old persisted sessions) to RefineQuestion.
   useEffect(() => {
     if (gate && !gate.passed && gate.questions.length > 0) {
-      setAnswers(gate.questions.map(() => ''));
+      const normalized = gate.questions.map((q): RefineQuestion =>
+        typeof q === 'string'
+          ? { id: 'q', question: q as string, options: [] }
+          : (!Array.isArray((q as RefineQuestion).options) ? { ...(q as RefineQuestion), options: [] } : q as RefineQuestion)
+      );
+      setAnswers(normalized.map(() => ({ optionId: null, text: '' })));
     }
   }, [gate]);
 
@@ -102,8 +108,22 @@ export function RefineTicketDialog() {
 
   const handleSubmitAnswers = useCallback(async () => {
     if (!session || !projectDir) return;
-    const combined = (gate?.questions ?? [])
-      .map((q, i) => `Q${i + 1}: ${q}\nA: ${answers[i]?.trim() || '(no answer)'}`)
+    const questions = gate?.questions ?? [];
+    const combined = questions
+      .map((q, i) => {
+        const ans = answers[i];
+        const questionText = typeof q === 'string' ? q : q.question;
+        const selectedLabel =
+          ans?.optionId != null
+            ? (typeof q === 'string' ? null : q.options.find((o) => o.id === ans.optionId)?.label ?? null)
+            : null;
+        const lines = [
+          `Q${i + 1}: ${questionText}`,
+          `Selected: ${selectedLabel ?? '(none)'}`,
+          `Additional context: ${ans?.text.trim() || '(none)'}`,
+        ];
+        return lines.join('\n');
+      })
       .join('\n\n');
     setLocalError(null);
     // Update session optimistically to 'running' while we wait
@@ -194,7 +214,7 @@ export function RefineTicketDialog() {
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       data-testid="refine-ticket-dialog"
     >
-      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[560px] max-h-[90vh] overflow-y-auto shadow-dialog animate-slide-up">
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[768px] max-h-[90vh] overflow-y-auto shadow-dialog animate-slide-up">
         <div className="px-6 py-4 border-b border-sandstorm-border flex items-center justify-between">
           <div>
             <h2 className="text-base font-semibold text-sandstorm-text">Refine Ticket</h2>
@@ -337,26 +357,54 @@ export function RefineTicketDialog() {
                   No structured questions parsed. The full report was committed to the ticket — open it on GitHub to read it.
                 </div>
               ) : (
-                <div className="space-y-2">
-                  {gate.questions.map((q, i) => (
-                    <div key={i}>
-                      <p className="text-xs text-sandstorm-text-secondary mb-1">
-                        <span className="text-sandstorm-muted">{i + 1}.</span> {q}
-                      </p>
-                      <textarea
-                        value={answers[i] ?? ''}
-                        onChange={(e) => {
-                          const next = [...answers];
-                          next[i] = e.target.value;
-                          setAnswers(next);
-                        }}
-                        rows={2}
-                        placeholder="Your answer…"
-                        className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-xs text-sandstorm-text resize-none outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
-                        data-testid={`refine-answer-${i}`}
-                      />
-                    </div>
-                  ))}
+                <div className="space-y-4">
+                  {gate.questions.map((q, i) => {
+                    const qItem: RefineQuestion = typeof q === 'string'
+                      ? { id: `q${i}`, question: q as string, options: [] }
+                      : (!Array.isArray((q as RefineQuestion).options) ? { ...(q as RefineQuestion), options: [] } : q as RefineQuestion);
+                    const ans = answers[i] ?? { optionId: null, text: '' };
+                    return (
+                      <div key={i} className="space-y-2">
+                        <p className="text-xs text-sandstorm-text-secondary">
+                          <span className="text-sandstorm-muted">{i + 1}.</span> {qItem.question}
+                        </p>
+                        {qItem.options.length > 0 && (
+                          <div className="space-y-1 pl-3">
+                            {qItem.options.map((opt) => (
+                              <label key={opt.id} className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                  type="radio"
+                                  name={`refine-q-${i}`}
+                                  value={opt.id}
+                                  checked={ans.optionId === opt.id}
+                                  onChange={() => {
+                                    const next = [...answers];
+                                    next[i] = { ...ans, optionId: opt.id };
+                                    setAnswers(next);
+                                  }}
+                                  className="accent-sandstorm-accent"
+                                  data-testid={`refine-option-${i}-${opt.id}`}
+                                />
+                                <span className="text-xs text-sandstorm-text">{opt.label}</span>
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                        <textarea
+                          value={ans.text}
+                          onChange={(e) => {
+                            const next = [...answers];
+                            next[i] = { ...ans, text: e.target.value };
+                            setAnswers(next);
+                          }}
+                          rows={2}
+                          placeholder="Add more detail…"
+                          className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-xs text-sandstorm-text resize-none outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+                          data-testid={`refine-answer-${i}`}
+                        />
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -419,7 +467,7 @@ export function RefineTicketDialog() {
               {showFailState && gate && gate.questions.length > 0 && (
                 <button
                   onClick={handleSubmitAnswers}
-                  disabled={answers.some((a) => !a.trim())}
+                  disabled={answers.some((a) => a.optionId === null && !a.text.trim())}
                   className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
                   data-testid="refine-submit-answers"
                 >

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -695,10 +695,21 @@ declare global {
   }
 }
 
+export interface RefineQuestionOption {
+  id: string;
+  label: string;
+}
+
+export interface RefineQuestion {
+  id: string;
+  question: string;
+  options: RefineQuestionOption[];
+}
+
 /** Renderer-side mirror of `SpecGateResult` from main/control-plane/ticket-spec.ts. */
 export interface SpecGateResult {
   passed: boolean;
-  questions: string[];
+  questions: RefineQuestion[];
   gateSummary: string;
   ticketUrl: string | null;
   cached: boolean;

--- a/tests/integration/refinement-streaming.spec.ts
+++ b/tests/integration/refinement-streaming.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures';
+import type { RefineQuestion } from '../../src/renderer/store';
 
 test.describe('Refinement streaming panel', () => {
   test('refine-stream-panel shows live streamed text mid-run', async ({ electronApp, mainWindow }) => {
@@ -86,5 +87,84 @@ test.describe('Refinement streaming panel', () => {
     // panel populated (not the static spinner alone).
     const screenshot = await mainWindow.screenshot();
     expect(screenshot.byteLength).toBeGreaterThan(0);
+  });
+
+  test('RefineTicketDialog renders radio buttons, textareas, and wider modal for structured questions', async ({ electronApp, mainWindow }) => {
+    await mainWindow.waitForSelector('text=Sandstorm', { timeout: 15000 });
+
+    const sessionId = 'int-test-refine-structured-1';
+    const structuredQuestions: RefineQuestion[] = [
+      {
+        id: 'q1',
+        question: 'Should X do A or B?',
+        options: [
+          { id: 'a', label: 'Do A' },
+          { id: 'b', label: 'Do B' },
+        ],
+      },
+      {
+        id: 'q2',
+        question: 'What is the expected throughput?',
+        options: [
+          { id: 'a', label: 'Under 100 RPS' },
+          { id: 'b', label: 'Over 100 RPS' },
+        ],
+      },
+    ];
+
+    // Inject a failed gate with structured questions directly as a ready session.
+    await electronApp.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (electron: any, args: { sid: string; ts: number; questions: RefineQuestion[] }) => {
+        const win = electron.BrowserWindow.getAllWindows()[0];
+        win.webContents.send('refinement:update', {
+          id: args.sid,
+          ticketId: '998',
+          projectDir: '/tmp/integration-test',
+          status: 'ready',
+          phase: 'check',
+          startedAt: args.ts,
+          result: {
+            passed: false,
+            questions: args.questions,
+            gateSummary: 'Gate=FAIL, questions=2',
+            ticketUrl: null,
+            cached: false,
+          },
+        });
+      },
+      { sid: sessionId, ts: Date.now(), questions: structuredQuestions },
+    );
+
+    // The electronApp fixture is worker-scoped and shared across tests in this file.
+    // Test 1 leaves the dialog open; close it before interacting with the indicator pill.
+    const priorDialog = mainWindow.locator('[data-testid="refine-ticket-dialog"]');
+    if (await priorDialog.isVisible().catch(() => false)) {
+      // Click the backdrop overlay at the top-left corner (outside the centered modal content)
+      // to trigger handleClose via the overlay's onClick handler.
+      await priorDialog.click({ position: { x: 5, y: 5 } });
+      await priorDialog.waitFor({ state: 'hidden', timeout: 3000 });
+    }
+
+    // Open the dialog via the refinement indicator.
+    await mainWindow.waitForSelector('[data-testid="refinement-indicator-pill"]', { timeout: 5000 });
+    await mainWindow.click('[data-testid="refinement-indicator-pill"]');
+    await mainWindow.waitForSelector(`[data-testid="refinement-session-${sessionId}"]`, { timeout: 5000 });
+    await mainWindow.click(`[data-testid="refinement-session-${sessionId}"]`);
+    await mainWindow.waitForSelector('[data-testid="refine-ticket-dialog"]', { timeout: 5000 });
+    await mainWindow.waitForSelector('[data-testid="refine-fail"]', { timeout: 5000 });
+
+    // (a) Radio inputs are present for each option (2 questions × 2 options = 4 radios).
+    const radios = mainWindow.locator('input[type="radio"]');
+    await expect(radios).toHaveCount(4);
+
+    // (b) A textarea is present per question (2 textareas).
+    const textareas = mainWindow.locator('[data-testid="refine-fail"] textarea');
+    await expect(textareas).toHaveCount(2);
+
+    // (c) The modal element's class list includes the wider w-[768px] class.
+    const modal = mainWindow.locator('[data-testid="refine-ticket-dialog"] > div').first();
+    const className = await modal.getAttribute('class');
+    expect(className).toContain('w-[768px]');
   });
 });

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -6,8 +6,38 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RefineTicketDialog, formatElapsed } from '../../../src/renderer/components/RefineTicketDialog';
-import { useAppStore } from '../../../src/renderer/store';
+import { useAppStore, type RefineQuestion } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
+
+const MULTI_OPT_QUESTIONS: RefineQuestion[] = [
+  {
+    id: 'q1',
+    question: 'What is X?',
+    options: [
+      { id: 'a', label: 'Option A' },
+      { id: 'b', label: 'Option B' },
+    ],
+  },
+  {
+    id: 'q2',
+    question: 'What is Y?',
+    options: [
+      { id: 'a', label: 'Yes' },
+      { id: 'b', label: 'No' },
+    ],
+  },
+];
+
+const SINGLE_OPT_QUESTION: RefineQuestion[] = [
+  {
+    id: 'q1',
+    question: 'What is X?',
+    options: [
+      { id: 'a', label: 'Option A' },
+      { id: 'b', label: 'Option B' },
+    ],
+  },
+];
 
 describe('RefineTicketDialog', () => {
   let api: ReturnType<typeof mockSandstormApi>;
@@ -130,7 +160,7 @@ describe('RefineTicketDialog', () => {
         status: 'ready', phase: 'check', startedAt: Date.now(),
         result: {
           passed: false,
-          questions: ['What is X?', 'What is Y?'],
+          questions: MULTI_OPT_QUESTIONS,
           gateSummary: 'Gate=FAIL, questions=2',
           ticketUrl: null, cached: false,
         },
@@ -144,6 +174,81 @@ describe('RefineTicketDialog', () => {
     expect(screen.getByTestId('refine-answer-1')).toBeDefined();
     const submit = screen.getByTestId('refine-submit-answers');
     expect(submit.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('renders radio buttons for each option per question', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'session-1', ticketId: '310', projectDir: '/proj',
+        status: 'ready', phase: 'check', startedAt: Date.now(),
+        result: {
+          passed: false,
+          questions: MULTI_OPT_QUESTIONS,
+          gateSummary: 'Gate=FAIL, questions=2',
+          ticketUrl: null, cached: false,
+        },
+      }],
+      currentRefinementSessionId: 'session-1',
+    });
+    render(<RefineTicketDialog />);
+    // 2 options per question × 2 questions = 4 radio inputs
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(4);
+    // 1 textarea per question = 2 textareas
+    const textareas = screen.getAllByRole('textbox');
+    expect(textareas).toHaveLength(2);
+  });
+
+  it('submit is enabled when an option is selected (no text required)', async () => {
+    const user = userEvent.setup();
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'session-1', ticketId: '310', projectDir: '/proj',
+        status: 'ready', phase: 'check', startedAt: Date.now(),
+        result: {
+          passed: false,
+          questions: MULTI_OPT_QUESTIONS,
+          gateSummary: 'Gate=FAIL, questions=2',
+          ticketUrl: null, cached: false,
+        },
+      }],
+      currentRefinementSessionId: 'session-1',
+    });
+    render(<RefineTicketDialog />);
+    const submit = screen.getByTestId('refine-submit-answers');
+    expect(submit.hasAttribute('disabled')).toBe(true);
+
+    // Select one option for q1 — submit still disabled (q2 unanswered)
+    await user.click(screen.getByTestId('refine-option-0-a'));
+    expect(submit.hasAttribute('disabled')).toBe(true);
+
+    // Select one option for q2 — now both answered, submit enabled
+    await user.click(screen.getByTestId('refine-option-1-a'));
+    expect(submit.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('submit is enabled when additional context text is provided (no option required)', async () => {
+    const user = userEvent.setup();
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'session-1', ticketId: '310', projectDir: '/proj',
+        status: 'ready', phase: 'check', startedAt: Date.now(),
+        result: {
+          passed: false,
+          questions: MULTI_OPT_QUESTIONS,
+          gateSummary: 'Gate=FAIL, questions=2',
+          ticketUrl: null, cached: false,
+        },
+      }],
+      currentRefinementSessionId: 'session-1',
+    });
+    render(<RefineTicketDialog />);
+    const submit = screen.getByTestId('refine-submit-answers');
+
+    // Type text into both textareas
+    await user.type(screen.getByTestId('refine-answer-0'), 'custom detail for q1');
+    await user.type(screen.getByTestId('refine-answer-1'), 'custom detail for q2');
+    expect(submit.hasAttribute('disabled')).toBe(false);
   });
 
   it('shows Run Gate button when gate failed with zero questions and calls specCheckAsync on click', async () => {
@@ -175,7 +280,7 @@ describe('RefineTicketDialog', () => {
     });
   });
 
-  it('calls specRefineAsync with formatted Q/A when answers are submitted', async () => {
+  it('calls specRefineAsync with formatted Q/Selected/Additional serialization when option selected', async () => {
     const user = userEvent.setup();
     useAppStore.setState({
       refinementSessions: [{
@@ -183,7 +288,44 @@ describe('RefineTicketDialog', () => {
         status: 'ready', phase: 'check', startedAt: Date.now(),
         result: {
           passed: false,
-          questions: ['What is X?'],
+          questions: SINGLE_OPT_QUESTION,
+          gateSummary: 'Gate=FAIL, questions=1',
+          ticketUrl: null, cached: false,
+        },
+      }],
+      currentRefinementSessionId: 'session-1',
+    });
+    render(<RefineTicketDialog />);
+    // Select option A and add extra context
+    await user.click(screen.getByTestId('refine-option-0-a'));
+    await user.type(screen.getByTestId('refine-answer-0'), 'extra detail');
+    fireEvent.click(screen.getByTestId('refine-submit-answers'));
+
+    await waitFor(() => {
+      expect(api.tickets.specRefineAsync).toHaveBeenCalledWith(
+        'session-1',
+        '310',
+        '/proj',
+        expect.stringContaining('Q1: What is X?'),
+      );
+    });
+    await waitFor(() => {
+      const call = (api.tickets.specRefineAsync as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body: string = call[3];
+      expect(body).toContain('Selected: Option A');
+      expect(body).toContain('Additional context: extra detail');
+    });
+  });
+
+  it('calls specRefineAsync with (none) selected when only text is provided', async () => {
+    const user = userEvent.setup();
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'session-1', ticketId: '310', projectDir: '/proj',
+        status: 'ready', phase: 'check', startedAt: Date.now(),
+        result: {
+          passed: false,
+          questions: SINGLE_OPT_QUESTION,
           gateSummary: 'Gate=FAIL, questions=1',
           ticketUrl: null, cached: false,
         },
@@ -195,12 +337,11 @@ describe('RefineTicketDialog', () => {
     fireEvent.click(screen.getByTestId('refine-submit-answers'));
 
     await waitFor(() => {
-      expect(api.tickets.specRefineAsync).toHaveBeenCalledWith(
-        'session-1',
-        '310',
-        '/proj',
-        expect.stringContaining('Q1: What is X?\nA: X is foo'),
-      );
+      const call = (api.tickets.specRefineAsync as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body: string = call[3];
+      expect(body).toContain('Q1: What is X?');
+      expect(body).toContain('Selected: (none)');
+      expect(body).toContain('Additional context: X is foo');
     });
   });
 

--- a/tests/unit/main/scheduler/refine-to-comments.test.ts
+++ b/tests/unit/main/scheduler/refine-to-comments.test.ts
@@ -9,7 +9,7 @@ import {
   type RefineToCommentsDeps,
 } from '../../../../src/main/scheduler/refine-to-comments';
 import type { TicketEntry, TicketComment } from '../../../../src/main/control-plane/ticket-comments';
-import type { SpecGateResult } from '../../../../src/main/control-plane/ticket-spec';
+import type { SpecGateResult, RefineQuestion } from '../../../../src/main/control-plane/ticket-spec';
 
 const PASS_RESULT: SpecGateResult = {
   passed: true,
@@ -19,9 +19,25 @@ const PASS_RESULT: SpecGateResult = {
   cached: false,
 };
 
+const FAIL_QUESTIONS: RefineQuestion[] = [
+  {
+    id: 'q1',
+    question: 'What does "fast" mean?',
+    options: [
+      { id: 'a', label: 'Under 100ms' },
+      { id: 'b', label: 'Under 1s' },
+    ],
+  },
+  {
+    id: 'q2',
+    question: 'Which provider handles auth?',
+    options: [],
+  },
+];
+
 const FAIL_RESULT: SpecGateResult = {
   passed: false,
-  questions: ['What does "fast" mean?', 'Which provider handles auth?'],
+  questions: FAIL_QUESTIONS,
   gateSummary: 'Gate=FAIL, questions=2',
   ticketUrl: null,
   cached: false,
@@ -103,19 +119,38 @@ describe('getUserAnswersAfterBot', () => {
 });
 
 describe('formatQuestionComment', () => {
+  const questions: RefineQuestion[] = [
+    { id: 'q1', question: 'What is X?', options: [{ id: 'a', label: 'Option A' }, { id: 'b', label: 'Option B' }] },
+    { id: 'q2', question: 'Why Y?', options: [] },
+  ];
+
   it('includes the bot marker', () => {
-    const result = formatQuestionComment(['Q1', 'Q2'], 'Gate=FAIL, questions=2');
+    const result = formatQuestionComment(questions, 'Gate=FAIL, questions=2');
     expect(result).toContain(BOT_COMMENT_MARKER);
   });
 
   it('formats questions as numbered list', () => {
-    const result = formatQuestionComment(['What is X?', 'Why Y?'], '');
+    const result = formatQuestionComment(questions, '');
     expect(result).toContain('1. What is X?');
     expect(result).toContain('2. Why Y?');
   });
 
+  it('renders options as lettered markdown sub-items', () => {
+    const result = formatQuestionComment(questions, '');
+    expect(result).toContain('   - A) Option A');
+    expect(result).toContain('   - B) Option B');
+  });
+
+  it('does not emit option lines when a question has no options', () => {
+    const noOpts: RefineQuestion[] = [{ id: 'q1', question: 'Open ended?', options: [] }];
+    const result = formatQuestionComment(noOpts, '');
+    expect(result).toContain('1. Open ended?');
+    expect(result).not.toContain('   - A)');
+  });
+
   it('includes gate summary when provided', () => {
-    const result = formatQuestionComment(['Q'], 'Gate=FAIL, questions=1');
+    const single: RefineQuestion[] = [{ id: 'q1', question: 'Q', options: [] }];
+    const result = formatQuestionComment(single, 'Gate=FAIL, questions=1');
     expect(result).toContain('Gate=FAIL, questions=1');
   });
 });

--- a/tests/unit/ticket-spec.test.ts
+++ b/tests/unit/ticket-spec.test.ts
@@ -29,6 +29,37 @@ const FAIL_REPORT = `## Spec Quality Gate: FAIL
 | Specificity | FAIL |
 `;
 
+const FAIL_REPORT_JSON = `## Spec Quality Gate: FAIL
+
+### Questions
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "What does fast mean?",
+    "options": [
+      { "id": "a", "label": "Under 100ms" },
+      { "id": "b", "label": "Under 1s" }
+    ]
+  },
+  {
+    "id": "q2",
+    "question": "Cache strategy?",
+    "options": [
+      { "id": "a", "label": "Full body" },
+      { "id": "b", "label": "Hash only" }
+    ]
+  }
+]
+\`\`\`
+
+### Results
+| Criterion | Result |
+|-----------|--------|
+| Specificity | FAIL |
+`;
+
 const GITHUB_CONFIG: ProjectTicketConfig = { provider: 'github' };
 
 function makeDeps(overrides: Partial<SpecGateDeps> = {}): SpecGateDeps {
@@ -49,8 +80,12 @@ describe('extractGateSummary', () => {
     expect(extractGateSummary(PASS_REPORT)).toBe('Gate=PASS, questions=0');
   });
 
-  it('parses FAIL verdict and counts numbered questions', () => {
+  it('parses FAIL verdict and counts numbered questions (fallback)', () => {
     expect(extractGateSummary(FAIL_REPORT)).toBe('Gate=FAIL, questions=2');
+  });
+
+  it('parses FAIL verdict and counts JSON questions', () => {
+    expect(extractGateSummary(FAIL_REPORT_JSON)).toBe('Gate=FAIL, questions=2');
   });
 
   it('returns empty string when report is empty', () => {
@@ -63,25 +98,65 @@ describe('extractGateSummary', () => {
 });
 
 describe('extractQuestions', () => {
-  it('pulls numbered items under a Questions heading', () => {
-    expect(extractQuestions(FAIL_REPORT)).toEqual([
-      'What does "fast" mean here in concrete numbers?',
-      'Should we cache the full body or just the hash?',
+  it('parses JSON block under a Questions heading', () => {
+    const questions = extractQuestions(FAIL_REPORT_JSON);
+    expect(questions).toHaveLength(2);
+    expect(questions[0].id).toBe('q1');
+    expect(questions[0].question).toBe('What does fast mean?');
+    expect(questions[0].options).toEqual([
+      { id: 'a', label: 'Under 100ms' },
+      { id: 'b', label: 'Under 1s' },
     ]);
+    expect(questions[1].id).toBe('q2');
+    expect(questions[1].question).toBe('Cache strategy?');
   });
 
-  it('also captures items under a Gaps heading', () => {
+  it('falls back to numbered list when no JSON block (legacy)', () => {
+    const questions = extractQuestions(FAIL_REPORT);
+    expect(questions).toHaveLength(2);
+    expect(questions[0].question).toBe('What does "fast" mean here in concrete numbers?');
+    expect(questions[0].options).toEqual([]);
+    expect(questions[1].question).toBe('Should we cache the full body or just the hash?');
+    expect(questions[1].options).toEqual([]);
+  });
+
+  it('also captures items under a Gaps heading (fallback)', () => {
     const r = `### Gaps\n1. First gap\n2. Second gap\n## Next\n3. Outside`;
-    expect(extractQuestions(r)).toEqual(['First gap', 'Second gap']);
+    const questions = extractQuestions(r);
+    expect(questions).toHaveLength(2);
+    expect(questions[0].question).toBe('First gap');
+    expect(questions[1].question).toBe('Second gap');
+  });
+
+  it('also captures JSON block under a Gaps heading', () => {
+    const r = `### Gaps\n\n\`\`\`json\n[{"id":"q1","question":"Gap Q?","options":[{"id":"a","label":"Yes"},{"id":"b","label":"No"}]}]\n\`\`\`\n## Next`;
+    const questions = extractQuestions(r);
+    expect(questions).toHaveLength(1);
+    expect(questions[0].question).toBe('Gap Q?');
+    expect(questions[0].options).toHaveLength(2);
   });
 
   it('returns empty array when no Questions/Gaps heading exists', () => {
     expect(extractQuestions(PASS_REPORT)).toEqual([]);
   });
 
-  it('stops capturing at the next ## heading boundary', () => {
+  it('stops capturing at the next ## heading boundary (fallback)', () => {
     const r = `### Questions\n1. Inside\n## Other\n2. Outside`;
-    expect(extractQuestions(r)).toEqual(['Inside']);
+    const questions = extractQuestions(r);
+    expect(questions).toHaveLength(1);
+    expect(questions[0].question).toBe('Inside');
+  });
+
+  it('falls back gracefully when JSON block is malformed', () => {
+    const r = `### Questions\n\`\`\`json\nnot valid json\n\`\`\``;
+    expect(extractQuestions(r)).toEqual([]);
+  });
+
+  it('returns empty options array when options key is missing in JSON item', () => {
+    const r = `### Questions\n\n\`\`\`json\n[{"id":"q1","question":"A question?"}]\n\`\`\``;
+    const questions = extractQuestions(r);
+    expect(questions).toHaveLength(1);
+    expect(questions[0].options).toEqual([]);
   });
 });
 
@@ -148,7 +223,8 @@ describe('runSpecCheck', () => {
     });
     const result = await runSpecCheck('1', '/proj', deps);
     expect(result.passed).toBe(false);
-    expect(result.questions.length).toBe(2);
+    expect(result.questions).toHaveLength(2);
+    expect(result.questions[0]).toMatchObject({ question: expect.any(String), options: [] });
     expect(result.gateSummary).toBe('Gate=FAIL, questions=2');
     expect(deps.markSpecReady).not.toHaveBeenCalled();
   });
@@ -199,7 +275,8 @@ describe('runSpecRefine', () => {
     });
     const result = await runSpecRefine('1', '/proj', 'answers', deps);
     expect(result.passed).toBe(false);
-    expect(result.questions.length).toBe(2);
+    expect(result.questions).toHaveLength(2);
+    expect(result.questions[0]).toMatchObject({ question: expect.any(String), options: [] });
     expect(deps.markSpecReady).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Spec gate questions are now structured multiple-choice items (`RefineQuestion` with `options`) instead of plain strings, so the refine flow can offer concrete choices rather than free-text-only prompts. The LLM prompts in `tools.ts` now instruct the model to emit questions as a JSON block.
- `extractQuestions` parses the new ```json fence under `### Questions`/`### Gaps`, with a fallback to the legacy numbered-list parser (coerced to options-less questions) so older reports and persisted sessions still work.
- `RefineTicketDialog` renders radio options plus an optional free-text box per question, widened to fit choices; bot comments posted to the ticket render lettered options (A, B, C…).

## Test plan
- [ ] `npm test` — unit suites for `ticket-spec`, `refine-to-comments`, and `RefineTicketDialog` pass
- [ ] Run a refine on a ticket that fails the spec gate; confirm the dialog shows multiple-choice options with a per-question detail box
- [ ] Verify selecting an option (no extra text) enables submit, and that the submitted answers include the selected label
- [ ] Confirm a gate report with the old numbered-list format still parses and renders (legacy fallback)
- [ ] Check the GitHub bot comment lists questions with lettered options
- [ ] `npx playwright test --config playwright.integration.config.ts tests/integration/refinement-streaming.spec.ts` passes (dialog isolation between tests)

Closes #373