### PR TITLE
Sync Kanban ticket to pr_open on pr_created (#403)

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -1161,6 +1161,31 @@ export class Registry {
     ).run(ticketId, normalizedDir, column);
   }
 
+  /**
+   * Forward-only guard: advances a linked ticket from in_stack → pr_open.
+   * No-op if the ticket does not exist or is not currently in in_stack.
+   */
+  advanceTicketToPrOpenIfInStack(ticketId: string, projectDir: string): void {
+    const tickets = this.listBoardTickets(projectDir);
+    const ticket = tickets.find(t => t.ticket_id === ticketId);
+    if (ticket?.column === 'in_stack') {
+      this.setBoardTicketColumn(ticketId, projectDir, 'pr_open');
+    }
+  }
+
+  /**
+   * Backfill: for every stack with status='pr_created' and a non-null ticket,
+   * advance the linked ticket from in_stack → pr_open (forward-only, idempotent).
+   */
+  reconcilePrCreatedTickets(): void {
+    const stacks = this.db.prepare(
+      "SELECT ticket, project_dir FROM stacks WHERE status = 'pr_created' AND ticket IS NOT NULL"
+    ).all() as { ticket: string; project_dir: string }[];
+    for (const stack of stacks) {
+      this.advanceTicketToPrOpenIfInStack(stack.ticket, stack.project_dir);
+    }
+  }
+
   /** Returns all ticket_board rows for a project, ordered by created_at asc. */
   listBoardTickets(projectDir: string): { ticket_id: string; project_dir: string; column: string; title: string; created_at: string; updated_at: string }[] {
     const normalizedDir = path.resolve(projectDir);

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -935,6 +935,11 @@ export class StackManager {
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
 
     this.registry.setPullRequest(stackId, prUrl, prNumber);
+
+    if (stack.ticket) {
+      this.registry.advanceTicketToPrOpenIfInStack(stack.ticket, stack.project_dir);
+    }
+
     this.notifyUpdate();
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,6 +139,9 @@ async function initializeApp(): Promise<void> {
   );
   stackManager.setPortProxy(portProxy);
 
+  // Backfill: advance any tickets stuck in in_stack whose linked stack is already pr_created.
+  registry.reconcilePrCreatedTickets();
+
   // Set up Docker connection manager for health monitoring
   if (dockerRuntime instanceof DockerRuntime) {
     dockerConnectionManager = (dockerRuntime as DockerRuntime).getConnectionManager();

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -92,6 +92,17 @@ export default function App() {
     };
   }, []);
 
+  // Close create-ticket dialog on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      const state = useAppStore.getState();
+      if (state.showCreateTicketDialog) state.setShowCreateTicketDialog(false);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   // Refinement sessions: restore persisted sessions and listen for updates
   useEffect(() => {
     window.sandstorm.tickets.listRefinements().then((sessions) => {
@@ -185,6 +196,11 @@ export default function App() {
     const unsubStacksUpdated = window.sandstorm.on('stacks:updated', () => {
       refreshStacks();
       refreshStackHistory();
+      const state = useAppStore.getState();
+      const project = state.activeProject();
+      if (project) {
+        void state.refreshBoardTickets(project.directory);
+      }
     });
 
     return () => {

--- a/tests/integration/kanban-column-transitions.spec.ts
+++ b/tests/integration/kanban-column-transitions.spec.ts
@@ -259,3 +259,167 @@ test.describe('Kanban column transitions (#388)', () => {
     });
   });
 });
+
+/**
+ * Regression tests for #403 — ticket must move to pr_open when the stack
+ * reaches pr_created via the agent/IPC path (not only via the UI optimistic move).
+ *
+ * The stacks:updated event must also trigger refreshBoardTickets so the renderer
+ * sees the column change without requiring a manual remount.
+ */
+const TICKET_403 = `kanban403-${Date.now()}`;
+const PROJECT_403 = `/tmp/kanban403-${Date.now()}`;
+const STACK_403 = `stack-403-${Date.now()}`;
+
+test.describe('Kanban column sync via setPullRequest (#403)', () => {
+  test('ticket moves from in_stack to pr_open when stack transitions to pr_created via IPC (not UI)', async ({ mainWindow }) => {
+    await mainWindow.waitForSelector('[data-testid="kanban-board"]', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    // Set the active project so the board renders for this project dir.
+    await mainWindow.evaluate(({ dir, name }) => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [{ id: 9403, name, directory: dir, added_at: '' }],
+        activeProjectId: 9403,
+        refinementSessions: [],
+        stacks: [],
+        moveTicketColumnError: null,
+      });
+    }, { dir: PROJECT_403, name: 'kanban-403-test' });
+
+    // Seed the ticket at in_stack via real IPC.
+    await mainWindow.evaluate(({ id, dir }) => {
+      return (window as unknown as {
+        sandstorm: { ticketBoard: { setColumn: (i: string, d: string, c: string) => Promise<void> } };
+      }).sandstorm.ticketBoard.setColumn(id, dir, 'in_stack');
+    }, { id: TICKET_403, dir: PROJECT_403 });
+
+    // Refresh the board so the renderer reflects the seeded row.
+    await mainWindow.evaluate((dir) => {
+      const store = (window as unknown as {
+        __useAppStore: { getState: () => { refreshBoardTickets: (d: string) => Promise<void> } };
+      }).__useAppStore;
+      return store.getState().refreshBoardTickets(dir);
+    }, PROJECT_403);
+
+    await assertColumn(mainWindow, 'in_stack', TICKET_403);
+
+    // Create a real stack record linked to this ticket. forceBypass skips the spec
+    // gate (ticket is already in in_stack, past spec_ready). createStack inserts the
+    // DB row synchronously before the IPC resolves; the Docker build runs in the
+    // background and fails gracefully since Docker is unavailable in the test env.
+    await mainWindow.evaluate(({ stackId, ticketId, dir }) => {
+      return (window as unknown as {
+        sandstorm: { stacks: { create: (opts: Record<string, unknown>) => Promise<unknown> } };
+      }).sandstorm.stacks.create({ name: stackId, projectDir: dir, ticket: ticketId, runtime: 'docker', forceBypass: true });
+    }, { stackId: STACK_403, ticketId: TICKET_403, dir: PROJECT_403 });
+
+    // Call stacks:setPr via IPC — the agent/CLI path, not the UI optimistic move.
+    // stackManager.setPullRequest() calls advanceTicketToPrOpenIfInStack() and
+    // notifyUpdate(), which broadcasts stacks:updated to the renderer. The App.tsx
+    // stacks:updated listener calls refreshBoardTickets(), advancing the card
+    // reactively without any manual refresh call.
+    await mainWindow.evaluate(({ stackId }) => {
+      return (window as unknown as {
+        sandstorm: { stacks: { setPr: (id: string, url: string, num: number) => Promise<void> } };
+      }).sandstorm.stacks.setPr(stackId, 'https://github.com/o/r/pull/403', 403);
+    }, { stackId: STACK_403 });
+
+    await assertColumn(mainWindow, 'pr_open', TICKET_403);
+    await assertNotInColumn(mainWindow, 'in_stack', TICKET_403);
+  });
+
+  test('ticket stays in merged when stack reaches pr_created (forward-only rule)', async ({ mainWindow }) => {
+    await mainWindow.waitForSelector('[data-testid="kanban-board"]', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    const MERGED_TICKET = `kanban403-merged-${Date.now()}`;
+
+    await mainWindow.evaluate(({ dir, name }) => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [{ id: 9404, name, directory: dir, added_at: '' }],
+        activeProjectId: 9404,
+        refinementSessions: [],
+        stacks: [],
+        moveTicketColumnError: null,
+      });
+    }, { dir: PROJECT_403, name: 'kanban-403-merged-test' });
+
+    // Seed the ticket at merged (the forward-only rule must not pull it back).
+    await mainWindow.evaluate(({ id, dir }) => {
+      return (window as unknown as {
+        sandstorm: { ticketBoard: { setColumn: (i: string, d: string, c: string) => Promise<void> } };
+      }).sandstorm.ticketBoard.setColumn(id, dir, 'merged');
+    }, { id: MERGED_TICKET, dir: PROJECT_403 });
+
+    // Refresh the board.
+    await mainWindow.evaluate((dir) => {
+      const store = (window as unknown as {
+        __useAppStore: { getState: () => { refreshBoardTickets: (d: string) => Promise<void> } };
+      }).__useAppStore;
+      return store.getState().refreshBoardTickets(dir);
+    }, PROJECT_403);
+
+    await assertColumn(mainWindow, 'merged', MERGED_TICKET);
+
+    const STACK_403_MERGED = `stack-403-merged-${Date.now()}`;
+
+    // Create a real stack record linked to the merged ticket. forceBypass skips
+    // the spec gate; the DB row is inserted synchronously before IPC resolves.
+    await mainWindow.evaluate(({ stackId, ticketId, dir }) => {
+      return (window as unknown as {
+        sandstorm: { stacks: { create: (opts: Record<string, unknown>) => Promise<unknown> } };
+      }).sandstorm.stacks.create({ name: stackId, projectDir: dir, ticket: ticketId, runtime: 'docker', forceBypass: true });
+    }, { stackId: STACK_403_MERGED, ticketId: MERGED_TICKET, dir: PROJECT_403 });
+
+    // Call stacks:setPr — the forward-only guard in advanceTicketToPrOpenIfInStack
+    // must be a no-op when the ticket is already in merged. notifyUpdate() fires
+    // stacks:updated which triggers refreshBoardTickets() via the App.tsx listener.
+    await mainWindow.evaluate(({ stackId }) => {
+      return (window as unknown as {
+        sandstorm: { stacks: { setPr: (id: string, url: string, num: number) => Promise<void> } };
+      }).sandstorm.stacks.setPr(stackId, 'https://github.com/o/r/pull/404', 404);
+    }, { stackId: STACK_403_MERGED });
+
+    // Wait for refreshStacks (called in the same stacks:updated listener as
+    // refreshBoardTickets) to populate the store with the updated stack pr_url.
+    // This confirms the listener fired and the board has been refreshed from DB.
+    await mainWindow.waitForFunction(({ stackId }) => {
+      const store = (window as unknown as {
+        __useAppStore: { getState: () => { stacks: Array<{ id: string; pr_url: string | null }> } };
+      }).__useAppStore;
+      return store.getState().stacks.some(
+        (s: { id: string; pr_url: string | null }) => s.id === stackId && s.pr_url !== null,
+      );
+    }, { stackId: STACK_403_MERGED });
+
+    await assertColumn(mainWindow, 'merged', MERGED_TICKET);
+    await assertNotInColumn(mainWindow, 'pr_open', MERGED_TICKET);
+
+    // Cleanup
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [],
+        activeProjectId: null,
+        stacks: [],
+        boardTickets: [],
+        moveTicketColumnError: null,
+      });
+    });
+  });
+});

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -2351,3 +2351,69 @@ describe('tailBytes', () => {
     expect(LOGS_TOTAL_MAX_BYTES).toBe(32768);
   });
 });
