### PR TITLE
fix: disable wall-clock timeout for interactive spec refine sessions

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -499,16 +499,19 @@ export class ClaudeBackend implements AgentBackend {
       fn();
     };
 
-    const timer = setTimeout(() => {
-      if (child.exitCode === null) {
-        isCancelled = true;
-        child.kill('SIGTERM');
-        setTimeout(() => {
-          if (child.exitCode === null) child.kill('SIGKILL');
-        }, 5_000);
-        settle(() => rejectFn(new Error(`Ephemeral agent timed out after ${timeoutMs}ms`)));
-      }
-    }, timeoutMs);
+    let timer: NodeJS.Timeout | undefined;
+    if (timeoutMs != null && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        if (child.exitCode === null) {
+          isCancelled = true;
+          child.kill('SIGTERM');
+          setTimeout(() => {
+            if (child.exitCode === null) child.kill('SIGKILL');
+          }, 5_000);
+          settle(() => rejectFn(new Error(`Ephemeral agent timed out after ${timeoutMs}ms`)));
+        }
+      }, timeoutMs);
+    }
 
     child.stdout?.on('data', (data: Buffer) => {
       outputBuffer += data.toString();
@@ -628,6 +631,7 @@ export class ClaudeBackend implements AgentBackend {
 
     const resetIdleTimer = (): void => {
       if (idleTimer) clearTimeout(idleTimer);
+      if (timeoutMs == null || timeoutMs <= 0) return;
       idleTimer = setTimeout(() => {
         if (currentReject) currentReject(new Error(`Ephemeral session timed out after ${timeoutMs}ms`));
         dispose();

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -28,7 +28,7 @@ import type { EphemeralStreamEvent, EphemeralSessionHandle } from '../agent/type
 
 export { validateProjectDir };
 
-
+const SCHEDULED_REFINE_TIMEOUT_MS = 1_800_000;
 
 export async function handleToolCall(
   name: string,
@@ -326,7 +326,7 @@ async function handleSpecCheck(
   const { ctx } = res;
 
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir);
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS);
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -499,13 +499,13 @@ async function handleSpecRefine(
 
   if (!userAnswers) {
     const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody);
-    const result = await agentBackend.runEphemeralAgent(prompt, projectDir);
+    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS);
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   }
 
   const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir);
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS);
   return applySpecRefineResult(ticketId, projectDir, result, true);
 }
 
@@ -531,7 +531,7 @@ export function spawnSpecCheck(
     if (cancelled) throw new Error('Cancelled');
 
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 300_000, onChunk);
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk);
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 
@@ -626,7 +626,7 @@ export function spawnSpecRefine(
       // No pooled session (timed out, app restarted, etc.) — fall back to a
       // cold ephemeral so the user's answers still produce a result.
       const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(
-        answerPrompt, projectDir, 300_000, onChunk,
+        answerPrompt, projectDir, 0, onChunk,
       );
       activeDispose = epCancel;
       if (cancelled) { epCancel(); throw new Error('Cancelled'); }
@@ -637,7 +637,7 @@ export function spawnSpecRefine(
     // Initial-questions pass. Spawn a long-lived session so the after-answers
     // pass can reuse it.
     const initialPrompt = buildSpecRefineInitialPrompt(res.ctx.gate, res.ctx.ticketBody);
-    const handle = agentBackend.spawnEphemeralSession(initialPrompt, projectDir, 300_000, onChunk);
+    const handle = agentBackend.spawnEphemeralSession(initialPrompt, projectDir, 0, onChunk);
     // Cancel during the initial pass must dispose the live handle even though
     // it isn't pooled yet — otherwise SIGTERM never reaches the held subprocess.
     activeDispose = (): void => {

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1891,3 +1891,88 @@ describe('Outer Claude context-bloat suppression (#302, #303)', () => {
     backend.destroy();
   });
 });
+
+describe('ClaudeBackend — disabled-timeout sentinel and scheduled ceiling (#375)', () => {
+  beforeEach(() => {
+    spawnedProcesses.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function getEphemeralProcess(): MockChildProcess {
+    return spawnedProcesses[spawnedProcesses.length - 1];
+  }
+
+  it('spawnEphemeralAgent with 0 timeout never rejects with a timeout error (stays pending past 300_000ms)', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    let settled = false;
+    const { promise } = backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 0);
+    promise.then(() => { settled = true; }).catch(() => { settled = true; });
+
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    expect(settled).toBe(false);
+
+    backendUnderTest.destroy();
+  });
+
+  it('spawnEphemeralSession with 0 timeout never rejects with a timeout error (initialResult stays pending past 300_000ms)', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    let settled = false;
+    const handle = backendUnderTest.spawnEphemeralSession('prompt', '/tmp', 0);
+    handle.initialResult.then(() => { settled = true; }).catch(() => { settled = true; });
+
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    expect(settled).toBe(false);
+
+    handle.dispose();
+    backendUnderTest.destroy();
+  });
+
+  it('spawnEphemeralAgent with 0 timeout: cancel() still SIGTERMs child and rejects with Cancelled', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    const { promise, cancel } = backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 0);
+    const proc = getEphemeralProcess();
+
+    cancel();
+    proc.exitCode = 143;
+    proc.emit('close', 143);
+
+    await expect(promise).rejects.toThrow('Cancelled');
+    expect(proc.killed).toBe(true);
+
+    backendUnderTest.destroy();
+  });
+
+  it('runEphemeralAgent with 1_800_000ms stays pending at 1_799_999ms and rejects at the ceiling', async () => {
+    const backendUnderTest = new ClaudeBackend(60_000);
+    let settled = false;
+    const promise = backendUnderTest.runEphemeralAgent('prompt', '/tmp', 1_800_000);
+    promise.then(() => { settled = true; }).catch(() => { settled = true; });
+
+    // Below old 5-min default — must still be pending
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(settled).toBe(false);
+
+    // Just below the 30-min ceiling
+    await vi.advanceTimersByTimeAsync(1_500_000); // total 1_799_999ms
+    expect(settled).toBe(false);
+
+    // Cross the ceiling
+    await vi.advanceTimersByTimeAsync(2); // total 1_800_001ms
+    expect(settled).toBe(true);
+
+    const proc = getEphemeralProcess();
+    proc.exitCode = 143;
+    proc.emit('close', 143);
+
+    await expect(promise).rejects.toThrow('Ephemeral agent timed out after 1800000ms');
+
+    backendUnderTest.destroy();
+  });
+});

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleToolCall, validateProjectDir, _clearTicketBodyCacheForTests, _disposeAllRefineSessionsForTests, spawnSpecRefine } from '../../src/main/claude/tools';
+import { handleToolCall, validateProjectDir, _clearTicketBodyCacheForTests, _disposeAllRefineSessionsForTests, spawnSpecRefine, spawnSpecCheck } from '../../src/main/claude/tools';
 import type { EphemeralSessionHandle } from '../../src/main/agent/types';
 
 // Mock the stackManager, agentBackend, and registry imports
