### PR TITLE
ticket-394: share makePrEligible util and expand PR-eligible statuses

### DIFF
--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Stack, StackMetrics, useAppStore } from '../store';
-import { getStackDuration, isTerminalStatus, DURATION_UPDATE_INTERVAL } from '../utils/duration';
+import { getStackDuration, isTerminalStatus, makePrEligible, DURATION_UPDATE_INTERVAL } from '../utils/duration';
 import { StackRowPopover } from './StackRowPopover';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -34,10 +34,6 @@ const STATUS_LABELS: Record<string, string> = {
 };
 
 const POPOVER_OPEN_DELAY_MS = 150;
-
-function makePrEligible(stack: Stack): boolean {
-  return (stack.status === 'completed' || stack.status === 'pushed') && !stack.pr_url;
-}
 
 export function StackTableRow({
   stack,

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAppStore, KanbanColumn, TicketBoardEntry, Stack } from '../store';
+import { makePrEligible } from '../utils/duration';
 
 interface TicketCardProps {
   ticket: TicketBoardEntry;
@@ -125,14 +126,15 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               <span className="text-xs text-sandstorm-muted">{stack.status}</span>
             </div>
           )}
-          <button
-            onClick={handleCreatePR}
-            disabled={!stack}
-            className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-state-instack/10 text-sandstorm-state-instack border border-sandstorm-state-instack/30 hover:bg-sandstorm-state-instack/20 transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed"
-            data-testid={`ticket-card-create-pr-${ticket.ticket_id}`}
-          >
-            Create PR
-          </button>
+          {stack && makePrEligible(stack) && (
+            <button
+              onClick={handleCreatePR}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-state-instack/10 text-sandstorm-state-instack border border-sandstorm-state-instack/30 hover:bg-sandstorm-state-instack/20 transition-colors font-medium"
+              data-testid={`ticket-card-create-pr-${ticket.ticket_id}`}
+            >
+              Create PR
+            </button>
+          )}
         </div>
       )}
 

