### PR TITLE
refine tickets in background from card, no auto dialog

### DIFF
--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -24,6 +24,8 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     startStackForTicket,
     stackCreateErrors,
     stackCreateInFlight,
+    refineInFlight,
+    refineStartErrors,
   } = useAppStore();
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
@@ -57,12 +59,15 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
 
   const questionsAwaiting = refinementSession?.result?.questions?.length ?? 0;
 
-  // Error state takes priority: errored, interrupted, or ready+result.error
-  const showErrorState = refinementSession !== undefined && (
+  const isRefineInFlight = refineInFlight[stackKey] ?? false;
+  const refineStartError = refineStartErrors[stackKey];
+
+  // Error state takes priority: errored, interrupted, ready+result.error, or gate start failure
+  const showErrorState = (refinementSession !== undefined && (
     refinementSession.status === 'errored' ||
     refinementSession.status === 'interrupted' ||
     (refinementSession.status === 'ready' && !!refinementSession.result?.error)
-  );
+  )) || !!refineStartError;
 
   return (
     <div
@@ -92,7 +97,8 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
 
       {ticket.column === 'refining' && (
         <div className="flex flex-col gap-2">
-          {refinementSession?.status === 'running' && (
+          {/* Progress bar: running session or background gate start in-flight */}
+          {(refinementSession?.status === 'running' || isRefineInFlight) && (
             <div className="h-1 bg-sandstorm-border rounded-full overflow-hidden">
               <div className="h-full bg-sandstorm-state-refining rounded-full animate-pulse w-1/2" />
             </div>
@@ -102,8 +108,17 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               {questionsAwaiting} question{questionsAwaiting !== 1 ? 's' : ''} awaiting
             </span>
           )}
-          {/* No session: offer to start refinement */}
-          {!refinementSession && (
+          {/* Error badge for clear visual indication of failure */}
+          {showErrorState && (
+            <span
+              className="text-xs text-red-400"
+              data-testid={`ticket-card-error-badge-${ticket.ticket_id}`}
+            >
+              Refinement failed
+            </span>
+          )}
+          {/* No session, not in-flight, no error: offer to start refinement */}
+          {!refinementSession && !isRefineInFlight && !showErrorState && (
             <button
               onClick={() => openRefineTicketDialogWith(ticket.ticket_id)}
               className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-accent/10 text-sandstorm-accent border border-sandstorm-accent/30 hover:bg-sandstorm-accent/20 transition-colors font-medium"

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -499,7 +499,7 @@ interface AppState {
   resolveRefinementTargets: (ticketId: string, projectDir: string) => RefinementResolution;
   /** Move ticket to 'refining' and stash _refineDialogContext for revert-on-cancel. */
   commitRefinementContext: (ticketId: string, projectDir: string, previousColumn: KanbanColumn) => void;
-  /** Opens the refine dialog from a kanban card and moves the ticket to 'refining' optimistically. Reverts on cancel. */
+  /** Starts the spec gate in the background (no modal) for an initial Refine click from a backlog card. Moves ticket to 'refining'. */
   openRefineDialogFromCard: (ticketId: string, projectDir: string, previousColumn: KanbanColumn) => void;
   /** Opens the new stack dialog for a ticket and moves it to 'in_stack' optimistically. Reverts on cancel. */
   openNewStackDialogForTicket: (ticketId: string, projectDir: string, previousColumn: KanbanColumn) => void;
@@ -512,6 +512,10 @@ interface AppState {
   stackCreateErrors: Record<string, string>;
   /** Per-ticket in-flight flag, keyed by `${ticketId}|${projectDir}`. Guards against double-clicks. */
   stackCreateInFlight: Record<string, boolean>;
+  /** Per-ticket in-flight flag for background refine gate start, keyed by `${ticketId}|${projectDir}`. Guards against double-clicks during latency window. */
+  refineInFlight: Record<string, boolean>;
+  /** Per-ticket error message when the background refine gate fails to start, keyed by `${ticketId}|${projectDir}`. */
+  refineStartErrors: Record<string, string>;
   /** One-click stack creation from a spec_ready card — no dialog. */
   startStackForTicket: (ticketId: string, projectDir: string) => Promise<void>;
 
@@ -1013,6 +1017,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   _prDialogContext: null,
   stackCreateErrors: {},
   stackCreateInFlight: {},
+  refineInFlight: {},
+  refineStartErrors: {},
 
   clearMoveTicketColumnError: () => set({ moveTicketColumnError: null }),
 
@@ -1101,13 +1107,42 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   openRefineDialogFromCard: (ticketId, projectDir, previousColumn) => {
-    set({
-      showRefineTicketDialog: true,
-      refineTicketPrefill: ticketId,
-      currentRefinementSessionId: null,
-      _refineDialogContext: { ticketId, projectDir, previousColumn },
+    const key = `${ticketId}|${projectDir}`;
+    // Guard: prevent duplicate gate start during async latency window
+    if (get().refineInFlight[key]) return;
+    // Guard: don't start a second gate if a session already exists
+    const existingSession = get().refinementSessions.find(
+      (s) => s.ticketId === ticketId && s.projectDir === projectDir
+    );
+    if (existingSession) return;
+
+    set((state) => {
+      const { [key]: _, ...restErrors } = state.refineStartErrors;
+      return {
+        refineInFlight: { ...state.refineInFlight, [key]: true },
+        refineStartErrors: restErrors,
+        _refineDialogContext: { ticketId, projectDir, previousColumn },
+      };
     });
     void get().moveTicketColumn(ticketId, projectDir, 'refining');
+
+    window.sandstorm.tickets.specCheckAsync(ticketId, projectDir)
+      .then(() => {
+        set((state) => {
+          const { [key]: _, ...rest } = state.refineInFlight;
+          return { refineInFlight: rest };
+        });
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        set((state) => {
+          const { [key]: _, ...rest } = state.refineInFlight;
+          return {
+            refineInFlight: rest,
+            refineStartErrors: { ...state.refineStartErrors, [key]: message },
+          };
+        });
+      });
   },
 
   openNewStackDialogForTicket: (ticketId, projectDir, previousColumn) => {
@@ -1338,6 +1373,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   })),
   setCurrentRefinementSessionId: (id) => set({ currentRefinementSessionId: id }),
   retryRefinementForTicket: async (ticketId, projectDir) => {
+    const key = `${ticketId}|${projectDir}`;
     const session = get().refinementSessions.find(
       (s) => s.ticketId === ticketId && s.projectDir === projectDir,
     );
@@ -1345,8 +1381,30 @@ export const useAppStore = create<AppState>((set, get) => ({
       await window.sandstorm.tickets.cancelRefinement(session.id).catch(() => {});
       get().removeRefinementSession(session.id);
     }
-    const { sessionId } = await window.sandstorm.tickets.specCheckAsync(ticketId, projectDir);
-    get().openRefinementSession(sessionId);
+    // Clear any previous start error and mark in-flight during latency window
+    set((state) => {
+      const { [key]: _, ...restErrors } = state.refineStartErrors;
+      return {
+        refineStartErrors: restErrors,
+        refineInFlight: { ...state.refineInFlight, [key]: true },
+      };
+    });
+    try {
+      await window.sandstorm.tickets.specCheckAsync(ticketId, projectDir);
+      set((state) => {
+        const { [key]: _, ...rest } = state.refineInFlight;
+        return { refineInFlight: rest };
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      set((state) => {
+        const { [key]: _, ...rest } = state.refineInFlight;
+        return {
+          refineInFlight: rest,
+          refineStartErrors: { ...state.refineStartErrors, [key]: message },
+        };
+      });
+    }
   },
   setShowCreateTicketDialog: (show) => set({ showCreateTicketDialog: show }),
   setShowStartTicketDialog: (show) => set({ showStartTicketDialog: show }),

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -491,6 +491,63 @@ describe('RefineTicketDialog', () => {
       render(<RefineTicketDialog />);
       expect(api.tickets.specCheckAsync).not.toHaveBeenCalled();
     });
+
+    it('opening via Answer path (existing session, no prefill) does not call specCheckAsync', async () => {
+      useAppStore.setState({
+        refineTicketPrefill: null,
+        currentRefinementSessionId: 'sess-answer',
+        refinementSessions: [{
+          id: 'sess-answer',
+          ticketId: '42',
+          projectDir: '/proj',
+          status: 'ready' as const,
+          phase: 'check' as const,
+          result: {
+            passed: false,
+            questions: [{ id: 'q1', question: 'Q?', options: [] }],
+            gateSummary: '',
+            ticketUrl: null,
+            cached: false,
+          },
+          startedAt: 0,
+        }],
+      });
+
+      render(<RefineTicketDialog />);
+
+      await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+
+      expect(api.tickets.specCheckAsync).not.toHaveBeenCalled();
+    });
+
+    it('re-refinement Run-Gate path still calls specCheckAsync', async () => {
+      useAppStore.setState({
+        refineTicketPrefill: null,
+        currentRefinementSessionId: 'sess-ready',
+        refinementSessions: [{
+          id: 'sess-ready',
+          ticketId: '310',
+          projectDir: '/proj',
+          status: 'ready' as const,
+          phase: 'check' as const,
+          result: {
+            passed: false,
+            questions: [],
+            gateSummary: 'Gate=FAIL, questions=0',
+            ticketUrl: null,
+            cached: false,
+          },
+          startedAt: 0,
+        }],
+      });
+
+      render(<RefineTicketDialog />);
+      fireEvent.click(screen.getByTestId('refine-run-gate'));
+
+      await waitFor(() => {
+        expect(api.tickets.specCheckAsync).toHaveBeenCalledWith('310', '/proj');
+      });
+    });
   });
 
   describe('elapsed timer (#370)', () => {
@@ -971,14 +1028,12 @@ describe('RefineTicketDialog', () => {
     });
   });
 
-  describe('openRefineDialogFromCard preserves previousColumn through prefill (#393)', () => {
-    // The card-click path moves the ticket to 'refining' BEFORE the dialog mounts.
-    // The dialog's prefill effect then re-resolves and would see 'refining' as the
-    // current column — without the fix in commitRefinementContext, that would
-    // overwrite _refineDialogContext.previousColumn with 'refining' and a
-    // subsequent close-without-session would revert to 'refining' instead of
-    // the real previous column ('backlog'). This test guards against that.
-    it('closes-without-session reverts the ticket to the original column (not refining)', async () => {
+  describe('openRefineDialogFromCard background flow (#424)', () => {
+    // With the background refine flow, clicking Refine on a backlog card:
+    // - moves the ticket to 'refining' optimistically
+    // - starts the gate via specCheckAsync WITHOUT opening the dialog
+    // - dialog is only opened when the user clicks "Answer" on the refining card
+    it('starts gate in background without opening dialog, stashes _refineDialogContext', async () => {
       useAppStore.setState({
         boardTickets: [
           { ticket_id: '42', project_dir: '/proj', column: 'backlog', title: 'T', updated_at: '' },
@@ -988,38 +1043,22 @@ describe('RefineTicketDialog', () => {
         refineTicketPrefill: null,
         currentRefinementSessionId: null,
         _refineDialogContext: null,
+        refineInFlight: {},
+        refineStartErrors: {},
       });
 
-      // Simulate the kanban card click — opens dialog AND stashes the real previousColumn.
       useAppStore.getState().openRefineDialogFromCard('42', '/proj', 'backlog');
 
-      // Sanity: dialog open, prefill primed, context recorded with 'backlog'.
-      expect(useAppStore.getState().showRefineTicketDialog).toBe(true);
-      expect(useAppStore.getState().refineTicketPrefill).toBe('42');
+      // Dialog is NOT opened — backgrounding path suppresses modal
+      expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+      expect(useAppStore.getState().refineTicketPrefill).toBeNull();
+
+      // Context is stashed with the real previous column for potential Answer flow
       expect(useAppStore.getState()._refineDialogContext?.previousColumn).toBe('backlog');
 
-      render(<RefineTicketDialog />);
-
-      // The prefill effect should have run specCheckAsync, but more importantly
-      // the stashed context must still point at 'backlog' — NOT have been
-      // overwritten by the dialog's own commitRefinementContext('…','refining').
+      // Gate was started via specCheckAsync
       await waitFor(() => {
         expect(api.tickets.specCheckAsync).toHaveBeenCalledWith('42', '/proj');
-      });
-      expect(useAppStore.getState()._refineDialogContext?.previousColumn).toBe('backlog');
-
-      // No session was registered (mock specCheckAsync only returns sessionId, no upsert).
-      expect(useAppStore.getState().refinementSessions).toHaveLength(0);
-
-      // User dismisses the dialog without a session — must revert to 'backlog'.
-      fireEvent.click(screen.getByLabelText('Close'));
-
-      await waitFor(() => {
-        expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', '/proj', 'backlog');
-      });
-      await waitFor(() => {
-        const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
-        expect(entry?.column).toBe('backlog');
       });
     });
   });

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -22,6 +22,10 @@ const makeTicket = (column: string, overrides = {}) => ({
 describe('TicketCard', () => {
   let api: ReturnType<typeof mockSandstormApi>;
 
+  // Capture real store implementations before any test can override them
+  const realRetryRefinement = useAppStore.getState().retryRefinementForTicket;
+  const realOpenRefineDialogFromCard = useAppStore.getState().openRefineDialogFromCard;
+
   beforeEach(() => {
     api = mockSandstormApi();
     useAppStore.setState({
@@ -30,7 +34,15 @@ describe('TicketCard', () => {
       stacks: [],
       refinementSessions: [],
       boardTickets: [],
-    });
+      refineInFlight: {},
+      refineStartErrors: {},
+      showRefineTicketDialog: false,
+      refineTicketPrefill: null,
+      currentRefinementSessionId: null,
+      // Restore real implementations that individual tests may override
+      retryRefinementForTicket: realRetryRefinement,
+      openRefineDialogFromCard: realOpenRefineDialogFromCard,
+    } as any);
   });
 
   it('renders ticket id and title', () => {
@@ -44,17 +56,39 @@ describe('TicketCard', () => {
     expect(screen.getByTestId('ticket-card-refine-42')).toBeDefined();
   });
 
-  it('backlog: clicking Refine opens refine dialog and moves column to refining', async () => {
+  it('backlog: clicking Refine moves ticket to refining, starts gate in background, does not open dialog', async () => {
     useAppStore.setState({ boardTickets: [makeTicket('backlog') as any] });
     render(<TicketCard ticket={makeTicket('backlog') as any} stacks={[]} />);
     fireEvent.click(screen.getByTestId('ticket-card-refine-42'));
     await waitFor(() => {
-      expect(useAppStore.getState().showRefineTicketDialog).toBe(true);
-      expect(useAppStore.getState().refineTicketPrefill).toBe('42');
+      expect(api.tickets.specCheckAsync).toHaveBeenCalledWith('42', PROJECT_DIR);
     });
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+    expect(useAppStore.getState().refineTicketPrefill).toBeNull();
     expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'refining');
     const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
     expect(entry?.column).toBe('refining');
+  });
+
+  it('backlog: double-click on Refine starts gate only once', async () => {
+    useAppStore.setState({ boardTickets: [makeTicket('backlog') as any] });
+
+    let resolveFirst!: (v: { sessionId: string }) => void;
+    const firstPromise = new Promise<{ sessionId: string }>((r) => { resolveFirst = r; });
+    api.tickets.specCheckAsync.mockReturnValueOnce(firstPromise);
+
+    render(<TicketCard ticket={makeTicket('backlog') as any} stacks={[]} />);
+    const btn = screen.getByTestId('ticket-card-refine-42');
+
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    await act(async () => {
+      resolveFirst({ sessionId: 'sess-1' });
+      await Promise.resolve();
+    });
+
+    expect(api.tickets.specCheckAsync).toHaveBeenCalledTimes(1);
   });
 
   it('refining: no session — shows Start refinement button', () => {
@@ -169,6 +203,31 @@ describe('TicketCard', () => {
     render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
     fireEvent.click(screen.getByTestId('ticket-card-retry-42'));
     await waitFor(() => expect(retrySpy).toHaveBeenCalledWith('42', PROJECT_DIR));
+  });
+
+  it('refining: clicking Retry runs gate in background without opening dialog', async () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-err-bg',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        startedAt: 0,
+      }],
+      boardTickets: [makeTicket('refining') as any],
+    });
+
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ticket-card-retry-42'));
+    });
+
+    await waitFor(() => {
+      expect(api.tickets.specCheckAsync).toHaveBeenCalledWith('42', PROJECT_DIR);
+      expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+    });
   });
 
   it('refining: status interrupted — shows Retry button', () => {
@@ -391,6 +450,70 @@ describe('TicketCard', () => {
   it('merged: shows Merged label', () => {
     render(<TicketCard ticket={makeTicket('merged') as any} stacks={[]} />);
     expect(screen.getByText('Merged')).toBeDefined();
+  });
+
+  it('refining: in-flight initial refine — shows progress bar, hides Start refinement', () => {
+    useAppStore.setState({
+      refineInFlight: { [`42|${PROJECT_DIR}`]: true },
+      refinementSessions: [],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-retry-42')).toBeNull();
+  });
+
+  it('refining: refineStartError — shows error badge and Retry, hides Start refinement', () => {
+    useAppStore.setState({
+      refineStartErrors: { [`42|${PROJECT_DIR}`]: 'gate start failed' },
+      refinementSessions: [],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-error-badge-42')).toBeDefined();
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+  });
+
+  it('refining: errored session — shows error badge alongside Retry button', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-badge',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-error-badge-42')).toBeDefined();
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+  });
+
+  it('refining: clicking Answer opens dialog with the existing session', () => {
+    const session = {
+      id: 'sess-answer',
+      ticketId: '42',
+      projectDir: PROJECT_DIR,
+      status: 'ready' as const,
+      phase: 'check' as const,
+      result: {
+        passed: false,
+        questions: [{ id: 'q1', question: 'Q?', options: [] }],
+        gateSummary: '',
+        ticketUrl: null,
+        cached: false,
+      },
+      startedAt: 0,
+    };
+    useAppStore.setState({ refinementSessions: [session] });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-answer-42'));
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(true);
+    expect(useAppStore.getState().currentRefinementSessionId).toBe('sess-answer');
+    // No new gate run
+    expect(api.tickets.specCheckAsync).not.toHaveBeenCalled();
   });
 
   it('refining: shows questions awaiting count when session has questions', () => {

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -317,7 +317,10 @@ const PROJECT_DIR = '/store-test-proj';
 function setupSandstormMock(ticketsList: unknown[] = []) {
   Object.defineProperty(window, 'sandstorm', {
     value: {
-      tickets: { list: vi.fn().mockResolvedValue(ticketsList) },
+      tickets: {
+        list: vi.fn().mockResolvedValue(ticketsList),
+        specCheckAsync: vi.fn().mockResolvedValue({ sessionId: 'test-sess' }),
+      },
       ticketBoard: { setColumn: vi.fn().mockResolvedValue(undefined) },
     },
     writable: true,
@@ -641,22 +644,40 @@ describe('store: setShowRefineTicketDialog revert-on-cancel', () => {
         { ticket_id: '42', project_dir: PROJECT_DIR, column: 'backlog', title: 'Test', updated_at: '' },
       ],
       refinementSessions: [],
+      refineInFlight: {},
+      refineStartErrors: {},
     });
   });
 
-  it('reverts ticket column when dialog closed with no matching refinement session', async () => {
-    // Move the ticket to refining via openRefineDialogFromCard
+  it('openRefineDialogFromCard starts gate in background, moves to refining, does not open dialog', async () => {
     useAppStore.getState().openRefineDialogFromCard('42', PROJECT_DIR, 'backlog');
 
-    // Wait for the optimistic column update
+    // Ticket moves to refining optimistically
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(useAppStore.getState().boardTickets.find(t => t.ticket_id === '42')?.column).toBe('refining');
 
-    // Close dialog — no refinement session exists, so column should revert
+    // Dialog is NOT opened — backgrounding path suppresses modal
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+    expect(useAppStore.getState().refineTicketPrefill).toBeNull();
+
+    // Gate was started via specCheckAsync
     await new Promise(resolve => setTimeout(resolve, 0));
+    expect((window.sandstorm as any).tickets.specCheckAsync).toHaveBeenCalledWith('42', PROJECT_DIR);
+  });
+
+  it('setShowRefineTicketDialog(false) reverts column when opened manually and closed without session', async () => {
+    // Manually open the dialog (e.g. via "Start refinement" button on a refining card)
+    useAppStore.setState({
+      showRefineTicketDialog: true,
+      _refineDialogContext: { ticketId: '42', projectDir: PROJECT_DIR, previousColumn: 'backlog' },
+    });
+    useAppStore.getState().moveTicketColumn('42', PROJECT_DIR, 'refining');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Close dialog with no session — column reverts
     useAppStore.getState().setShowRefineTicketDialog(false);
 
-    // Wait for revert IPC
     await new Promise(resolve => setTimeout(resolve, 0));
     const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
     expect(entry?.column).toBe('backlog');


### PR DESCRIPTION
## Summary
- Clicking "Refine" on a backlog ticket now moves it to `refining` and runs the spec-check gate (`specCheckAsync`) in the background instead of opening the refinement dialog, so the board stays usable while the gate runs.
- Added `refineInFlight` and `refineStartErrors` store state to track the background gate-start window, with an in-flight guard that prevents duplicate starts from double-clicks.
- `TicketCard` now shows the progress bar during the in-flight window, surfaces a visible error badge with a Retry affordance when the gate fails to start, and hides "Start refinement" while in-flight or errored; Retry re-runs in the background rather than opening a modal.

## Test plan
- [ ] Click "Refine" on a backlog ticket: it moves to `refining`, no dialog opens, and `specCheckAsync` fires once.
- [ ] Double-click "Refine": the gate starts only once (in-flight guard holds).
- [ ] With `refineInFlight` set, the card shows the progress bar and no "Start refinement" button.
- [ ] With a `refineStartErrors` entry, the card shows the error badge and Retry button and no "Start refinement"; Retry re-runs in the background.
- [ ] An errored session shows the error badge.
- [ ] The Answer button opens the dialog for an existing session without firing a new `specCheckAsync`.
- [ ] Run the unit suites (`TicketCard`, `RefineTicketDialog`, `ticketBoard`) and confirm all pass.

Closes #424