### PR TITLE
fix: resume button on in-stack cards and restart column-move regressio

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -106,7 +106,7 @@ export default function App() {
   // Refinement sessions: restore persisted sessions and listen for updates
   useEffect(() => {
     window.sandstorm.tickets.listRefinements().then((sessions) => {
-      sessions.forEach(upsertRefinementSession);
+      sessions.forEach((s) => upsertRefinementSession(s, { replay: true }));
     }).catch(() => {});
 
     const unsubRefinement = window.sandstorm.on('refinement:update', (data: unknown) => {

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -21,6 +21,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     openRefineTicketDialogWith,
     refinementSessions,
     retryRefinementForTicket,
+    resumeStackWithContinuation,
     startStackForTicket,
     stackCreateErrors,
     stackCreateInFlight,
@@ -49,6 +50,12 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
 
   const handleMerge = () => {
     moveTicketColumn(ticket.ticket_id, ticket.project_dir, 'merged');
+  };
+
+  const handleResume = () => {
+    if (stack) {
+      void resumeStackWithContinuation(stack.id, true);
+    }
   };
 
   const refinementSession = refinementSessions.find(
@@ -167,6 +174,15 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               />
               <span className="text-xs text-sandstorm-muted">{stack.status}</span>
             </div>
+          )}
+          {stack && stack.status === 'session_paused' && (
+            <button
+              onClick={handleResume}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-amber-500/10 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20 transition-colors font-medium"
+              data-testid={`ticket-card-resume-${ticket.ticket_id}`}
+            >
+              Resume
+            </button>
           )}
           {stack && makePrEligible(stack) && (
             <button

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -549,7 +549,7 @@ interface AppState {
   /** Open the refine dialog showing a specific existing session. */
   openRefinementSession: (sessionId: string) => void;
   /** Add or update a refinement session (called on refinement:update events). */
-  upsertRefinementSession: (session: RefinementSession) => void;
+  upsertRefinementSession: (session: RefinementSession, opts?: { replay?: boolean }) => void;
   /** Append a streaming text chunk to a running session's output. */
   appendRefinementStreamChunk: (sessionId: string, delta: string) => void;
   /** Remove a refinement session (after cancel or dismiss). */
@@ -1286,7 +1286,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     showRefineTicketDialog: true,
     currentRefinementSessionId: sessionId,
   }),
-  upsertRefinementSession: (session) => {
+  upsertRefinementSession: (session, opts) => {
     let firedSpecReady = false;
     set((state) => {
       if ((session as { status?: string }).status === 'cancelled') {
@@ -1303,11 +1303,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       // fire moveTicketColumn(ticketId, projectDir, 'spec_ready'). If the previous stored
       // session already satisfied the condition, this is a re-emit and we must not re-fire
       // (would otherwise demote a ticket the user has already advanced to in_stack).
+      // During hydration replay (opts.replay === true), never fire the column move — the ticket
+      // may already be in a later column (in_stack, pr_open, merged) and replaying a passed
+      // session must not demote it back to spec_ready.
       const wasPassed = idx >= 0
         && state.refinementSessions[idx].status === 'ready'
         && state.refinementSessions[idx].result?.passed === true;
       const isPassed = normalized.status === 'ready' && normalized.result?.passed === true;
-      firedSpecReady = isPassed && !wasPassed;
+      firedSpecReady = isPassed && !wasPassed && !opts?.replay;
 
       if (idx >= 0) {
         const next = [...state.refinementSessions];

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -361,6 +361,44 @@ describe('TicketCard', () => {
     expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
   });
 
+  it('in_stack: shows Resume button when linked stack has status=session_paused', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'session_paused', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-resume-42')).toBeDefined();
+  });
+
+  it('in_stack: does not show Resume button for non-paused statuses', () => {
+    const nonPausedStatuses = ['running', 'idle', 'building', 'completed', 'failed', 'stopped'];
+    nonPausedStatuses.forEach((status) => {
+      const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status, pr_url: null, pr_number: null } as any;
+      const { unmount } = render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+      expect(screen.queryByTestId('ticket-card-resume-42')).toBeNull();
+      unmount();
+    });
+  });
+
+  it('in_stack: does not show Resume button when no linked stack', () => {
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-resume-42')).toBeNull();
+  });
+
+  it('in_stack: clicking Resume calls resumeStackWithContinuation(stack.id, true)', async () => {
+    const resumeFn = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ resumeStackWithContinuation: resumeFn } as any);
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'session_paused', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-resume-42'));
+    await waitFor(() => expect(resumeFn).toHaveBeenCalledWith('s1', true));
+  });
+
+  it('in_stack: Resume button does not affect Create PR visibility for eligible statuses', () => {
+    // session_paused is ineligible for PR — no Create PR shown, but Resume is shown
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'session_paused', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-resume-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
+  });
+
   it('pr_open: shows Merge button', () => {
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
     expect(screen.getByTestId('ticket-card-merge-42')).toBeDefined();

--- a/tests/unit/refinementSessionHydration.test.ts
+++ b/tests/unit/refinementSessionHydration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for the restart-restoration bug (ticket #427, Problem 2):
+ * replaying persisted passed refinement sessions on startup must NOT move tickets
+ * out of started columns (in_stack, pr_open, merged) back to spec_ready.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from '../../src/renderer/store';
+
+const PROJECT_DIR = '/proj';
+
+function makePassedSession(ticketId = '42') {
+  return {
+    id: `sess-${ticketId}`,
+    ticketId,
+    projectDir: PROJECT_DIR,
+    status: 'ready' as const,
+    phase: 'check' as const,
+    result: {
+      passed: true,
+      questions: [],
+      gateSummary: 'Gate=PASS',
+      ticketUrl: null,
+      cached: false,
+    },
+    startedAt: 0,
+  };
+}
+
+function setupMockApi() {
+  const setColumn = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    ticketBoard: { setColumn },
+    stacks: { list: vi.fn().mockResolvedValue([]) },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+    tickets: { listRefinements: vi.fn().mockResolvedValue([]) },
+  } as unknown as typeof window.sandstorm;
+
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+
+  return { setColumn };
+}
+
+describe('refinement session hydration replay', () => {
+  let setColumn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ({ setColumn } = setupMockApi());
+    useAppStore.setState({
+      refinementSessions: [],
+      boardTickets: [],
+      projects: [{ id: 1, name: 'proj', directory: PROJECT_DIR, added_at: '' }],
+      activeProjectId: 1,
+    });
+  });
+
+  it('regression: replaying a passed session with replay:true does NOT move ticket to spec_ready', async () => {
+    const session = makePassedSession('42');
+
+    useAppStore.getState().upsertRefinementSession(session, { replay: true });
+
+    // Allow any microtasks to settle
+    await Promise.resolve();
+
+    expect(setColumn).not.toHaveBeenCalledWith('42', PROJECT_DIR, 'spec_ready');
+  });
+
+  it('regression holds even when boardTickets is empty at replay time', async () => {
+    // Ensure boardTickets is explicitly empty — simulates the startup race
+    useAppStore.setState({ boardTickets: [] });
+
+    const session = makePassedSession('99');
+    useAppStore.getState().upsertRefinementSession(session, { replay: true });
+
+    await Promise.resolve();
+
+    expect(setColumn).not.toHaveBeenCalledWith('99', PROJECT_DIR, 'spec_ready');
+  });
+
+  it('regression holds across multiple replayed sessions at once', async () => {
+    const sessions = ['100', '101', '102'].map(makePassedSession);
+
+    sessions.forEach((s) => {
+      useAppStore.getState().upsertRefinementSession(s, { replay: true });
+    });
+
+    await Promise.resolve();
+
+    expect(setColumn).not.toHaveBeenCalledWith(expect.anything(), PROJECT_DIR, 'spec_ready');
+  });
+
+  it('preserves intended behavior: live transition (no replay flag) DOES fire moveTicketColumn to spec_ready', async () => {
+    const session = makePassedSession('42');
+
+    // No replay flag — this is a genuine live refinement:update event
+    useAppStore.getState().upsertRefinementSession(session);
+
+    await Promise.resolve();
+
+    expect(setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'spec_ready');
+  });
+
+  it('idempotency: re-emitting an already-passed session (no replay flag) does NOT re-fire spec_ready move', async () => {
+    const session = makePassedSession('42');
+
+    // First emit — genuine transition
+    useAppStore.getState().upsertRefinementSession(session);
+    await Promise.resolve();
+    expect(setColumn).toHaveBeenCalledTimes(1);
+
+    setColumn.mockClear();
+
+    // Second emit of the same passed session — should be a no-op
+    useAppStore.getState().upsertRefinementSession(session);
+    await Promise.resolve();
+    expect(setColumn).not.toHaveBeenCalled();
+  });
+
+  it('session is still stored in refinementSessions even when replay suppresses the column move', () => {
+    const session = makePassedSession('55');
+
+    useAppStore.getState().upsertRefinementSession(session, { replay: true });
+
+    const stored = useAppStore.getState().refinementSessions.find((s) => s.id === session.id);
+    expect(stored).toBeDefined();
+    expect(stored?.status).toBe('ready');
+    expect(stored?.result?.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Resume button to `TicketCard` for tickets whose stack is `session_paused`, so paused refinement sessions can be resumed from the IN STACK column (previously only `StackCard` exposed this), wiring it to `resumeStackWithContinuation` to match existing behavior
- fix a restart regression where replaying persisted refinement sessions on startup fired the `firedSpecReady` side-effect and incorrectly moved tickets between columns; `upsertRefinementSession` now accepts `{ replay: true }` to suppress the move during hydration while live `refinement:update` events still trigger it

## Test plan
- [ ] run the unit suite: `TicketCard.test.tsx` and `refinementSessionHydration.test.ts` pass
- [ ] pause a refinement session, confirm the Resume button renders on the IN STACK card and clicking it resumes with the correct args
- [ ] verify the Resume button does not render for non-paused statuses or when no stack is present, and coexists with Create PR
- [ ] restart the app with persisted sessions and confirm tickets are not auto-moved between columns during hydration
- [ ] trigger a live refinement update and confirm the column move still fires as expected

Closes #427