### PR TITLE
feat: add recommended option flag to ticket refine questions

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -322,12 +322,14 @@ Every question MUST be phrased as an actionable multiple-choice question — nev
     "id": "q1",
     "question": "<specific actionable question>",
     "options": [
-      { "id": "a", "label": "<option A>" },
+      { "id": "a", "label": "<option A>", "recommended": true },
       { "id": "b", "label": "<option B>" }
     ]
   }
 ]
 \`\`\`
+
+Mark at most one option per question with \`"recommended": true\` when you have a clear recommendation. Omit the field (or omit all recommendations) when there is no obvious best choice.
 `;
 }
 
@@ -404,12 +406,14 @@ Every question MUST be phrased as an actionable multiple-choice question — nev
     "id": "q1",
     "question": "<specific actionable question>",
     "options": [
-      { "id": "a", "label": "<option A>" },
+      { "id": "a", "label": "<option A>", "recommended": true },
       { "id": "b", "label": "<option B>" }
     ]
   }
 ]
 \`\`\`
+
+Mark at most one option per question with \`"recommended": true\` when you have a clear recommendation. Omit the field (or omit all recommendations) when there is no obvious best choice.
 `;
 }
 
@@ -469,12 +473,14 @@ Every question MUST be phrased as an actionable multiple-choice question — nev
     "id": "q1",
     "question": "<specific actionable question>",
     "options": [
-      { "id": "a", "label": "<option A>" },
+      { "id": "a", "label": "<option A>", "recommended": true },
       { "id": "b", "label": "<option B>" }
     ]
   }
 ]
 \`\`\`
+
+Mark at most one option per question with \`"recommended": true\` when you have a clear recommendation. Omit the field (or omit all recommendations) when there is no obvious best choice.
 `;
 }
 

--- a/src/main/control-plane/ticket-spec.ts
+++ b/src/main/control-plane/ticket-spec.ts
@@ -8,6 +8,7 @@ const execFileAsync = promisify(execFile);
 export interface RefineQuestionOption {
   id: string;
   label: string;
+  recommended?: boolean;
 }
 
 export interface RefineQuestion {
@@ -137,7 +138,8 @@ function tryParseJsonBlock(report: string): RefineQuestion[] | null {
           if (typeof opt === 'object' && opt !== null) {
             const o = opt as Record<string, unknown>;
             if (typeof o.id === 'string' && typeof o.label === 'string') {
-              options.push({ id: o.id, label: o.label });
+              const rec = o.recommended === true ? { recommended: true as const } : {};
+              options.push({ id: o.id, label: o.label, ...rec });
             }
           }
         }

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -83,7 +83,10 @@ export function RefineTicketDialog() {
           ? { id: 'q', question: q as string, options: [] }
           : (!Array.isArray((q as RefineQuestion).options) ? { ...(q as RefineQuestion), options: [] } : q as RefineQuestion)
       );
-      setAnswers(normalized.map(() => ({ optionId: null, text: '' })));
+      setAnswers(normalized.map((q) => {
+        const firstRecommended = q.options.find((o) => o.recommended === true);
+        return { optionId: firstRecommended ? firstRecommended.id : null, text: '' };
+      }));
     }
   }, [gate]);
 
