### PR TITLE
feat: honor project PR template and [TICKET-ID] title convention in pr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- High-level description of how this change achieves the user's intent. No file-by-file narration — the diff already shows that. -->
+
+## QA plan
+
+<!-- Steps a reviewer takes to manually validate this change. Do not list automated checks (typecheck, tests, build) — those run automatically. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,22 @@
 # Contributing to Sandstorm Desktop
 
+## PR title convention
+
+PR titles must follow this format:
+
+```
+[TICKET-ID] fix: short description
+```
+
+- **`[TICKET-ID]`** — the issue or ticket number (e.g. `[423]`). Omit only when there is no associated ticket.
+- **verb** — lowercase imperative: `fix`, `add`, `update`, `remove`, `refactor`, etc.
+- **short description** — concise summary of the change; total title length must not exceed 70 characters.
+
+Examples:
+- `[423] add: GH PR template and agent drafter alignment`
+- `[310] fix: cap PR body at 8192 bytes`
+- `add: initial project scaffold` *(no ticket)*
+
 ## Test style guide
 
 ### Anti-pattern: silently assuming a runtime environment

--- a/src/main/control-plane/pr-creator.ts
+++ b/src/main/control-plane/pr-creator.ts
@@ -84,21 +84,30 @@ export function buildDraftPrompt(opts: {
   commits: string;
   diffStat: string;
   taskOutputTail: string;
+  /** Contents of <workspace>/.github/pull_request_template.md, or null to use the built-in. */
+  projectTemplate?: string | null;
 }): string {
-  const ticketLine = opts.ticket
-    ? `Closes #${opts.ticket.replace(/^#/, '')}`
-    : '';
+  const ticketId = opts.ticket ? opts.ticket.replace(/^#/, '') : null;
+  const ticketLine = ticketId ? `Closes #${ticketId}` : '';
+  const titleSchema = ticketId
+    ? `"[${ticketId}] fix: <short description>"`
+    : `"<≤70 chars summary>"`;
+  const bodyStructure = opts.projectTemplate
+    ? `Follow this project's PR template exactly (fill every section; do not add or remove sections):
+
+${opts.projectTemplate}`
+    : `## Summary
+- 1–3 bullets describing the user's intent and how this change achieves it (no file-by-file narration — the diff shows that)
+
+## QA plan
+- [ ] steps a reviewer takes to manually validate (manual steps only — do NOT list automated checks; the CI suite runs those separately)`;
   return `You are drafting a GitHub pull request body for changes on the branch "${opts.branch}".
 
 Output STRICT JSON only — no prose, no code fences, no preamble. Schema:
-{"title": "<≤70 chars summary>", "body": "<markdown body>"}
+{"title": ${titleSchema}, "body": "<markdown body>"}
 
 Body structure:
-## Summary
-- 1–3 bullets describing what changed and WHY (not what files moved)
-
-## Test plan
-- [ ] checklist of how a reviewer should validate
+${bodyStructure}
 
 ${ticketLine ? ticketLine + '\n\n' : ''}Hard limits: title ≤ 70 chars, body ≤ ${PR_BODY_MAX_BYTES} bytes.
 Do NOT include "Generated with Claude Code" boilerplate. Do NOT include emojis.
@@ -171,6 +180,18 @@ export async function draftPullRequest(args: DraftPRArgs, deps: DraftDeps): Prom
     throw new Error(`Stack workspace not found at ${args.workspace}`);
   }
   const baseBranch = args.baseBranch || 'main';
+
+  // Probe for the project's own PR template at the standard GitHub location.
+  let projectTemplate: string | null = null;
+  const templatePath = path.join(args.workspace, '.github', 'pull_request_template.md');
+  try {
+    const raw = fs.readFileSync(templatePath, 'utf-8');
+    const trimmed = raw.trim();
+    if (trimmed) projectTemplate = trimmed;
+  } catch {
+    // file absent — fall back to built-in
+  }
+
   const [commits, diffStat, branch, tail] = await Promise.all([
     gitCommits(args.workspace, baseBranch),
     gitDiffStat(args.workspace, baseBranch),
@@ -184,6 +205,7 @@ export async function draftPullRequest(args: DraftPRArgs, deps: DraftDeps): Prom
     commits,
     diffStat,
     taskOutputTail: tail,
+    projectTemplate,
   });
   const raw = await deps.runEphemeral(prompt, args.workspace, PR_DRAFT_TIMEOUT_MS);
   return parseDraftResponse(raw);

--- a/tests/unit/pr-creator.test.ts
+++ b/tests/unit/pr-creator.test.ts
@@ -65,6 +65,63 @@ describe('buildDraftPrompt', () => {
     const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
     expect(out).toContain(`${PR_BODY_MAX_BYTES} bytes`);
   });
+
+  it('built-in structure uses QA plan not Test plan', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).toContain('## QA plan');
+    expect(out).not.toContain('## Test plan');
+  });
+
+  it('built-in structure includes Summary section', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).toContain('## Summary');
+  });
+
+  it('built-in structure does not instruct running automated tests', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).not.toMatch(/npm test/);
+    expect(out).not.toMatch(/typecheck/);
+    expect(out).not.toMatch(/run.*build/i);
+  });
+
+  it('uses built-in body structure when projectTemplate is null', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '', projectTemplate: null });
+    expect(out).toContain('## Summary');
+    expect(out).toContain('## QA plan');
+    expect(out).not.toContain("Follow this project's PR template");
+  });
+
+  it('uses built-in body structure when projectTemplate is undefined', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).toContain('## Summary');
+    expect(out).toContain('## QA plan');
+    expect(out).not.toContain("Follow this project's PR template");
+  });
+
+  it('instructs the agent to follow project template when projectTemplate is provided', () => {
+    const template = '## My Section\n<!-- description -->\n\n## Steps\n<!-- steps -->';
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '', projectTemplate: template });
+    expect(out).toContain("Follow this project's PR template");
+    expect(out).toContain(template);
+    expect(out).not.toContain('## QA plan');
+  });
+
+  it('includes [TICKET-ID] title convention in schema when ticket is present', () => {
+    const out = buildDraftPrompt({ ticket: '42', branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).toContain('[42] fix:');
+  });
+
+  it('strips leading # from ticket in title convention', () => {
+    const out = buildDraftPrompt({ ticket: '#99', branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).toContain('[99] fix:');
+    expect(out).not.toContain('[#99]');
+  });
+
+  it('omits [TICKET-ID] prefix in schema when no ticket', () => {
+    const out = buildDraftPrompt({ ticket: null, branch: 'b', commits: '', diffStat: '', taskOutputTail: '' });
+    expect(out).not.toMatch(/\[\d+\]/);
+    expect(out).toContain('≤70 chars summary');
+  });
 });
 
 describe('parseDraftResponse', () => {
@@ -141,7 +198,7 @@ describe('draftPullRequest', () => {
   });
 
   it('calls the ephemeral agent with a prompt that mentions the branch and commit', async () => {
-    const runEphemeral = vi.fn().mockResolvedValue('{"title":"feat: add b","body":"## Summary\\n- adds b\\n\\n## Test plan\\n- [ ] verify"}');
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"feat: add b","body":"## Summary\\n- adds b\\n\\n## QA plan\\n- [ ] verify"}');
     const drafted = await draftPullRequest(
       { stackId: 's', workspace, ticket: '42' },
       { runEphemeral },
@@ -170,6 +227,39 @@ describe('draftPullRequest', () => {
     );
     expect(fetchTaskTail).toHaveBeenCalledWith('s');
     expect(runEphemeral.mock.calls[0][0]).toContain('important task log');
+  });
+
+  it('uses built-in structure when .github/pull_request_template.md is absent', async () => {
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"x","body":"## Summary\\n- y"}');
+    await draftPullRequest({ stackId: 's', workspace, ticket: null }, { runEphemeral });
+    const prompt = runEphemeral.mock.calls[0][0] as string;
+    expect(prompt).toContain('## QA plan');
+    expect(prompt).not.toContain("Follow this project's PR template");
+  });
+
+  it('uses project template when .github/pull_request_template.md exists and is non-empty', async () => {
+    const templateDir = path.join(workspace, '.github');
+    fs.mkdirSync(templateDir, { recursive: true });
+    fs.writeFileSync(path.join(templateDir, 'pull_request_template.md'), '## Custom Section\n<!-- fill me in -->');
+
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"x","body":"## Custom Section\\n- done"}');
+    await draftPullRequest({ stackId: 's', workspace, ticket: null }, { runEphemeral });
+    const prompt = runEphemeral.mock.calls[0][0] as string;
+    expect(prompt).toContain("Follow this project's PR template");
+    expect(prompt).toContain('## Custom Section');
+    expect(prompt).not.toContain('## QA plan');
+  });
+
+  it('uses built-in structure when .github/pull_request_template.md exists but is whitespace-only', async () => {
+    const templateDir = path.join(workspace, '.github');
+    fs.mkdirSync(templateDir, { recursive: true });
+    fs.writeFileSync(path.join(templateDir, 'pull_request_template.md'), '   \n\n  ');
+
+    const runEphemeral = vi.fn().mockResolvedValue('{"title":"x","body":"## Summary\\n- y"}');
+    await draftPullRequest({ stackId: 's', workspace, ticket: null }, { runEphemeral });
+    const prompt = runEphemeral.mock.calls[0][0] as string;
+    expect(prompt).toContain('## QA plan');
+    expect(prompt).not.toContain("Follow this project's PR template");
   });
 });
 


### PR DESCRIPTION
## Summary
- the PR drafter now probes `<workspace>/.github/pull_request_template.md` and, when present and non-empty, instructs the agent to follow the project's own template verbatim instead of the built-in structure — so generated PRs match each repo's conventions
- when a ticket is supplied, the title schema now enforces the `[TICKET-ID] fix: <short description>` format (falling back to a plain summary when absent), and the built-in body uses a manual-only `## QA plan` section that explicitly excludes automated checks (CI runs those)
- adds a `.github/pull_request_template.md` for this repo and documents the title convention in `CONTRIBUTING.md`

## Test plan
- [ ] review `buildDraftPrompt` output with a `projectTemplate` set — confirm the prompt tells the agent to follow it exactly and omits the built-in sections
- [ ] review `buildDraftPrompt` output with `projectTemplate` null/undefined/whitespace — confirm it falls back to `## Summary` + `## QA plan`
- [ ] confirm the generated title schema shows `[TICKET-ID] fix: ...` when a ticket is passed and `<≤70 chars summary>` when not
- [ ] confirm `draftPullRequest` reads `.github/pull_request_template.md` from the workspace and tolerates the file being absent
- [ ] confirm the built-in QA plan instructs manual steps only and excludes automated checks

Closes #423