+
+describe('StackManager.setPullRequest → board sync', () => {
+  let registry: Registry;
+  let manager: StackManager;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    const runtime = createMockRuntime();
+    const portAllocator = new PortAllocator(registry, [40000, 40099]);
+    const taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  it('advances a linked ticket from in_stack to pr_open', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pushed', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'in_stack');
+
+    manager.setPullRequest('s1', 'https://github.com/o/r/pull/1', 1);
+
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('leaves a merged ticket at merged (forward-only rule)', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pushed', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'merged');
+
+    manager.setPullRequest('s1', 'https://github.com/o/r/pull/1', 1);
+
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('merged');
+  });
+
+  it('leaves a pr_open ticket at pr_open', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pushed', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'pr_open');
+
+    manager.setPullRequest('s1', 'https://github.com/o/r/pull/1', 1);
+
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('makes no board change when the stack has no linked ticket', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: null, branch: null, description: null, status: 'pushed', runtime: 'docker' });
+
+    manager.setPullRequest('s1', 'https://github.com/o/r/pull/1', 1);
+
+    expect(registry.listBoardTickets('/proj')).toHaveLength(0);
+  });
+
+  it('also persists the pr_url and pr_number on the stack', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: null, branch: null, description: null, status: 'pushed', runtime: 'docker' });
+
+    manager.setPullRequest('s1', 'https://github.com/o/r/pull/42', 42);
+
+    const stack = registry.getStack('s1')!;
+    expect(stack.pr_url).toBe('https://github.com/o/r/pull/42');
+    expect(stack.pr_number).toBe(42);
+    expect(stack.status).toBe('pr_created');
+  });
+});

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -151,6 +151,80 @@ describe('tickets:create seeding behavior', () => {
   });
 });
 
