### PR TITLE
feat: add discard and clear-all for active refinements

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1179,6 +1179,16 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
+  // Discard removes the notification without killing any running subprocess.
+  // Distinct from cancelRefinement which invokes entry.cancel() to terminate.
+  ipcMain.handle('tickets:discardRefinement', (_event, id: string) => {
+    const entry = activeRefinements.get(id);
+    if (entry) {
+      activeRefinements.delete(id);
+      deleteRefinement(id);
+    }
+  });
+
   ipcMain.handle('tickets:listRefinements', () => {
     return Array.from(activeRefinements.values()).map((e) => e.session);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -199,6 +199,7 @@ export interface SandstormAPI {
     retryRefinementAsync: (sessionId: string, ticketId: string, projectDir: string) => Promise<{ sessionId: string }>;
     postAnswers: (ticketId: string, projectDir: string, answersBody: string) => Promise<void>;
     cancelRefinement: (sessionId: string) => Promise<void>;
+    discardRefinement: (sessionId: string) => Promise<void>;
     listRefinements: () => Promise<unknown[]>;
     create: (projectDir: string, title: string, body: string) => Promise<{ url: string; ticketId: string }>;
     list: (projectDir: string) => Promise<unknown[]>;
@@ -375,6 +376,8 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('tickets:postAnswers', ticketId, projectDir, answersBody),
     cancelRefinement: (sessionId) =>
       ipcRenderer.invoke('tickets:cancelRefinement', sessionId),
+    discardRefinement: (sessionId) =>
+      ipcRenderer.invoke('tickets:discardRefinement', sessionId),
     listRefinements: () =>
       ipcRenderer.invoke('tickets:listRefinements'),
     create: (projectDir, title, body) =>

--- a/src/renderer/components/RefinementIndicator.tsx
+++ b/src/renderer/components/RefinementIndicator.tsx
@@ -42,6 +42,8 @@ export function RefinementIndicator() {
     setShowRefineTicketDialog,
     showRefineTicketDialog,
     activeProject,
+    currentRefinementSessionId,
+    removeRefinementSession,
   } = useAppStore();
   const project = activeProject();
   const [expanded, setExpanded] = useState(false);
@@ -60,6 +62,21 @@ export function RefinementIndicator() {
     openRefinementSession(session.id);
     setShowRefineTicketDialog(true);
     setExpanded(false);
+  };
+
+  const handleDiscard = async (sessionId: string) => {
+    const isCurrentSession = currentRefinementSessionId === sessionId;
+    await window.sandstorm.tickets.discardRefinement(sessionId);
+    removeRefinementSession(sessionId);
+    if (isCurrentSession) {
+      setShowRefineTicketDialog(false);
+    }
+  };
+
+  const handleClearAll = async () => {
+    for (const session of visibleSessions) {
+      await handleDiscard(session.id);
+    }
   };
 
   return (
@@ -90,23 +107,44 @@ export function RefinementIndicator() {
           data-testid="refinement-indicator-dropdown"
         >
           {visibleSessions.map((session) => (
-            <button
+            <div
               key={session.id}
-              onClick={() => handleOpen(session)}
-              className="w-full flex items-center gap-2 px-3 py-2 hover:bg-sandstorm-surface-hover text-left transition-colors"
-              data-testid={`refinement-session-${session.id}`}
+              className="w-full flex items-center hover:bg-sandstorm-surface-hover transition-colors"
             >
-              <StatusDot session={session} />
-              <div className="min-w-0 flex-1">
-                <div className="text-xs text-sandstorm-text font-mono truncate">
-                  #{session.ticketId}
+              <button
+                onClick={() => handleOpen(session)}
+                className="flex items-center gap-2 px-3 py-2 flex-1 min-w-0 text-left"
+                data-testid={`refinement-session-${session.id}`}
+              >
+                <StatusDot session={session} />
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs text-sandstorm-text font-mono truncate">
+                    #{session.ticketId}
+                  </div>
+                  <div className={`text-[10px] ${statusColor(session)}`}>
+                    {sessionLabel(session)}
+                  </div>
                 </div>
-                <div className={`text-[10px] ${statusColor(session)}`}>
-                  {sessionLabel(session)}
-                </div>
-              </div>
-            </button>
+              </button>
+              <button
+                onClick={() => void handleDiscard(session.id)}
+                className="shrink-0 px-2 py-2 text-sandstorm-muted hover:text-sandstorm-text transition-colors"
+                aria-label={`Discard refinement for ticket ${session.ticketId}`}
+                data-testid={`refinement-session-discard-${session.id}`}
+              >
+                ✕
+              </button>
+            </div>
           ))}
+          <div className="border-t border-sandstorm-border px-3 py-1.5">
+            <button
+              onClick={() => void handleClearAll()}
+              className="text-xs text-sandstorm-muted hover:text-sandstorm-text transition-colors"
+              data-testid="refinement-clear-all"
+            >
+              Clear all
+            </button>
+          </div>
         </div>
       )}
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -749,6 +749,7 @@ declare global {
         retryRefinementAsync: (sessionId: string, ticketId: string, projectDir: string) => Promise<{ sessionId: string }>;
         postAnswers: (ticketId: string, projectDir: string, answersBody: string) => Promise<void>;
         cancelRefinement: (sessionId: string) => Promise<void>;
+        discardRefinement: (sessionId: string) => Promise<void>;
         listRefinements: () => Promise<RefinementSession[]>;
         create: (projectDir: string, title: string, body: string) => Promise<{ url: string; number: number; ticketId: string }>;
         list: (projectDir: string) => Promise<TicketBoardEntry[]>;

--- a/tests/unit/components/RefinementIndicator.test.tsx
+++ b/tests/unit/components/RefinementIndicator.test.tsx
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { RefinementIndicator } from '../../../src/renderer/components/RefinementIndicator';
 import { useAppStore, RefinementSession } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
@@ -21,8 +21,10 @@ function makeSession(overrides: Partial<RefinementSession> = {}): RefinementSess
 }
 
 describe('RefinementIndicator', () => {
+  let api: ReturnType<typeof mockSandstormApi>;
+
   beforeEach(() => {
-    mockSandstormApi();
+    api = mockSandstormApi();
     useAppStore.setState({
       projects: [{ id: 1, name: 'proj', directory: '/proj', added_at: '' }],
       activeProjectId: 1,
@@ -102,5 +104,182 @@ describe('RefinementIndicator', () => {
     // Only 1 session for /proj should be shown
     expect(screen.getByTestId('refinement-indicator-pill').textContent).toMatch(/1 refinement/);
   });
-});
 
+  // =========================================================================
+  // Discard (✕) button tests
+  // =========================================================================
+
+  it('renders an inline discard button for each visible session row', () => {
+    useAppStore.setState({
+      refinementSessions: [
+        makeSession({ id: 's1', ticketId: '1', status: 'running' }),
+        makeSession({ id: 's2', ticketId: '2', status: 'errored' }),
+      ],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+    expect(screen.getByTestId('refinement-session-discard-s1')).toBeDefined();
+    expect(screen.getByTestId('refinement-session-discard-s2')).toBeDefined();
+  });
+
+  it('clicking ✕ invokes discardRefinement IPC with the session id', async () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 's1', ticketId: '1', status: 'errored' })],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-session-discard-s1'));
+    });
+
+    expect(api.tickets.discardRefinement).toHaveBeenCalledWith('s1');
+  });
+
+  it('clicking ✕ removes the session from the store', async () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 's1', ticketId: '1', status: 'errored' })],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-session-discard-s1'));
+    });
+
+    expect(useAppStore.getState().refinementSessions.find((s) => s.id === 's1')).toBeUndefined();
+  });
+
+  it('clicking ✕ does not trigger the open-dialog handler', async () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 's1', ticketId: '1', status: 'ready', result: { passed: true, questions: [], gateSummary: '', ticketUrl: null, cached: false } })],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-session-discard-s1'));
+    });
+
+    // Dialog should not have been opened
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+    expect(useAppStore.getState().currentRefinementSessionId).toBeNull();
+  });
+
+  it('clicking ✕ closes the dialog when the discarded session is the currently open one', async () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 's1', ticketId: '1', status: 'ready', result: { passed: true, questions: [], gateSummary: '', ticketUrl: null, cached: false } })],
+      currentRefinementSessionId: 's1',
+      showRefineTicketDialog: true,
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-session-discard-s1'));
+    });
+
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(false);
+  });
+
+  // =========================================================================
+  // "Clear all" button tests
+  // =========================================================================
+
+  it('renders a "Clear all" button in the dropdown', () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 's1', status: 'errored' })],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+    expect(screen.getByTestId('refinement-clear-all')).toBeDefined();
+  });
+
+  it('"Clear all" discards every visible session', async () => {
+    useAppStore.setState({
+      refinementSessions: [
+        makeSession({ id: 's1', ticketId: '1', status: 'errored' }),
+        makeSession({ id: 's2', ticketId: '2', status: 'interrupted' }),
+      ],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-clear-all'));
+    });
+
+    expect(api.tickets.discardRefinement).toHaveBeenCalledWith('s1');
+    expect(api.tickets.discardRefinement).toHaveBeenCalledWith('s2');
+    expect(api.tickets.discardRefinement).toHaveBeenCalledTimes(2);
+  });
+
+  it('"Clear all" only discards sessions from the active project', async () => {
+    useAppStore.setState({
+      refinementSessions: [
+        makeSession({ id: 's1', ticketId: '1', projectDir: '/proj', status: 'errored' }),
+        makeSession({ id: 's2', ticketId: '2', projectDir: '/other-proj', status: 'errored' }),
+      ],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-clear-all'));
+    });
+
+    expect(api.tickets.discardRefinement).toHaveBeenCalledWith('s1');
+    expect(api.tickets.discardRefinement).not.toHaveBeenCalledWith('s2');
+  });
+
+  it('"Clear all" removes all visible sessions from the store', async () => {
+    useAppStore.setState({
+      refinementSessions: [
+        makeSession({ id: 's1', ticketId: '1', status: 'errored' }),
+        makeSession({ id: 's2', ticketId: '2', status: 'interrupted' }),
+      ],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-clear-all'));
+    });
+
+    expect(useAppStore.getState().refinementSessions).toHaveLength(0);
+  });
+
+  // =========================================================================
+  // Regression: terminal-state sessions can be discarded
+  // =========================================================================
+
+  it('discards an errored session (regression: previously no discard path existed)', async () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 'err-1', ticketId: '99', status: 'errored' })],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-session-discard-err-1'));
+    });
+
+    expect(api.tickets.discardRefinement).toHaveBeenCalledWith('err-1');
+    expect(useAppStore.getState().refinementSessions.find((s) => s.id === 'err-1')).toBeUndefined();
+  });
+
+  it('discards an interrupted session', async () => {
+    useAppStore.setState({
+      refinementSessions: [makeSession({ id: 'int-1', ticketId: '88', status: 'interrupted' })],
+    });
+    render(<RefinementIndicator />);
+    fireEvent.click(screen.getByTestId('refinement-indicator-pill'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('refinement-session-discard-int-1'));
+    });
+
+    expect(api.tickets.discardRefinement).toHaveBeenCalledWith('int-1');
+    expect(useAppStore.getState().refinementSessions.find((s) => s.id === 'int-1')).toBeUndefined();
+  });
+});

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -165,6 +165,7 @@ export function mockSandstormApi() {
       retryRefinementAsync: vi.fn().mockResolvedValue({ sessionId: 'retry-session-id' }),
       postAnswers: vi.fn().mockResolvedValue(undefined),
       cancelRefinement: vi.fn().mockResolvedValue(undefined),
+      discardRefinement: vi.fn().mockResolvedValue(undefined),
       listRefinements: vi.fn().mockResolvedValue([]),
       create: vi.fn().mockResolvedValue({
         url: 'https://github.com/o/r/issues/42', ticketId: '42',

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -27,11 +27,17 @@ const {
   mockSpawnSpecCheck,
   mockSpawnSpecRefine,
   mockListTicketComments,
+  mockDeleteRefinement,
+  mockPersistRefinement,
+  mockLoadRefinements,
 } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
   const mockSpawnSpecCheck = vi.fn();
   const mockSpawnSpecRefine = vi.fn();
   const mockListTicketComments = vi.fn().mockResolvedValue([]);
+  const mockDeleteRefinement = vi.fn();
+  const mockPersistRefinement = vi.fn();
+  const mockLoadRefinements = vi.fn().mockReturnValue([]);
 
   const mockRegistry = {
     listProjects: vi.fn(),
@@ -140,6 +146,9 @@ const {
     mockSpawnSpecCheck,
     mockSpawnSpecRefine,
     mockListTicketComments,
+    mockDeleteRefinement,
+    mockPersistRefinement,
+    mockLoadRefinements,
   };
 });
 
@@ -228,6 +237,12 @@ vi.mock('../../src/main/claude/tools', () => ({
 vi.mock('../../src/main/control-plane/ticket-comments', () => ({
   listTicketComments: (...args: unknown[]) => mockListTicketComments(...args),
   postComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/main/control-plane/refinement-store', () => ({
+  persistRefinement: (...args: unknown[]) => mockPersistRefinement(...args),
+  deleteRefinement: (...args: unknown[]) => mockDeleteRefinement(...args),
+  loadRefinements: () => mockLoadRefinements(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -1648,6 +1663,72 @@ describe('IPC Handlers', () => {
   });
 
   // =========================================================================
+  // tickets:discardRefinement
+  // =========================================================================
+  describe('tickets:discardRefinement', () => {
+    beforeEach(() => {
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: vi.fn(),
+      });
+    });
+
+    it('removes the activeRefinements entry and calls deleteRefinement', async () => {
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'TICKET-D1', '/tmp/proj-d') as { sessionId: string };
+      mockDeleteRefinement.mockClear();
+
+      await invokeHandler('tickets:discardRefinement', sessionId);
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith(sessionId);
+
+      // The session should no longer appear in listRefinements
+      const list = await invokeHandler('tickets:listRefinements') as unknown[];
+      expect(list.find((s: unknown) => (s as { id: string }).id === sessionId)).toBeUndefined();
+    });
+
+    it('does NOT call entry.cancel for a running session', async () => {
+      const cancelSpy = vi.fn();
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>(() => {}),
+        cancel: cancelSpy,
+      });
+
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'TICKET-D2', '/tmp/proj-d2') as { sessionId: string };
+
+      await invokeHandler('tickets:discardRefinement', sessionId);
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op for an unknown session id', async () => {
+      mockDeleteRefinement.mockClear();
+      await invokeHandler('tickets:discardRefinement', 'no-such-id');
+      expect(mockDeleteRefinement).not.toHaveBeenCalled();
+    });
+
+    it('removes an errored (terminal-state) session — regression for original bug', async () => {
+      // Register a session and let it error out
+      let rejectFn!: (err: Error) => void;
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>((_resolve, reject) => {
+          rejectFn = reject;
+        }),
+        cancel: vi.fn(),
+      });
+
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'TICKET-D3', '/tmp/proj-d3') as { sessionId: string };
+      rejectFn(new Error('gate failed'));
+      // Allow the rejection handler to settle
+      await new Promise((r) => setTimeout(r, 0));
+
+      mockDeleteRefinement.mockClear();
+      await invokeHandler('tickets:discardRefinement', sessionId);
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith(sessionId);
+    });
+  });
+
+  // =========================================================================
   // Handler Registration Completeness
   // =========================================================================
   describe('handler registration', () => {
@@ -1739,6 +1820,7 @@ describe('IPC Handlers', () => {
       'tickets:retryRefinementAsync',
       'tickets:postAnswers',
       'tickets:cancelRefinement',
+      'tickets:discardRefinement',
       'tickets:listRefinements',
       'tickets:create',
       'tickets:list',


### PR DESCRIPTION
## Summary
- Add a `tickets:discardRefinement` IPC handler that removes a refinement from the active store and deletes it without invoking the session's `cancel?.()` — discarding a finished/errored/interrupted session should drop its state, not cancel a running task.
- Surface discard in the UI: each session row in `RefinementIndicator` gets an inline discard button, plus a "Clear all" footer that removes all refinements for the current project; discarding the open session also closes its dialog.
- Expose `discardRefinement` through the preload bridge and renderer store types so the renderer can call it.

## Test plan
- [ ] Run the unit suite (`RefinementIndicator.test.tsx`, `ipc-handlers.test.ts`) and confirm all pass.
- [ ] Trigger a refinement, then click the inline discard button — verify the entry is removed from the indicator and `cancel` is not called.
- [ ] Open a refinement dialog, discard that session, and confirm the dialog closes.
- [ ] With multiple refinements across projects, click "Clear all" and verify only the current project's refinements are removed.
- [ ] Discard an errored/interrupted session and confirm it is removed cleanly.

Closes #384