### PR TITLE
Seed board with newly created ticket (#385)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1235,7 +1235,9 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       if (!config) {
         throw new Error('No ticket provider configured for this project. Configure GitHub or Jira in Project Settings.');
       }
-      return createTicketWithConfig({ title, body, config, cwd: projectDir });
+      const result = await createTicketWithConfig({ title, body, config, cwd: projectDir });
+      registry.seedBoardTicket(result.ticketId, path.resolve(projectDir), title);
+      return result;
     },
   );
 

--- a/src/renderer/components/CreateTicketDialog.tsx
+++ b/src/renderer/components/CreateTicketDialog.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from '../store';
 type Phase = 'input' | 'creating' | 'created';
 
 export function CreateTicketDialog() {
-  const { setShowCreateTicketDialog, openRefineTicketDialogWith, activeProject } = useAppStore();
+  const { setShowCreateTicketDialog, openRefineTicketDialogWith, activeProject, refreshBoardTickets } = useAppStore();
   const project = activeProject();
 
   const [title, setTitle] = useState('');
@@ -30,6 +30,7 @@ export function CreateTicketDialog() {
       const result = await window.sandstorm.tickets.create(project.directory, title.trim(), body.trim());
       setCreated({ url: result.url, ticketId: result.ticketId });
       setPhase('created');
+      void refreshBoardTickets(project.directory);
     } catch (err) {
       setPhase('input');
       setError(err instanceof Error ? err.message : String(err));

--- a/tests/integration/create-ticket-board.spec.ts
+++ b/tests/integration/create-ticket-board.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Playwright e2e spec: create ticket → board seeding → card appears in Backlog.
+ *
+ * 1. Sets up a test project with ticket config in the main-process registry via
+ *    app.evaluate(), using the real registry API (not raw SQL).
+ * 2. Stubs the tickets:create IPC handler so no real provider call is needed —
+ *    the stub calls registry.seedBoardTicket() exactly as the real handler does.
+ * 3. Drives the full UI: activates the project, opens Create Ticket dialog,
+ *    fills the form, submits.
+ * 4. Asserts via DOM testids that the new card renders in the Backlog column
+ *    without any manual refresh or project switch.
+ * 5. Captures a screenshot for visual confirmation.
+ */
+import { test, expect, _electron as electron, ElectronApplication } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+let app: ElectronApplication;
+const TEST_PROJECT_DIR = '/tmp/e2e-create-ticket-board';
+const TICKET_ID = 'E2E-42';
+let testProjectId: number;
+
+test.beforeAll(async () => {
+  fs.mkdirSync(TEST_PROJECT_DIR, { recursive: true });
+
+  app = await electron.launch({ args: ['dist/main/index.cjs', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'] });
+
+  // Set up test project and install the tickets:create stub in the main process.
+  // All registry calls use the live registry instance (not raw SQL).
+  testProjectId = await app.evaluate(async () => {
+    const { ipcMain } = require('electron');
+    const pathMod = require('path');
+
+    const projectDir = '/tmp/e2e-create-ticket-board';
+    const normalizedDir = pathMod.resolve(projectDir);
+
+    // Get the live registry instance exported from dist/main/index.js
+    const { registry } = require.main.exports;
+
+    // Register the project and configure its ticket provider
+    const project = registry.addProject(normalizedDir, 'E2E Test Project');
+    registry.setProjectTicketConfig(normalizedDir, { provider: 'github' });
+
+    // Replace the IPC handler with a stub that skips the real provider call
+    // but still calls registry.seedBoardTicket() — exactly as the real handler does.
+    // The tickets:list handler (called by refreshBoardTickets after success) already
+    // degrades gracefully when the provider is unreachable, so no stub is needed there.
+    ipcMain.removeHandler('tickets:create');
+    ipcMain.handle('tickets:create', async (_event, dir, title) => {
+      const ticketId = 'E2E-42';
+      registry.seedBoardTicket(ticketId, pathMod.resolve(dir), title);
+      return { ticketId, url: 'https://github.com/e2e-test/repo/issues/42' };
+    });
+
+    return project.id;
+  });
+
+  // Reload the renderer — its useEffect calls refreshProjects() on mount which
+  // picks up the new project via the projects:list IPC handler.
+  const window = await app.firstWindow();
+  await window.reload();
+  await window.waitForLoadState('domcontentloaded');
+  await expect(window.locator('[data-testid="left-rail"]')).toBeVisible({ timeout: 15000 });
+});
+
+test.afterAll(async () => {
+  await app?.close();
+  try { fs.rmSync(TEST_PROJECT_DIR, { recursive: true, force: true }); } catch {}
+});
+
+test('app launches and shows main UI', async () => {
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+  await expect(window.locator('[data-testid="left-rail"]')).toBeVisible({ timeout: 15000 });
+});
+
+test('Create Ticket dialog opens and has required testids', async () => {
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  // Activate the test project so the New Ticket button is rendered
+  await window.locator(`[data-testid="workspace-pill-${testProjectId}"]`).click();
+  await expect(window.locator('[data-testid="new-ticket-btn"]')).toBeVisible({ timeout: 5000 });
+
+  // Open the Create Ticket dialog and verify all required testids are present
+  await window.locator('[data-testid="new-ticket-btn"]').click();
+  await expect(window.locator('[data-testid="create-ticket-dialog"]')).toBeVisible({ timeout: 5000 });
+  await expect(window.locator('[data-testid="create-ticket-title"]')).toBeVisible();
+  await expect(window.locator('[data-testid="create-ticket-body"]')).toBeVisible();
+  await expect(window.locator('[data-testid="create-ticket-submit"]')).toBeVisible();
+
+  // Close dialog
+  await window.keyboard.press('Escape');
+});
+
+test('tickets:create IPC handler seeds board and card appears in Backlog column without refresh', async () => {
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  // Activate the test project
+  await window.locator(`[data-testid="workspace-pill-${testProjectId}"]`).click();
+  await expect(window.locator('[data-testid="new-ticket-btn"]')).toBeVisible({ timeout: 5000 });
+
+  // Open the Create Ticket dialog
+  await window.locator('[data-testid="new-ticket-btn"]').click();
+  await expect(window.locator('[data-testid="create-ticket-dialog"]')).toBeVisible({ timeout: 5000 });
+
+  // Fill in the form
+  await window.locator('[data-testid="create-ticket-title"]').fill('E2E Backlog Seeding Test');
+  await window.locator('[data-testid="create-ticket-body"]').fill(
+    'Verify ticket appears in Backlog immediately after creation.'
+  );
+
+  // Submit — calls the stubbed tickets:create IPC handler, which calls
+  // registry.seedBoardTicket() then returns { ticketId: 'E2E-42', url }.
+  // The renderer then calls refreshBoardTickets() (fire-and-forget) which
+  // invokes tickets:list; that handler returns the seeded row from the local DB
+  // even when the provider fetch fails (graceful degradation).
+  await window.locator('[data-testid="create-ticket-submit"]').click();
+
+  // Success state in the dialog confirms the IPC round-trip completed
+  await expect(window.locator('[data-testid="create-ticket-success"]')).toBeVisible({ timeout: 10000 });
+
+  // Close the dialog
+  await window.keyboard.press('Escape');
+
+  // The Backlog column must now contain the new card — no project switch or
+  // manual refresh required.
+  await expect(window.locator('[data-testid="kanban-column-backlog"]')).toBeVisible({ timeout: 5000 });
+  await expect(window.locator(`[data-testid="ticket-card-${TICKET_ID}"]`)).toBeVisible({ timeout: 5000 });
+
+  // Screenshot for visual confirmation of the board state after creation
+  const screenshotDir = path.join('tests', 'integration', 'screenshots');
+  fs.mkdirSync(screenshotDir, { recursive: true });
+  await window.screenshot({ path: path.join(screenshotDir, 'create-ticket-board.png') });
+});
+
+test('ticket seeded in backlog does not change column on re-seed (UPSERT preserves column)', async () => {
+  const result = await app.evaluate(async () => {
+    const pathMod = require('path');
+    const { registry } = require.main.exports;
+
+    const projectDir = pathMod.resolve('/tmp/integration-test-proj-2');
+    const ticketId = 'INTTEST-2';
+
+    // Seed at backlog
+    registry.seedBoardTicket(ticketId, projectDir, 'Original title');
+
+    // Simulate user moving to spec_ready
+    registry.setBoardTicketColumn(ticketId, projectDir, 'spec_ready');
+
+    // Re-seed (as would happen on tickets:list or a second create with same ID)
+    registry.seedBoardTicket(ticketId, projectDir, 'Updated title');
+
+    const rows = registry.listBoardTickets(projectDir);
+    return rows.filter((r: { ticket_id: string }) => r.ticket_id === ticketId);
+  });
+
+  const row = (result as Array<{ ticket_id: string; column: string; title: string }>)[0];
+  expect(row.column).toBe('spec_ready');
+  expect(row.title).toBe('Updated title');
+});

--- a/tests/unit/components/CreateTicketDialog.test.tsx
+++ b/tests/unit/components/CreateTicketDialog.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -69,6 +69,23 @@ describe('CreateTicketDialog', () => {
     // #317 — the just-filed ticket id is handed off so the Refine dialog
     // doesn't ask for it again.
     expect(useAppStore.getState().refineTicketPrefill).toBe('77');
+  });
+
+  it('calls refreshBoardTickets with the project directory after successful create', async () => {
+    const user = userEvent.setup();
+    api.tickets.create.mockResolvedValue({
+      url: 'https://github.com/o/r/issues/77', ticketId: '77',
+    });
+    const refreshBoardTickets = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ refreshBoardTickets });
+
+    render(<CreateTicketDialog />);
+    await user.type(screen.getByTestId('create-ticket-title'), 'My Title');
+    await user.type(screen.getByTestId('create-ticket-body'), 'My Body');
+    fireEvent.click(screen.getByTestId('create-ticket-submit'));
+
+    await waitFor(() => screen.getByTestId('create-ticket-success'));
+    expect(refreshBoardTickets).toHaveBeenCalledWith('/proj');
   });
 
   it('surfaces an error from tickets.create', async () => {

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -22,6 +22,7 @@ const {
   mockFetchAccountUsage,
   mockRemoveProjectFromCrontab,
   mockListTicketsWithConfig,
+  mockCreateTicketWithConfig,
   mockSessionMonitor,
 } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
@@ -104,6 +105,7 @@ const {
   const mockFetchAccountUsage = vi.fn();
   const mockRemoveProjectFromCrontab = vi.fn();
   const mockListTicketsWithConfig = vi.fn().mockResolvedValue([]);
+  const mockCreateTicketWithConfig = vi.fn().mockResolvedValue({ url: 'https://github.com/o/r/issues/1', ticketId: '1' });
 
   const mockSessionMonitor = {
     getState: vi.fn(),
@@ -126,6 +128,7 @@ const {
     mockFetchAccountUsage,
     mockRemoveProjectFromCrontab,
     mockListTicketsWithConfig,
+    mockCreateTicketWithConfig,
     mockSessionMonitor,
   };
 });
@@ -199,6 +202,10 @@ vi.mock('../../src/main/scheduler/scheduler-manager', () => ({
 
 vi.mock('../../src/main/control-plane/ticket-lister', () => ({
   listTicketsWithConfig: (...args: unknown[]) => mockListTicketsWithConfig(...args),
+}));
+
+vi.mock('../../src/main/control-plane/ticket-config', () => ({
+  createTicketWithConfig: (...args: unknown[]) => mockCreateTicketWithConfig(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1331,6 +1338,62 @@ describe('IPC Handlers', () => {
 
       await invokeHandler('tickets:list', '/proj');
 
+      expect(mockRegistry.seedBoardTicket).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tickets:create', () => {
+    beforeEach(() => {
+      mockRegistry.getProjectTicketConfig.mockReturnValue({ provider: 'github' });
+      mockCreateTicketWithConfig.mockResolvedValue({ url: 'https://github.com/o/r/issues/99', ticketId: '99' });
+      mockRegistry.seedBoardTicket.mockClear();
+    });
+
+    it('throws when no provider is configured', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce(null);
+      await expect(
+        invokeHandler('tickets:create', '/proj', 'My Title', 'My Body')
+      ).rejects.toThrow('No ticket provider configured');
+      expect(mockRegistry.seedBoardTicket).not.toHaveBeenCalled();
+    });
+
+    it('seeds the board with the new ticket after creation', async () => {
+      await invokeHandler('tickets:create', '/proj', 'My Title', 'My Body');
+      expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('99', '/proj', 'My Title');
+    });
+
+    it('ticket seeded by create appears in board even when tickets:list provider fetch fails', async () => {
+      // tickets:create succeeds and seeds the board
+      await invokeHandler('tickets:create', '/proj', 'My Title', 'My Body');
+      expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('99', '/proj', 'My Title');
+
+      // When tickets:list is subsequently called with a failing provider, the
+      // seeded ticket must still appear — tickets:list degrades to the local DB.
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
+      mockListTicketsWithConfig.mockRejectedValueOnce(new Error('provider unavailable'));
+      mockRegistry.listBoardTickets.mockReturnValueOnce([
+        { ticket_id: '99', project_dir: '/proj', column: 'backlog', title: 'My Title', updated_at: '' },
+      ]);
+
+      const result = await invokeHandler('tickets:list', '/proj');
+
+      expect(result).toHaveLength(1);
+      expect((result as Array<{ ticket_id: string; column: string }>)[0]).toMatchObject({
+        ticket_id: '99',
+        column: 'backlog',
+      });
+    });
+
+    it('returns the created ticket result', async () => {
+      const result = await invokeHandler('tickets:create', '/proj', 'My Title', 'My Body');
+      expect(result).toEqual({ url: 'https://github.com/o/r/issues/99', ticketId: '99' });
+    });
+
+    it('does not seed the board when createTicketWithConfig throws', async () => {
+      mockCreateTicketWithConfig.mockRejectedValueOnce(new Error('gh auth required'));
+      await expect(
+        invokeHandler('tickets:create', '/proj', 'My Title', 'My Body')
+      ).rejects.toThrow('gh auth required');
       expect(mockRegistry.seedBoardTicket).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -122,6 +122,35 @@ describe('listBoardTickets', () => {
   });
 });
 
+// --- tickets:create board-seeding simulation ---
+// Simulates the main-process behavior added in #385: after tickets:create
+// resolves, the handler calls registry.seedBoardTicket so the card appears
+// immediately without waiting for a provider list call.
+
+describe('tickets:create seeding behavior', () => {
+  it('listBoardTickets includes the new ticket after seeding at creation time', () => {
+    registry.seedBoardTicket('99', '/proj', 'My new ticket');
+    const rows = registry.listBoardTickets('/proj');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ticket_id).toBe('99');
+    expect(rows[0].column).toBe('backlog');
+    expect(rows[0].title).toBe('My new ticket');
+  });
+
+  it('card appears in backlog even when provider list call returns empty', () => {
+    // Simulate: tickets:create succeeded and seeded the board.
+    // Provider list (tickets:list) returns [] — simulating a lag.
+    registry.seedBoardTicket('100', '/proj', 'Another ticket');
+
+    // Normally tickets:list would call provider and get [], then listBoardTickets.
+    // Since we seeded in step 1, the ticket must still be present.
+    const rows = registry.listBoardTickets('/proj');
+    const found = rows.find(r => r.ticket_id === '100');
+    expect(found).toBeDefined();
+    expect(found?.column).toBe('backlog');
+  });
+});
+
 // --- Store-level tests ---
 
 import { useAppStore } from '../../src/renderer/store';


### PR DESCRIPTION
## What

Newly created tickets now appear on the board immediately, without waiting for a provider list refresh.

- `tickets:create` IPC handler now awaits `createTicketWithConfig` and calls `registry.seedBoardTicket(ticketId, projectDir, title)` so the card is persisted to the local board DB at creation time.
- `CreateTicketDialog` triggers `refreshBoardTickets(project.directory)` after a successful create so the UI updates right away.

## Why

Previously a new ticket would only show up on the board once a provider list call succeeded, causing a lag (or no card at all if the provider fetch failed). Seeding the local board DB at creation time makes the card appear instantly and keeps it visible even when the provider list call degrades.

## Tests

- Unit coverage for the `tickets:create` handler: seeds on success, returns the created result, does not seed when the provider throws, and the seeded card survives a failing `tickets:list` provider fetch.
- `CreateTicketDialog` test verifying `refreshBoardTickets` is called after a successful create.
- Board-seeding simulation tests in `ticketBoard.test.ts`.
- New integration spec `tests/integration/create-ticket-board.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)