### PR TITLE
add jira test connection and structured ticket list errors

### DIFF
--- a/src/main/control-plane/ticket-config.ts
+++ b/src/main/control-plane/ticket-config.ts
@@ -34,8 +34,16 @@ export interface TicketListEntry {
   author: string;
 }
 
+/** Structured failure reason carried on the ok:false branch of TicketListResult. */
+export type TicketListError =
+  | { reason: 'missing-creds' }
+  | { reason: 'http-status'; status: number; body?: string }
+  | { reason: 'network'; message: string };
+
 /** Discriminated result for ticket list fetches — lets callers distinguish success from failure. */
-export type TicketListResult = { ok: true; tickets: TicketListEntry[] } | { ok: false };
+export type TicketListResult =
+  | { ok: true; tickets: TicketListEntry[] }
+  | { ok: false; error: TicketListError };
 
 // ---------------------------------------------------------------------------
 // GitHub: built-in ticket operations via gh CLI
@@ -120,7 +128,7 @@ export async function githubListTickets(cwd: string, label?: string): Promise<Ti
       })),
     };
   } catch {
-    return { ok: false };
+    return { ok: false, error: { reason: 'network', message: 'Failed to fetch GitHub tickets' } };
   }
 }
 
@@ -184,7 +192,10 @@ async function jiraRequest(opts: {
       res.on('data', (chunk: string) => { data += chunk; });
       res.on('end', () => {
         if (res.statusCode && res.statusCode >= 400) {
-          reject(new Error(`Jira API error ${res.statusCode}: ${data.slice(0, 300)}`));
+          reject(Object.assign(
+            new Error(`Jira API error ${res.statusCode}: ${data.slice(0, 300)}`),
+            { status: res.statusCode, body: data.slice(0, 300) },
+          ));
         } else {
           resolve(data);
         }
@@ -259,7 +270,7 @@ export async function jiraListTickets(
   label?: string,
 ): Promise<TicketListResult> {
   if (!config.jira_url || !config.jira_username || !config.jira_api_token) {
-    return { ok: false };
+    return { ok: false, error: { reason: 'missing-creds' } };
   }
   try {
     let jql = 'reporter = currentUser() AND statusCategory != Done';
@@ -284,8 +295,12 @@ export async function jiraListTickets(
         author: issue.fields.reporter?.accountId ?? issue.fields.reporter?.displayName ?? '',
       })),
     };
-  } catch {
-    return { ok: false };
+  } catch (err: unknown) {
+    const e = err as { status?: number; body?: string; message?: string };
+    if (typeof e.status === 'number') {
+      return { ok: false, error: { reason: 'http-status', status: e.status, body: e.body } };
+    }
+    return { ok: false, error: { reason: 'network', message: (err as Error).message ?? String(err) } };
   }
 }
 
@@ -392,6 +407,60 @@ export async function createTicketWithConfig(opts: {
     return githubCreateTicket(title, body, opts.cwd);
   }
   return jiraCreateTicket(title, body, opts.config);
+}
+
+/** Result shape for the Test Connection feature in JIRA settings. */
+export interface TestJiraConnectionResult {
+  auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };
+  jql: { ok: true; count: number } | { ok: false; status?: number; message: string } | null;
+}
+
+/**
+ * Test a JIRA connection using unsaved form values.
+ * Pings /rest/api/2/myself for auth, then runs the standard list JQL if auth succeeds.
+ */
+export async function testJiraConnection(params: {
+  jiraUrl: string;
+  jiraUsername: string;
+  jiraApiToken: string;
+  label?: string;
+}): Promise<TestJiraConnectionResult> {
+  const { jiraUrl, jiraUsername, jiraApiToken, label } = params;
+  const auth = Buffer.from(`${jiraUsername}:${jiraApiToken}`).toString('base64');
+  const baseUrl = jiraUrl.replace(/\/$/, '');
+
+  let displayName: string;
+  try {
+    const raw = await jiraRequest({ url: `${baseUrl}/rest/api/2/myself`, method: 'GET', auth });
+    const myself = JSON.parse(raw) as { displayName?: string };
+    displayName = myself.displayName ?? 'Unknown User';
+  } catch (err: unknown) {
+    const e = err as { status?: number; message?: string };
+    return {
+      auth: { ok: false, status: e.status, message: e.message ?? String(err) },
+      jql: null,
+    };
+  }
+
+  let jql = 'reporter = currentUser() AND statusCategory != Done';
+  if (label && label.trim()) {
+    jql += ` AND labels = "${label.trim().replace(/"/g, '\\"')}"`;
+  }
+  const searchUrl =
+    `${baseUrl}/rest/api/2/search` +
+    `?jql=${encodeURIComponent(jql)}&fields=summary&maxResults=100`;
+  try {
+    const raw = await jiraRequest({ url: searchUrl, method: 'GET', auth });
+    const result = JSON.parse(raw) as { total?: number; issues?: unknown[] };
+    const count = result.total ?? result.issues?.length ?? 0;
+    return { auth: { ok: true, displayName }, jql: { ok: true, count } };
+  } catch (err: unknown) {
+    const e = err as { status?: number; message?: string };
+    return {
+      auth: { ok: true, displayName },
+      jql: { ok: false, status: e.status, message: e.message ?? String(err) },
+    };
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -84,7 +84,8 @@ import {
   createPullRequest,
 } from './control-plane/pr-creator';
 import { showNotification } from './tray';
-import { createTicketWithConfig } from './control-plane/ticket-config';
+import { createTicketWithConfig, testJiraConnection } from './control-plane/ticket-config';
+import type { TicketListError } from './control-plane/ticket-config';
 import type { ProjectTicketConfig } from './control-plane/registry';
 import type { EphemeralStreamEvent } from './agent/types';
 import { handleToolCall, spawnSpecCheck, spawnSpecRefine } from './claude/tools';
@@ -1290,6 +1291,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
     // Fetch from the project's configured ticket provider (built-in, no per-project
     // script). When no provider is configured, skip and return existing board rows.
+    let listError: TicketListError | null = null;
     const config = registry.getProjectTicketConfig(normalizedDir);
     if (config) {
       try {
@@ -1303,13 +1305,25 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
           if (deletedCount > 0) {
             console.log(`[tickets:list] Removed ${deletedCount} closed early-column ticket(s) from board for project: ${normalizedDir}`);
           }
+        } else {
+          listError = result.error;
+          console.error('[tickets:list] Failed to fetch tickets from provider:', result.error);
         }
       } catch (err) {
         console.error('[tickets:list] Failed to fetch tickets from provider:', err);
       }
     }
 
-    return registry.listBoardTickets(normalizedDir);
+    return { tickets: registry.listBoardTickets(normalizedDir), error: listError };
+  });
+
+  ipcMain.handle('tickets:testJiraConnection', async (_event, params: {
+    jiraUrl: string;
+    jiraUsername: string;
+    jiraApiToken: string;
+    label?: string;
+  }) => {
+    return testJiraConnection(params);
   });
 
   ipcMain.handle('ticket-board:set-column', async (_event, ticketId: string, projectDir: string, column: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -208,7 +208,16 @@ export interface SandstormAPI {
     cancelRefinement: (sessionId: string) => Promise<void>;
     listRefinements: () => Promise<unknown[]>;
     create: (projectDir: string, title: string, body: string) => Promise<{ url: string; ticketId: string }>;
-    list: (projectDir: string) => Promise<unknown[]>;
+    list: (projectDir: string) => Promise<{ tickets: unknown[]; error: unknown }>;
+    testJiraConnection: (params: {
+      jiraUrl: string;
+      jiraUsername: string;
+      jiraApiToken: string;
+      label?: string;
+    }) => Promise<{
+      auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };
+      jql: { ok: true; count: number } | { ok: false; status?: number; message: string } | null;
+    }>;
   };
   ticketBoard: {
     setColumn: (ticketId: string, projectDir: string, column: string) => Promise<void>;
@@ -392,8 +401,13 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('tickets:listRefinements'),
     create: (projectDir, title, body) =>
       ipcRenderer.invoke('tickets:create', projectDir, title, body),
-    list: (projectDir) =>
-      ipcRenderer.invoke('tickets:list', projectDir),
+    list: async (projectDir) => {
+      const raw = await ipcRenderer.invoke('tickets:list', projectDir);
+      if (Array.isArray(raw)) return { tickets: raw, error: null };
+      return raw;
+    },
+    testJiraConnection: (params) =>
+      ipcRenderer.invoke('tickets:testJiraConnection', params),
   },
   ticketBoard: {
     setColumn: (ticketId, projectDir, column) =>

--- a/src/renderer/components/KanbanBoard.tsx
+++ b/src/renderer/components/KanbanBoard.tsx
@@ -82,7 +82,7 @@ export function KanbanBoard() {
                 <span className="text-xs text-sandstorm-muted animate-pulse">Refreshing…</span>
               )}
               {boardTicketsError && !boardTicketsLoading && (
-                <span className="text-xs text-red-400" data-testid="board-tickets-error">Failed to load tickets</span>
+                <span className="text-xs text-red-400" data-testid="board-tickets-error">{boardTicketsError}</span>
               )}
               {moveTicketColumnError && (
                 <button

--- a/src/renderer/components/ModelSettings.tsx
+++ b/src/renderer/components/ModelSettings.tsx
@@ -96,6 +96,14 @@ export function ModelSettingsModal() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  type TestConnState = 'idle' | 'testing' | 'success-with-count' | 'auth-fail' | 'jql-empty';
+  interface TestConnResult {
+    auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };
+    jql: { ok: true; count: number } | { ok: false; status?: number; message: string } | null;
+  }
+  const [testConnState, setTestConnState] = useState<TestConnState>('idle');
+  const [testConnResult, setTestConnResult] = useState<TestConnResult | null>(null);
+
   useEffect(() => {
     refreshGlobalModelSettings();
   }, [refreshGlobalModelSettings]);
@@ -198,6 +206,29 @@ export function ModelSettingsModal() {
       setError(String(err));
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleTestConnection = async () => {
+    setTestConnState('testing');
+    setTestConnResult(null);
+    try {
+      const result = await window.sandstorm.tickets.testJiraConnection({
+        jiraUrl: jiraUrl.trim(),
+        jiraUsername: jiraUsername.trim(),
+        jiraApiToken: jiraApiToken.trim(),
+      });
+      setTestConnResult(result);
+      if (!result.auth.ok) {
+        setTestConnState('auth-fail');
+      } else if (result.jql && result.jql.ok && result.jql.count === 0) {
+        setTestConnState('jql-empty');
+      } else {
+        setTestConnState('success-with-count');
+      }
+    } catch {
+      setTestConnState('auth-fail');
+      setTestConnResult({ auth: { ok: false, message: 'Connection failed' }, jql: null });
     }
   };
 
@@ -477,6 +508,44 @@ export function ModelSettingsModal() {
                       className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
                       data-testid="jira-issue-type"
                     />
+                  </div>
+
+                  <div className="pt-1">
+                    <button
+                      onClick={handleTestConnection}
+                      disabled={testConnState === 'testing' || !jiraUrl.trim() || !jiraUsername.trim() || !jiraApiToken.trim()}
+                      className="px-3 py-1.5 text-xs font-medium rounded-lg border border-sandstorm-border bg-sandstorm-bg text-sandstorm-text hover:border-sandstorm-border-light disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                      data-testid="jira-test-connection"
+                    >
+                      {testConnState === 'testing' ? 'Testing…' : 'Test Connection'}
+                    </button>
+
+                    {testConnResult && testConnState !== 'testing' && (
+                      <div className="mt-2 space-y-1" data-testid="jira-test-connection-result">
+                        {testConnResult.auth.ok ? (
+                          <p className="text-[11px] text-green-400" data-testid="jira-test-auth-ok">
+                            ✓ Connected as {testConnResult.auth.displayName}
+                          </p>
+                        ) : (
+                          <p className="text-[11px] text-red-400" data-testid="jira-test-auth-fail">
+                            ✗ Auth failed{testConnResult.auth.status ? ` (${testConnResult.auth.status})` : ''}: {(testConnResult.auth as { ok: false; message: string }).message}
+                          </p>
+                        )}
+                        {testConnResult.jql && (
+                          testConnResult.jql.ok ? (
+                            <p className="text-[11px] text-sandstorm-muted" data-testid="jira-test-jql-ok">
+                              {testConnResult.jql.count === 0
+                                ? '⚠ JQL returned 0 tickets — filter may be excluding everything'
+                                : `✓ JQL returned ${testConnResult.jql.count} ticket${testConnResult.jql.count === 1 ? '' : 's'}`}
+                            </p>
+                          ) : (
+                            <p className="text-[11px] text-red-400" data-testid="jira-test-jql-fail">
+                              ✗ JQL failed: {(testConnResult.jql as { ok: false; message: string }).message}
+                            </p>
+                          )
+                        )}
+                      </div>
+                    )}
                   </div>
                 </div>
               )}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -331,6 +331,22 @@ export interface ModelSettings {
   outer_model: string;
 }
 
+export type TicketListError =
+  | { reason: 'missing-creds' }
+  | { reason: 'http-status'; status: number; body?: string }
+  | { reason: 'network'; message: string };
+
+function formatTicketListError(error: TicketListError): string {
+  switch (error.reason) {
+    case 'missing-creds':
+      return 'JIRA credentials missing — configure them in Project Settings';
+    case 'http-status':
+      return `JIRA error ${error.status}${error.body ? ': ' + error.body.slice(0, 100) : ''}`;
+    case 'network':
+      return error.message;
+  }
+}
+
 export interface ProjectTicketConfig {
   provider: 'github' | 'jira';
   jira_url?: string | null;
@@ -754,7 +770,16 @@ declare global {
         cancelRefinement: (sessionId: string) => Promise<void>;
         listRefinements: () => Promise<RefinementSession[]>;
         create: (projectDir: string, title: string, body: string) => Promise<{ url: string; number: number; ticketId: string }>;
-        list: (projectDir: string) => Promise<TicketBoardEntry[]>;
+        list: (projectDir: string) => Promise<{ tickets: TicketBoardEntry[]; error: TicketListError | null }>;
+        testJiraConnection: (params: {
+          jiraUrl: string;
+          jiraUsername: string;
+          jiraApiToken: string;
+          label?: string;
+        }) => Promise<{
+          auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };
+          jql: { ok: true; count: number } | { ok: false; status?: number; message: string } | null;
+        }>;
       };
       ticketBoard: {
         setColumn: (ticketId: string, projectDir: string, column: string) => Promise<void>;
@@ -1038,8 +1063,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   refreshBoardTickets: async (projectDir: string) => {
     try {
       set({ boardTicketsLoading: true });
-      const tickets = await window.sandstorm.tickets.list(projectDir);
-      set({ boardTickets: tickets as TicketBoardEntry[], boardTicketsLoading: false, boardTicketsError: null, lastTicketFetchAt: Date.now() });
+      const { tickets, error } = await window.sandstorm.tickets.list(projectDir);
+      const errorMessage = error ? formatTicketListError(error) : null;
+      set({ boardTickets: tickets ?? [], boardTicketsLoading: false, boardTicketsError: errorMessage, lastTicketFetchAt: Date.now() });
     } catch (err) {
       console.error('[refreshBoardTickets]', err);
       set({ boardTicketsLoading: false, boardTicketsError: String(err) });

--- a/tests/unit/components/KanbanBoard.test.tsx
+++ b/tests/unit/components/KanbanBoard.test.tsx
@@ -3,14 +3,16 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { KanbanBoard } from '../../../src/renderer/components/KanbanBoard';
 import { useAppStore } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
 
 describe('KanbanBoard', () => {
+  let api: ReturnType<typeof mockSandstormApi>;
+
   beforeEach(() => {
-    mockSandstormApi();
+    api = mockSandstormApi();
     useAppStore.setState({
       projects: [{ id: 1, name: 'proj', directory: '/proj', added_at: '' }],
       activeProjectId: 1,
@@ -110,5 +112,34 @@ describe('KanbanBoard', () => {
     useAppStore.setState({ moveTicketColumnError: null });
     render(<KanbanBoard />);
     expect(screen.queryByTestId('move-ticket-column-error')).toBeNull();
+  });
+
+  it('shows the boardTicketsError message (not hardcoded string) when error is set (#435)', async () => {
+    const errorMsg = 'JIRA credentials missing — configure them in Project Settings';
+    api.tickets.list.mockResolvedValue({ tickets: [], error: { reason: 'missing-creds' } });
+    render(<KanbanBoard />);
+    // Wait for refreshBoardTickets to complete and set the error
+    await waitFor(() => {
+      expect(screen.getByTestId('board-tickets-error')).toBeDefined();
+    });
+    expect(screen.getByTestId('board-tickets-error').textContent).toBe(errorMsg);
+  });
+
+  it('shows http-status error message in the banner when boardTicketsError is set', async () => {
+    api.tickets.list.mockResolvedValue({ tickets: [], error: { reason: 'http-status', status: 401, body: 'Unauthorized' } });
+    render(<KanbanBoard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('board-tickets-error')).toBeDefined();
+    });
+    expect(screen.getByTestId('board-tickets-error').textContent).toContain('401');
+  });
+
+  it('does not show error banner when boardTicketsError is null (empty tickets is valid state)', async () => {
+    api.tickets.list.mockResolvedValue({ tickets: [], error: null });
+    render(<KanbanBoard />);
+    // Wait for the component to settle after mount fetch
+    await waitFor(() => {
+      expect(screen.queryByTestId('board-tickets-error')).toBeNull();
+    });
   });
 });

--- a/tests/unit/components/ModelSettings.test.tsx
+++ b/tests/unit/components/ModelSettings.test.tsx
@@ -186,5 +186,98 @@ describe('ModelSettingsModal', () => {
         expect(urlInput.value).toBe('https://existing.atlassian.net');
       });
     });
+
+    describe('Test Connection button (#435)', () => {
+      beforeEach(async () => {
+        render(<ModelSettingsModal />);
+        fireEvent.click(screen.getByTestId('model-settings-tab-ticketing'));
+        await waitFor(() => {
+          expect(screen.getByTestId('ticket-provider-jira')).toBeDefined();
+        });
+        fireEvent.click(screen.getByTestId('ticket-provider-jira'));
+        // Fill in creds so button is enabled
+        fireEvent.change(screen.getByTestId('jira-url'), { target: { value: 'https://acme.atlassian.net' } });
+        fireEvent.change(screen.getByTestId('jira-username'), { target: { value: 'user@acme.com' } });
+        fireEvent.change(screen.getByTestId('jira-api-token'), { target: { value: 'secret' } });
+      });
+
+      it('shows Test Connection button in the Jira section', () => {
+        expect(screen.getByTestId('jira-test-connection')).toBeDefined();
+      });
+
+      it('shows Testing… and disables button while in-flight', async () => {
+        let resolve: (val: unknown) => void;
+        const pending = new Promise((r) => { resolve = r; });
+        api.tickets.testJiraConnection.mockReturnValueOnce(pending);
+
+        fireEvent.click(screen.getByTestId('jira-test-connection'));
+
+        await waitFor(() => {
+          const btn = screen.getByTestId('jira-test-connection') as HTMLButtonElement;
+          expect(btn.textContent).toBe('Testing…');
+          expect(btn.disabled).toBe(true);
+        });
+
+        // Resolve to avoid dangling promise
+        resolve!({ auth: { ok: true, displayName: 'X' }, jql: { ok: true, count: 1 } });
+      });
+
+      it('button is disabled when required creds are empty', () => {
+        fireEvent.change(screen.getByTestId('jira-url'), { target: { value: '' } });
+        const btn = screen.getByTestId('jira-test-connection') as HTMLButtonElement;
+        expect(btn.disabled).toBe(true);
+      });
+
+      it('shows success-with-count state after successful connection', async () => {
+        api.tickets.testJiraConnection.mockResolvedValueOnce({
+          auth: { ok: true, displayName: 'Alice Smith' },
+          jql: { ok: true, count: 5 },
+        });
+        fireEvent.click(screen.getByTestId('jira-test-connection'));
+        await waitFor(() => {
+          expect(screen.getByTestId('jira-test-auth-ok')).toBeDefined();
+          expect(screen.getByTestId('jira-test-auth-ok').textContent).toContain('Alice Smith');
+        });
+        expect(screen.getByTestId('jira-test-jql-ok').textContent).toContain('5 tickets');
+      });
+
+      it('shows auth-fail state when auth fails', async () => {
+        api.tickets.testJiraConnection.mockResolvedValueOnce({
+          auth: { ok: false, status: 401, message: 'Unauthorized' },
+          jql: null,
+        });
+        fireEvent.click(screen.getByTestId('jira-test-connection'));
+        await waitFor(() => {
+          expect(screen.getByTestId('jira-test-auth-fail')).toBeDefined();
+          expect(screen.getByTestId('jira-test-auth-fail').textContent).toContain('401');
+        });
+        expect(screen.queryByTestId('jira-test-jql-ok')).toBeNull();
+        expect(screen.queryByTestId('jira-test-jql-fail')).toBeNull();
+      });
+
+      it('shows jql-empty hint when auth passes but JQL returns 0', async () => {
+        api.tickets.testJiraConnection.mockResolvedValueOnce({
+          auth: { ok: true, displayName: 'Bob' },
+          jql: { ok: true, count: 0 },
+        });
+        fireEvent.click(screen.getByTestId('jira-test-connection'));
+        await waitFor(() => {
+          expect(screen.getByTestId('jira-test-auth-ok')).toBeDefined();
+        });
+        expect(screen.getByTestId('jira-test-jql-ok').textContent).toContain('filter may be excluding everything');
+      });
+
+      it('auth and jql results are visually separate elements', async () => {
+        api.tickets.testJiraConnection.mockResolvedValueOnce({
+          auth: { ok: true, displayName: 'Carol' },
+          jql: { ok: false, status: 400, message: 'Bad JQL' },
+        });
+        fireEvent.click(screen.getByTestId('jira-test-connection'));
+        await waitFor(() => {
+          expect(screen.getByTestId('jira-test-auth-ok')).toBeDefined();
+          expect(screen.getByTestId('jira-test-jql-fail')).toBeDefined();
+        });
+      });
+    });
   });
 });

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -169,7 +169,11 @@ export function mockSandstormApi() {
       create: vi.fn().mockResolvedValue({
         url: 'https://github.com/o/r/issues/42', ticketId: '42',
       }),
-      list: vi.fn().mockResolvedValue([]),
+      list: vi.fn().mockResolvedValue({ tickets: [], error: null }),
+      testJiraConnection: vi.fn().mockResolvedValue({
+        auth: { ok: true, displayName: 'Test User' },
+        jql: { ok: true, count: 5 },
+      }),
     },
     ticketBoard: {
       setColumn: vi.fn().mockResolvedValue(undefined),

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -23,6 +23,7 @@ const {
   mockRemoveProjectFromCrontab,
   mockListTicketsWithConfig,
   mockCreateTicketWithConfig,
+  mockTestJiraConnection,
   mockSessionMonitor,
   mockSpawnSpecCheck,
   mockSpawnSpecRefine,
@@ -111,8 +112,12 @@ const {
   const mockSpawn = vi.fn();
   const mockFetchAccountUsage = vi.fn();
   const mockRemoveProjectFromCrontab = vi.fn();
-  const mockListTicketsWithConfig = vi.fn().mockResolvedValue({ ok: false });
+  const mockListTicketsWithConfig = vi.fn().mockResolvedValue({ ok: false, error: { reason: 'network', message: 'Failed to fetch GitHub tickets' } });
   const mockCreateTicketWithConfig = vi.fn().mockResolvedValue({ url: 'https://github.com/o/r/issues/1', ticketId: '1' });
+  const mockTestJiraConnection = vi.fn().mockResolvedValue({
+    auth: { ok: true, displayName: 'Test User' },
+    jql: { ok: true, count: 5 },
+  });
 
   const mockSessionMonitor = {
     getState: vi.fn(),
@@ -136,6 +141,7 @@ const {
     mockRemoveProjectFromCrontab,
     mockListTicketsWithConfig,
     mockCreateTicketWithConfig,
+    mockTestJiraConnection,
     mockSessionMonitor,
     mockSpawnSpecCheck,
     mockSpawnSpecRefine,
@@ -216,6 +222,7 @@ vi.mock('../../src/main/control-plane/ticket-lister', () => ({
 
 vi.mock('../../src/main/control-plane/ticket-config', () => ({
   createTicketWithConfig: (...args: unknown[]) => mockCreateTicketWithConfig(...args),
+  testJiraConnection: (...args: unknown[]) => mockTestJiraConnection(...args),
 }));
 
 vi.mock('../../src/main/claude/tools', () => ({
@@ -1314,7 +1321,7 @@ describe('IPC Handlers', () => {
   // Ticket Board
   // =========================================================================
   describe('tickets:list', () => {
-    it('skips the provider fetch and returns DB rows when no provider is configured', async () => {
+    it('skips the provider fetch and returns { tickets, error:null } when no provider is configured', async () => {
       mockRegistry.getProjectTicketConfig.mockReturnValueOnce(null);
       const boardRows = [
         { ticket_id: 'T-1', project_dir: '/proj', column: 'backlog', title: 'First ticket', updated_at: '' },
@@ -1328,10 +1335,10 @@ describe('IPC Handlers', () => {
       expect(mockListTicketsWithConfig).not.toHaveBeenCalled();
       expect(mockRegistry.seedBoardTicket).not.toHaveBeenCalled();
       expect(mockRegistry.listBoardTickets).toHaveBeenCalled();
-      expect(result).toEqual(boardRows);
+      expect(result).toEqual({ tickets: boardRows, error: null });
     });
 
-    it('returns DB rows when the provider fetch throws (graceful degradation)', async () => {
+    it('returns { tickets, error:null } when the provider fetch throws (graceful degradation)', async () => {
       mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
       mockListTicketsWithConfig.mockRejectedValueOnce(new Error('gh not authenticated'));
       const boardRows = [
@@ -1341,7 +1348,22 @@ describe('IPC Handlers', () => {
 
       const result = await invokeHandler('tickets:list', '/proj');
 
-      expect(result).toEqual(boardRows);
+      expect(result).toEqual({ tickets: boardRows, error: null });
+    });
+
+    it('returns structured error in the error field when fetch returns ok:false', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'jira' });
+      const listError = { reason: 'missing-creds' } as const;
+      mockListTicketsWithConfig.mockResolvedValueOnce({ ok: false, error: listError });
+      const boardRows = [{ ticket_id: 'T-1', project_dir: '/proj', column: 'backlog', title: 'Cached', updated_at: '' }];
+      mockRegistry.listBoardTickets.mockReturnValue(boardRows);
+      mockRegistry.seedBoardTicket.mockClear();
+
+      const result = await invokeHandler('tickets:list', '/proj') as { tickets: unknown[]; error: unknown };
+
+      expect(result.tickets).toEqual(boardRows);
+      expect(result.error).toEqual(listError);
+      expect(mockRegistry.seedBoardTicket).not.toHaveBeenCalled();
     });
 
     it('passes the project config to the provider and seeds each returned ticket', async () => {
@@ -1379,7 +1401,7 @@ describe('IPC Handlers', () => {
 
     it('does not call seedBoardTicket or deleteClosedEarlyColumnTickets when fetch returns ok:false', async () => {
       mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
-      mockListTicketsWithConfig.mockResolvedValueOnce({ ok: false });
+      mockListTicketsWithConfig.mockResolvedValueOnce({ ok: false, error: { reason: 'network', message: 'Failed to fetch GitHub tickets' } });
       mockRegistry.seedBoardTicket.mockClear();
       mockRegistry.deleteClosedEarlyColumnTickets.mockClear();
 
@@ -1408,6 +1430,45 @@ describe('IPC Handlers', () => {
       } finally {
         consoleSpy.mockRestore();
       }
+    });
+  });
+
+  describe('tickets:testJiraConnection', () => {
+    it('delegates to testJiraConnection and returns its result', async () => {
+      const expected = {
+        auth: { ok: true, displayName: 'Alice' },
+        jql: { ok: true, count: 7 },
+      };
+      mockTestJiraConnection.mockResolvedValueOnce(expected);
+
+      const result = await invokeHandler('tickets:testJiraConnection', {
+        jiraUrl: 'https://acme.atlassian.net',
+        jiraUsername: 'user@acme.com',
+        jiraApiToken: 'secret',
+      });
+
+      expect(mockTestJiraConnection).toHaveBeenCalledWith({
+        jiraUrl: 'https://acme.atlassian.net',
+        jiraUsername: 'user@acme.com',
+        jiraApiToken: 'secret',
+      });
+      expect(result).toEqual(expected);
+    });
+
+    it('returns auth:false result when testJiraConnection returns auth failure', async () => {
+      mockTestJiraConnection.mockResolvedValueOnce({
+        auth: { ok: false, status: 401, message: 'Unauthorized' },
+        jql: null,
+      });
+
+      const result = await invokeHandler('tickets:testJiraConnection', {
+        jiraUrl: 'https://acme.atlassian.net',
+        jiraUsername: 'bad@acme.com',
+        jiraApiToken: 'wrong',
+      }) as { auth: { ok: boolean }; jql: null };
+
+      expect(result.auth.ok).toBe(false);
+      expect(result.jql).toBeNull();
     });
   });
 
@@ -1444,10 +1505,10 @@ describe('IPC Handlers', () => {
         { ticket_id: '99', project_dir: '/proj', column: 'backlog', title: 'My Title', updated_at: '' },
       ]);
 
-      const result = await invokeHandler('tickets:list', '/proj');
+      const result = await invokeHandler('tickets:list', '/proj') as { tickets: Array<{ ticket_id: string; column: string }>; error: null };
 
-      expect(result).toHaveLength(1);
-      expect((result as Array<{ ticket_id: string; column: string }>)[0]).toMatchObject({
+      expect(result.tickets).toHaveLength(1);
+      expect(result.tickets[0]).toMatchObject({
         ticket_id: '99',
         column: 'backlog',
       });
@@ -1674,6 +1735,7 @@ describe('IPC Handlers', () => {
       'tickets:listRefinements',
       'tickets:create',
       'tickets:list',
+      'tickets:testJiraConnection',
       'ticket-board:set-column',
       'pr:draftBody',
       'pr:create',

--- a/tests/unit/ticket-config.test.ts
+++ b/tests/unit/ticket-config.test.ts
@@ -13,6 +13,7 @@ import {
   updateTicketWithConfig,
   createTicketWithConfig,
   listTicketsWithConfig,
+  testJiraConnection,
 } from '../../src/main/control-plane/ticket-config';
 import type { ProjectTicketConfig } from '../../src/main/control-plane/registry';
 
@@ -360,25 +361,25 @@ describe('githubListTickets', () => {
     expect(result).toEqual({ ok: true, tickets: [{ id: '1', title: 'Orphan', author: '' }] });
   });
 
-  it('returns ok:false when gh fails (graceful degradation)', async () => {
+  it('returns ok:false with network error when gh fails (graceful degradation)', async () => {
     mockExecFileError('gh not authenticated');
     const result = await githubListTickets('/proj');
-    expect(result).toEqual({ ok: false });
+    expect(result).toEqual({ ok: false, error: { reason: 'network', message: 'Failed to fetch GitHub tickets' } });
   });
 
-  it('returns ok:false on unparseable output', async () => {
+  it('returns ok:false with network error on unparseable output', async () => {
     mockExecFileSuccess('not json');
     const result = await githubListTickets('/proj');
-    expect(result).toEqual({ ok: false });
+    expect(result).toEqual({ ok: false, error: { reason: 'network', message: 'Failed to fetch GitHub tickets' } });
   });
 });
 
 describe('jiraListTickets', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns ok:false when credentials are missing', async () => {
+  it('returns ok:false with missing-creds error when credentials are missing', async () => {
     const cfg: ProjectTicketConfig = { provider: 'jira' };
-    expect(await jiraListTickets(cfg)).toEqual({ ok: false });
+    expect(await jiraListTickets(cfg)).toEqual({ ok: false, error: { reason: 'missing-creds' } });
   });
 
   it('maps Jira search results into TicketListEntry[]', async () => {
@@ -400,9 +401,51 @@ describe('jiraListTickets', () => {
     });
   });
 
-  it('returns ok:false on HTTP error', async () => {
+  it('returns ok:false with http-status error on HTTP 401', async () => {
     mockJiraRequest('Unauthorized', 401);
-    expect(await jiraListTickets(JIRA_CONFIG)).toEqual({ ok: false });
+    const result = await jiraListTickets(JIRA_CONFIG);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe('http-status');
+      expect((result.error as { reason: 'http-status'; status: number }).status).toBe(401);
+    }
+  });
+
+  it('returns ok:false with http-status error on HTTP 403', async () => {
+    mockJiraRequest('Forbidden', 403);
+    const result = await jiraListTickets(JIRA_CONFIG);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe('http-status');
+      expect((result.error as { reason: 'http-status'; status: number }).status).toBe(403);
+    }
+  });
+
+  it('returns ok:false with network error on timeout', async () => {
+    const mockRequest = {
+      on: vi.fn((event: string, handler: Function) => {
+        if (event === 'error') {
+          setTimeout(() => handler(new Error('Jira API request timed out')), 0);
+        }
+        return mockRequest;
+      }),
+      write: vi.fn(),
+      end: vi.fn(),
+      setTimeout: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+    };
+    mockHttpsRequest.mockImplementation(() => mockRequest as unknown as ReturnType<typeof https.request>);
+    const result = await jiraListTickets(JIRA_CONFIG);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe('network');
+    }
+  });
+
+  it('returns ok:true with empty tickets array when JQL matches zero results', async () => {
+    mockJiraRequest(JSON.stringify({ total: 0, issues: [] }));
+    const result = await jiraListTickets(JIRA_CONFIG);
+    expect(result).toEqual({ ok: true, tickets: [] });
   });
 });
 
@@ -422,4 +465,143 @@ describe('listTicketsWithConfig', () => {
     expect(result).toEqual({ ok: true, tickets: [{ id: 'ACME-1', title: 'J', author: 'a' }] });
     expect(mockExecFile).not.toHaveBeenCalled();
   });
+});
+
+// ---------------------------------------------------------------------------
+// jiraRequest structured error + testJiraConnection
+// ---------------------------------------------------------------------------
+
+describe('jiraRequest structured rejection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('jiraListTickets carries http-status error with status and body on HTTP >= 400', async () => {
+    mockJiraRequest('{"errorMessages":["Issue Does Not Exist"]}', 404);
+    const result = await jiraListTickets(JIRA_CONFIG);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe('http-status');
+      expect((result.error as { reason: 'http-status'; status: number; body?: string }).status).toBe(404);
+      expect((result.error as { reason: 'http-status'; status: number; body?: string }).body).toContain('errorMessages');
+    }
+  });
+});
+
+describe('testJiraConnection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns auth ok with displayName on successful myself ping', async () => {
+    // First call: myself, Second call: search
+    let callCount = 0;
+    mockHttpsRequest.mockImplementation((_opts: unknown, callback?: Function) => {
+      callCount++;
+      const body = callCount === 1
+        ? JSON.stringify({ displayName: 'Alice Smith' })
+        : JSON.stringify({ total: 3, issues: [{}, {}, {}] });
+      const mockResponse = {
+        statusCode: 200,
+        on: vi.fn((event: string, handler: Function) => {
+          if (event === 'data') handler(body);
+          if (event === 'end') handler();
+        }),
+      };
+      const mockReq = { on: vi.fn().mockReturnThis(), write: vi.fn(), end: vi.fn(), setTimeout: vi.fn().mockReturnThis(), destroy: vi.fn() };
+      if (callback) callback(mockResponse);
+      return mockReq as unknown as ReturnType<typeof https.request>;
+    });
+
+    const result = await testJiraConnection({
+      jiraUrl: 'https://acme.atlassian.net',
+      jiraUsername: 'user@acme.com',
+      jiraApiToken: 'token123',
+    });
+
+    expect(result.auth.ok).toBe(true);
+    if (result.auth.ok) {
+      expect(result.auth.displayName).toBe('Alice Smith');
+    }
+    expect(result.jql).not.toBeNull();
+    if (result.jql && result.jql.ok) {
+      expect(result.jql.count).toBe(3);
+    }
+  });
+
+  it('returns auth fail and jql:null when myself ping returns 401', async () => {
+    mockJiraRequest('Unauthorized', 401);
+    const result = await testJiraConnection({
+      jiraUrl: 'https://acme.atlassian.net',
+      jiraUsername: 'bad@acme.com',
+      jiraApiToken: 'wrong',
+    });
+
+    expect(result.auth.ok).toBe(false);
+    if (!result.auth.ok) {
+      expect(result.auth.status).toBe(401);
+    }
+    expect(result.jql).toBeNull();
+  });
+
+  it('returns auth ok and jql count:0 when JQL returns empty', async () => {
+    let callCount = 0;
+    mockHttpsRequest.mockImplementation((_opts: unknown, callback?: Function) => {
+      callCount++;
+      const body = callCount === 1
+        ? JSON.stringify({ displayName: 'Bob' })
+        : JSON.stringify({ total: 0, issues: [] });
+      const mockResponse = {
+        statusCode: 200,
+        on: vi.fn((event: string, handler: Function) => {
+          if (event === 'data') handler(body);
+          if (event === 'end') handler();
+        }),
+      };
+      const mockReq = { on: vi.fn().mockReturnThis(), write: vi.fn(), end: vi.fn(), setTimeout: vi.fn().mockReturnThis(), destroy: vi.fn() };
+      if (callback) callback(mockResponse);
+      return mockReq as unknown as ReturnType<typeof https.request>;
+    });
+
+    const result = await testJiraConnection({
+      jiraUrl: 'https://acme.atlassian.net',
+      jiraUsername: 'user@acme.com',
+      jiraApiToken: 'token',
+    });
+
+    expect(result.auth.ok).toBe(true);
+    if (result.jql && result.jql.ok) {
+      expect(result.jql.count).toBe(0);
+    }
+  });
+
+  it('returns auth ok and jql fail when JQL returns 400', async () => {
+    let callCount = 0;
+    mockHttpsRequest.mockImplementation((_opts: unknown, callback?: Function) => {
+      callCount++;
+      const statusCode = callCount === 1 ? 200 : 400;
+      const body = callCount === 1
+        ? JSON.stringify({ displayName: 'Carol' })
+        : 'Bad JQL';
+      const mockResponse = {
+        statusCode,
+        on: vi.fn((event: string, handler: Function) => {
+          if (event === 'data') handler(body);
+          if (event === 'end') handler();
+        }),
+      };
+      const mockReq = { on: vi.fn().mockReturnThis(), write: vi.fn(), end: vi.fn(), setTimeout: vi.fn().mockReturnThis(), destroy: vi.fn() };
+      if (callback) callback(mockResponse);
+      return mockReq as unknown as ReturnType<typeof https.request>;
+    });
+
+    const result = await testJiraConnection({
+      jiraUrl: 'https://acme.atlassian.net',
+      jiraUsername: 'user@acme.com',
+      jiraApiToken: 'token',
+    });
+
+    expect(result.auth.ok).toBe(true);
+    expect(result.jql).not.toBeNull();
+    if (result.jql) {
+      expect(result.jql.ok).toBe(false);
+    }
+  });
+
 });

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -314,11 +314,11 @@ import { useAppStore } from '../../src/renderer/store';
 
 const PROJECT_DIR = '/store-test-proj';
 
-function setupSandstormMock(ticketsList: unknown[] = []) {
+function setupSandstormMock(ticketsList: unknown[] = [], error: unknown = null) {
   Object.defineProperty(window, 'sandstorm', {
     value: {
       tickets: {
-        list: vi.fn().mockResolvedValue(ticketsList),
+        list: vi.fn().mockResolvedValue({ tickets: ticketsList, error }),
         specCheckAsync: vi.fn().mockResolvedValue({ sessionId: 'test-sess' }),
       },
       ticketBoard: { setColumn: vi.fn().mockResolvedValue(undefined) },
@@ -349,7 +349,7 @@ describe('store: refreshBoardTickets', () => {
     expect((window.sandstorm as any).tickets.list).toHaveBeenCalledWith(PROJECT_DIR);
   });
 
-  it('clears loading state on fetch error', async () => {
+  it('clears loading state on IPC throw', async () => {
     Object.defineProperty(window, 'sandstorm', {
       value: { tickets: { list: vi.fn().mockRejectedValue(new Error('fail')) }, ticketBoard: { setColumn: vi.fn() } },
       writable: true,
@@ -363,7 +363,7 @@ describe('store: refreshBoardTickets', () => {
     expect(state.boardTickets).toEqual([]);
   });
 
-  it('sets boardTicketsError on fetch error', async () => {
+  it('sets boardTicketsError on IPC throw', async () => {
     Object.defineProperty(window, 'sandstorm', {
       value: { tickets: { list: vi.fn().mockRejectedValue(new Error('network failure')) }, ticketBoard: { setColumn: vi.fn() } },
       writable: true,
@@ -377,14 +377,34 @@ describe('store: refreshBoardTickets', () => {
     expect(typeof state.boardTicketsError).toBe('string');
   });
 
-  it('clears boardTicketsError on successful fetch', async () => {
-    useAppStore.setState({ boardTicketsError: 'previous error' });
-    setupSandstormMock([]);
-
+  it('sets boardTicketsError from structured missing-creds error', async () => {
+    setupSandstormMock([], { reason: 'missing-creds' });
     await useAppStore.getState().refreshBoardTickets(PROJECT_DIR);
+    const state = useAppStore.getState();
+    expect(state.boardTicketsError).toContain('JIRA credentials missing');
+  });
 
+  it('sets boardTicketsError from structured http-status error', async () => {
+    setupSandstormMock([], { reason: 'http-status', status: 401, body: 'Unauthorized' });
+    await useAppStore.getState().refreshBoardTickets(PROJECT_DIR);
+    const state = useAppStore.getState();
+    expect(state.boardTicketsError).toContain('401');
+  });
+
+  it('sets boardTicketsError from structured network error', async () => {
+    setupSandstormMock([], { reason: 'network', message: 'Connection timed out' });
+    await useAppStore.getState().refreshBoardTickets(PROJECT_DIR);
+    const state = useAppStore.getState();
+    expect(state.boardTicketsError).toBe('Connection timed out');
+  });
+
+  it('clears boardTicketsError to null on successful fetch (error:null)', async () => {
+    useAppStore.setState({ boardTicketsError: 'JIRA credentials missing — configure them in Project Settings' });
+    setupSandstormMock([]);
+    await useAppStore.getState().refreshBoardTickets(PROJECT_DIR);
     expect(useAppStore.getState().boardTicketsError).toBeNull();
   });
+
 });
 
 describe('store: moveTicketColumn', () => {


### PR DESCRIPTION
## Summary
- add a "Test Connection" button to JIRA settings that pings `/myself` for auth and runs the board JQL, surfacing connected user, result count, auth failures, and empty-result states inline so misconfiguration is caught before saving
- replace the boolean `{ ok: false }` ticket fetch failure with a structured `TicketListError` union (`missing-creds` / `http-status` / `network`) and propagate it through `tickets:list`, which now returns `{ tickets, error }` instead of a bare array
- normalize the `tickets:list` IPC response at the preload boundary and add a defensive `tickets ?? []` fallback in the store so the board never crashes when a plain-array response is returned

## Test plan
- [ ] `npm run typecheck` and `npm run test` pass
- [ ] in JIRA settings, click Test Connection with valid creds — shows "Connected as <name>" and a ticket count
- [ ] with bad creds — shows the auth failure with status/message; button is disabled until url/username/token are filled
- [ ] with valid creds but no matching tickets — shows the empty-result state
- [ ] open the ticket board with a configured provider and confirm tickets render and the new-ticket button stays present even when the provider errors

Closes #435