### PR TITLE
ticket-415: distinct refinement states on ticket cards

### DIFF
--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -20,6 +20,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     openRefinementSession,
     openRefineTicketDialogWith,
     refinementSessions,
+    retryRefinementForTicket,
     startStackForTicket,
     stackCreateErrors,
     stackCreateInFlight,
@@ -56,6 +57,13 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
 
   const questionsAwaiting = refinementSession?.result?.questions?.length ?? 0;
 
+  // Error state takes priority: errored, interrupted, or ready+result.error
+  const showErrorState = refinementSession !== undefined && (
+    refinementSession.status === 'errored' ||
+    refinementSession.status === 'interrupted' ||
+    (refinementSession.status === 'ready' && !!refinementSession.result?.error)
+  );
+
   return (
     <div
       className={`bg-sandstorm-surface border border-sandstorm-border rounded-lg p-3 flex flex-col gap-2 shadow-card ${ticket.column === 'merged' ? 'opacity-40' : ''}`}
@@ -89,24 +97,41 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               <div className="h-full bg-sandstorm-state-refining rounded-full animate-pulse w-1/2" />
             </div>
           )}
-          {questionsAwaiting > 0 && (
+          {refinementSession?.status === 'ready' && !showErrorState && questionsAwaiting > 0 && (
             <span className="text-xs text-sandstorm-state-refining">
               {questionsAwaiting} question{questionsAwaiting !== 1 ? 's' : ''} awaiting
             </span>
           )}
-          <button
-            onClick={() => {
-              if (refinementSession) {
-                openRefinementSession(refinementSession.id);
-              } else {
-                openRefineTicketDialogWith(ticket.ticket_id);
-              }
-            }}
-            className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-state-refining/10 text-sandstorm-state-refining border border-sandstorm-state-refining/30 hover:bg-sandstorm-state-refining/20 transition-colors font-medium"
-            data-testid={`ticket-card-answer-${ticket.ticket_id}`}
-          >
-            Answer
-          </button>
+          {/* No session: offer to start refinement */}
+          {!refinementSession && (
+            <button
+              onClick={() => openRefineTicketDialogWith(ticket.ticket_id)}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-accent/10 text-sandstorm-accent border border-sandstorm-accent/30 hover:bg-sandstorm-accent/20 transition-colors font-medium"
+              data-testid={`ticket-card-start-refine-${ticket.ticket_id}`}
+            >
+              Start refinement
+            </button>
+          )}
+          {/* Error/interrupted: offer to retry */}
+          {showErrorState && (
+            <button
+              onClick={() => void retryRefinementForTicket(ticket.ticket_id, ticket.project_dir)}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-red-500/10 text-red-400 border border-red-500/30 hover:bg-red-500/20 transition-colors font-medium"
+              data-testid={`ticket-card-retry-${ticket.ticket_id}`}
+            >
+              Retry
+            </button>
+          )}
+          {/* Ready with questions and no error: answer questions */}
+          {!showErrorState && refinementSession?.status === 'ready' && questionsAwaiting > 0 && (
+            <button
+              onClick={() => openRefinementSession(refinementSession.id)}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-state-refining/10 text-sandstorm-state-refining border border-sandstorm-state-refining/30 hover:bg-sandstorm-state-refining/20 transition-colors font-medium"
+              data-testid={`ticket-card-answer-${ticket.ticket_id}`}
+            >
+              Answer
+            </button>
+          )}
         </div>
       )}
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -556,6 +556,8 @@ interface AppState {
   removeRefinementSession: (sessionId: string) => void;
   /** Set which session id is shown in the refine dialog. */
   setCurrentRefinementSessionId: (id: string | null) => void;
+  /** Cancel the current session for a ticket and start a fresh spec-gate run. Opens the dialog to the new session. */
+  retryRefinementForTicket: (ticketId: string, projectDir: string) => Promise<void>;
   setShowCreateTicketDialog: (show: boolean) => void;
   setShowStartTicketDialog: (show: boolean) => void;
   setShowCreatePRDialog: (state: { stackId: string } | null) => void;
@@ -1335,6 +1337,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       : state.currentRefinementSessionId,
   })),
   setCurrentRefinementSessionId: (id) => set({ currentRefinementSessionId: id }),