--- a/src/renderer/utils/duration.ts
+++ b/src/renderer/utils/duration.ts
@@ -57,3 +57,15 @@ export function getStackDuration(
 
 /** Duration update interval in milliseconds (5 seconds). */
 export const DURATION_UPDATE_INTERVAL = 5000;
+
+const PR_ELIGIBLE_STATUSES = new Set([
+  'completed',
+  'failed',
+  'pushed',
+  'needs_human',
+  'verify_blocked_environmental',
+]);
+
+export function makePrEligible(stack: { status: string; pr_url: string | null | undefined }): boolean {
+  return PR_ELIGIBLE_STATUSES.has(stack.status) && !stack.pr_url;
+}

--- a/tests/integration/kanban-column-transitions.spec.ts
+++ b/tests/integration/kanban-column-transitions.spec.ts
@@ -165,7 +165,7 @@ test.describe('Kanban column transitions (#388)', () => {
         _newStackDialogContext: ctx ? { ...ctx, stackCreated: true } : ctx,
         stacks: [{
           id: stackId, project: 'kanban-388-test', project_dir: dir, ticket: id,
-          branch: null, description: null, status: 'running', error: null,
+          branch: null, description: null, status: 'completed', error: null,
           pr_url: null, pr_number: null, runtime: 'docker',
           total_input_tokens: 0, total_output_tokens: 0,
           total_execution_input_tokens: 0, total_execution_output_tokens: 0,

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -209,6 +209,30 @@ describe('StackTableRow primary-action chip (#315)', () => {
     expect(screen.queryByTestId('row-make-pr-qux')).toBeNull();
   });
 
+  it('shows Make PR chip when status is failed and pr_url is null', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'fail1', status: 'failed', pr_url: null }));
+    expect(screen.getByTestId('row-make-pr-fail1')).toBeDefined();
+  });
+
+  it('shows Make PR chip when status is needs_human and pr_url is null', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'nh1', status: 'needs_human', pr_url: null }));
+    expect(screen.getByTestId('row-make-pr-nh1')).toBeDefined();
+  });
+
+  it('shows Make PR chip when status is verify_blocked_environmental and pr_url is null', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'vbe1', status: 'verify_blocked_environmental', pr_url: null }));
+    expect(screen.getByTestId('row-make-pr-vbe1')).toBeDefined();
+  });
+
+  it('hides Make PR chip for failed when pr_url already exists', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'fail2', status: 'failed', pr_url: 'https://github.com/o/r/pull/5', pr_number: 5 }));
+    expect(screen.queryByTestId('row-make-pr-fail2')).toBeNull();
+  });
+
   it('clicking Make PR opens the CreatePRDialog for that stack', () => {
     vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
     renderRow(makeStack({ id: 'foo', status: 'completed', pr_url: null }));

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -76,14 +76,14 @@ describe('TicketCard', () => {
     expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'in_stack');
   });
 
-  it('in_stack: shows Create PR button', () => {
-    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'running', pr_url: null, pr_number: null } as any;
+  it('in_stack: shows Create PR button for eligible status (completed)', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     expect(screen.getByTestId('ticket-card-create-pr-42')).toBeDefined();
   });
 
-  it('in_stack: clicking Create PR with a stack opens PR dialog and moves column to pr_open', async () => {
-    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'running', pr_url: null, pr_number: null } as any;
+  it('in_stack: clicking Create PR with an eligible stack opens PR dialog and moves column to pr_open', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     fireEvent.click(screen.getByTestId('ticket-card-create-pr-42'));
     await waitFor(() => {
@@ -92,10 +92,35 @@ describe('TicketCard', () => {
     expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'pr_open');
   });
 
-  it('in_stack: Create PR disabled when no matching stack', () => {
+  it('in_stack: Create PR button absent when no matching stack', () => {
     render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
-    const btn = screen.getByTestId('ticket-card-create-pr-42');
-    expect(btn.hasAttribute('disabled')).toBe(true);
+    expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
+  });
+
+  // All 14 StackStatus values — PR button visibility map
+  const ELIGIBLE_STATUSES = ['completed', 'failed', 'pushed', 'needs_human', 'verify_blocked_environmental'];
+  const INELIGIBLE_STATUSES = ['building', 'rebuilding', 'up', 'running', 'idle', 'stopped', 'pr_created', 'rate_limited', 'session_paused'];
+
+  ELIGIBLE_STATUSES.forEach((status) => {
+    it(`in_stack: Create PR button is present for status="${status}"`, () => {
+      const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status, pr_url: null, pr_number: null } as any;
+      render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+      expect(screen.queryByTestId('ticket-card-create-pr-42')).not.toBeNull();
+    });
+  });
+
+  INELIGIBLE_STATUSES.forEach((status) => {
+    it(`in_stack: Create PR button is absent for status="${status}"`, () => {
+      const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status, pr_url: null, pr_number: null } as any;
+      render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+      expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
+    });
+  });
+
+  it('in_stack: Create PR button is absent when pr_url is set on an eligible status', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: 'https://github.com/o/r/pull/1', pr_number: 1 } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
   });
 
   it('pr_open: shows Merge button', () => {


### PR DESCRIPTION
## Summary
- Hoist \`makePrEligible\` into \`src/renderer/utils/duration.ts\` as a shared helper (was duplicated/inline in \`StackTableRow\`)
- Expand PR-eligible statuses to \`completed\`, \`failed\`, \`pushed\`, \`needs_human\`, \`verify_blocked_environmental\`
- \`TicketCard\` now conditionally renders the Create PR button instead of rendering it disabled
- Add unit coverage across all 14 stack statuses; fix kanban integration fixture (\`status: 'running'\` → \`'completed'\`)

## Test notes
- Targeted kanban integration test now passes; unit suites cover the full status matrix.
- One unrelated, pre-existing integration failure remains: \`create-ticket-board.spec.ts\` (\`ReferenceError: require is not defined\` in \`installCrontab\`). Verified pre-existing on base by stashing this branch's changes — out of scope for this ticket, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)