### PR TITLE
Fix kanban tickets stuck after spec-gate/stack actions (#388)

### DIFF
--- a/src/renderer/components/KanbanBoard.tsx
+++ b/src/renderer/components/KanbanBoard.tsx
@@ -20,6 +20,8 @@ export function KanbanBoard() {
     boardTickets,
     boardTicketsLoading,
     boardTicketsError,
+    moveTicketColumnError,
+    clearMoveTicketColumnError,
     stacks,
     activeProject,
     refreshBoardTickets,
@@ -81,6 +83,16 @@ export function KanbanBoard() {
               )}
               {boardTicketsError && !boardTicketsLoading && (
                 <span className="text-xs text-red-400" data-testid="board-tickets-error">Failed to load tickets</span>
+              )}
+              {moveTicketColumnError && (
+                <button
+                  onClick={clearMoveTicketColumnError}
+                  className="text-xs text-red-400 hover:text-red-300 underline decoration-dotted"
+                  data-testid="move-ticket-column-error"
+                  title={moveTicketColumnError}
+                >
+                  Failed to update ticket column — click to dismiss
+                </button>
               )}
             </>
           )}

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -40,6 +40,7 @@ export function RefineTicketDialog() {
     setCurrentRefinementSessionId,
     removeRefinementSession,
     upsertRefinementSession,
+    moveTicketColumn,
   } = useAppStore();
   const project = activeProject();
 
@@ -154,6 +155,10 @@ export function RefineTicketDialog() {
         task: fetched.body,
         gateApproved: true,
       });
+      // Advance the kanban column to in_stack now that the stack exists.
+      // Parallel to the card-based path (openNewStackDialogForTicket); without this,
+      // tickets started from the Refine dialog stayed in spec_ready / backlog (#388).
+      await moveTicketColumn(session.ticketId, projectDir, 'in_stack');
       await refreshStacks();
       // Clean up session after stack created
       removeRefinementSession(session.id);
@@ -163,7 +168,7 @@ export function RefineTicketDialog() {
       setLocalPhase('input');
       setLocalError(err instanceof Error ? err.message : String(err));
     }
