### PR TITLE
feat: phase-aware retry for ticket refinement

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -88,6 +88,8 @@ import type { ProjectTicketConfig } from './control-plane/registry';
 import type { EphemeralStreamEvent } from './agent/types';
 import { handleToolCall, spawnSpecCheck, spawnSpecRefine } from './claude/tools';
 import { listTicketsWithConfig } from './control-plane/ticket-lister';
+import { listTicketComments, postComment } from './control-plane/ticket-comments';
+import { getLatestUserAnswers, ANSWER_COMMENT_MARKER } from './scheduler/refine-to-comments';
 import { KANBAN_COLUMNS } from '../shared/kanban';
 
 // Set __sandstorm at module-load time so app.evaluate() works immediately
@@ -1216,6 +1218,52 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   ipcMain.handle('tickets:listRefinements', () => {
     return Array.from(activeRefinements.values()).map((e) => e.session);
   });
+
+  ipcMain.handle(
+    'tickets:retryRefinementAsync',
+    async (_event, sessionId: string, ticketId: string, projectDir: string) => {
+      // Read the existing session to determine phase before cancelling it.
+      const existingEntry = sessionId ? activeRefinements.get(sessionId) : undefined;
+      const existingSession = existingEntry?.session;
+
+      // Cancel the existing session internally (without sending a cancelled event
+      // to the renderer, since we are immediately replacing it).
+      if (existingEntry) {
+        existingEntry.cancel?.();
+        activeRefinements.delete(sessionId);
+        deleteRefinement(sessionId);
+      }
+
+      // Determine whether to resume from refine phase or restart from check.
+      let phase: 'check' | 'refine' = 'check';
+      let userAnswers: string | undefined;
+
+      if (existingSession?.phase === 'refine') {
+        try {
+          const comments = await listTicketComments(ticketId, projectDir);
+          const answers = getLatestUserAnswers(comments);
+          if (answers) {
+            phase = 'refine';
+            userAnswers = answers;
+          }
+        } catch {
+          // fall through to check
+        }
+      }
+
+      const newSessionId = startRefinementAsync(ticketId, projectDir, null, phase, userAnswers);
+      return { sessionId: newSessionId };
+    },
+  );
+
+  ipcMain.handle(
+    'tickets:postAnswers',
+    async (_event, ticketId: string, projectDir: string, answersBody: string) => {
+      if (!answersBody.trim()) return;
+      const body = `${ANSWER_COMMENT_MARKER}\n\n${answersBody}`;
+      await postComment(ticketId, projectDir, body);
+    },
+  );
 
   ipcMain.handle(
     'tickets:create',

--- a/src/main/scheduler/refine-to-comments.ts
+++ b/src/main/scheduler/refine-to-comments.ts
@@ -42,6 +42,9 @@ import type { SpecGateResult, RefineQuestion } from '../control-plane/ticket-spe
 /** Marker that identifies comments posted by this bot. */
 export const BOT_COMMENT_MARKER = '<!-- sandstorm:bot-question -->';
 
+/** Marker that identifies answer comments posted by the interactive dialog. */
+export const ANSWER_COMMENT_MARKER = '<!-- sandstorm:user-answers -->';
+
 export interface RefineToCommentsDeps {
   listTickets: (label: string, projectDir: string) => Promise<TicketEntry[]>;
   listComments: (ticketId: string, projectDir: string) => Promise<TicketComment[]>;
@@ -82,6 +85,24 @@ export function getUserAnswersAfterBot(
       (afterTimestamp === null || c.createdAt > afterTimestamp),
   );
   return answers.map((c) => c.body).join('\n\n');
+}
+
+/**
+ * Returns the combined answer text from the most-recent ANSWER_COMMENT_MARKER comment,
+ * optionally filtered to comments created at or after sinceTimestamp.
+ */
+export function getLatestUserAnswers(
+  comments: TicketComment[],
+  sinceTimestamp?: string,
+): string {
+  const candidates = comments.filter(
+    (c) =>
+      c.body.includes(ANSWER_COMMENT_MARKER) &&
+      (sinceTimestamp === undefined || c.createdAt >= sinceTimestamp),
+  );
+  if (candidates.length === 0) return '';
+  const latest = candidates[candidates.length - 1];
+  return latest.body.replace(ANSWER_COMMENT_MARKER, '').trim();
 }
 
 export function formatQuestionComment(questions: RefineQuestion[], gateSummary: string): string {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,6 +203,8 @@ export interface SandstormAPI {
     specRefine: (ticketId: string, projectDir: string, userAnswers: string) => Promise<unknown>;
     specCheckAsync: (ticketId: string, projectDir: string) => Promise<{ sessionId: string }>;
     specRefineAsync: (sessionId: string, ticketId: string, projectDir: string, userAnswers: string) => Promise<void>;
+    retryRefinementAsync: (sessionId: string, ticketId: string, projectDir: string) => Promise<{ sessionId: string }>;
+    postAnswers: (ticketId: string, projectDir: string, answersBody: string) => Promise<void>;
     cancelRefinement: (sessionId: string) => Promise<void>;
     listRefinements: () => Promise<unknown[]>;
     create: (projectDir: string, title: string, body: string) => Promise<{ url: string; ticketId: string }>;
@@ -375,6 +377,10 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('tickets:specCheckAsync', ticketId, projectDir),
     specRefineAsync: (sessionId, ticketId, projectDir, userAnswers) =>
       ipcRenderer.invoke('tickets:specRefineAsync', sessionId, ticketId, projectDir, userAnswers),
+    retryRefinementAsync: (sessionId, ticketId, projectDir) =>
+      ipcRenderer.invoke('tickets:retryRefinementAsync', sessionId, ticketId, projectDir),
+    postAnswers: (ticketId, projectDir, answersBody) =>
+      ipcRenderer.invoke('tickets:postAnswers', ticketId, projectDir, answersBody),
     cancelRefinement: (sessionId) =>
       ipcRenderer.invoke('tickets:cancelRefinement', sessionId),
     listRefinements: () =>

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -204,6 +204,16 @@ export function RefineTicketDialog() {
     setLocalError(null);
     // Update session optimistically to 'running' while we wait
     upsertRefinementSession({ ...session, status: 'running', phase: 'refine' });
+    // Persist answers to comments (best-effort) so phase-aware Retry can resume.
+    if (combined.trim()) {
+      await window.sandstorm.tickets.postAnswers(
+        session.ticketId,
+        projectDir,
+        combined,
+      ).catch(() => {
+        // non-fatal: Retry falls back to check if no answer comments found
+      });
+    }
     await window.sandstorm.tickets.specRefineAsync(
       session.id,
       session.ticketId,

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -144,6 +144,16 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               Retry
             </button>
           )}
+          {/* Inert state: ready + not-passed + no questions + no error — offer to retry */}
+          {!showErrorState && refinementSession?.status === 'ready' && !refinementSession?.result?.passed && questionsAwaiting === 0 && !refinementSession?.result?.error && (
+            <button
+              onClick={() => void retryRefinementForTicket(ticket.ticket_id, ticket.project_dir)}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-red-500/10 text-red-400 border border-red-500/30 hover:bg-red-500/20 transition-colors font-medium"
+              data-testid={`ticket-card-retry-${ticket.ticket_id}`}
+            >
+              Retry
+            </button>
+          )}
           {/* Ready with questions and no error: answer questions */}
           {!showErrorState && refinementSession?.status === 'ready' && questionsAwaiting > 0 && (
             <button

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -745,6 +745,8 @@ declare global {
         specRefine: (ticketId: string, projectDir: string, userAnswers: string) => Promise<SpecGateResult>;
         specCheckAsync: (ticketId: string, projectDir: string) => Promise<{ sessionId: string }>;
         specRefineAsync: (sessionId: string, ticketId: string, projectDir: string, userAnswers: string) => Promise<void>;
+        retryRefinementAsync: (sessionId: string, ticketId: string, projectDir: string) => Promise<{ sessionId: string }>;
+        postAnswers: (ticketId: string, projectDir: string, answersBody: string) => Promise<void>;
         cancelRefinement: (sessionId: string) => Promise<void>;
         listRefinements: () => Promise<RefinementSession[]>;
         create: (projectDir: string, title: string, body: string) => Promise<{ url: string; number: number; ticketId: string }>;
@@ -1381,8 +1383,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const session = get().refinementSessions.find(
       (s) => s.ticketId === ticketId && s.projectDir === projectDir,
     );
+    // Remove old session from store — retryRefinementAsync cancels it in main.
     if (session) {
-      await window.sandstorm.tickets.cancelRefinement(session.id).catch(() => {});
       get().removeRefinementSession(session.id);
     }
     // Clear any previous start error and mark in-flight during latency window
@@ -1394,7 +1396,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       };
     });
     try {
-      await window.sandstorm.tickets.specCheckAsync(ticketId, projectDir);
+      await window.sandstorm.tickets.retryRefinementAsync(
+        session?.id ?? '',
+        ticketId,
+        projectDir,
+      );
       set((state) => {
         const { [key]: _, ...rest } = state.refineInFlight;
         return { refineInFlight: rest };

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -1231,6 +1231,81 @@ describe('RefineTicketDialog', () => {
     });
   });
 
+  describe('answer persistence (#429)', () => {
+    it('calls postAnswers with combined answers before specRefineAsync when submitting', async () => {
+      const user = userEvent.setup();
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: SINGLE_OPT_QUESTION,
+            gateSummary: 'Gate=FAIL, questions=1',
+            ticketUrl: null, cached: false,
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+
+      const callOrder: string[] = [];
+      api.tickets.postAnswers = vi.fn().mockImplementation(async () => {
+        callOrder.push('postAnswers');
+      });
+      api.tickets.specRefineAsync = vi.fn().mockImplementation(async () => {
+        callOrder.push('specRefineAsync');
+      });
+
+      render(<RefineTicketDialog />);
+      await user.click(screen.getByTestId('refine-option-0-a'));
+      fireEvent.click(screen.getByTestId('refine-submit-answers'));
+
+      await waitFor(() => {
+        expect(api.tickets.postAnswers).toHaveBeenCalled();
+        expect(api.tickets.specRefineAsync).toHaveBeenCalled();
+      });
+
+      // Verify postAnswers received ticketId, projectDir, and the combined answers body
+      const postCall = (api.tickets.postAnswers as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(postCall[0]).toBe('310');
+      expect(postCall[1]).toBe('/proj');
+      expect(postCall[2]).toContain('Q1: What is X?');
+      expect(postCall[2]).toContain('Selected: Option A');
+
+      // Verify postAnswers was called before specRefineAsync
+      expect(callOrder[0]).toBe('postAnswers');
+      expect(callOrder[1]).toBe('specRefineAsync');
+    });
+
+    it('still calls specRefineAsync even if postAnswers fails', async () => {
+      const user = userEvent.setup();
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: SINGLE_OPT_QUESTION,
+            gateSummary: 'Gate=FAIL, questions=1',
+            ticketUrl: null, cached: false,
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+
+      api.tickets.postAnswers = vi.fn().mockRejectedValue(new Error('network error'));
+      api.tickets.specRefineAsync = vi.fn().mockResolvedValue(undefined);
+
+      render(<RefineTicketDialog />);
+      await user.click(screen.getByTestId('refine-option-0-a'));
+      fireEvent.click(screen.getByTestId('refine-submit-answers'));
+
+      await waitFor(() => {
+        expect(api.tickets.specRefineAsync).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('upsertRefinementSession clears streamingOutput on completion', () => {
     it('clears streamingOutput when status transitions to ready', () => {
       useAppStore.setState({

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -225,7 +225,7 @@ describe('TicketCard', () => {
     });
 
     await waitFor(() => {
-      expect(api.tickets.specCheckAsync).toHaveBeenCalledWith('42', PROJECT_DIR);
+      expect(api.tickets.retryRefinementAsync).toHaveBeenCalledWith('sess-err-bg', '42', PROJECT_DIR);
       expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
     });
   });
@@ -552,6 +552,82 @@ describe('TicketCard', () => {
     expect(useAppStore.getState().currentRefinementSessionId).toBe('sess-answer');
     // No new gate run
     expect(api.tickets.specCheckAsync).not.toHaveBeenCalled();
+  });
+
+  it('refining: inert state (ready + not-passed + no questions + no error) — shows Retry button', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-inert',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-error-badge-42')).toBeNull();
+  });
+
+  it('refining: inert state — clicking Retry invokes retryRefinementForTicket', async () => {
+    const retrySpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-inert-click',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'refine',
+        result: {
+          passed: false,
+          questions: [],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+      retryRefinementForTicket: retrySpy,
+    } as any);
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-retry-42'));
+    await waitFor(() => expect(retrySpy).toHaveBeenCalledWith('42', PROJECT_DIR));
+  });
+
+  it('refining: inert state regression — blank card before fix would have no actionable element', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-regression',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [],
+          gateSummary: 'Gate=FAIL',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    // After fix: Retry button is present
+    expect(screen.getByTestId('ticket-card-retry-42')).toBeDefined();
+    // No other actionable buttons
+    expect(screen.queryByTestId('ticket-card-answer-42')).toBeNull();
+    expect(screen.queryByTestId('ticket-card-start-refine-42')).toBeNull();
   });
 
   it('refining: shows questions awaiting count when session has questions', () => {

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -162,6 +162,8 @@ export function mockSandstormApi() {
       }),
       specCheckAsync: vi.fn().mockResolvedValue({ sessionId: 'test-session-id' }),
       specRefineAsync: vi.fn().mockResolvedValue(undefined),
+      retryRefinementAsync: vi.fn().mockResolvedValue({ sessionId: 'retry-session-id' }),
+      postAnswers: vi.fn().mockResolvedValue(undefined),
       cancelRefinement: vi.fn().mockResolvedValue(undefined),
       listRefinements: vi.fn().mockResolvedValue([]),
       create: vi.fn().mockResolvedValue({

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -24,8 +24,14 @@ const {
   mockListTicketsWithConfig,
   mockCreateTicketWithConfig,
   mockSessionMonitor,
+  mockSpawnSpecCheck,
+  mockSpawnSpecRefine,
+  mockListTicketComments,
 } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
+  const mockSpawnSpecCheck = vi.fn();
+  const mockSpawnSpecRefine = vi.fn();
+  const mockListTicketComments = vi.fn().mockResolvedValue([]);
 
   const mockRegistry = {
     listProjects: vi.fn(),
@@ -131,6 +137,9 @@ const {
     mockListTicketsWithConfig,
     mockCreateTicketWithConfig,
     mockSessionMonitor,
+    mockSpawnSpecCheck,
+    mockSpawnSpecRefine,
+    mockListTicketComments,
   };
 });
 
@@ -207,6 +216,18 @@ vi.mock('../../src/main/control-plane/ticket-lister', () => ({
 
 vi.mock('../../src/main/control-plane/ticket-config', () => ({
   createTicketWithConfig: (...args: unknown[]) => mockCreateTicketWithConfig(...args),
+}));
+
+vi.mock('../../src/main/claude/tools', () => ({
+  handleToolCall: vi.fn(),
+  spawnSpecCheck: (...args: unknown[]) => mockSpawnSpecCheck(...args),
+  spawnSpecRefine: (...args: unknown[]) => mockSpawnSpecRefine(...args),
+  validateProjectDir: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/main/control-plane/ticket-comments', () => ({
+  listTicketComments: (...args: unknown[]) => mockListTicketComments(...args),
+  postComment: vi.fn().mockResolvedValue(undefined),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1469,6 +1490,92 @@ describe('IPC Handlers', () => {
   });
 
   // =========================================================================
+  // Phase-aware retryRefinementAsync
+  // =========================================================================
+  describe('tickets:retryRefinementAsync', () => {
+    const ANSWER_MARKER = '<!-- sandstorm:user-answers -->';
+
+    beforeEach(() => {
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: vi.fn(),
+      });
+      mockSpawnSpecRefine.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: vi.fn(),
+      });
+    });
+
+    it('calls check when session.phase is check', async () => {
+      const r1 = await invokeHandler('tickets:specCheckAsync', 'TICKET-1', '/tmp/proj') as { sessionId: string };
+
+      vi.clearAllMocks();
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: vi.fn(),
+      });
+
+      await invokeHandler('tickets:retryRefinementAsync', r1.sessionId, 'TICKET-1', '/tmp/proj');
+
+      expect(mockSpawnSpecCheck).toHaveBeenCalledWith('TICKET-1', '/tmp/proj', expect.any(Function));
+      expect(mockSpawnSpecRefine).not.toHaveBeenCalled();
+    });
+
+    it('calls refine with extracted answers when session.phase is refine and ANSWER_COMMENT_MARKER comments exist', async () => {
+      const fakeSessionId = 'refine-ipc-test-1';
+      await invokeHandler('tickets:specRefineAsync', fakeSessionId, 'TICKET-2', '/tmp/proj2', 'some answers');
+
+      mockListTicketComments.mockResolvedValue([
+        {
+          author: 'devuser',
+          body: `${ANSWER_MARKER}\n\nQ1: Answer A\nQ2: Answer B`,
+          createdAt: new Date(Date.now() - 60000).toISOString(),
+        },
+      ]);
+
+      vi.clearAllMocks();
+      mockSpawnSpecRefine.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: vi.fn(),
+      });
+
+      const result = await invokeHandler(
+        'tickets:retryRefinementAsync',
+        fakeSessionId,
+        'TICKET-2',
+        '/tmp/proj2',
+      ) as { sessionId: string };
+
+      expect(result).toHaveProperty('sessionId');
+      expect(mockSpawnSpecRefine).toHaveBeenCalledWith(
+        'TICKET-2',
+        '/tmp/proj2',
+        'Q1: Answer A\nQ2: Answer B',
+        expect.any(Function),
+      );
+      expect(mockSpawnSpecCheck).not.toHaveBeenCalled();
+    });
+
+    it('falls back to check when session.phase is refine but no answer comments exist', async () => {
+      const fakeSessionId = 'refine-ipc-test-2';
+      await invokeHandler('tickets:specRefineAsync', fakeSessionId, 'TICKET-3', '/tmp/proj3', 'answers');
+
+      mockListTicketComments.mockResolvedValue([]);
+
+      vi.clearAllMocks();
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: vi.fn(),
+      });
+
+      await invokeHandler('tickets:retryRefinementAsync', fakeSessionId, 'TICKET-3', '/tmp/proj3');
+
+      expect(mockSpawnSpecCheck).toHaveBeenCalledWith('TICKET-3', '/tmp/proj3', expect.any(Function));
+      expect(mockSpawnSpecRefine).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
   // Handler Registration Completeness
   // =========================================================================
   describe('handler registration', () => {
@@ -1561,6 +1668,8 @@ describe('IPC Handlers', () => {
       'tickets:specRefine',
       'tickets:specCheckAsync',
       'tickets:specRefineAsync',
+      'tickets:retryRefinementAsync',
+      'tickets:postAnswers',
       'tickets:cancelRefinement',
       'tickets:listRefinements',
       'tickets:create',

--- a/tests/unit/main/scheduler/refine-to-comments.test.ts
+++ b/tests/unit/main/scheduler/refine-to-comments.test.ts
@@ -5,7 +5,9 @@ import {
   isBotComment,
   getLastBotComment,
   getUserAnswersAfterBot,
+  getLatestUserAnswers,
   BOT_COMMENT_MARKER,
+  ANSWER_COMMENT_MARKER,
   type RefineToCommentsDeps,
 } from '../../../../src/main/scheduler/refine-to-comments';
 import type { TicketEntry, TicketComment } from '../../../../src/main/control-plane/ticket-comments';
@@ -115,6 +117,70 @@ describe('getUserAnswersAfterBot', () => {
   it('includes all user comments when no bot comment exists (first pass)', () => {
     const userComment: TicketComment = { author: 'devuser', body: 'Initial clarification', createdAt: '2026-05-01T10:00:00Z' };
     expect(getUserAnswersAfterBot([userComment], 'devuser', null)).toBe('Initial clarification');
+  });
+});
+
+describe('ANSWER_COMMENT_MARKER', () => {
+  it('is a distinct value from BOT_COMMENT_MARKER', () => {
+    expect(ANSWER_COMMENT_MARKER).not.toBe(BOT_COMMENT_MARKER);
+    expect(ANSWER_COMMENT_MARKER).toContain('user-answers');
+  });
+});
+
+describe('getLatestUserAnswers', () => {
+  it('returns empty string when no answer comments exist', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: 'A regular comment', createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments)).toBe('');
+  });
+
+  it('returns answer text from a marked comment (marker stripped)', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nQ1: What is X?\nSelected: A`, createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments)).toBe('Q1: What is X?\nSelected: A');
+  });
+
+  it('returns the most recent marked comment when multiple exist', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nFirst answers`, createdAt: '2026-05-01T10:00:00Z' },
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nSecond answers`, createdAt: '2026-05-02T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments)).toBe('Second answers');
+  });
+
+  it('filters by sinceTimestamp — excludes comments before the threshold', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nOld answers`, createdAt: '2026-05-01T10:00:00Z' },
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nNew answers`, createdAt: '2026-05-03T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments, '2026-05-02T00:00:00Z')).toBe('New answers');
+  });
+
+  it('returns empty string when all marked comments precede sinceTimestamp', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nOld answers`, createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments, '2026-05-02T00:00:00Z')).toBe('');
+  });
+
+  it('works without bot comment (interactive dialog case — no BOT_COMMENT_MARKER present)', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: `${ANSWER_COMMENT_MARKER}\n\nQ1: Yes\nQ2: No`, createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments)).toBe('Q1: Yes\nQ2: No');
+  });
+
+  it('ignores non-marked comments even if they look like answers', () => {
+    const comments: TicketComment[] = [
+      { author: 'devuser', body: 'Q1: Yes\nQ2: No', createdAt: '2026-05-01T10:00:00Z' },
+    ];
+    expect(getLatestUserAnswers(comments)).toBe('');
+  });
+
+  it('returns empty string for empty comments array', () => {
+    expect(getLatestUserAnswers([])).toBe('');
   });
 });
 

--- a/tests/unit/refinement-streaming.test.ts
+++ b/tests/unit/refinement-streaming.test.ts
@@ -13,11 +13,12 @@ import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 // Hoisted mocks — vi.mock factories are hoisted above all imports, so any
 // variables they reference must also be hoisted via vi.hoisted().
 // ---------------------------------------------------------------------------
-const { registeredHandlers, mockSpawnSpecCheck, mockSpawnSpecRefine } = vi.hoisted(() => {
+const { registeredHandlers, mockSpawnSpecCheck, mockSpawnSpecRefine, mockListTicketComments } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
   const mockSpawnSpecCheck = vi.fn();
   const mockSpawnSpecRefine = vi.fn();
-  return { registeredHandlers, mockSpawnSpecCheck, mockSpawnSpecRefine };
+  const mockListTicketComments = vi.fn().mockResolvedValue([]);
+  return { registeredHandlers, mockSpawnSpecCheck, mockSpawnSpecRefine, mockListTicketComments };
 });
 
 // ---------------------------------------------------------------------------
@@ -111,6 +112,11 @@ vi.mock('../../src/main/claude/tools', () => ({
   spawnSpecCheck: mockSpawnSpecCheck,
   spawnSpecRefine: mockSpawnSpecRefine,
   validateProjectDir: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/main/control-plane/ticket-comments', () => ({
+  listTicketComments: (...args: unknown[]) => mockListTicketComments(...args),
+  postComment: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/main/custom-context', () => ({
@@ -309,6 +315,143 @@ describe('refinement streaming — IPC chain', () => {
     expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(
       'refinement:update',
       expect.objectContaining({ status: 'running', ticketId: 'TICKET-1' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retryRefinementAsync — phase-aware retry
+// ---------------------------------------------------------------------------
+describe('retryRefinementAsync — phase-aware retry', () => {
+  let mockMainWindow: { webContents: { send: Mock } };
+
+  beforeEach(() => {
+    for (const key of Object.keys(registeredHandlers)) {
+      delete registeredHandlers[key];
+    }
+    vi.clearAllMocks();
+    mockListTicketComments.mockResolvedValue([]);
+
+    mockMainWindow = { webContents: { send: vi.fn() } };
+    registerIpcHandlers(mockMainWindow as unknown as import('electron').BrowserWindow);
+  });
+
+  it('falls back to check phase when no session ID is provided', async () => {
+    mockSpawnSpecCheck.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+
+    const result = (await invokeHandler(
+      'tickets:retryRefinementAsync',
+      '',
+      'TICKET-1',
+      '/tmp/proj',
+    )) as { sessionId: string };
+
+    expect(result).toHaveProperty('sessionId');
+    expect(mockSpawnSpecCheck).toHaveBeenCalledWith('TICKET-1', '/tmp/proj', expect.any(Function));
+    expect(mockSpawnSpecRefine).not.toHaveBeenCalled();
+  });
+
+  it('uses check phase when existing session has phase=check', async () => {
+    // First create a session in check phase
+    mockSpawnSpecCheck.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+    const r1 = (await invokeHandler('tickets:specCheckAsync', 'TICKET-1', '/tmp/proj')) as { sessionId: string };
+
+    vi.clearAllMocks();
+    mockSpawnSpecCheck.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+
+    await invokeHandler('tickets:retryRefinementAsync', r1.sessionId, 'TICKET-1', '/tmp/proj');
+
+    expect(mockSpawnSpecCheck).toHaveBeenCalledWith('TICKET-1', '/tmp/proj', expect.any(Function));
+    expect(mockSpawnSpecRefine).not.toHaveBeenCalled();
+  });
+
+  it('uses refine phase and passes answer comments when session has phase=refine and answers exist', async () => {
+    // Create a session in refine phase by calling specRefineAsync
+    mockSpawnSpecRefine.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+    const fakeSessionId = 'refine-session-1';
+    // Manually invoke the specRefineAsync handler, which creates a 'refine' phase session
+    await invokeHandler('tickets:specRefineAsync', fakeSessionId, 'TICKET-2', '/tmp/proj2', 'some answers');
+
+    // Set up answer comments for retrieval
+    const ANSWER_MARKER = '<!-- sandstorm:user-answers -->';
+    mockListTicketComments.mockResolvedValue([
+      {
+        author: 'devuser',
+        body: `${ANSWER_MARKER}\n\nQ1: Answer A\nQ2: Answer B`,
+        createdAt: new Date(Date.now() - 60000).toISOString(),
+      },
+    ]);
+
+    vi.clearAllMocks();
+    mockSpawnSpecRefine.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+
+    const result = (await invokeHandler(
+      'tickets:retryRefinementAsync',
+      fakeSessionId,
+      'TICKET-2',
+      '/tmp/proj2',
+    )) as { sessionId: string };
+
+    expect(result).toHaveProperty('sessionId');
+    expect(mockSpawnSpecRefine).toHaveBeenCalledWith(
+      'TICKET-2',
+      '/tmp/proj2',
+      'Q1: Answer A\nQ2: Answer B',
+      expect.any(Function),
+    );
+    expect(mockSpawnSpecCheck).not.toHaveBeenCalled();
+  });
+
+  it('falls back to check phase when session has phase=refine but no answer comments', async () => {
+    // Create a session in refine phase
+    mockSpawnSpecRefine.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+    const fakeSessionId = 'refine-session-2';
+    await invokeHandler('tickets:specRefineAsync', fakeSessionId, 'TICKET-3', '/tmp/proj3', 'answers');
+
+    // No answer comments
+    mockListTicketComments.mockResolvedValue([]);
+
+    vi.clearAllMocks();
+    mockSpawnSpecCheck.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+
+    await invokeHandler('tickets:retryRefinementAsync', fakeSessionId, 'TICKET-3', '/tmp/proj3');
+
+    expect(mockSpawnSpecCheck).toHaveBeenCalledWith('TICKET-3', '/tmp/proj3', expect.any(Function));
+    expect(mockSpawnSpecRefine).not.toHaveBeenCalled();
+  });
+
+  it('sends running update event for the new session', async () => {
+    mockSpawnSpecCheck.mockReturnValue({
+      promise: new Promise<Record<string, unknown>>(() => {}),
+      cancel: vi.fn(),
+    });
+
+    await invokeHandler('tickets:retryRefinementAsync', '', 'TICKET-4', '/tmp/proj4');
+
+    expect(mockMainWindow.webContents.send).toHaveBeenCalledWith(
+      'refinement:update',
+      expect.objectContaining({ status: 'running', ticketId: 'TICKET-4' }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add `retryRefinementAsync` IPC handler that inspects the existing refinement session's phase: if it was already in `refine` and the ticket has user answers, it resumes from `refine` instead of restarting the spec `check` — avoiding loss of progress and re-asking answered questions.
- Persist dialog answers to ticket comments via a new `postAnswers` handler and `ANSWER_COMMENT_MARKER`, so a later retry can recover them with `getLatestUserAnswers`; posting is best-effort and falls back to `check` when no answer comment exists.
- Surface a Retry button on `TicketCard` for the inert ready state (not passed, no pending questions, no error), and switch `store.retryRefinementForTicket` to the new handler so cancellation happens server-side.

## Test plan
- [ ] `npm test` passes (full suite, including new ipc-handlers, refine-to-comments, refinement-streaming, RefineTicketDialog, and TicketCard tests)
- [ ] Refine a ticket to the question phase, submit answers, then click Retry — confirm it resumes from `refine` with the prior answers rather than restarting from `check`
- [ ] Retry a ticket that never reached `refine` (or has no answer comments) — confirm it restarts from `check`
- [ ] Verify the inert Retry button appears only when the session is ready, not passed, has no awaiting questions, and has no error

Closes #429