+// --- advanceTicketToPrOpenIfInStack ---
+
+describe('registry.advanceTicketToPrOpenIfInStack', () => {
+  it('moves a ticket from in_stack to pr_open', () => {
+    registry.setBoardTicketColumn('t1', '/proj', 'in_stack');
+    registry.advanceTicketToPrOpenIfInStack('t1', '/proj');
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('leaves a merged ticket at merged (forward-only)', () => {
+    registry.setBoardTicketColumn('t1', '/proj', 'merged');
+    registry.advanceTicketToPrOpenIfInStack('t1', '/proj');
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('merged');
+  });
+
+  it('leaves a pr_open ticket at pr_open', () => {
+    registry.setBoardTicketColumn('t1', '/proj', 'pr_open');
+    registry.advanceTicketToPrOpenIfInStack('t1', '/proj');
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('is a no-op when the ticket does not exist in the board', () => {
+    registry.advanceTicketToPrOpenIfInStack('nonexistent', '/proj');
+    expect(registry.listBoardTickets('/proj')).toHaveLength(0);
+  });
+});
+
+// --- reconcilePrCreatedTickets (backfill) ---
+
+describe('registry.reconcilePrCreatedTickets', () => {
+  it('advances an in_stack ticket to pr_open when linked stack is pr_created', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pr_created', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'in_stack');
+    registry.reconcilePrCreatedTickets();
+    const rows = registry.listBoardTickets('/proj');
+    expect(rows[0].column).toBe('pr_open');
+  });
+
+  it('leaves a merged ticket at merged (forward-only)', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pr_created', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'merged');
+    registry.reconcilePrCreatedTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('merged');
+  });
+
+  it('leaves a pr_open ticket at pr_open', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pr_created', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'pr_open');
+    registry.reconcilePrCreatedTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('skips stacks with no linked ticket', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: null, branch: null, description: null, status: 'pr_created', runtime: 'docker' });
+    registry.reconcilePrCreatedTickets();
+    expect(registry.listBoardTickets('/proj')).toHaveLength(0);
+  });
+
+  it('skips stacks not in pr_created status', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'in_stack' as any, runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'in_stack');
+    registry.reconcilePrCreatedTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('in_stack');
+  });
+
+  it('is idempotent — calling twice does not break anything', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pr_created', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'in_stack');
+    registry.reconcilePrCreatedTickets();
+    registry.reconcilePrCreatedTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+});
+
 // --- deleteClosedEarlyColumnTickets ---
 
 describe('deleteClosedEarlyColumnTickets', () => {


### PR DESCRIPTION
## What

When a stack reaches `pr_created`, the linked Kanban ticket now advances from `in_stack` to `pr_open` — including via the agent/IPC path, not just the UI optimistic move.

## Changes

- **registry.ts** — Added `advanceTicketToPrOpenIfInStack()`, a forward-only guard that moves a linked ticket from `in_stack` → `pr_open` (no-op if the ticket is missing or already past `in_stack`). Added `reconcilePrCreatedTickets()` to backfill any tickets stuck in `in_stack` whose linked stack is already `pr_created`.
- **stack-manager.ts** — `setPullRequest()` now calls `advanceTicketToPrOpenIfInStack()` for the linked ticket before notifying the UI.
- **index.ts** — Runs `reconcilePrCreatedTickets()` on app startup to repair previously stuck tickets.
- **App.tsx** — The `stacks:updated` listener now also refreshes board tickets so the card moves reactively without a manual remount. Also added a global Escape handler to close the create-ticket dialog.

## Tests

- Integration regression tests in `kanban-column-transitions.spec.ts` covering the IPC path and the forward-only rule (merged tickets are not pulled back).
- Unit tests in `stack-manager.test.ts` and `ticketBoard.test.ts` covering `advanceTicketToPrOpenIfInStack` and `reconcilePrCreatedTickets`, including idempotency and no-op cases.

## Notes

The forward-only rule guarantees tickets already in `merged` or `pr_open` are never moved backward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