-  }, [session, stackName, projectDir, refreshStacks, removeRefinementSession, setShowRefineTicketDialog]);
+  }, [session, stackName, projectDir, refreshStacks, removeRefinementSession, setShowRefineTicketDialog, moveTicketColumn]);
 
   const handleRetry = useCallback(async () => {
     if (!session || !projectDir) return;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { useAppStore } from './store';
 import './index.css';
+
+// Exposed for Playwright integration tests to seed/inspect renderer state.
+// Mirrors the React DevTools view of the same store — no extra surface area for prod.
+(window as unknown as { __useAppStore?: typeof useAppStore }).__useAppStore = useAppStore;
 
 const root = createRoot(document.getElementById('root')!);
 root.render(

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -477,6 +477,10 @@ interface AppState {
   boardTickets: TicketBoardEntry[];
   boardTicketsLoading: boolean;
   boardTicketsError: string | null;
+  /** Surfaced when persisting a column move via IPC fails — separate from the load-error field so the UI can show it independently. */
+  moveTicketColumnError: string | null;
+  /** Clears the surfaced column-move error. */
+  clearMoveTicketColumnError: () => void;
   lastTicketFetchAt: number | null;
   refreshBoardTickets: (projectDir: string) => Promise<void>;
   moveTicketColumn: (ticketId: string, projectDir: string, column: KanbanColumn) => Promise<void>;
@@ -983,10 +987,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   boardTickets: [],
   boardTicketsLoading: false,
   boardTicketsError: null,
+  moveTicketColumnError: null,
   lastTicketFetchAt: null,
   _refineDialogContext: null,
   _newStackDialogContext: null,
   _prDialogContext: null,
+
+  clearMoveTicketColumnError: () => set({ moveTicketColumnError: null }),
 
   refreshBoardTickets: async (projectDir: string) => {
     try {
@@ -1007,7 +1014,15 @@ export const useAppStore = create<AppState>((set, get) => ({
         t.ticket_id === ticketId ? { ...t, column } : t
       ),
     }));
-    await window.sandstorm.ticketBoard.setColumn(ticketId, projectDir, column).catch(() => {
+    try {
+      await window.sandstorm.ticketBoard.setColumn(ticketId, projectDir, column);
+      // Clear any prior surfaced move error on success.
+      if (get().moveTicketColumnError !== null) set({ moveTicketColumnError: null });
+    } catch (err) {
+      // Persistence failed — revert the optimistic update AND surface the error.
+      // Without surfacing, the user sees a card revert to its old column with no explanation
+      // (the original silent rollback that caused #388 reports of "stuck in backlog").
+      console.error('[moveTicketColumn]', err);
       if (previousColumn !== undefined) {
         set((state) => ({
           boardTickets: state.boardTickets.map((t) =>
@@ -1015,7 +1030,9 @@ export const useAppStore = create<AppState>((set, get) => ({
           ),
         }));
       }
-    });
+      const message = err instanceof Error ? err.message : String(err);
+      set({ moveTicketColumnError: `Failed to move ticket #${ticketId} to ${column}: ${message}` });
+    }
   },
 
   openRefineDialogFromCard: (ticketId, projectDir, previousColumn) => {
@@ -1157,22 +1174,41 @@ export const useAppStore = create<AppState>((set, get) => ({
     showRefineTicketDialog: true,
     currentRefinementSessionId: sessionId,
   }),
-  upsertRefinementSession: (session) => set((state) => {
-    if ((session as { status?: string }).status === 'cancelled') {
-      return { refinementSessions: state.refinementSessions.filter((s) => s.id !== session.id) };
+  upsertRefinementSession: (session) => {
+    let firedSpecReady = false;
+    set((state) => {
+      if ((session as { status?: string }).status === 'cancelled') {
+        return { refinementSessions: state.refinementSessions.filter((s) => s.id !== session.id) };
+      }
+      // Clear streamingOutput when the session leaves the running state.
+      const normalized = session.status !== 'running'
+        ? { ...session, streamingOutput: undefined }
+        : session;
+      const idx = state.refinementSessions.findIndex((s) => s.id === session.id);
+
+      // Detect the spec-gate-pass transition exactly once per session.
+      // Idempotency contract (#388): when (status === 'ready' && result.passed) becomes true,
+      // fire moveTicketColumn(ticketId, projectDir, 'spec_ready'). If the previous stored
+      // session already satisfied the condition, this is a re-emit and we must not re-fire
+      // (would otherwise demote a ticket the user has already advanced to in_stack).
+      const wasPassed = idx >= 0
+        && state.refinementSessions[idx].status === 'ready'
+        && state.refinementSessions[idx].result?.passed === true;
+      const isPassed = normalized.status === 'ready' && normalized.result?.passed === true;
+      firedSpecReady = isPassed && !wasPassed;
+
+      if (idx >= 0) {
+        const next = [...state.refinementSessions];
+        next[idx] = normalized;
+        return { refinementSessions: next };
+      }
+      return { refinementSessions: [...state.refinementSessions, normalized] };
+    });
+
+    if (firedSpecReady) {
+      void get().moveTicketColumn(session.ticketId, session.projectDir, 'spec_ready');
     }
-    // Clear streamingOutput when the session leaves the running state.
-    const normalized = session.status !== 'running'
-      ? { ...session, streamingOutput: undefined }
-      : session;
-    const idx = state.refinementSessions.findIndex((s) => s.id === session.id);
-    if (idx >= 0) {
-      const next = [...state.refinementSessions];
-      next[idx] = normalized;
-      return { refinementSessions: next };
-    }
-    return { refinementSessions: [...state.refinementSessions, normalized] };
-  }),
+  },
   appendRefinementStreamChunk: (sessionId, delta) => set((state) => {
     const idx = state.refinementSessions.findIndex((s) => s.id === sessionId);
     if (idx < 0) return {};

--- a/tests/integration/kanban-column-transitions.spec.ts
+++ b/tests/integration/kanban-column-transitions.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Regression test for #388 — tickets must move between kanban columns.
+ *
+ * Drives the renderer through the full progression:
+ *   backlog → refining → spec_ready → in_stack → pr_open → merged
+ *
+ * Assertions are real DOM membership checks on
+ *   data-testid="kanban-column-<column>" containing
+ *   data-testid="ticket-card-<id>"
+ *
+ * What the test exercises end-to-end:
+ *  - Real moveTicketColumn store action (optimistic update + revert on fail)
+ *  - Real ticketBoard.setColumn IPC + registry SQLite persistence
+ *  - Real refreshBoardTickets → tickets:list IPC → renderer state sync
+ *  - Real KanbanBoard / TicketCard column-rendering logic
+ *  - Real upsertRefinementSession → spec_ready transition (the #388 fix)
+ *
+ * What is shimmed via the exposed store:
+ *  - The renderer's active project (no UI flow for adding /tmp/... as a project)
+ *  - Dialog "succeeded" flags (so cancelling the dialog after the move doesn't
+ *    revert — we're testing column persistence, not dialog UX)
+ *  - The stack record (Create PR / Merge enablement depends on a stack with the
+ *    ticket; we inject one rather than running the real Docker build)
+ *
+ * The bug being regressed against (#388) was that moveTicketColumn was wired
+ * for backlog→refining and refining→in_stack-via-card but NOT for the gate-pass
+ * → spec_ready transition NOR the Refine-dialog Start Stack → in_stack
+ * transition. Both are now exercised.
+ */
+import { test, expect, type Page } from './fixtures';
+
+const TICKET_ID = `kanban388-${Date.now()}`;
+const PROJECT_DIR = `/tmp/kanban388-${Date.now()}`;
+const PROJECT_NAME = 'kanban-388-test';
+const STACK_ID = `stack-388-${Date.now()}`;
+
+async function assertColumn(window: Page, column: string, ticketId: string) {
+  const col = window.locator(`[data-testid="kanban-column-${column}"]`);
+  await expect(col).toBeVisible();
+  await expect(col.locator(`[data-testid="ticket-card-${ticketId}"]`)).toBeVisible();
+}
+
+async function assertNotInColumn(window: Page, column: string, ticketId: string) {
+  const col = window.locator(`[data-testid="kanban-column-${column}"]`);
+  await expect(col.locator(`[data-testid="ticket-card-${ticketId}"]`)).toHaveCount(0);
+}
+
+/** Returns the column the ticket lives in by querying the DOM. */
+async function currentColumn(window: Page, ticketId: string): Promise<string | null> {
+  const card = window.locator(`[data-testid="ticket-card-${ticketId}"]`).first();
+  if (await card.count() === 0) return null;
+  return await card.evaluate((el) => {
+    let n: HTMLElement | null = el as HTMLElement;
+    while (n) {
+      const tid = n.getAttribute('data-testid');
+      if (tid && tid.startsWith('kanban-column-')) return tid.replace('kanban-column-', '');
+      n = n.parentElement;
+    }
+    return null;
+  });
+}
+
+test.describe('Kanban column transitions (#388)', () => {
+  test('ticket progresses through all 5 column transitions and persists across a board refresh', async ({ mainWindow }) => {
+    await mainWindow.waitForSelector('[data-testid="kanban-board"]', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    // --- Set the active project in the store ---------------------------------
+    // KanbanBoard's useEffect calls refreshBoardTickets the moment project.directory
+    // changes. We do this BEFORE seeding any ticket so the initial refresh
+    // returns an empty board, then we seed via the real setColumn IPC.
+    await mainWindow.evaluate(({ dir, name }) => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [{ id: 9388, name, directory: dir, added_at: '' }],
+        activeProjectId: 9388,
+        refinementSessions: [],
+        stacks: [],
+        moveTicketColumnError: null,
+      });
+    }, { dir: PROJECT_DIR, name: PROJECT_NAME });
+
+    // --- Seed a backlog row via the real setColumn IPC -----------------------
+    // The registry inserts at the target column if the row doesn't exist; the
+    // INSERT is idempotent and writes to the real SQLite ticket_board table.
+    await mainWindow.evaluate(({ id, dir }) => {
+      return (window as unknown as {
+        sandstorm: { ticketBoard: { setColumn: (i: string, d: string, c: string) => Promise<void> } };
+      }).sandstorm.ticketBoard.setColumn(id, dir, 'backlog');
+    }, { id: TICKET_ID, dir: PROJECT_DIR });
+
+    // --- Refresh the board so the renderer picks up the seeded row -----------
+    await mainWindow.evaluate((dir) => {
+      const store = (window as unknown as {
+        __useAppStore: { getState: () => { refreshBoardTickets: (d: string) => Promise<void> } };
+      }).__useAppStore;
+      return store.getState().refreshBoardTickets(dir);
+    }, PROJECT_DIR);
+
+    await assertColumn(mainWindow, 'backlog', TICKET_ID);
+
+    // --- 1. backlog → refining (real click on Refine card button) -----------
+    await mainWindow.click(`[data-testid="ticket-card-refine-${TICKET_ID}"]`);
+    await assertColumn(mainWindow, 'refining', TICKET_ID);
+
+    // Seed a fake "session exists" entry so the dialog-close revert guard
+    // sees a session for this ticket and leaves the column at 'refining'.
+    await mainWindow.evaluate(({ id, dir }) => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        refinementSessions: [{
+          id: 'placeholder-session', ticketId: id, projectDir: dir,
+          status: 'running', phase: 'check', startedAt: 0,
+        }],
+      });
+    }, { id: TICKET_ID, dir: PROJECT_DIR });
+
+    // Close the Refine dialog so subsequent card buttons aren't blocked.
+    const refineDialog = mainWindow.locator('[data-testid="refine-ticket-dialog"]');
+    if (await refineDialog.isVisible().catch(() => false)) {
+      await mainWindow.click('[data-testid="refine-ticket-dialog"] [aria-label="Close"]');
+      await refineDialog.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+    }
+    await assertColumn(mainWindow, 'refining', TICKET_ID);
+
+    // --- 2. refining → spec_ready (the #388 fix path) -----------------------
+    // Calling upsertRefinementSession with status='ready' && passed=true is
+    // exactly what the refinement:update IPC handler does on gate pass.
+    // The store action fires moveTicketColumn(..., 'spec_ready') exactly once.
+    await mainWindow.evaluate(({ id, dir }) => {
+      const store = (window as unknown as {
+        __useAppStore: {
+          getState: () => { upsertRefinementSession: (s: Record<string, unknown>) => void };
+        };
+      }).__useAppStore;
+      store.getState().upsertRefinementSession({
+        id: 'gate-pass-session', ticketId: id, projectDir: dir,
+        status: 'ready', phase: 'check', startedAt: 0,
+        result: { passed: true, questions: [], gateSummary: 'PASS', ticketUrl: null, cached: false },
+      });
+    }, { id: TICKET_ID, dir: PROJECT_DIR });
+    await assertColumn(mainWindow, 'spec_ready', TICKET_ID);
+
+    // --- 3. spec_ready → in_stack (real click on Start stack card button) ---
+    await mainWindow.click(`[data-testid="ticket-card-start-stack-${TICKET_ID}"]`);
+    await assertColumn(mainWindow, 'in_stack', TICKET_ID);
+    // Mark the dialog as having "created a stack" and inject a stack row so
+    // dialog dismissal doesn't trigger the revert, and so Create PR enables.
+    await mainWindow.evaluate(({ id, dir, stackId }) => {
+      const store = (window as unknown as {
+        __useAppStore: {
+          getState: () => { _newStackDialogContext: Record<string, unknown> | null };
+          setState: (s: Record<string, unknown>) => void;
+        };
+      }).__useAppStore;
+      const ctx = store.getState()._newStackDialogContext;
+      store.setState({
+        _newStackDialogContext: ctx ? { ...ctx, stackCreated: true } : ctx,
+        stacks: [{
+          id: stackId, project: 'kanban-388-test', project_dir: dir, ticket: id,
+          branch: null, description: null, status: 'running', error: null,
+          pr_url: null, pr_number: null, runtime: 'docker',
+          total_input_tokens: 0, total_output_tokens: 0,
+          total_execution_input_tokens: 0, total_execution_output_tokens: 0,
+          total_review_input_tokens: 0, total_review_output_tokens: 0,
+          rate_limit_reset_at: null, created_at: '', updated_at: '',
+          current_model: null, services: [],
+        }],
+      });
+    }, { id: TICKET_ID, dir: PROJECT_DIR, stackId: STACK_ID });
+    const newStackInput = mainWindow.locator('[data-testid="stack-name"]');
+    if (await newStackInput.isVisible().catch(() => false)) {
+      await mainWindow.locator('text=Cancel').first().click();
+      await newStackInput.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+    }
+    await assertColumn(mainWindow, 'in_stack', TICKET_ID);
+
+    // --- 4. in_stack → pr_open (real click on Create PR card button) --------
+    await mainWindow.click(`[data-testid="ticket-card-create-pr-${TICKET_ID}"]`);
+    await assertColumn(mainWindow, 'pr_open', TICKET_ID);
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: {
+          getState: () => { _prDialogContext: Record<string, unknown> | null };
+          setState: (s: Record<string, unknown>) => void;
+        };
+      }).__useAppStore;
+      const ctx = store.getState()._prDialogContext;
+      if (ctx) store.setState({ _prDialogContext: { ...ctx, prCreated: true } });
+    });
+    const prDialog = mainWindow.locator('[data-testid="create-pr-dialog"]');
+    if (await prDialog.isVisible().catch(() => false)) {
+      await prDialog.click({ position: { x: 5, y: 5 } });
+      await prDialog.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+    }
+    await assertColumn(mainWindow, 'pr_open', TICKET_ID);
+
+    // Give the stack a pr_number so the link renders before the Merge click.
+    await mainWindow.evaluate(({ id }) => {
+      const store = (window as unknown as {
+        __useAppStore: {
+          getState: () => { stacks: Array<{ id: string; ticket: string | null }> };
+          setState: (s: Record<string, unknown>) => void;
+        };
+      }).__useAppStore;
+      const stacks = store.getState().stacks.map((s) =>
+        s.ticket === id ? { ...s, pr_number: 388, pr_url: 'https://github.com/o/r/pull/388' } : s,
+      );
+      store.setState({ stacks });
+    }, { id: TICKET_ID });
+
+    // --- 5. pr_open → merged (real click on Merge card button) -------------
+    await mainWindow.click(`[data-testid="ticket-card-merge-${TICKET_ID}"]`);
+    await assertColumn(mainWindow, 'merged', TICKET_ID);
+
+    // --- Persistence across a real board refresh ---------------------------
+    // The whole point of #388 is that the moves stick. Re-fetching from the
+    // real SQLite DB and re-rendering the board must show the same column.
+    await mainWindow.evaluate((dir) => {
+      const store = (window as unknown as {
+        __useAppStore: {
+          getState: () => { refreshBoardTickets: (d: string) => Promise<void> };
+        };
+      }).__useAppStore;
+      return store.getState().refreshBoardTickets(dir);
+    }, PROJECT_DIR);
+
+    expect(await currentColumn(mainWindow, TICKET_ID)).toBe('merged');
+    await assertColumn(mainWindow, 'merged', TICKET_ID);
+    for (const col of ['backlog', 'refining', 'spec_ready', 'in_stack', 'pr_open']) {
+      await assertNotInColumn(mainWindow, col, TICKET_ID);
+    }
+
+    // Reset shared state so the next worker-scoped test starts clean.
+    // (The Electron app fixture is shared across tests in this run; without
+    // this, downstream tests inherit our project/stacks/sessions.)
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [],
+        activeProjectId: null,
+        refinementSessions: [],
+        stacks: [],
+        boardTickets: [],
+        _refineDialogContext: null,
+        _newStackDialogContext: null,
+        _prDialogContext: null,
+        moveTicketColumnError: null,
+      });
+    });
+  });
+});

--- a/tests/unit/components/KanbanBoard.test.tsx
+++ b/tests/unit/components/KanbanBoard.test.tsx
@@ -94,4 +94,21 @@ describe('KanbanBoard', () => {
     render(<KanbanBoard />);
     expect(screen.getByTestId('kanban-board-no-project')).toBeDefined();
   });
+
+  // #388: when a column-move IPC fails, the optimistic update reverts. Before
+  // the fix, that revert was silent and the user assumed the click did nothing.
+  // The error banner now makes the failure visible and clearable.
+  it('shows move-ticket-column error banner when moveTicketColumnError is set (#388)', () => {
+    useAppStore.setState({ moveTicketColumnError: 'Failed to move ticket #42 to spec_ready: IPC boom' });
+    render(<KanbanBoard />);
+    const banner = screen.getByTestId('move-ticket-column-error');
+    expect(banner).toBeDefined();
+    expect(banner.getAttribute('title')).toMatch(/IPC boom/);
+  });
+
+  it('does not render the move-error banner when no error is set (#388)', () => {
+    useAppStore.setState({ moveTicketColumnError: null });
+    render(<KanbanBoard />);
+    expect(screen.queryByTestId('move-ticket-column-error')).toBeNull();
+  });
 });

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -427,6 +427,36 @@ describe('RefineTicketDialog', () => {
     expect(useAppStore.getState().refinementSessions).toHaveLength(0);
   });
 
