### PR TITLE
Migrate ticket listing to built-in provider so backlog board populates (#382)

### DIFF
--- a/src/main/control-plane/ticket-config.ts
+++ b/src/main/control-plane/ticket-config.ts
@@ -27,6 +27,13 @@ export interface CreatedTicket {
   ticketId: string;
 }
 
+/** A ticket as surfaced for the backlog board: stable id, display title, author identity. */
+export interface TicketListEntry {
+  id: string;
+  title: string;
+  author: string;
+}
+
 // ---------------------------------------------------------------------------
 // GitHub: built-in ticket operations via gh CLI
 // ---------------------------------------------------------------------------
@@ -72,6 +79,43 @@ export async function githubUpdateTicket(ticketId: string, body: string, cwd: st
     const msg = err.stderr?.trim() || err.message;
     throw new Error(`gh issue edit failed: ${msg}`);
   });
+}
+
+/**
+ * List the authenticated user's open issues for the backlog board.
+ * Optionally filter by label. Excludes PRs (gh issue list does so by default).
+ * Returns [] on any failure so the board degrades gracefully to existing rows.
+ */
+export async function githubListTickets(cwd: string, label?: string): Promise<TicketListEntry[]> {
+  try {
+    const args = [
+      'issue', 'list',
+      '--author', '@me',
+      '--state', 'open',
+      '--json', 'number,title,author',
+      '--limit', '100',
+    ];
+    if (label && label.trim()) {
+      args.push('--label', label.trim());
+    }
+    const { stdout } = await execFileAsync('gh', args, {
+      cwd,
+      timeout: 30000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    const issues = JSON.parse(stdout) as {
+      number: number;
+      title: string;
+      author: { login: string } | null;
+    }[];
+    return issues.map((issue) => ({
+      id: String(issue.number),
+      title: issue.title,
+      author: issue.author?.login ?? '',
+    }));
+  } catch {
+    return [];
+  }
 }
 
 export async function githubCreateTicket(title: string, body: string, cwd: string): Promise<CreatedTicket> {
@@ -200,6 +244,42 @@ export async function jiraFetchTicket(
   }
 }
 
+/**
+ * List the reporting user's not-done issues for the backlog board.
+ * Optionally filter by label. Returns [] on any failure (graceful degradation).
+ */
+export async function jiraListTickets(
+  config: ProjectTicketConfig,
+  label?: string,
+): Promise<TicketListEntry[]> {
+  if (!config.jira_url || !config.jira_username || !config.jira_api_token) {
+    return [];
+  }
+  try {
+    let jql = 'reporter = currentUser() AND statusCategory != Done';
+    if (label && label.trim()) {
+      jql += ` AND labels = "${label.trim().replace(/"/g, '\\"')}"`;
+    }
+    const url =
+      `${config.jira_url.replace(/\/$/, '')}/rest/api/2/search` +
+      `?jql=${encodeURIComponent(jql)}&fields=summary,reporter&maxResults=100`;
+    const raw = await jiraRequest({ url, method: 'GET', auth: jiraAuth(config) });
+    const result = JSON.parse(raw) as {
+      issues: {
+        key: string;
+        fields: { summary: string; reporter: { accountId?: string; displayName?: string } | null };
+      }[];
+    };
+    return (result.issues ?? []).map((issue) => ({
+      id: issue.key,
+      title: issue.fields.summary,
+      author: issue.fields.reporter?.accountId ?? issue.fields.reporter?.displayName ?? '',
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export async function jiraUpdateTicket(
   ticketId: string,
   body: string,
@@ -262,6 +342,17 @@ export async function fetchTicketWithConfig(
     return githubFetchTicket(ticketId, cwd);
   }
   return jiraFetchTicket(ticketId, config);
+}
+
+export async function listTicketsWithConfig(
+  config: ProjectTicketConfig,
+  cwd: string,
+  label?: string,
+): Promise<TicketListEntry[]> {
+  if (config.provider === 'github') {
+    return githubListTickets(cwd, label);
+  }
+  return jiraListTickets(config, label);
 }
 
 export async function updateTicketWithConfig(

--- a/src/main/control-plane/ticket-lister.ts
+++ b/src/main/control-plane/ticket-lister.ts
@@ -1,3 +1,5 @@
 // Dedicated module for the ticket-listing concern, separate from comment operations.
-export { listTickets } from './ticket-comments';
-export type { TicketEntry } from './ticket-comments';
+// Listing is a built-in provider operation (keyed off the project's ticket config),
+// mirroring fetch/create/update — no per-project shell script required.
+export { listTicketsWithConfig } from './ticket-config';
+export type { TicketListEntry } from './ticket-config';

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -93,7 +93,7 @@ import { createTicketWithConfig } from './control-plane/ticket-config';
 import type { ProjectTicketConfig } from './control-plane/registry';
 import type { EphemeralStreamEvent } from './agent/types';
 import { handleToolCall, spawnSpecCheck, spawnSpecRefine } from './claude/tools';
-import { listTickets } from './control-plane/ticket-lister';
+import { listTicketsWithConfig } from './control-plane/ticket-lister';
 import { KANBAN_COLUMNS } from '../shared/kanban';
 
 /**
@@ -1248,18 +1248,17 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     if (dirError) throw new Error(dirError.error);
     const normalizedDir = path.resolve(projectDir);
 
-    // Fetch from provider; if the script is missing, fall through and return existing board rows.
-    try {
-      const tickets = await listTickets('', normalizedDir);
-      for (const ticket of tickets) {
-        registry.seedBoardTicket(ticket.id, normalizedDir, ticket.title);
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const isKnownProviderError = msg.includes('ENOENT') || msg.includes('not found') ||
-        msg.includes('script') || msg.includes('exit code') || msg.includes('No ticket provider');
-      if (!isKnownProviderError) {
-        console.error('[tickets:list] Unexpected error fetching tickets from provider:', err);
+    // Fetch from the project's configured ticket provider (built-in, no per-project
+    // script). When no provider is configured, skip and return existing board rows.
+    const config = registry.getProjectTicketConfig(normalizedDir);
+    if (config) {
+      try {
+        const tickets = await listTicketsWithConfig(config, normalizedDir);
+        for (const ticket of tickets) {
+          registry.seedBoardTicket(ticket.id, normalizedDir, ticket.title);
+        }
+      } catch (err) {
+        console.error('[tickets:list] Failed to fetch tickets from provider:', err);
       }
     }
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -21,7 +21,7 @@ const {
   mockSpawn,
   mockFetchAccountUsage,
   mockRemoveProjectFromCrontab,
-  mockListTickets,
+  mockListTicketsWithConfig,
   mockSessionMonitor,
 } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
@@ -103,7 +103,7 @@ const {
   const mockSpawn = vi.fn();
   const mockFetchAccountUsage = vi.fn();
   const mockRemoveProjectFromCrontab = vi.fn();
-  const mockListTickets = vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT: not found'), { code: 'ENOENT' }));
+  const mockListTicketsWithConfig = vi.fn().mockResolvedValue([]);
 
   const mockSessionMonitor = {
     getState: vi.fn(),
@@ -125,7 +125,7 @@ const {
     mockSpawn,
     mockFetchAccountUsage,
     mockRemoveProjectFromCrontab,
-    mockListTickets,
+    mockListTicketsWithConfig,
     mockSessionMonitor,
   };
 });
@@ -198,7 +198,7 @@ vi.mock('../../src/main/scheduler/scheduler-manager', () => ({
 }));
 
 vi.mock('../../src/main/control-plane/ticket-lister', () => ({
-  listTickets: (...args: unknown[]) => mockListTickets(...args),
+  listTicketsWithConfig: (...args: unknown[]) => mockListTicketsWithConfig(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1275,35 +1275,58 @@ describe('IPC Handlers', () => {
   // Ticket Board
   // =========================================================================
   describe('tickets:list', () => {
-    it('returns listBoardTickets result when provider is unavailable (fallback path)', async () => {
-      // mockListTickets defaults to rejecting with ENOENT — handler falls through to DB rows
+    it('skips the provider fetch and returns DB rows when no provider is configured', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce(null);
       const boardRows = [
         { ticket_id: 'T-1', project_dir: '/proj', column: 'backlog', title: 'First ticket', updated_at: '' },
       ];
       mockRegistry.listBoardTickets.mockReturnValue(boardRows);
+      mockListTicketsWithConfig.mockClear();
+      mockRegistry.seedBoardTicket.mockClear();
 
       const result = await invokeHandler('tickets:list', '/proj');
+
+      expect(mockListTicketsWithConfig).not.toHaveBeenCalled();
+      expect(mockRegistry.seedBoardTicket).not.toHaveBeenCalled();
       expect(mockRegistry.listBoardTickets).toHaveBeenCalled();
       expect(result).toEqual(boardRows);
     });
 
-    it('calls seedBoardTicket for each provider ticket when listTickets succeeds', async () => {
+    it('returns DB rows when the provider fetch throws (graceful degradation)', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
+      mockListTicketsWithConfig.mockRejectedValueOnce(new Error('gh not authenticated'));
+      const boardRows = [
+        { ticket_id: 'T-9', project_dir: '/proj', column: 'backlog', title: 'Existing', updated_at: '' },
+      ];
+      mockRegistry.listBoardTickets.mockReturnValue(boardRows);
+
+      const result = await invokeHandler('tickets:list', '/proj');
+
+      expect(result).toEqual(boardRows);
+    });
+
+    it('passes the project config to the provider and seeds each returned ticket', async () => {
+      const config = { provider: 'github' };
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce(config);
       const providerTickets = [
         { id: 'T-1', title: 'First ticket', author: 'alice' },
         { id: 'T-2', title: 'Second ticket', author: 'bob' },
       ];
-      mockListTickets.mockResolvedValueOnce(providerTickets);
+      mockListTicketsWithConfig.mockResolvedValueOnce(providerTickets);
       mockRegistry.listBoardTickets.mockReturnValue([]);
+      mockRegistry.seedBoardTicket.mockClear();
 
       await invokeHandler('tickets:list', '/proj');
 
+      expect(mockListTicketsWithConfig).toHaveBeenCalledWith(config, '/proj');
       expect(mockRegistry.seedBoardTicket).toHaveBeenCalledTimes(2);
       expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('T-1', '/proj', 'First ticket');
       expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('T-2', '/proj', 'Second ticket');
     });
 
     it('does not call seedBoardTicket when provider returns no tickets', async () => {
-      mockListTickets.mockResolvedValueOnce([]);
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
+      mockListTicketsWithConfig.mockResolvedValueOnce([]);
       mockRegistry.seedBoardTicket.mockClear();
 
       await invokeHandler('tickets:list', '/proj');

--- a/tests/unit/ticket-config.test.ts
+++ b/tests/unit/ticket-config.test.ts
@@ -4,12 +4,15 @@ import {
   githubFetchTicket,
   githubUpdateTicket,
   githubCreateTicket,
+  githubListTickets,
   jiraFetchTicket,
   jiraUpdateTicket,
   jiraCreateTicket,
+  jiraListTickets,
   fetchTicketWithConfig,
   updateTicketWithConfig,
   createTicketWithConfig,
+  listTicketsWithConfig,
 } from '../../src/main/control-plane/ticket-config';
 import type { ProjectTicketConfig } from '../../src/main/control-plane/registry';
 
@@ -305,5 +308,112 @@ describe('createTicketWithConfig', () => {
 
   it('rejects when body is empty', async () => {
     await expect(createTicketWithConfig({ title: 't', body: '', config: GITHUB_CONFIG, cwd: '/proj' })).rejects.toThrow(/body is required/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Listing (backlog board)
+// ---------------------------------------------------------------------------
+
+describe('githubListTickets', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps gh issue list JSON into TicketListEntry[]', async () => {
+    mockExecFileSuccess(JSON.stringify([
+      { number: 42, title: 'Fix the bug', author: { login: 'alice' } },
+      { number: 7, title: 'Add feature', author: { login: 'bob' } },
+    ]));
+
+    const result = await githubListTickets('/proj');
+
+    expect(result).toEqual([
+      { id: '42', title: 'Fix the bug', author: 'alice' },
+      { id: '7', title: 'Add feature', author: 'bob' },
+    ]);
+  });
+
+  it('invokes gh with @me open-issue args and no label filter by default', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'list', '--author', '@me', '--state', 'open', '--json', 'number,title,author', '--limit', '100'],
+      expect.objectContaining({ cwd: '/myproj' }),
+      expect.any(Function),
+    );
+  });
+
+  it('appends --label when a label is provided', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/proj', 'needs-spec');
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args).toContain('--label');
+    expect(args).toContain('needs-spec');
+  });
+
+  it('tolerates a missing author login', async () => {
+    mockExecFileSuccess(JSON.stringify([{ number: 1, title: 'Orphan', author: null }]));
+    const result = await githubListTickets('/proj');
+    expect(result).toEqual([{ id: '1', title: 'Orphan', author: '' }]);
+  });
+
+  it('returns [] when gh fails (graceful degradation)', async () => {
+    mockExecFileError('gh not authenticated');
+    const result = await githubListTickets('/proj');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] on unparseable output', async () => {
+    mockExecFileSuccess('not json');
+    const result = await githubListTickets('/proj');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('jiraListTickets', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns [] when credentials are missing', async () => {
+    const cfg: ProjectTicketConfig = { provider: 'jira' };
+    expect(await jiraListTickets(cfg)).toEqual([]);
+  });
+
+  it('maps Jira search results into TicketListEntry[]', async () => {
+    mockJiraRequest(JSON.stringify({
+      issues: [
+        { key: 'ACME-42', fields: { summary: 'Fix Jira bug', reporter: { accountId: 'acc-1' } } },
+        { key: 'ACME-7', fields: { summary: 'Add Jira feature', reporter: { displayName: 'Bob' } } },
+      ],
+    }));
+
+    const result = await jiraListTickets(JIRA_CONFIG);
+
+    expect(result).toEqual([
+      { id: 'ACME-42', title: 'Fix Jira bug', author: 'acc-1' },
+      { id: 'ACME-7', title: 'Add Jira feature', author: 'Bob' },
+    ]);
+  });
+
+  it('returns [] on HTTP error', async () => {
+    mockJiraRequest('Unauthorized', 401);
+    expect(await jiraListTickets(JIRA_CONFIG)).toEqual([]);
+  });
+});
+
+describe('listTicketsWithConfig', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes to github for GitHub config', async () => {
+    mockExecFileSuccess(JSON.stringify([{ number: 1, title: 'T', author: { login: 'u' } }]));
+    const result = await listTicketsWithConfig(GITHUB_CONFIG, '/proj');
+    expect(result).toEqual([{ id: '1', title: 'T', author: 'u' }]);
+    expect(mockExecFile).toHaveBeenCalled();
+  });
+
+  it('routes to jira for Jira config', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [{ key: 'ACME-1', fields: { summary: 'J', reporter: { accountId: 'a' } } }] }));
+    const result = await listTicketsWithConfig(JIRA_CONFIG, '/proj');
+    expect(result).toEqual([{ id: 'ACME-1', title: 'J', author: 'a' }]);
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #382.

## What was broken
After the skin-5 redesign, the **Backlog** kanban column never showed any tickets. The board expects a *list* of the project's tickets, but the app only ever fetched tickets one-by-one by ID.

## Root cause
Ticket operations were migrated to be **built into the desktop app** (keyed off the per-project provider config in Project Settings → Ticketing). Fetch / create / update were migrated to `ticket-config.ts`, but **listing was never migrated**. `tickets:list` still called the legacy shell-based `listTickets('', dir)`, which shelled out to `<projectDir>/.sandstorm/scripts/list-tickets.sh`:

- `init` no longer installs that script (project `.sandstorm/scripts/` is empty).
- Even when present, the github template *requires* a label arg and `exit 1`s on the empty label the board passed.

The IPC handler swallowed the error and returned empty board rows → the backlog was always empty.

## Fix
- Add built-in `listTicketsWithConfig(config, cwd, label?)` to `ticket-config.ts`, mirroring `fetchTicketWithConfig`:
  - **GitHub:** `gh issue list --author @me --state open --json number,title,author [--label <label>]`
  - **Jira:** REST search `reporter = currentUser() AND statusCategory != Done [AND labels = "<label>"]`
  - Both return `[]` on failure (graceful degradation; the caller iterates the array).
- Route `tickets:list` through it, keyed off `registry.getProjectTicketConfig(projectDir)`; skip the provider fetch entirely when no provider is configured.
- Repurpose `ticket-lister.ts` to re-export the built-in function.
- Legacy shell `listTickets` in `ticket-comments.ts` left intact — still used by the `refine-to-comments` scheduler.

**Backlog scope:** the authenticated user's open issues (`@me`), no label filter; all seeded into the **backlog** column. Column placement is tracked locally and not clobbered on re-list (`seedBoardTicket` `ON CONFLICT DO UPDATE SET title`).

## Verification
- `npm run typecheck` — clean
- `npm run build` — green
- `vitest run` on `ticket-config.test.ts` + `ipc-handlers.test.ts` — 140 passed
- Confirmed `gh issue list --author @me --state open` returns 97 open issues for this repo
- Fresh-context review pass (dual-loop): no blocking issues

## To see it live
Merge, then restart the app. The project must have a ticket provider configured (Project Settings → Ticketing) — the handler skips the fetch when none is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)