+  retryRefinementForTicket: async (ticketId, projectDir) => {
+    const session = get().refinementSessions.find(
+      (s) => s.ticketId === ticketId && s.projectDir === projectDir,
+    );
+    if (session) {
+      await window.sandstorm.tickets.cancelRefinement(session.id).catch(() => {});
+      get().removeRefinementSession(session.id);
+    }
+    const { sessionId } = await window.sandstorm.tickets.specCheckAsync(ticketId, projectDir);
+    get().openRefinementSession(sessionId);
+  },
   setShowCreateTicketDialog: (show) => set({ showCreateTicketDialog: show }),
   setShowStartTicketDialog: (show) => set({ showStartTicketDialog: show }),
   setShowCreatePRDialog: (state) => {

--- a/tests/integration/refinement-streaming.spec.ts
+++ b/tests/integration/refinement-streaming.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import type { RefineQuestion } from '../../src/renderer/store';
+import type { RefineQuestion, RefinementSession } from '../../src/renderer/store';
 
 test.describe('Refinement streaming panel', () => {
   test('refine-stream-panel shows live streamed text mid-run', async ({ electronApp, mainWindow }) => {
@@ -166,5 +166,141 @@ test.describe('Refinement streaming panel', () => {
     const modal = mainWindow.locator('[data-testid="refine-ticket-dialog"] > div').first();
     const className = await modal.getAttribute('class');
     expect(className).toContain('w-[768px]');
+  });
+
+  test('Answer button hidden while running, visible once ready with questions (#415)', async ({ electronApp, mainWindow }) => {
+    await mainWindow.waitForSelector('text=Sandstorm', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    const TICKET_415 = `ticket-415-${Date.now()}`;
+    const PROJECT_415 = `/tmp/int-test-415-${Date.now()}`;
+    const SESSION_415 = `sess-415-${Date.now()}`;
+
+    // Capture the current lastTicketFetchAt before seeding so we can detect when
+    // the board refresh triggered by setting activeProjectId has completed.
+    const prevFetchAt = await mainWindow.evaluate(() =>
+      (window as unknown as {
+        __useAppStore: { getState: () => { lastTicketFetchAt: number | null } };
+      }).__useAppStore.getState().lastTicketFetchAt,
+    );
+
+    // Seed project/activeProjectId first — this triggers the KanbanBoard useEffect
+    // which calls refreshBoardTickets (an IPC round-trip that will return an empty
+    // array for this fake project directory). Do NOT seed boardTickets yet.
+    await mainWindow.evaluate(({ dir }) => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [{ id: 9415, name: 'int-test-415', directory: dir, added_at: '' }],
+        activeProjectId: 9415,
+        boardTickets: [],
+        refinementSessions: [],
+        stacks: [],
+      });
+    }, { dir: PROJECT_415 });
+
+    // Wait for the board refresh to complete. The refresh resolves to an empty array
+    // (this project has no DB rows), setting lastTicketFetchAt to a new timestamp.
+    await mainWindow.waitForFunction(
+      (prev: number | null) => {
+        const state = (window as unknown as {
+          __useAppStore: { getState: () => { lastTicketFetchAt: number | null; boardTicketsLoading: boolean } };
+        }).__useAppStore.getState();
+        return state.lastTicketFetchAt !== prev && !state.boardTicketsLoading;
+      },
+      prevFetchAt,
+      { timeout: 5000 },
+    );
+
+    // Now seed boardTickets. The KanbanBoard effect won't fire again because
+    // project.directory hasn't changed, so this seeded state is stable.
+    await mainWindow.evaluate(({ ticketId, dir }) => {
+      (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore.setState({
+        boardTickets: [{ ticket_id: ticketId, project_dir: dir, column: 'refining', title: 'Ticket 415 test', updated_at: '' }],
+      });
+    }, { ticketId: TICKET_415, dir: PROJECT_415 });
+
+    // Wait for the ticket card to be in the DOM before injecting the session.
+    await mainWindow.waitForSelector(`[data-testid="ticket-card-${TICKET_415}"]`, { timeout: 3000 });
+
+    // Inject a running refinement session via IPC (same path the real daemon uses).
+    await electronApp.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (electron: any, args: { sid: string; ticketId: string; dir: string; ts: number }) => {
+        const win = electron.BrowserWindow.getAllWindows()[0];
+        win.webContents.send('refinement:update', {
+          id: args.sid,
+          ticketId: args.ticketId,
+          projectDir: args.dir,
+          status: 'running',
+          phase: 'check',
+          startedAt: args.ts,
+        });
+      },
+      { sid: SESSION_415, ticketId: TICKET_415, dir: PROJECT_415, ts: Date.now() },
+    );
+
+    // Wait for the session to land in the store.
+    await mainWindow.waitForFunction(
+      (sid: string) => {
+        const store = (window as unknown as {
+          __useAppStore: { getState: () => { refinementSessions: Array<{ id: string }> } };
+        }).__useAppStore;
+        return store.getState().refinementSessions.some((s) => s.id === sid);
+      },
+      SESSION_415,
+      { timeout: 5000 },
+    );
+
+    // Assert the Answer button is absent while running.
+    const answerBtn = mainWindow.locator(`[data-testid="ticket-card-answer-${TICKET_415}"]`);
+    await expect(answerBtn).toHaveCount(0);
+
+    // Transition to ready with questions via the same IPC path.
+    await electronApp.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (electron: any, args: { sid: string; ticketId: string; dir: string; ts: number }) => {
+        const win = electron.BrowserWindow.getAllWindows()[0];
+        win.webContents.send('refinement:update', {
+          id: args.sid,
+          ticketId: args.ticketId,
+          projectDir: args.dir,
+          status: 'ready',
+          phase: 'check',
+          startedAt: args.ts,
+          result: {
+            passed: false,
+            questions: [{ id: 'q1', question: 'What approach should be used?', options: [] }],
+            gateSummary: 'Gate=FAIL, questions=1',
+            ticketUrl: null,
+            cached: false,
+          },
+        });
+      },
+      { sid: SESSION_415, ticketId: TICKET_415, dir: PROJECT_415, ts: Date.now() },
+    );
+
+    // The Answer button must appear once the session is ready with questions.
+    await expect(answerBtn).toBeVisible({ timeout: 5000 });
+
+    // Cleanup
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        projects: [],
+        activeProjectId: null,
+        refinementSessions: [],
+        stacks: [],
+        boardTickets: [],
+      });
+    });
   });
 });

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -57,9 +57,158 @@ describe('TicketCard', () => {
     expect(entry?.column).toBe('refining');
   });
 