+  // #388: Refine-dialog "Start Stack" must move the ticket column to 'in_stack'.
+  // Before the fix, handleStartStack created the stack but never called
+  // moveTicketColumn — leaving the ticket visually stuck in spec_ready/backlog.
+  it('persists in_stack column after Start Stack succeeds (#388)', async () => {
+    api.tickets.fetch.mockResolvedValue({ body: '# title\nbody', url: null });
+    api.stacks.create.mockResolvedValue({ id: 'ticket-310', project: 'proj', status: 'building', services: [] });
+
+    useAppStore.setState({
+      boardTickets: [
+        { ticket_id: '310', project_dir: '/proj', column: 'spec_ready', title: 'T', updated_at: '' },
+      ],
+      refinementSessions: [{
+        id: 'session-1', ticketId: '310', projectDir: '/proj',
+        status: 'ready', phase: 'check', startedAt: Date.now(),
+        result: { passed: true, questions: [], gateSummary: 'Gate=PASS', ticketUrl: null, cached: false },
+      }],
+      currentRefinementSessionId: 'session-1',
+    });
+    render(<RefineTicketDialog />);
+    fireEvent.click(screen.getByTestId('refine-start-stack'));
+
+    await waitFor(() => {
+      expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('310', '/proj', 'in_stack');
+    });
+    await waitFor(() => {
+      const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '310');
+      expect(entry?.column).toBe('in_stack');
+    });
+  });
+
   it('shows the cached banner copy when gate result is cached', () => {
     useAppStore.setState({
       refinementSessions: [{

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -247,6 +247,121 @@ describe('store: moveTicketColumn', () => {
     const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
     expect(entry?.column).toBe('backlog');
   });
+
+  // #388: rejection used to be swallowed with .catch(() => {}) which left the
+  // card silently reverted to backlog with no error surfaced — directly producing
+  // the reporter's "stuck in backlog and no feedback" symptom.
+  it('surfaces moveTicketColumnError when setColumn IPC rejects (#388)', async () => {
+    useAppStore.setState({ moveTicketColumnError: null });
+    Object.defineProperty(window, 'sandstorm', {
+      value: {
+        tickets: { list: vi.fn().mockResolvedValue([]) },
+        ticketBoard: { setColumn: vi.fn().mockRejectedValue(new Error('IPC boom')) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    await useAppStore.getState().moveTicketColumn('42', PROJECT_DIR, 'spec_ready');
+    const err = useAppStore.getState().moveTicketColumnError;
+    expect(err).toBeTruthy();
+    expect(err).toMatch(/42/);
+    expect(err).toMatch(/spec_ready/);
+    expect(err).toMatch(/IPC boom/);
+  });
+
+  it('clears moveTicketColumnError on a subsequent successful move (#388)', async () => {
+    useAppStore.setState({ moveTicketColumnError: 'prior failure' });
+    await useAppStore.getState().moveTicketColumn('42', PROJECT_DIR, 'spec_ready');
+    expect(useAppStore.getState().moveTicketColumnError).toBeNull();
+  });
+
+  it('clearMoveTicketColumnError() resets the surfaced error (#388)', () => {
+    useAppStore.setState({ moveTicketColumnError: 'something failed' });
+    useAppStore.getState().clearMoveTicketColumnError();
+    expect(useAppStore.getState().moveTicketColumnError).toBeNull();
+  });
+});
+
+// #388: spec-gate-pass → spec_ready transition is wired in the store's
+// upsertRefinementSession handler (not the dialog) so that it fires even when
+// the user closed the Refine dialog while the async gate was still running.
+describe('store: upsertRefinementSession → spec_ready transition (#388)', () => {
+  beforeEach(() => {
+    setupSandstormMock();
+    useAppStore.setState({
+      boardTickets: [
+        { ticket_id: '310', project_dir: PROJECT_DIR, column: 'refining', title: 'T', updated_at: '' },
+      ],
+      refinementSessions: [],
+      moveTicketColumnError: null,
+    });
+  });
+
+  it('moves to spec_ready when status becomes ready && passed', async () => {
+    useAppStore.getState().upsertRefinementSession({
+      id: 'sess', ticketId: '310', projectDir: PROJECT_DIR,
+      status: 'ready', phase: 'check', startedAt: 0,
+      result: { passed: true, questions: [], gateSummary: 'PASS', ticketUrl: null, cached: false },
+    });
+
+    // setColumn is fire-and-forget from upsert; wait a microtask for the optimistic update.
+    await new Promise(r => setTimeout(r, 0));
+    expect((window.sandstorm as any).ticketBoard.setColumn).toHaveBeenCalledWith('310', PROJECT_DIR, 'spec_ready');
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '310');
+    expect(entry?.column).toBe('spec_ready');
+  });
+
+  it('does NOT move to spec_ready when gate failed', async () => {
+    useAppStore.getState().upsertRefinementSession({
+      id: 'sess', ticketId: '310', projectDir: PROJECT_DIR,
+      status: 'ready', phase: 'check', startedAt: 0,
+      result: { passed: false, questions: [], gateSummary: 'FAIL', ticketUrl: null, cached: false },
+    });
+    await new Promise(r => setTimeout(r, 0));
+    expect((window.sandstorm as any).ticketBoard.setColumn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT move to spec_ready while the session is still running', async () => {
+    useAppStore.getState().upsertRefinementSession({
+      id: 'sess', ticketId: '310', projectDir: PROJECT_DIR,
+      status: 'running', phase: 'check', startedAt: 0,
+    });
+    await new Promise(r => setTimeout(r, 0));
+    expect((window.sandstorm as any).ticketBoard.setColumn).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent on a re-emit — fires moveTicketColumn exactly once', async () => {
+    const passedSession = {
+      id: 'sess', ticketId: '310', projectDir: PROJECT_DIR,
+      status: 'ready' as const, phase: 'check' as const, startedAt: 0,
+      result: { passed: true, questions: [], gateSummary: 'PASS', ticketUrl: null, cached: false },
+    };
+    useAppStore.getState().upsertRefinementSession(passedSession);
+    await new Promise(r => setTimeout(r, 0));
+    expect((window.sandstorm as any).ticketBoard.setColumn).toHaveBeenCalledTimes(1);
+
+    // A second upsert with the same ready+passed state must NOT re-fire.
+    // Otherwise an in-flight 'in_stack' move could be demoted to 'spec_ready'.
+    useAppStore.getState().upsertRefinementSession(passedSession);
+    await new Promise(r => setTimeout(r, 0));
+    expect((window.sandstorm as any).ticketBoard.setColumn).toHaveBeenCalledTimes(1);
+  });
+
+  it('final state is in_stack when Start Stack fires immediately after gate pass', async () => {
+    // Simulate the documented edge case: gate-pass move fires, then user clicks
+    // Start Stack which fires moveTicketColumn(in_stack). Final persisted state
+    // must be in_stack (the later move wins).
+    useAppStore.getState().upsertRefinementSession({
+      id: 'sess', ticketId: '310', projectDir: PROJECT_DIR,
+      status: 'ready', phase: 'check', startedAt: 0,
+      result: { passed: true, questions: [], gateSummary: 'PASS', ticketUrl: null, cached: false },
+    });
+    await useAppStore.getState().moveTicketColumn('310', PROJECT_DIR, 'in_stack');
+    await new Promise(r => setTimeout(r, 0));
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '310');
+    expect(entry?.column).toBe('in_stack');
+  });
 });
 
 describe('store: openCreatePRDialogForTicket revert-on-cancel', () => {


### PR DESCRIPTION
## Summary

Fixes tickets getting visually stuck in `backlog` / `spec_ready` because kanban column transitions were either never fired or silently swallowed (#388).

## Changes

- **Spec-gate-pass → `spec_ready`**: wired into the store's `upsertRefinementSession` handler (not the dialog), so the transition fires even if the user closed the Refine dialog while the async gate was still running. Made idempotent so a re-emit of the same `ready && passed` session never re-fires (which could demote a ticket already advanced to `in_stack`).
- **Refine dialog "Start Stack" → `in_stack`**: `handleStartStack` now calls `moveTicketColumn(..., 'in_stack')` after stack creation, matching the card-based path.
- **Surface move failures**: `moveTicketColumn` no longer swallows IPC rejections with `.catch(() => {})`. On failure it reverts the optimistic update AND sets a new `moveTicketColumnError`, shown as a dismissable banner in `KanbanBoard`. This removes the "stuck in backlog with no feedback" symptom.

## Tests

- Unit coverage for the `spec_ready` transition (fires on pass, not on fail/running, idempotent on re-emit, `in_stack` wins when Start Stack follows).
- Unit coverage for error surfacing, clearing on success, and `clearMoveTicketColumnError()`.
- Unit coverage for the Refine-dialog `in_stack` move and the error banner rendering.
- New Playwright integration spec for column transitions (`tests/integration/kanban-column-transitions.spec.ts`); `main.tsx` exposes the store as `window.__useAppStore` for test seeding/inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
