### PR TITLE
Add resume button + token-limit detection for stalled stacks (#398)

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -47,6 +47,20 @@ check_for_stop_and_ask() {
   return 1
 }
 
+# Check if a run_claude invocation was terminated by a session token limit.
+# Scans the given log file (default: /tmp/claude-raw.log) for the case-insensitive
+# substring "You've hit your session limit". Structured for future expansion:
+# add additional confirmed limit patterns to the grep list below.
+# Returns 0 if token limit detected, 1 otherwise.
+check_for_token_limit() {
+  local log_file="${1:-/tmp/claude-raw.log}"
+  if grep -qi "You've hit your session limit" "$log_file" 2>/dev/null; then
+    log_loop "Session token limit detected"
+    return 0
+  fi
+  return 1
+}
+
 # Run the claude CLI with streaming output.
 # Args: $1 = prompt file path, $2 = raw log path, $3 = task log path, $4 = phase (execution|review|verify), $5 = iteration (1-based), $6... = extra claude args
 run_claude() {
@@ -482,6 +496,21 @@ while true; do
     tail -50 /tmp/claude-task.log 2>/dev/null > /tmp/claude-execution-summary.txt
 
     if [ $EXIT_CODE -ne 0 ]; then
+      if check_for_token_limit /tmp/claude-raw.log; then
+        log_loop "Session token limit reached during initial execution — marking token_limited"
+        rm -f /tmp/claude-task-prompt.txt
+        echo 1 > /tmp/claude-task.exit
+        echo "token_limited" > /tmp/claude-task.status
+        rm -f /tmp/claude-task.pid
+        echo ""
+        echo "=========================================="
+        echo "  Task finished — SESSION TOKEN LIMIT"
+        echo "=========================================="
+        echo ""
+        echo "ready" > /tmp/claude-ready
+        echo "Waiting for tasks..."
+        continue
+      fi
       log_loop "Initial execution failed (exit $EXIT_CODE), skipping review loop"
       rm -f /tmp/claude-task-prompt.txt
       echo $EXIT_CODE > /tmp/claude-task.exit
@@ -552,6 +581,7 @@ while true; do
     TASK_DONE=0
     TASK_FAILED=0
     TASK_NEEDS_HUMAN=0
+    TASK_TOKEN_LIMITED=0
     TOTAL_REVIEW_ITERATIONS=0
     TOTAL_VERIFY_RETRIES=0
     VERIFY_BLOCKED_ENVIRONMENTAL=0
@@ -593,6 +623,14 @@ while true; do
           # Save numbered review verdict (copy full review output)
           cp /tmp/claude-review-output.txt "/tmp/claude-review-verdict-${TOTAL_REVIEW_ITERATIONS}.txt" 2>/dev/null || echo "REVIEW_FAIL" > "/tmp/claude-review-verdict-${TOTAL_REVIEW_ITERATIONS}.txt"
           log_loop "Review iteration $INNER_ITERATION/$MAX_INNER_ITERATIONS: FAIL"
+
+          # Token limit takes priority — check the review agent's raw log before normal handling
+          if check_for_token_limit /tmp/claude-review-raw.log; then
+            TASK_TOKEN_LIMITED=1
+            TASK_FAILED=1
+            break
+          fi
+
           CONSECUTIVE_REVIEW_FAILS=$((CONSECUTIVE_REVIEW_FAILS + 1))
 
           if [ $INNER_ITERATION -ge $MAX_INNER_ITERATIONS ]; then
@@ -609,6 +647,11 @@ while true; do
           if [ $CONSECUTIVE_REVIEW_FAILS -ge 2 ] && [ $META_REVIEW_FIRED_REVIEW -eq 0 ]; then
             META_REVIEW_FIRED_REVIEW=1
             if ! run_meta_review "review" "$TOTAL_REVIEW_ITERATIONS"; then
+              if check_for_token_limit /tmp/claude-meta-review-raw.log; then
+                TASK_TOKEN_LIMITED=1
+                TASK_FAILED=1
+                break
+              fi
               log_loop "Meta-review found no viable path — halting for human intervention"
               TASK_NEEDS_HUMAN=1
               TASK_FAILED=1
@@ -656,6 +699,13 @@ while true; do
           fix_exit=$?
           echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
           rm -f "$local_fix_prompt"
+
+          # Token limit takes priority over STOP_AND_ASK and general failures
+          if [ $fix_exit -ne 0 ] && check_for_token_limit /tmp/claude-raw.log; then
+            TASK_TOKEN_LIMITED=1
+            TASK_FAILED=1
+            break
+          fi
 
           if check_for_stop_and_ask /tmp/claude-task.log; then
             log_loop "STOP_AND_ASK detected after review feedback — halting, needs human intervention"
@@ -792,6 +842,13 @@ while true; do
         echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
         rm -f "$local_verify_fix"
 
+        # Token limit takes priority over STOP_AND_ASK and general failures
+        if [ $verify_fix_exit -ne 0 ] && check_for_token_limit /tmp/claude-raw.log; then
+          TASK_TOKEN_LIMITED=1
+          TASK_FAILED=1
+          break
+        fi
+
         if check_for_stop_and_ask /tmp/claude-task.log; then
           log_loop "STOP_AND_ASK detected after verify failure — halting, needs human intervention"
           TASK_NEEDS_HUMAN=1
@@ -827,6 +884,10 @@ while true; do
       echo 0 > /tmp/claude-task.exit
       echo "completed" > /tmp/claude-task.status
       EXIT_CODE=0
+    elif [ $TASK_TOKEN_LIMITED -eq 1 ]; then
+      echo 1 > /tmp/claude-task.exit
+      echo "token_limited" > /tmp/claude-task.status
+      EXIT_CODE=1
     elif [ $TASK_NEEDS_HUMAN -eq 1 ]; then
       echo 1 > /tmp/claude-task.exit
       echo "needs_human" > /tmp/claude-task.status
@@ -846,6 +907,10 @@ while true; do
     echo "=========================================="
     echo "  Task finished (exit: $EXIT_CODE)"
     if [ $TASK_DONE -eq 1 ]; then
+      echo "  Review iterations: $TOTAL_REVIEW_ITERATIONS"
+      echo "  Verify retries: $TOTAL_VERIFY_RETRIES"
+    elif [ $TASK_TOKEN_LIMITED -eq 1 ]; then
+      echo "  STATUS: SESSION TOKEN LIMIT — stack marked session_paused, Resume to continue"
       echo "  Review iterations: $TOTAL_REVIEW_ITERATIONS"
       echo "  Verify retries: $TOTAL_VERIFY_RETRIES"
     elif [ $TASK_NEEDS_HUMAN -eq 1 ]; then

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -581,15 +581,19 @@ export class StackManager {
    */
   async resumeStackWithContinuation(
     stackId: string,
-    isHalted: () => boolean = () => false
+    isHalted: () => boolean = () => false,
+    manual: boolean = false
   ): Promise<{
     outcome: 'resuming_with_session' | 'resumed_fresh' | 'idle';
   }> {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
-    // Pre-flight: block resume if session token limit hasn't refreshed yet
-    if (isHalted()) {
+    // Pre-flight: block resume if session token limit hasn't refreshed yet.
+    // Manual resumes (user clicking Resume) bypass this — if the session is
+    // still limited the inner agent will hit it again, and the per-stack
+    // token-limit detector will re-classify the stack back to session_paused.
+    if (!manual && isHalted()) {
       throw new SandstormError(ErrorCode.SESSION_HALTED, 'Session token limit has not refreshed yet');
     }
 
@@ -621,14 +625,26 @@ export class StackManager {
 
     if (runningTask.session_id) {
       // Case A: resume with existing Claude session
-      await this.dispatchContinuation(stack, stackId, runningTask);
+      try {
+        await this.dispatchContinuation(stack, stackId, runningTask);
+      } catch (err) {
+        this.registry.updateStackStatus(stackId, 'session_paused');
+        this.notifyUpdate();
+        throw err;
+      }
       return { outcome: 'resuming_with_session' };
     } else {
       // Case B: session not yet logged — interrupt and redispatch fresh
       this.registry.interruptTask(runningTask.id);
-      await this.dispatchTask(stackId, runningTask.prompt, runningTask.model ?? undefined, {
-        skipTicketFetch: true,
-      });
+      try {
+        await this.dispatchTask(stackId, runningTask.prompt, runningTask.model ?? undefined, {
+          skipTicketFetch: true,
+        });
+      } catch (err) {
+        this.registry.updateStackStatus(stackId, 'session_paused');
+        this.notifyUpdate();
+        throw err;
+      }
       return { outcome: 'resumed_fresh' };
     }
   }

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -565,6 +565,30 @@ export class TaskWatcher extends EventEmitter {
         return;
       }
 
+      if (status === 'token_limited') {
+        // Stale-poll guard (same as terminal statuses)
+        if (!this.seenRunning.get(stackId)) {
+          const staleCount = (this.stalePollCounts.get(stackId) ?? 0) + 1;
+          this.stalePollCounts.set(stackId, staleCount);
+          if (staleCount < MAX_STALE_POLLS) {
+            this.schedulePoll(stackId, containerId, this.pollInterval);
+            return;
+          }
+        }
+
+        // Capture session_id and tokens before transitioning so the Resume
+        // button can enter Case A (--resume <session_id>).
+        await this.readTaskTokens(task.id, stackId, containerId).catch(() => {});
+
+        // Transition to session_paused WITHOUT completing the task — the
+        // running task and its session_id remain intact so resumeStackWithContinuation
+        // enters Case A rather than Case C.
+        this.registry.updateStackStatus(stackId, 'session_paused');
+        this.onStatusChange?.();
+        this.unwatch(stackId);
+        return;
+      }
+
       if (status === 'completed' || status === 'failed' || status === 'needs_human' || status === 'verify_blocked_environmental') {
         // Ignore stale completion from a prior task — we must see "running"
         // at least once before treating completion as valid.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -931,11 +931,12 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     stackManager.sessionResumeStack(stackId);
   });
 
-  ipcMain.handle('session:resumeStackWithContinuation', async (_event, stackId: string) => {
+  ipcMain.handle('session:resumeStackWithContinuation', async (_event, stackId: string, manual: boolean = false) => {
     try {
       const result = await stackManager.resumeStackWithContinuation(
         stackId,
-        () => sessionMonitor.getState().halted
+        () => sessionMonitor.getState().halted,
+        manual
       );
       return { halted: false, ...result };
     } catch (err) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -173,7 +173,7 @@ export interface SandstormAPI {
     haltAll: () => Promise<string[]>;
     resumeAll: () => Promise<string[]>;
     resumeStack: (stackId: string) => Promise<void>;
-    resumeStackWithContinuation: (stackId: string) => Promise<{
+    resumeStackWithContinuation: (stackId: string, manual?: boolean) => Promise<{
       halted: boolean;
       resetAt?: string | null;
       outcome?: 'resuming_with_session' | 'resumed_fresh' | 'idle';
@@ -343,8 +343,8 @@ const api: SandstormAPI = {
     haltAll: () => ipcRenderer.invoke('session:haltAll'),
     resumeAll: () => ipcRenderer.invoke('session:resumeAll'),
     resumeStack: (stackId) => ipcRenderer.invoke('session:resumeStack', stackId),
-    resumeStackWithContinuation: (stackId) =>
-      ipcRenderer.invoke('session:resumeStackWithContinuation', stackId),
+    resumeStackWithContinuation: (stackId, manual) =>
+      ipcRenderer.invoke('session:resumeStackWithContinuation', stackId, manual),
     forcePoll: () => ipcRenderer.invoke('session:forcePoll'),
     reportActivity: () => { ipcRenderer.send('session:activity'); },
   },

--- a/src/renderer/components/StackCard.tsx
+++ b/src/renderer/components/StackCard.tsx
@@ -120,7 +120,7 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
   const handleResume = async (e: React.MouseEvent) => {
     e.stopPropagation();
     try {
-      await resumeStackWithContinuation(stack.id);
+      await resumeStackWithContinuation(stack.id, true);
     } catch (err) {
       alert(`Failed to resume: ${err}`);
     }

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -121,7 +121,7 @@ export function StackTableRow({
   const handleResume = async (e: React.MouseEvent) => {
     e.stopPropagation();
     try {
-      await resumeStackWithContinuation(stack.id);
+      await resumeStackWithContinuation(stack.id, true);
     } catch (err) {
       alert(`Failed to resume: ${err}`);
     }

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -471,7 +471,7 @@ interface AppState {
   sessionAcknowledgeCritical: () => Promise<void>;
   sessionHaltAll: () => Promise<string[]>;
   sessionResumeAll: () => Promise<string[]>;
-  resumeStackWithContinuation: (stackId: string) => Promise<void>;
+  resumeStackWithContinuation: (stackId: string, manual?: boolean) => Promise<void>;
 
   // Kanban board
   boardTickets: TicketBoardEntry[];
@@ -688,7 +688,7 @@ declare global {
         haltAll: () => Promise<string[]>;
         resumeAll: () => Promise<string[]>;
         resumeStack: (stackId: string) => Promise<void>;
-        resumeStackWithContinuation: (stackId: string) => Promise<{
+        resumeStackWithContinuation: (stackId: string, manual?: boolean) => Promise<{
           halted: boolean;
           resetAt?: string | null;
           outcome?: 'resuming_with_session' | 'resumed_fresh' | 'idle';
@@ -970,8 +970,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     return resumed;
   },
 
-  resumeStackWithContinuation: async (stackId: string) => {
-    const result = await window.sandstorm.session.resumeStackWithContinuation(stackId);
+  resumeStackWithContinuation: async (stackId: string, manual?: boolean) => {
+    const result = await window.sandstorm.session.resumeStackWithContinuation(stackId, manual);
     if (result.halted) {
       get().setSessionTokenLimitModal({ resetAt: result.resetAt ?? null });
       return;

--- a/tests/unit/components/StackCard.test.tsx
+++ b/tests/unit/components/StackCard.test.tsx
@@ -217,13 +217,13 @@ describe('StackCard', () => {
     expect(screen.queryByTestId('card-resume-running')).toBeNull();
   });
 
-  it('calls resumeStackWithContinuation when Resume button is clicked', () => {
+  it('calls resumeStackWithContinuation with manual=true when Resume button is clicked', () => {
     const resumeFn = vi.fn().mockResolvedValue({ halted: false, outcome: 'resuming_with_session' });
     useAppStore.setState({ resumeStackWithContinuation: resumeFn } as any);
 
     render(<StackCard stack={makeStack({ id: 'paused2', status: 'session_paused' })} />);
     fireEvent.click(screen.getByTestId('card-resume-paused2'));
 
-    expect(resumeFn).toHaveBeenCalledWith('paused2');
+    expect(resumeFn).toHaveBeenCalledWith('paused2', true);
   });
 });

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -323,7 +323,7 @@ describe('StackTableRow session_paused Resume button', () => {
     expect(screen.getByText('Halted')).toBeDefined();
   });
 
-  it('calls resumeStackWithContinuation when Resume is clicked', () => {
+  it('calls resumeStackWithContinuation with manual=true when Resume is clicked', () => {
     vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
     const resumeFn = vi.fn().mockResolvedValue(undefined);
     useAppStore.setState({ resumeStackWithContinuation: resumeFn } as any);
@@ -331,7 +331,7 @@ describe('StackTableRow session_paused Resume button', () => {
     renderRow(makeStack({ id: 'paused2', status: 'session_paused' }));
     fireEvent.click(screen.getByTestId('row-resume-paused2'));
 
-    expect(resumeFn).toHaveBeenCalledWith('paused2');
+    expect(resumeFn).toHaveBeenCalledWith('paused2', true);
   });
 });
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -931,7 +931,7 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1');
 
       expect(result).toEqual({ halted: true, resetAt: '2026-05-04T15:00:00Z' });
-      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function));
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function), false);
     });
 
     it('returns halted=true with null resetAt when usage is absent', async () => {
@@ -943,7 +943,7 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1');
 
       expect(result).toEqual({ halted: true, resetAt: null });
-      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function));
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function), false);
     });
 
     it('calls resumeStackWithContinuation with isHalted callback when monitor is not halted', async () => {
@@ -952,8 +952,18 @@ describe('IPC Handlers', () => {
 
       const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1');
 
-      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function));
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function), false);
       expect(result).toEqual({ halted: false, status: 'running' });
+    });
+
+    it('passes manual=true to resumeStackWithContinuation when manual flag is provided', async () => {
+      mockSessionMonitor.getState.mockReturnValue({ halted: true });
+      mockStackManager.resumeStackWithContinuation.mockResolvedValue({ outcome: 'resuming_with_session' });
+
+      const result = await invokeHandler('session:resumeStackWithContinuation', 'stack-1', true);
+
+      expect(mockStackManager.resumeStackWithContinuation).toHaveBeenCalledWith('stack-1', expect.any(Function), true);
+      expect(result).toEqual({ halted: false, outcome: 'resuming_with_session' });
     });
   });
 

--- a/tests/unit/stack-lifecycle.test.ts
+++ b/tests/unit/stack-lifecycle.test.ts
@@ -664,6 +664,73 @@ describe('Stack Lifecycle Integration', () => {
     });
   });
 
+  describe('resumeStackWithContinuation — manual bypass of isHalted()', () => {
+    it('throws SESSION_HALTED when isHalted() returns true and manual is false', async () => {
+      registry.createStack(makeStack('halted-auto', 'session_paused'));
+      await expect(
+        manager.resumeStackWithContinuation('halted-auto', () => true, false)
+      ).rejects.toThrow(expect.objectContaining({
+        code: ErrorCode.SESSION_HALTED,
+      }));
+    });
+
+    it('does NOT throw SESSION_HALTED when manual is true, even if isHalted() returns true', async () => {
+      registry.createStack(makeStack('halted-manual', 'session_paused'));
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 });
+
+      // Should not throw even though isHalted() returns true
+      const result = await manager.resumeStackWithContinuation('halted-manual', () => true, true);
+      // No running task → idle (Case C)
+      expect(result.outcome).toBe('idle');
+    });
+
+    it('defaults manual to false, preserving existing SESSION_HALTED behaviour', async () => {
+      registry.createStack(makeStack('halted-default', 'session_paused'));
+      await expect(
+        manager.resumeStackWithContinuation('halted-default', () => true)
+      ).rejects.toThrow(expect.objectContaining({
+        code: ErrorCode.SESSION_HALTED,
+      }));
+    });
+
+    it('reverts to session_paused on container failure during manual resume', async () => {
+      registry.createStack(makeStack('revert-on-fail', 'session_paused'));
+      vi.spyOn(manager, 'ensureStackContainersRunning' as any).mockRejectedValueOnce(
+        new Error('Container start failed')
+      );
+
+      await expect(
+        manager.resumeStackWithContinuation('revert-on-fail', () => false, true)
+      ).rejects.toThrow('Container start failed');
+
+      // Stack must revert to session_paused so the Resume button reappears
+      expect(registry.getStack('revert-on-fail')!.status).toBe('session_paused');
+    });
+
+    it('reverts to session_paused when dispatchContinuation fails (Case A)', async () => {
+      registry.createStack(makeStack('revert-on-dispatch-fail', 'session_paused'));
+      vi.spyOn(manager, 'ensureStackContainersRunning' as any).mockResolvedValue(undefined);
+
+      // Seed a running task with a session_id directly via registry (bypasses container lookup)
+      const task = registry.createTask('revert-on-dispatch-fail', 'Token-limited task');
+      registry.setTaskSessionId(task.id, 'test-session-abc');
+      // Put the stack back to session_paused (as token-limit detection would)
+      registry.updateStackStatus('revert-on-dispatch-fail', 'session_paused');
+
+      // Mock dispatchContinuation to throw
+      vi.spyOn(manager, 'dispatchContinuation' as any).mockRejectedValueOnce(
+        new Error('Dispatch failed — still token limited')
+      );
+
+      await expect(
+        manager.resumeStackWithContinuation('revert-on-dispatch-fail', () => false, true)
+      ).rejects.toThrow('Dispatch failed — still token limited');
+
+      // Stack must revert to session_paused, not stay in building
+      expect(registry.getStack('revert-on-dispatch-fail')!.status).toBe('session_paused');
+    });
+  });
+
   describe('update callbacks fire at correct times', () => {
     it('callback fires for all state transitions in lifecycle', async () => {
       const updateCallback = vi.fn();

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -435,7 +435,7 @@ describe('task-runner.sh dual-loop workflow', () => {
     it('does not use `local` in the outer/inner while loops', () => {
       // Find all `local ` usages and verify they are inside function bodies.
       // Functions in the script: log_loop, run_claude, check_for_diff, run_review, run_verify, check_for_stop_and_ask
-      const functionNames = ['log_loop', 'run_claude', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'run_meta_review', 'inject_meta_review_guidance']
+      const functionNames = ['log_loop', 'run_claude', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance']
 
       // Collect the line ranges of all function bodies
       const functionRanges: Array<{ start: number; end: number }> = []

--- a/tests/unit/task-runner-token-limit.test.ts
+++ b/tests/unit/task-runner-token-limit.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const taskRunnerPath = resolve(__dirname, '../../sandstorm-cli/docker/task-runner.sh')
+const taskRunner = readFileSync(taskRunnerPath, 'utf-8')
+
+describe('task-runner.sh token limit detection', () => {
+  describe('check_for_token_limit function', () => {
+    it('defines check_for_token_limit function', () => {
+      expect(taskRunner).toContain('check_for_token_limit()')
+    })
+
+    it('scans the given log file, defaulting to /tmp/claude-raw.log', () => {
+      expect(taskRunner).toContain('local log_file="${1:-/tmp/claude-raw.log}"')
+    })
+
+    it('uses case-insensitive grep for the session limit string', () => {
+      expect(taskRunner).toContain('grep -qi "You\'ve hit your session limit"')
+    })
+
+    it('returns 0 on detection (success), 1 otherwise', () => {
+      expect(taskRunner).toContain('return 0')
+      expect(taskRunner).toContain('return 1')
+    })
+  })
+
+  describe('token_limited status token', () => {
+    it('writes token_limited to /tmp/claude-task.status', () => {
+      expect(taskRunner).toContain('echo "token_limited" > /tmp/claude-task.status')
+    })
+
+    it('initializes TASK_TOKEN_LIMITED=0 in dual-loop variables', () => {
+      expect(taskRunner).toContain('TASK_TOKEN_LIMITED=0')
+    })
+
+    it('sets TASK_TOKEN_LIMITED=1 when token limit is detected', () => {
+      expect(taskRunner).toContain('TASK_TOKEN_LIMITED=1')
+    })
+  })
+
+  describe('detection call sites', () => {
+    it('checks for token limit during initial execution failure', () => {
+      expect(taskRunner).toContain('check_for_token_limit /tmp/claude-raw.log')
+    })
+
+    it('checks for token limit after review agent fails (review raw log)', () => {
+      expect(taskRunner).toContain('check_for_token_limit /tmp/claude-review-raw.log')
+    })
+
+    it('checks for token limit after meta-review fails (meta-review raw log)', () => {
+      expect(taskRunner).toContain('check_for_token_limit /tmp/claude-meta-review-raw.log')
+    })
+
+    it('token limit check comes before failed/needs_human classification in final status', () => {
+      const tokenLimitedIdx = taskRunner.indexOf('TASK_TOKEN_LIMITED -eq 1')
+      const needsHumanIdx = taskRunner.indexOf('TASK_NEEDS_HUMAN -eq 1')
+      const verifyBlockedIdx = taskRunner.indexOf('VERIFY_BLOCKED_ENVIRONMENTAL -eq 1')
+      expect(tokenLimitedIdx).toBeGreaterThan(-1)
+      expect(tokenLimitedIdx).toBeLessThan(needsHumanIdx)
+      expect(tokenLimitedIdx).toBeLessThan(verifyBlockedIdx)
+    })
+
+    it('token limit check in initial execution path comes before echo failed', () => {
+      const tokenLimitCheck = taskRunner.indexOf('check_for_token_limit /tmp/claude-raw.log')
+      const echoFailed = taskRunner.indexOf('echo "failed" > /tmp/claude-task.status')
+      expect(tokenLimitCheck).toBeGreaterThan(-1)
+      expect(tokenLimitCheck).toBeLessThan(echoFailed)
+    })
+  })
+
+  describe('precedence', () => {
+    it('check_for_token_limit is defined before run_claude (structurally correct)', () => {
+      const tokenLimitFnIdx = taskRunner.indexOf('check_for_token_limit()')
+      const runClaudeIdx = taskRunner.indexOf('run_claude()')
+      expect(tokenLimitFnIdx).toBeLessThan(runClaudeIdx)
+    })
+
+    it('token limit check appears before check_for_stop_and_ask in local-fix path', () => {
+      // Find the local-fix section — verify fix-exit + token limit appears before STOP_AND_ASK
+      const fixSection = taskRunner.slice(taskRunner.indexOf('fix_exit=$?'))
+      const tokenLimitCheckInFix = fixSection.indexOf('check_for_token_limit /tmp/claude-raw.log')
+      const stopAndAskInFix = fixSection.indexOf('check_for_stop_and_ask /tmp/claude-task.log')
+      expect(tokenLimitCheckInFix).toBeGreaterThan(-1)
+      expect(stopAndAskInFix).toBeGreaterThan(-1)
+      expect(tokenLimitCheckInFix).toBeLessThan(stopAndAskInFix)
+    })
+
+    it('includes SESSION TOKEN LIMIT in the summary output', () => {
+      expect(taskRunner).toContain('SESSION TOKEN LIMIT')
+    })
+  })
+})

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -981,6 +981,107 @@ describe('TaskWatcher', () => {
     watcher.unwatchAll();
   });
 
+  // --- token_limited status handling ---
+
+  it('sets stack to session_paused when status is token_limited (preserves running task)', async () => {
+    const sessionId = 'sess-token-limit-123';
+    const rawJsonOutput = `{"type":"result","usage":{"input_tokens":1000,"output_tokens":500},"session_id":"${sessionId}"}`;
+
+    const runtime: ContainerRuntime = {
+      name: 'mock',
+      composeUp: vi.fn(),
+      composeDown: vi.fn(),
+      listContainers: vi.fn().mockResolvedValue([]),
+      inspect: vi.fn(),
+      logs: vi.fn(),
+      exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+        const cmdStr = cmd.join(' ');
+        if (cmdStr.includes('/tmp/claude-task.status')) {
+          const callCount = (runtime.exec as ReturnType<typeof vi.fn>).mock.calls.length;
+          return { exitCode: 0, stdout: callCount <= 2 ? 'running' : 'token_limited', stderr: '' };
+        }
+        if (cmdStr.includes('/tmp/claude-raw.log')) {
+          return { exitCode: 0, stdout: rawJsonOutput, stderr: '' };
+        }
+        if (cmdStr.includes('/tmp/claude-tokens-execution') || cmdStr.includes('/tmp/claude-tokens-review')) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      version: vi.fn().mockResolvedValue('Mock 1.0'),
+    };
+
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+    const task = registry.createTask('watch-stack', 'token limit task');
+
+    const statusChangePromise = new Promise<void>((resolve) => {
+      watcher.setOnStatusChange(resolve);
+    });
+
+    watcher.watch('watch-stack', 'container-123');
+    await statusChangePromise;
+    watcher.unwatchAll();
+
+    // Give readTaskTokens time to complete
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Stack must be session_paused (not failed/needs_human)
+    const stack = registry.getStack('watch-stack');
+    expect(stack?.status).toBe('session_paused');
+
+    // Task must still be running (NOT completed) so resumeStackWithContinuation enters Case A
+    const runningTask = registry.getRunningTask('watch-stack');
+    expect(runningTask).not.toBeNull();
+    expect(runningTask?.id).toBe(task.id);
+
+    // session_id must be captured so Case A resume works
+    await new Promise((r) => setTimeout(r, 100));
+    const tasks = registry.getTasksForStack('watch-stack');
+    const storedTask = tasks.find((t) => t.id === task.id);
+    expect(storedTask?.session_id).toBe(sessionId);
+  });
+
+  it('does NOT emit task:completed or task:failed for token_limited status', async () => {
+    const runtime = createSequencedRuntime(['running', 'token_limited'], '1');
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+    registry.createTask('watch-stack', 'token limit no event task');
+
+    let completedEmitted = false;
+    let failedEmitted = false;
+    watcher.on('task:completed', () => { completedEmitted = true; });
+    watcher.on('task:failed', () => { failedEmitted = true; });
+
+    const statusChanged = new Promise<void>((resolve) => {
+      watcher.setOnStatusChange(resolve);
+    });
+
+    watcher.watch('watch-stack', 'container-123');
+    await statusChanged;
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(completedEmitted).toBe(false);
+    expect(failedEmitted).toBe(false);
+
+    watcher.unwatchAll();
+  });
+
+  it('calls onStatusChange when token_limited is detected', async () => {
+    const runtime = createSequencedRuntime(['running', 'token_limited'], '1');
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+    registry.createTask('watch-stack', 'token limit callback task');
+
+    const statusChangeFn = vi.fn();
+    watcher.setOnStatusChange(statusChangeFn);
+
+    watcher.watch('watch-stack', 'container-123');
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(statusChangeFn).toHaveBeenCalled();
+    watcher.unwatchAll();
+  });
+
   it('does not read stderr for error detection', async () => {
     const runtime = createSequencedRuntime(['running', 'completed'], '0');
     const origExec = (runtime.exec as ReturnType<typeof vi.fn>).getMockImplementation()!;


### PR DESCRIPTION
Implements token-limit detection and a manual Resume path for stalled stacks (#398).

## What
- **task-runner.sh**: new `check_for_token_limit()` scans Claude raw logs for the session-limit signal and is wired into all invocation points (initial execution, review-agent failures, meta-review failures, local-fix and verify-fix paths). Writes `token_limited` to the task status, taking precedence over `failed`/`needs_human`.
- **task-watcher.ts**: new `token_limited` branch transitions the stack to `session_paused` *without* completing the task, preserving the running task + `session_id` so Resume can re-enter Case A (`--resume <session_id>`). Same stale-poll guard as terminal statuses.
- **stack-manager.ts**: `resumeStackWithContinuation` gains a `manual` flag — a user-initiated Resume bypasses the global `isHalted()` gate. Both Case A and Case B are wrapped in try/catch that reverts the stack to `session_paused` on failure (no orphan state).
- **Plumbing**: surfaced through `ipc.ts` → `preload` → `store.ts` → Resume buttons in `StackCard.tsx` / `StackTableRow.tsx` (pass `manual=true`).

## Tests
- New `tests/unit/task-runner-token-limit.test.ts` (15 tests) plus new token-limit cases in `task-watcher.test.ts` and a manual-resume regression in `stack-lifecycle.test.ts`.
- typecheck, full unit suite (2318 tests), build, and package all clean.

## Notes
- One pre-existing integration flake remains in `create-ticket-board.spec.ts` (Create Ticket dialog leaks across tests, intercepting a workspace-pill click). It is unrelated to this work and its source files are outside this ticket's scope — filed as #412.

Closes #398