@@ -458,24 +461,36 @@ export function RefineTicketDialog() {
                           </p>
                           {qItem.options.length > 0 && (
                             <div className="space-y-1 pl-3">
-                              {qItem.options.map((opt) => (
-                                <label key={opt.id} className="flex items-center gap-2 cursor-pointer">
-                                  <input
-                                    type="radio"
-                                    name={`refine-q-${i}`}
-                                    value={opt.id}
-                                    checked={ans.optionId === opt.id}
-                                    onChange={() => {
-                                      const next = [...answers];
-                                      next[i] = { ...ans, optionId: opt.id };
-                                      setAnswers(next);
-                                    }}
-                                    className="accent-sandstorm-accent"
-                                    data-testid={`refine-option-${i}-${opt.id}`}
-                                  />
-                                  <span className="text-xs text-sandstorm-text">{opt.label}</span>
-                                </label>
-                              ))}
+                              {qItem.options.map((opt, optIdx) => {
+                                const isFirstRecommended = opt.recommended === true && optIdx === qItem.options.findIndex((o) => o.recommended === true);
+                                return (
+                                  <label key={opt.id} className="flex items-center gap-2 cursor-pointer">
+                                    <input
+                                      type="radio"
+                                      name={`refine-q-${i}`}
+                                      value={opt.id}
+                                      checked={ans.optionId === opt.id}
+                                      onChange={() => {}}
+                                      onClick={() => {
+                                        const next = [...answers];
+                                        next[i] = { ...ans, optionId: ans.optionId === opt.id ? null : opt.id };
+                                        setAnswers(next);
+                                      }}
+                                      className="accent-sandstorm-accent"
+                                      data-testid={`refine-option-${i}-${opt.id}`}
+                                    />
+                                    <span className="text-xs text-sandstorm-text">{opt.label}</span>
+                                    {isFirstRecommended && (
+                                      <span
+                                        className="text-xs font-medium text-sandstorm-accent border border-sandstorm-accent/40 rounded px-1.5 py-0.5 leading-none"
+                                        data-testid={`refine-option-recommended-${i}-${opt.id}`}
+                                      >
+                                        Recommended
+                                      </span>
+                                    )}
+                                  </label>
+                                );
+                              })}
                             </div>
                           )}
                           <textarea

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -761,6 +761,7 @@ declare global {
 export interface RefineQuestionOption {
   id: string;
   label: string;
+  recommended?: boolean;
 }
 
 export interface RefineQuestion {

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -1024,6 +1024,174 @@ describe('RefineTicketDialog', () => {
     });
   });
 
+  describe('recommended option badge and preselection (#421)', () => {
+    const RECOMMENDED_QUESTIONS: RefineQuestion[] = [
+      {
+        id: 'q1',
+        question: 'What is X?',
+        options: [
+          { id: 'a', label: 'Option A', recommended: true },
+          { id: 'b', label: 'Option B' },
+        ],
+      },
+      {
+        id: 'q2',
+        question: 'What is Y?',
+        options: [
+          { id: 'a', label: 'Yes' },
+          { id: 'b', label: 'No' },
+        ],
+      },
+    ];
+
+    const MULTI_RECOMMENDED_QUESTION: RefineQuestion[] = [
+      {
+        id: 'q1',
+        question: 'Pick one?',
+        options: [
+          { id: 'a', label: 'Option A', recommended: true },
+          { id: 'b', label: 'Option B', recommended: true },
+        ],
+      },
+    ];
+
+    function setupFailState(questions: RefineQuestion[]) {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions,
+            gateSummary: `Gate=FAIL, questions=${questions.length}`,
+            ticketUrl: null, cached: false,
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+    }
+
+    it('renders Recommended badge next to the flagged option only', () => {
+      setupFailState(RECOMMENDED_QUESTIONS);
+      render(<RefineTicketDialog />);
+      expect(screen.getByTestId('refine-option-recommended-0-a')).toBeDefined();
+      expect(screen.queryByTestId('refine-option-recommended-0-b')).toBeNull();
+      expect(screen.queryByTestId('refine-option-recommended-1-a')).toBeNull();
+      expect(screen.queryByTestId('refine-option-recommended-1-b')).toBeNull();
+    });
+
+    it('preselects the recommended option on first render', () => {
+      setupFailState(RECOMMENDED_QUESTIONS);
+      render(<RefineTicketDialog />);
+      const radioA = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+      const radioB = screen.getByTestId('refine-option-0-b') as HTMLInputElement;
+      expect(radioA.checked).toBe(true);
+      expect(radioB.checked).toBe(false);
+    });
+
+    it('no preselection when no option is recommended', () => {
+      setupFailState(MULTI_OPT_QUESTIONS);
+      render(<RefineTicketDialog />);
+      const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+      expect(radios.every((r) => !r.checked)).toBe(true);
+    });
+
+    it('submit stays disabled when some questions lack a recommendation (unanswered)', () => {
+      // RECOMMENDED_QUESTIONS: q1 has recommended option (preselected), q2 has none (null)
+      setupFailState(RECOMMENDED_QUESTIONS);
+      render(<RefineTicketDialog />);
+      const submit = screen.getByTestId('refine-submit-answers');
+      // q2 is unanswered — submit must be disabled despite q1 being preselected
+      expect(submit.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('submit is enabled when all questions have a recommendation preselected', async () => {
+      const allRecommended: RefineQuestion[] = [
+        {
+          id: 'q1', question: 'Q1?',
+          options: [
+            { id: 'a', label: 'A', recommended: true },
+            { id: 'b', label: 'B' },
+          ],
+        },
+        {
+          id: 'q2', question: 'Q2?',
+          options: [
+            { id: 'a', label: 'Yes' },
+            { id: 'b', label: 'No', recommended: true },
+          ],
+        },
+      ];
+      setupFailState(allRecommended);
+      render(<RefineTicketDialog />);
+      const submit = screen.getByTestId('refine-submit-answers');
+      expect(submit.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('escape hatch: clicking the already-selected recommended option deselects it', async () => {
+      const user = userEvent.setup();
+      setupFailState(RECOMMENDED_QUESTIONS);
+      render(<RefineTicketDialog />);
+
+      const radioA = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+      expect(radioA.checked).toBe(true);
+
+      // Click the already-selected radio — should toggle back to null
+      await user.click(radioA);
+      expect(radioA.checked).toBe(false);
+    });
+
+    it('escape hatch: submit is disabled after deselecting the only recommended answer with no text', async () => {
+      const user = userEvent.setup();
+      const oneQuestion: RefineQuestion[] = [
+        {
+          id: 'q1', question: 'Q?',
+          options: [
+            { id: 'a', label: 'A', recommended: true },
+            { id: 'b', label: 'B' },
+          ],
+        },
+      ];
+      setupFailState(oneQuestion);
+      render(<RefineTicketDialog />);
+
+      const submit = screen.getByTestId('refine-submit-answers');
+      expect(submit.hasAttribute('disabled')).toBe(false);
+
+      // Deselect the recommended option
+      await user.click(screen.getByTestId('refine-option-0-a'));
+      expect(submit.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('clicking a different option after deselect selects that option', async () => {
+      const user = userEvent.setup();
+      setupFailState(RECOMMENDED_QUESTIONS);
+      render(<RefineTicketDialog />);
+
+      const radioA = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+      const radioB = screen.getByTestId('refine-option-0-b') as HTMLInputElement;
+      expect(radioA.checked).toBe(true);
+
+      // Click B directly — should select B and deselect A
+      await user.click(radioB);
+      expect(radioB.checked).toBe(true);
+      expect(radioA.checked).toBe(false);
+    });
+
+    it('when multiple options are recommended, only the first gets badge and preselection', () => {
+      setupFailState(MULTI_RECOMMENDED_QUESTION);
+      render(<RefineTicketDialog />);
+
+      expect(screen.getByTestId('refine-option-recommended-0-a')).toBeDefined();
+      expect(screen.queryByTestId('refine-option-recommended-0-b')).toBeNull();
+
+      const radioA = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+      const radioB = screen.getByTestId('refine-option-0-b') as HTMLInputElement;
+      expect(radioA.checked).toBe(true);
+      expect(radioB.checked).toBe(false);
+    });
+  });
+
   describe('upsertRefinementSession clears streamingOutput on completion', () => {
     it('clears streamingOutput when status transitions to ready', () => {
       useAppStore.setState({

--- a/tests/unit/ticket-spec.test.ts
+++ b/tests/unit/ticket-spec.test.ts
@@ -60,6 +60,83 @@ const FAIL_REPORT_JSON = `## Spec Quality Gate: FAIL
 | Specificity | FAIL |
 `;
 
+const FAIL_REPORT_JSON_RECOMMENDED = `## Spec Quality Gate: FAIL
+
+### Questions
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "What does fast mean?",
+    "options": [
+      { "id": "a", "label": "Under 100ms", "recommended": true },
+      { "id": "b", "label": "Under 1s" }
+    ]
+  },
+  {
+    "id": "q2",
+    "question": "Cache strategy?",
+    "options": [
+      { "id": "a", "label": "Full body" },
+      { "id": "b", "label": "Hash only", "recommended": true }
+    ]
+  }
+]
+\`\`\`
+
+### Results
+| Criterion | Result |
+|-----------|--------|
+| Specificity | FAIL |
+`;
+
+const FAIL_REPORT_JSON_MALFORMED_RECOMMENDED = `## Spec Quality Gate: FAIL
+
+### Questions
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "Cache strategy?",
+    "options": [
+      { "id": "a", "label": "Full body", "recommended": "true" },
+      { "id": "b", "label": "Hash only", "recommended": 1 }
+    ]
+  }
+]
+\`\`\`
+
+### Results
+| Criterion | Result |
+|-----------|--------|
+| Specificity | FAIL |
+`;
+
+const FAIL_REPORT_JSON_MULTI_RECOMMENDED = `## Spec Quality Gate: FAIL
+
+### Questions
+
+\`\`\`json
+[
+  {
+    "id": "q1",
+    "question": "Pick one?",
+    "options": [
+      { "id": "a", "label": "Option A", "recommended": true },
+      { "id": "b", "label": "Option B", "recommended": true }
+    ]
+  }
+]
+\`\`\`
+
+### Results
+| Criterion | Result |
+|-----------|--------|
+| Specificity | FAIL |
+`;
+
 const GITHUB_CONFIG: ProjectTicketConfig = { provider: 'github' };
 
 function makeDeps(overrides: Partial<SpecGateDeps> = {}): SpecGateDeps {
@@ -157,6 +234,37 @@ describe('extractQuestions', () => {
     const questions = extractQuestions(r);
     expect(questions).toHaveLength(1);
     expect(questions[0].options).toEqual([]);
+  });
+
+  it('preserves recommended:true flag on options', () => {
+    const questions = extractQuestions(FAIL_REPORT_JSON_RECOMMENDED);
+    expect(questions[0].options[0]).toEqual({ id: 'a', label: 'Under 100ms', recommended: true });
+    expect(questions[0].options[1]).toEqual({ id: 'b', label: 'Under 1s' });
+    expect(questions[1].options[0]).toEqual({ id: 'a', label: 'Full body' });
+    expect(questions[1].options[1]).toEqual({ id: 'b', label: 'Hash only', recommended: true });
+  });
+
+  it('ignores non-boolean recommended values (string, number)', () => {
+    const questions = extractQuestions(FAIL_REPORT_JSON_MALFORMED_RECOMMENDED);
+    expect(questions[0].options[0]).toEqual({ id: 'a', label: 'Full body' });
+    expect(questions[0].options[1]).toEqual({ id: 'b', label: 'Hash only' });
+    expect(questions[0].options[0].recommended).toBeUndefined();
+    expect(questions[0].options[1].recommended).toBeUndefined();
+  });
+
+  it('preserves all recommended flags when multiple options are flagged (UI applies first-only rule)', () => {
+    const questions = extractQuestions(FAIL_REPORT_JSON_MULTI_RECOMMENDED);
+    expect(questions[0].options[0].recommended).toBe(true);
+    expect(questions[0].options[1].recommended).toBe(true);
+  });
+
+  it('options without recommended field have no recommended property', () => {
+    const questions = extractQuestions(FAIL_REPORT_JSON);
+    for (const q of questions) {
+      for (const opt of q.options) {
+        expect(opt.recommended).toBeUndefined();
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an optional `recommended` flag to refine-question options so the LLM can suggest a sensible default; the dialog preselects the first recommended option per question to reduce friction for the common case while still letting users change or clear their choice
- Surfaces the suggestion in the UI with a "Recommended" badge (first flagged option per question only) and uses click-to-toggle radios so a preselected answer can be deselected as an escape hatch
- Parser keeps `recommended` only when strictly `true` so malformed/non-boolean values are ignored, and the LLM prompt schemas document marking at most one option per question

## Test plan
- [ ] `ticket-spec.test.ts`: verify `recommended` parsing, non-boolean rejection, multiple-flag handling, and absent-flag default
- [ ] `RefineTicketDialog.test.tsx`: verify badge rendering, preselection, no-preselection fallback, toggle-to-deselect, submit guard, and multiple-recommended edge case
- [ ] Run full unit suite and typecheck; confirm both pass clean
- [ ] Manually open the refine dialog with a question that has a recommended option and confirm it is preselected, badged, and can be toggled off

Closes #421