### PR TITLE
fix: surface stale-workspace cleanup as modal on app start

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import { OpenProjectDialog } from './components/OpenProjectDialog';
 import { SessionWarningModal } from './components/SessionWarningModal';
 import { SessionTokenLimitModal } from './components/SessionTokenLimitModal';
 import { ModelSettingsModal } from './components/ModelSettings';
+import { StaleWorkspaces } from './components/StaleWorkspaces';
 import { LeftRail } from './components/LeftRail';
 import { KanbanBoard } from './components/KanbanBoard';
 
@@ -273,6 +274,9 @@ export default function App() {
       {showCreatePRDialog && <CreatePRDialog stackId={showCreatePRDialog.stackId} />}
       {showOpenProjectDialog && <OpenProjectDialog />}
       {showModelSettings && <ModelSettingsModal />}
+
+      {/* Stale workspaces modal — shown on app start when stale workspaces exist */}
+      <StaleWorkspaces />
 
       {/* Session warning modal (blocking) */}
       {showSessionWarningModal && sessionWarningLevel && sessionWarningLevel !== 'warning' && sessionWarningLevel !== 'normal' && (

--- a/src/renderer/components/StaleWorkspaces.tsx
+++ b/src/renderer/components/StaleWorkspaces.tsx
@@ -79,7 +79,9 @@ export function StaleWorkspaces() {
     }
   }, [selected, staleWorkspaces, cleanupStaleWorkspaces]);
 
-  if (dismissed || (staleWorkspaces.length === 0 && !staleWorkspacesLoading)) {
+  // Only show the modal after loading completes and there are stale workspaces.
+  // During loading, staleWorkspaces is still [], so no flash.
+  if (dismissed || staleWorkspaces.length === 0) {
     return null;
   }
 
@@ -89,85 +91,89 @@ export function StaleWorkspaces() {
     .reduce((sum, w) => sum + w.sizeBytes, 0);
 
   return (
-    <div className="mx-4 mt-3 bg-amber-500/5 border border-amber-500/20 rounded-xl overflow-hidden" data-testid="stale-workspaces">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 border-b border-amber-500/10">
-        <div className="flex items-center gap-2">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-amber-400">
-            <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
-          </svg>
-          <span className="text-xs font-semibold text-amber-400">
-            {staleWorkspaces.length} Stale Workspace{staleWorkspaces.length === 1 ? '' : 's'}
-          </span>
-          {totalSize > 0 && (
-            <span className="text-[11px] text-sandstorm-muted">
-              ({formatBytes(totalSize)} total)
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => refreshStaleWorkspaces()}
-            disabled={staleWorkspacesLoading}
-            className="text-[11px] text-sandstorm-muted hover:text-sandstorm-text-secondary transition-colors disabled:opacity-50"
-            data-testid="stale-refresh-btn"
-            title="Check again"
-          >
-            {staleWorkspacesLoading ? 'Scanning...' : 'Refresh'}
-          </button>
-          <button
-            onClick={() => setDismissed(true)}
-            className="text-sandstorm-muted hover:text-sandstorm-text-secondary transition-colors p-0.5"
-            title="Dismiss"
-            data-testid="stale-dismiss-btn"
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-              <path d="M18 6L6 18M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {/* Results banner */}
-      {results && (
-        <div className="px-4 py-2 border-b border-amber-500/10 bg-sandstorm-surface/50">
-          <div className="flex items-center gap-2 text-xs">
-            {results.every((r) => r.success) ? (
-              <span className="text-emerald-400">
-                Successfully cleaned up {results.length} workspace{results.length === 1 ? '' : 's'}.
-              </span>
-            ) : (
-              <span className="text-red-400">
-                {results.filter((r) => r.success).length} succeeded, {results.filter((r) => !r.success).length} failed.
-              </span>
-            )}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" data-testid="stale-workspaces-modal">
+      <div className="bg-sandstorm-surface border border-amber-500/30 rounded-xl shadow-2xl w-[540px] max-h-[80vh] flex flex-col overflow-hidden" data-testid="stale-workspaces">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-amber-500/20">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-full bg-amber-500/15 flex items-center justify-center shrink-0">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-amber-400">
+                <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-amber-400">
+                {staleWorkspaces.length} Stale Workspace{staleWorkspaces.length === 1 ? '' : 's'}
+              </h2>
+              {totalSize > 0 && (
+                <p className="text-[11px] text-sandstorm-muted">
+                  {formatBytes(totalSize)} total
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
             <button
-              onClick={() => setResults(null)}
-              className="text-sandstorm-muted hover:text-sandstorm-text-secondary"
+              onClick={() => refreshStaleWorkspaces()}
+              disabled={staleWorkspacesLoading}
+              className="text-[11px] text-sandstorm-muted hover:text-sandstorm-text-secondary transition-colors disabled:opacity-50"
+              data-testid="stale-refresh-btn"
+              title="Check again"
             >
-              Dismiss
+              {staleWorkspacesLoading ? 'Scanning...' : 'Refresh'}
+            </button>
+            <button
+              onClick={() => setDismissed(true)}
+              className="text-sandstorm-muted hover:text-sandstorm-text-secondary transition-colors p-0.5"
+              title="Dismiss"
+              data-testid="stale-dismiss-btn"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
             </button>
           </div>
         </div>
-      )}
 
-      {/* Workspace list */}
-      <div className="max-h-48 overflow-y-auto">
-        {staleWorkspaces.map((workspace) => (
-          <StaleWorkspaceRow
-            key={workspace.workspacePath}
-            workspace={workspace}
-            selected={selected.has(workspace.workspacePath)}
-            onToggle={() => toggleSelect(workspace.workspacePath)}
-          />
-        ))}
-      </div>
+        {/* Results banner */}
+        {results && (
+          <div className="px-5 py-2.5 border-b border-amber-500/10 bg-sandstorm-surface/50">
+            <div className="flex items-center gap-2 text-xs">
+              {results.every((r) => r.success) ? (
+                <span className="text-emerald-400">
+                  Successfully cleaned up {results.length} workspace{results.length === 1 ? '' : 's'}.
+                </span>
+              ) : (
+                <span className="text-red-400">
+                  {results.filter((r) => r.success).length} succeeded, {results.filter((r) => !r.success).length} failed.
+                </span>
+              )}
+              <button
+                onClick={() => setResults(null)}
+                className="text-sandstorm-muted hover:text-sandstorm-text-secondary"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
 
-      {/* Actions footer */}
-      {staleWorkspaces.length > 0 && (
-        <div className="flex items-center justify-between px-4 py-2 border-t border-amber-500/10 bg-sandstorm-surface/30">
+        {/* Workspace list */}
+        <div className="overflow-y-auto flex-1">
+          {staleWorkspaces.map((workspace) => (
+            <StaleWorkspaceRow
+              key={workspace.workspacePath}
+              workspace={workspace}
+              selected={selected.has(workspace.workspacePath)}
+              onToggle={() => toggleSelect(workspace.workspacePath)}
+            />
+          ))}
+        </div>
+
+        {/* Actions footer */}
+        <div className="flex items-center justify-between px-5 py-3 border-t border-amber-500/20 bg-sandstorm-surface/30">
           <label className="flex items-center gap-2 cursor-pointer text-xs text-sandstorm-muted">
             <input
               type="checkbox"
@@ -194,7 +200,7 @@ export function StaleWorkspaces() {
             </button>
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -210,7 +216,7 @@ function StaleWorkspaceRow({
 }) {
   return (
     <div
-      className={`flex items-center gap-3 px-4 py-2 hover:bg-sandstorm-surface-hover/50 transition-colors cursor-pointer ${
+      className={`flex items-center gap-3 px-5 py-2.5 hover:bg-sandstorm-surface-hover/50 transition-colors cursor-pointer ${
         selected ? 'bg-sandstorm-surface/40' : ''
       }`}
       onClick={onToggle}

--- a/tests/e2e/stale-workspaces.spec.ts
+++ b/tests/e2e/stale-workspaces.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * E2E test for the stale-workspace cleanup modal (issue #414).
+ *
+ * The UI was orphaned after the kanban migration — Dashboard is unmounted.
+ * This test verifies the full renderer→IPC→StackManager→filesystem path:
+ *
+ * 1. Arrange: register a project in the DB + create workspace dirs on disk
+ *    (one orphaned, one for a completed-status stack).
+ * 2. Act: trigger refreshStaleWorkspaces() from the renderer store.
+ * 3. Assert: the modal appears and lists both workspaces.
+ * 4. Assert: selecting + clicking cleanup removes the dirs from disk.
+ * 5. Assert: the modal closes once all stale workspaces are gone.
+ */
+import path from 'path';
+import { test, expect, _electron as electron } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+
+let app: ElectronApplication;
+
+test.beforeAll(async () => {
+  app = await electron.launch({
+    args: ['dist/main/index.js'],
+  });
+});
+
+test.afterAll(async () => {
+  await app?.close();
+});
+
+const RUN_ID = `stale414-${Date.now()}`;
+const PROJECT_DIR = `/tmp/sandstorm-${RUN_ID}`;
+const ORPHANED_STACK_ID = `orphaned-${RUN_ID}`;
+const ORPHANED_WORKSPACE = path.join(
+  PROJECT_DIR,
+  '.sandstorm',
+  'workspaces',
+  ORPHANED_STACK_ID,
+);
+const COMPLETED_STACK_ID = `completed-${RUN_ID}`;
+const COMPLETED_WORKSPACE = path.join(
+  PROJECT_DIR,
+  '.sandstorm',
+  'workspaces',
+  COMPLETED_STACK_ID,
+);
+
+/** Create the workspace dirs in the main (Node.js) process and register the project via IPC. */
+async function seedStaleWorkspace(mainWindow: Page): Promise<void> {
+  // filesystem ops run in the main process (renderer doesn't have Node.js 'fs')
+  await app.evaluate((_electronCtx, args: { orphaned: string; completed: string }) => {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const fs = require('fs') as typeof import('fs');
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    fs.mkdirSync(args.orphaned, { recursive: true });
+    fs.writeFileSync(`${args.orphaned}/dummy.txt`, 'stale workspace content');
+    fs.mkdirSync(args.completed, { recursive: true });
+    fs.writeFileSync(`${args.completed}/dummy.txt`, 'completed workspace content');
+  }, { orphaned: ORPHANED_WORKSPACE, completed: COMPLETED_WORKSPACE });
+
+  // Register the project via the real IPC so detectStaleWorkspaces() finds it
+  await mainWindow.evaluate((dir: string) => {
+    return (window as unknown as {
+      sandstorm: { projects: { add: (d: string) => Promise<unknown> } };
+    }).sandstorm.projects.add(dir);
+  }, PROJECT_DIR);
+
+  // Insert a completed-status stack row so detectStaleWorkspaces() flags it as stale
+  await app.evaluate(({ app: electronApp }, args: { stackId: string; projectDir: string }) => {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const nodePath = require('path') as typeof import('path');
+    const Database = require('better-sqlite3') as new (p: string) => {
+      prepare: (sql: string) => { run: (...args: unknown[]) => void };
+      close: () => void;
+    };
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    const dbPath = nodePath.join(electronApp.getPath('userData'), 'sandstorm.db');
+    const db = new Database(dbPath);
+    db.prepare(
+      `INSERT OR IGNORE INTO stacks (id, project, project_dir, status, runtime)
+       VALUES (?, ?, ?, 'completed', 'docker')`
+    ).run(args.stackId, nodePath.basename(args.projectDir), args.projectDir);
+    db.close();
+  }, { stackId: COMPLETED_STACK_ID, projectDir: PROJECT_DIR });
+}
+
+/** Remove workspace dirs and unregister the project to restore a clean state. */
+async function teardownStaleWorkspace(mainWindow: Page): Promise<void> {
+  // Remove the project dir tree from disk
+  await app.evaluate((_electronCtx, projectDir: string) => {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const fs = require('fs') as typeof import('fs');
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    if (fs.existsSync(projectDir)) {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  }, PROJECT_DIR);
+
+  // Remove the registered project row and the completed stack row from SQLite
+  await app.evaluate(({ app: electronApp }, args: { projectDir: string; completedStackId: string }) => {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const nodePath = require('path') as typeof import('path');
+    const Database = require('better-sqlite3') as new (p: string) => {
+      prepare: (sql: string) => { run: (...args: unknown[]) => void };
+      close: () => void;
+    };
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    const dbPath = nodePath.join(electronApp.getPath('userData'), 'sandstorm.db');
+    const db = new Database(dbPath);
+    db.prepare('DELETE FROM stacks WHERE id = ?').run(args.completedStackId);
+    db.prepare('DELETE FROM projects WHERE directory = ?').run(args.projectDir);
+    db.close();
+  }, { projectDir: PROJECT_DIR, completedStackId: COMPLETED_STACK_ID });
+
+  // Clear the renderer store so the stale state doesn't leak into subsequent tests
+  await mainWindow.evaluate(() => {
+    const store = (window as unknown as {
+      __useAppStore: { setState: (s: Record<string, unknown>) => void };
+    }).__useAppStore;
+    store.setState({ staleWorkspaces: [], staleWorkspacesLoading: false });
+  });
+}
+
+/** Call refreshStaleWorkspaces() in the renderer store and await the IPC response. */
+async function triggerRefreshStaleWorkspaces(mainWindow: Page): Promise<void> {
+  await mainWindow.evaluate(() => {
+    const store = (window as unknown as {
+      __useAppStore: {
+        getState: () => { refreshStaleWorkspaces: () => Promise<void> };
+      };
+    }).__useAppStore;
+    return store.getState().refreshStaleWorkspaces();
+  });
+}
+
+test.describe('Stale workspaces modal (#414)', () => {
+  test('modal appears when stale workspaces exist and cleans up on request', async () => {
+    const mainWindow = await app.firstWindow();
+    await mainWindow.waitForLoadState('domcontentloaded');
+    await mainWindow.waitForSelector('[data-testid="kanban-board"]', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    // Arrange: create orphaned workspace dir + register project + seed completed stack row
+    await seedStaleWorkspace(mainWindow);
+
+    try {
+      // Act: trigger stale detection via the renderer store action
+      await triggerRefreshStaleWorkspaces(mainWindow);
+
+      // Assert: modal is visible and lists the orphaned workspace
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspaces-modal"]'),
+      ).toBeVisible({ timeout: 10000 });
+
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspaces"]'),
+      ).toBeVisible();
+
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspace-row"]').first(),
+      ).toBeVisible();
+
+      // Both the orphaned directory and the completed-status stack must be listed
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspace-row"]'),
+      ).toHaveCount(2);
+
+      // The orphaned stack ID must appear in the modal
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspaces"]').getByText(ORPHANED_STACK_ID),
+      ).toBeVisible();
+
+      // The completed stack ID must also appear
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspaces"]').getByText(COMPLETED_STACK_ID),
+      ).toBeVisible();
+
+      // Visual check — baseline snapshot of the reskinned modal
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspaces-modal"]'),
+      ).toHaveScreenshot('stale-workspaces-modal.png');
+
+      // Override window.confirm so the native dialog doesn't block the test
+      await mainWindow.evaluate(() => {
+        window.confirm = () => true;
+      });
+
+      // Select all workspaces and click cleanup
+      await mainWindow.locator('[data-testid="stale-select-all"]').check();
+      const cleanupBtn = mainWindow.locator('[data-testid="stale-cleanup-btn"]');
+      await expect(cleanupBtn).not.toBeDisabled();
+      await cleanupBtn.click();
+
+      // After cleanup, all stale workspaces are gone → modal closes
+      await expect(
+        mainWindow.locator('[data-testid="stale-workspaces-modal"]'),
+      ).not.toBeVisible({ timeout: 15000 });
+
+      // Workspace directory must be removed from disk
+      const dirStillExists = await app.evaluate(
+        (_electronCtx, workspacePath: string) => {
+          /* eslint-disable @typescript-eslint/no-var-requires */
+          const fs = require('fs') as typeof import('fs');
+          /* eslint-enable @typescript-eslint/no-var-requires */
+          return fs.existsSync(workspacePath);
+        },
+        ORPHANED_WORKSPACE,
+      );
+      expect(dirStillExists).toBe(false);
+    } finally {
+      await teardownStaleWorkspace(mainWindow);
+    }
+  });
+
+  test('modal does not appear when no stale workspaces exist', async () => {
+    const mainWindow = await app.firstWindow();
+    await mainWindow.waitForLoadState('domcontentloaded');
+    await mainWindow.waitForSelector('[data-testid="kanban-board"]', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    // Ensure the store has no stale workspaces
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({ staleWorkspaces: [], staleWorkspacesLoading: false });
+    });
+
+    await expect(
+      mainWindow.locator('[data-testid="stale-workspaces-modal"]'),
+    ).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('modal dismisses for the session without deleting anything', async () => {
+    const mainWindow = await app.firstWindow();
+    await mainWindow.waitForLoadState('domcontentloaded');
+    await mainWindow.waitForSelector('[data-testid="kanban-board"]', { timeout: 15000 });
+    await mainWindow.waitForFunction(
+      () => Boolean((window as unknown as { __useAppStore?: unknown }).__useAppStore),
+      { timeout: 15000 },
+    );
+
+    // Inject a fake stale workspace directly into the store (no real filesystem ops needed)
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({
+        staleWorkspaces: [
+          {
+            stackId: 'dismiss-test-stack-414',
+            project: 'dismiss-test-project',
+            projectDir: '/tmp/dismiss-test-414',
+            workspacePath:
+              '/tmp/dismiss-test-414/.sandstorm/workspaces/dismiss-test-stack-414',
+            sizeBytes: 0,
+            hasUnpushedChanges: false,
+            reason: 'orphaned',
+            lastModified: new Date().toISOString(),
+          },
+        ],
+        staleWorkspacesLoading: false,
+      });
+    });
+
+    // Modal should be visible
+    await expect(
+      mainWindow.locator('[data-testid="stale-workspaces-modal"]'),
+    ).toBeVisible({ timeout: 5000 });
+
+    // Click dismiss — sets the component-local dismissed state
+    await mainWindow.locator('[data-testid="stale-dismiss-btn"]').click();
+
+    // Modal disappears without deleting anything
+    await expect(
+      mainWindow.locator('[data-testid="stale-workspaces-modal"]'),
+    ).not.toBeVisible({ timeout: 3000 });
+
+    // Cleanup store state
+    await mainWindow.evaluate(() => {
+      const store = (window as unknown as {
+        __useAppStore: { setState: (s: Record<string, unknown>) => void };
+      }).__useAppStore;
+      store.setState({ staleWorkspaces: [], staleWorkspacesLoading: false });
+    });
+  });
+});

--- a/tests/unit/components/StaleWorkspaces.test.tsx
+++ b/tests/unit/components/StaleWorkspaces.test.tsx
@@ -149,4 +149,40 @@ describe('StaleWorkspaces', () => {
     // Should show "2 selected" in the UI
     expect(screen.getByText(/2 selected/)).toBeDefined();
   });
+
+  // Modal-on-start visibility tests
+  it('renders a modal overlay when stale workspaces exist', () => {
+    useAppStore.setState({ staleWorkspaces: [makeStaleWorkspace()] });
+
+    const { container } = render(<StaleWorkspaces />);
+    expect(container.querySelector('[data-testid="stale-workspaces-modal"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="stale-workspaces"]')).not.toBeNull();
+  });
+
+  it('modal overlay not present when no stale workspaces', async () => {
+    api.stacks.detectStale.mockResolvedValue([]);
+    useAppStore.setState({ staleWorkspaces: [], staleWorkspacesLoading: false });
+
+    const { container } = render(<StaleWorkspaces />);
+    expect(container.querySelector('[data-testid="stale-workspaces-modal"]')).toBeNull();
+  });
+
+  it('modal overlay not present after dismiss', () => {
+    useAppStore.setState({ staleWorkspaces: [makeStaleWorkspace()] });
+
+    const { container } = render(<StaleWorkspaces />);
+    expect(container.querySelector('[data-testid="stale-workspaces-modal"]')).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId('stale-dismiss-btn'));
+
+    expect(container.querySelector('[data-testid="stale-workspaces-modal"]')).toBeNull();
+  });
+
+  it('modal does not flash during loading (no stale workspaces loaded yet)', () => {
+    // During the initial load, staleWorkspaces is still [] — modal must not appear
+    useAppStore.setState({ staleWorkspaces: [], staleWorkspacesLoading: true });
+
+    const { container } = render(<StaleWorkspaces />);
+    expect(container.querySelector('[data-testid="stale-workspaces-modal"]')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- The stale-workspace cleanup UI was orphaned after the kanban migration — it lived inside the now-unmounted Dashboard, so users could no longer see or clean up stale workspaces. This mounts `StaleWorkspaces` directly in `App` so it surfaces on app start.
- Reworks the component from an inline banner into a centered modal overlay, and gates visibility on `staleWorkspaces.length > 0` (instead of also keying off the loading flag) so the modal no longer flashes empty during the initial scan.

## Test plan
- [ ] Run `npm test` — unit tests cover modal visibility, dismiss, the empty case, and the no-flash-during-loading case
- [ ] Run the e2e spec `tests/e2e/stale-workspaces.spec.ts` — seeds orphaned + completed-status workspaces on disk, triggers a refresh, and asserts the modal lists them, cleanup removes the dirs, and the modal closes once none remain
- [ ] Manually: start the app with at least one stale workspace present and confirm the modal appears, refresh/dismiss work, and selecting + cleaning up removes the workspaces
- [ ] Confirm no empty modal flash on startup when there are no stale workspaces

Closes #414