@@ -201,7 +201,8 @@ describe('MCP tools', () => {
 
       expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
         expect.stringContaining('Fix bug'),
-        '/proj'
+        '/proj',
+        1_800_000
       );
       expect(result.passed).toBe(true);
       expect(result.report).toContain('PASS');
@@ -598,7 +599,8 @@ describe('MCP tools', () => {
 
       expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
         expect.stringContaining('auth tokens expire silently'),
-        '/proj'
+        '/proj',
+        1_800_000
       );
       expect(result.passed).toBe(true);
       expect(result.updatedBody).toContain('Better spec');
@@ -899,6 +901,80 @@ describe('MCP tools', () => {
       fakeHandle.initialResolve('## Spec Quality Gate: FAIL\n\n### Questions\n1. What?');
       await expect(promise).rejects.toThrow('Cancelled');
       expect(fakeHandle.disposeMock).toHaveBeenCalled();
+    });
+
+    it('cancel during pooled follow-up disposes the session and rejects with Cancelled', async () => {
+      // Establish a pooled session from the initial pass.
+      const { promise: initial } = spawnSpecRefine('42', '/proj');
+      fakeHandle.initialResolve('## Spec Quality Gate: FAIL\n\n### Questions\n1. What?');
+      await initial;
+
+      // Wire disposeMock to reject the pending sendFollowUp promise, mirroring
+      // the real EphemeralSessionHandle.dispose() behavior.
+      let rejectFollowUp!: (err: Error) => void;
+      const pendingFollowUp = new Promise<string>((_, rej) => { rejectFollowUp = rej; });
+      fakeHandle.sendFollowUpMock.mockReturnValue(pendingFollowUp);
+      fakeHandle.disposeMock.mockImplementation(() => rejectFollowUp(new Error('Cancelled')));
+
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      const { promise: followUp, cancel } = spawnSpecRefine('42', '/proj', 'Answer text');
+
+      await vi.waitFor(() => expect(fakeHandle.sendFollowUpMock).toHaveBeenCalled());
+      cancel();
+
+      await expect(followUp).rejects.toThrow('Cancelled');
+      expect(fakeHandle.disposeMock).toHaveBeenCalled();
+    });
+
+    it('cancel during cold-fallback invokes epCancel and rejects with Cancelled', async () => {
+      // No pooled session — simulate stale/app-restart scenario.
+      let rejectEp!: (err: Error) => void;
+      const ep = new Promise<string>((_, reject) => { rejectEp = reject; });
+      const epCancelMock = vi.fn(() => rejectEp(new Error('Cancelled')));
+      vi.mocked(agentBackend.spawnEphemeralAgent).mockReturnValue({ promise: ep, cancel: epCancelMock });
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      const { promise, cancel } = spawnSpecRefine('42', '/proj', 'Answer text');
+
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
+      cancel();
+
+      await expect(promise).rejects.toThrow('Cancelled');
+      expect(epCancelMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('spawnSpecCheck — cancel regression guard (#375)', () => {
+    let cancelFn: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      _clearTicketBodyCacheForTests();
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: body');
+      vi.mocked(getSpecQualityGate).mockReturnValue('### Problem Statement\nClear?');
+      // The mock cancel function rejects the promise, mirroring real spawnEphemeralAgent behavior.
+      let rejectEp!: (err: Error) => void;
+      const ep = new Promise<string>((_, reject) => { rejectEp = reject; });
+      cancelFn = vi.fn(() => rejectEp(new Error('Cancelled')));
+      vi.mocked(agentBackend.spawnEphemeralAgent).mockReturnValue({ promise: ep, cancel: cancelFn });
+    });
+
+    it('cancel() propagates to the inner ephemeral agent and rejects with Cancelled', async () => {
+      const { promise, cancel } = spawnSpecCheck('42', '/proj');
+
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
+      cancel();
+
+      await expect(promise).rejects.toThrow('Cancelled');
+      expect(cancelFn).toHaveBeenCalled();
+    });
+
+    it('spawnSpecCheck passes 0 as timeout to spawnEphemeralAgent (interactive, no ceiling)', async () => {
+      spawnSpecCheck('42', '/proj');
+
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
+      const [, , timeoutArg] = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls[0];
+      expect(timeoutArg).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- interactive `spawnSpecCheck`/`spawnSpecRefine` paths passed a hard 5-minute (`300_000`) timeout that could kill a live, on-task session out from under the user; they now pass `0` so cancellation — not a wall clock — ends the session
- `spawnEphemeralAgent`/session in `claude-backend` now treat a null or non-positive `timeoutMs` as "no timeout," skipping both the spawn timer and the idle-reset timer instead of arming a timer that never fires correctly
- scheduled (non-interactive) spec-check and refine runs get an explicit `SCHEDULED_REFINE_TIMEOUT_MS` (30 min) so unattended work still has an upper bound

## Test plan
- [ ] `npm test` passes (2110 tests green)
- [ ] verify `claude-backend.test.ts` covers the disabled-timeout path: no timer armed when `timeoutMs <= 0`, idle reset is a no-op
- [ ] verify `tools.test.ts` cancel regressions: `refine-pooled-follow-up` disposes the pooled session mid follow-up, `refine-cold-fallback` cancels the cold ephemeral fallback
- [ ] manually start a spec refine, leave it idle past 5 minutes, confirm the session stays alive and still responds
- [ ] cancel an in-flight refine and confirm SIGTERM reaches the subprocess

Closes #375