-  it('refining: shows Answer button', () => {
+  it('refining: no session — shows Start refinement button', () => {
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-start-refine-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-retry-42')).toBeNull();
+  });
+
+  it('refining: no session — clicking Start refinement calls openRefineTicketDialogWith', () => {
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-start-refine-42'));
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(true);
+    expect(useAppStore.getState().refineTicketPrefill).toBe('42');
+  });
+
+  it('refining: status running — no action buttons shown', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-run',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'running',
+        phase: 'check',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-retry-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+  });
+
+  it('refining: status ready with questions — shows Answer button', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-ready',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [{ id: 'q1', question: 'Q?', options: [] }],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+    });
     render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
     expect(screen.getByTestId('ticket-card-answer-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-retry-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+  });
+
+  it('refining: status ready passed=true, no questions — no button shown', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-pass',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: true,
+          questions: [],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-retry-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+  });
+
+  it('refining: status errored — shows Retry button', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-err',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+  });
+
+  it('refining: status errored — clicking Retry invokes retryRefinementForTicket', async () => {
+    const retrySpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-err2',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        startedAt: 0,
+      }],
+      retryRefinementForTicket: retrySpy,
+    } as any);
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-retry-42'));
+    await waitFor(() => expect(retrySpy).toHaveBeenCalledWith('42', PROJECT_DIR));
+  });
+
+  it('refining: status interrupted — shows Retry button', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-int',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'interrupted',
+        phase: 'check',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+  });
+
+  it('refining: status ready with result.error — shows Retry, not Answer', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-ready-err',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [{ id: 'q1', question: 'Q?', options: [] }],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+          error: 'spec gate failed',
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
   });
 
   it('spec_ready: shows Start stack button', () => {


### PR DESCRIPTION
## Summary
- split the single "Answer" button on `TicketCard` into distinct states so the card reflects what refinement actually needs: "Start refinement" when no session exists, "Retry" when the session errored/was interrupted (or finished ready with a result error), and "Answer" only when a ready session has pending questions
- add `retryRefinementForTicket` to the store, which cancels and removes the stale session then kicks off a fresh spec-gate run and opens the dialog to the new session
- fix the refinement-streaming integration test that was flaky because `boardTickets` seeded via `setState` got clobbered by the board's `refreshBoardTickets` effect; it now seeds the project first, waits for the refresh to settle, then seeds tickets and waits for the card to render

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] unit tests in `tests/unit/components/TicketCard.test.tsx` pass
- [ ] integration test `tests/integration/refinement-streaming.spec.ts` passes
- [ ] a ticket with no refinement session shows "Start refinement"
- [ ] an errored/interrupted session shows "Retry"; clicking it cancels the old session and starts a new spec-gate run
- [ ] a ready session with questions shows "Answer" and no error/retry button

Closes #415