### PR TITLE
fix: sanitize PR commit messages and exec as claude user in container

### DIFF
--- a/src/main/control-plane/pr-creator.ts
+++ b/src/main/control-plane/pr-creator.ts
@@ -191,6 +191,20 @@ export async function draftPullRequest(args: DraftPRArgs, deps: DraftDeps): Prom
 
 const PR_URL_PATTERN = /https:\/\/github\.com\/[^\s]+\/pull\/(\d+)/;
 
+/**
+ * Strip shell-problematic characters from a commit message derived from a PR
+ * title. The bash push script interpolates the message into a `bash -c '...'`
+ * string via single/double-quote concatenation, so double quotes, backticks,
+ * dollar signs, backslashes, and newlines can all break the inner command.
+ */
+export function sanitizeCommitMessage(title: string): string {
+  const cleaned = title
+    .replace(/["`$\\]/g, '')
+    .replace(/\n/g, ' ')
+    .trim();
+  return cleaned || 'Sandstorm changes';
+}
+
 export const MAX_PR_ATTEMPTS = 5;
 
 /**
@@ -282,7 +296,7 @@ export async function createPullRequest(
       }
 
       try {
-        await deps.runGitPush(args.title);
+        await deps.runGitPush(sanitizeCommitMessage(args.title));
       } catch (err) {
         failureReasons.push(
           `attempt ${attempt + 1} on branch "${currentBranch}": git push failed: ${String(err)}`,

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -964,7 +964,7 @@ export class StackManager {
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
     const runtime = this.getRuntimeForStack(stack);
     const claudeContainer = await this.findClaudeContainer(stack, runtime);
-    const result = await runtime.exec(claudeContainer.id, cmd, { workdir: '/app' });
+    const result = await runtime.exec(claudeContainer.id, cmd, { workdir: '/app', user: 'claude' });
     if (result.exitCode !== 0) {
       throw new Error(
         `exec in container failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`,

--- a/src/main/runtime/docker.ts
+++ b/src/main/runtime/docker.ts
@@ -245,6 +245,7 @@ export class DockerRuntime implements ContainerRuntime {
       AttachStderr: true,
       WorkingDir: opts?.workdir,
       Env: opts?.env,
+      User: opts?.user,
     });
 
     const stream = await exec.start({ hijack: true, stdin: false });

--- a/src/main/runtime/podman.ts
+++ b/src/main/runtime/podman.ts
@@ -110,6 +110,7 @@ export class PodmanRuntime implements ContainerRuntime {
   ): Promise<ExecResult> {
     const args = ['exec'];
     if (opts?.workdir) args.push('-w', opts.workdir);
+    if (opts?.user) args.push('-u', opts.user);
     if (opts?.env) {
       for (const e of opts.env) args.push('-e', e);
     }

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -56,6 +56,7 @@ export interface ExecOpts {
   workdir?: string;
   env?: string[];
   interactive?: boolean;
+  user?: string;
 }
 
 export interface ExecResult {

--- a/tests/unit/docker-runtime.test.ts
+++ b/tests/unit/docker-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DockerRuntime, demuxDockerStream } from '../../src/main/runtime/docker';
+import Dockerode from 'dockerode';
 
 // Mock dockerode
 vi.mock('dockerode', () => {
@@ -139,6 +140,34 @@ describe('DockerRuntime', () => {
     const stopSpy = vi.spyOn(cm, 'destroy');
     runtime.destroy();
     expect(stopSpy).toHaveBeenCalled();
+  });
+
+  describe('exec — User field', () => {
+    it('passes User to dockerode exec config when opts.user is set', async () => {
+      const MockDockerode = vi.mocked(Dockerode);
+      // mock.results gives the value returned by each new Dockerode() call
+      const dockerInstance = MockDockerode.mock.results.at(-1)!.value;
+      const getContainerFn = dockerInstance.getContainer as ReturnType<typeof vi.fn>;
+
+      await runtime.exec('abc123', ['git', 'status'], { user: 'claude' });
+
+      const container = getContainerFn.mock.results.at(-1)!.value;
+      expect(container.exec).toHaveBeenCalledWith(
+        expect.objectContaining({ User: 'claude' })
+      );
+    });
+
+    it('omits User from dockerode exec config when opts.user is not set', async () => {
+      const MockDockerode = vi.mocked(Dockerode);
+      const dockerInstance = MockDockerode.mock.results.at(-1)!.value;
+      const getContainerFn = dockerInstance.getContainer as ReturnType<typeof vi.fn>;
+
+      await runtime.exec('abc123', ['ls']);
+
+      const container = getContainerFn.mock.results.at(-1)!.value;
+      const callArg = (container.exec as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0];
+      expect(callArg.User).toBeUndefined();
+    });
   });
 });
 

--- a/tests/unit/podman-runtime.test.ts
+++ b/tests/unit/podman-runtime.test.ts
@@ -100,4 +100,24 @@ describe('PodmanRuntime', () => {
       expect.any(Object)
     );
   });
+
+  it('includes -u flag when opts.user is set', async () => {
+    mockSpawn('');
+    await runtime.exec('container-id', ['git', 'checkout', '-b', 'feat/foo'], { user: 'claude' });
+    expect(spawn).toHaveBeenCalledWith(
+      'podman',
+      ['exec', '-u', 'claude', 'container-id', 'git', 'checkout', '-b', 'feat/foo'],
+      expect.any(Object)
+    );
+  });
+
+  it('omits -u flag when opts.user is not set', async () => {
+    mockSpawn('');
+    await runtime.exec('container-id', ['ls']);
+    expect(spawn).toHaveBeenCalledWith(
+      'podman',
+      ['exec', 'container-id', 'ls'],
+      expect.any(Object)
+    );
+  });
 });

--- a/tests/unit/pr-creator.test.ts
+++ b/tests/unit/pr-creator.test.ts
@@ -10,6 +10,7 @@ import {
   draftPullRequest,
   nextBranchName,
   createPullRequest,
+  sanitizeCommitMessage,
   MAX_PR_ATTEMPTS,
   PR_BODY_MAX_BYTES,
   PR_TITLE_MAX_CHARS,
@@ -345,6 +346,62 @@ describe('createPullRequest — host-side gh pr create', () => {
     // but we read it before the cleanup completes? Actually the file is deleted
     // in the finally block, so it's already gone. Instead, verify via the mock call.
     expect(createPROnHost).toHaveBeenCalledWith('t', expect.stringContaining('pr-body-'), 'feat/bar', 'main');
+  });
+
+  it('sanitizes the title before passing it to runGitPush', async () => {
+    const runGitPush = vi.fn<[string], Promise<void>>().mockResolvedValue(undefined);
+    await createPullRequest(
+      {
+        stackId: 's',
+        title: 'handle "not found" as non-fatal during ticket merge',
+        body: 'body',
+        initialBranch: 'feat/foo',
+      },
+      makeDeps({ runGitPush }),
+    );
+    expect(runGitPush).toHaveBeenCalledTimes(1);
+    const commitMsg = runGitPush.mock.calls[0][0];
+    expect(commitMsg).not.toContain('"');
+  });
+});
+
+describe('sanitizeCommitMessage', () => {
+  it('removes double quotes', () => {
+    expect(sanitizeCommitMessage('handle "not found" error')).toBe('handle not found error');
+  });
+
+  it('removes backticks', () => {
+    expect(sanitizeCommitMessage('run `npm install`')).toBe('run npm install');
+  });
+
+  it('removes dollar signs', () => {
+    expect(sanitizeCommitMessage('fix $HOME path handling')).toBe('fix HOME path handling');
+  });
+
+  it('removes backslashes', () => {
+    expect(sanitizeCommitMessage('handle C:\\Users path')).toBe('handle C:Users path');
+  });
+
+  it('replaces newlines with spaces', () => {
+    expect(sanitizeCommitMessage('line one\nline two')).toBe('line one line two');
+  });
+
+  it('leaves normal titles unchanged', () => {
+    const normal = 'fix: handle non-fatal error during ticket merge';
+    expect(sanitizeCommitMessage(normal)).toBe(normal);
+  });
+
+  it('returns a safe fallback for an all-special-char input', () => {
+    const result = sanitizeCommitMessage('"`$\\');
+    expect(result).toBeTruthy();
+    expect(result).not.toMatch(/["`$\\]/);
+  });
+
+  it('regression: reported title with double quotes sanitizes without shell-special chars', () => {
+    const title = 'handle "not found" as non-fatal during ticket merge';
+    const sanitized = sanitizeCommitMessage(title);
+    expect(sanitized).not.toContain('"');
+    expect(sanitized).toMatch(/\S/);
   });
 });
 

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -617,6 +617,30 @@ describe('StackManager', () => {
     });
   });
 
+  describe('execInContainer', () => {
+    it('invokes runtime.exec with workdir /app and user claude', async () => {
+      registry.createStack(makeStack());
+      await manager.execInContainer('test-stack', ['git', 'status']);
+      expect(runtime.exec).toHaveBeenCalledWith(
+        'claude-container-1',
+        ['git', 'status'],
+        { workdir: '/app', user: 'claude' },
+      );
+    });
+
+    it('throws when exec returns non-zero exit code', async () => {
+      registry.createStack(makeStack());
+      (runtime.exec as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        exitCode: 128,
+        stdout: '',
+        stderr: 'fatal: detected dubious ownership in repository at \'/app\'',
+      });
+      await expect(
+        manager.execInContainer('test-stack', ['git', 'checkout', '-b', 'feat/foo'])
+      ).rejects.toThrow('exec in container failed');
+    });
+  });
+
   describe('dispatchTask with readiness', () => {
     it('waits for readiness before dispatching', async () => {
       registry.createStack(makeStack('ready-dispatch'));


### PR DESCRIPTION
## Summary
- sanitize the PR title before it is reused as a git commit message in `pr-creator.ts`, stripping `"`, backticks, `$`, `\`, and newlines so titles with shell metacharacters no longer break or inject into the push command
- thread a `user` option through `ExecOpts` so `execInContainer` runs as `claude` (matching the CLI's `-u claude`) instead of the container default; docker passes `User`, podman passes `-u <user>`, and an omitted user preserves prior behavior

## Test plan
- [ ] run `npm test` and confirm all suites pass (sanitizer edge cases, PR push wiring, exec-user plumbing, backward-compat)
- [ ] run `npm run typecheck` and confirm it is clean
- [ ] create a PR whose title contains quotes/backticks/`$` and verify the push succeeds with a clean commit message
- [ ] exec a command in a container and confirm it runs as `claude` (e.g. `whoami`) on both docker and podman runtimes

Closes #437