### PR TITLE
fix: keep tickets in_stack on failed PR creation, repair stranded card

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -1174,6 +1174,25 @@ export class Registry {
   }
 
   /**
+   * Startup repair: for every pr_open board ticket whose linked stack has pr_number == null,
+   * move the ticket back to in_stack. This repairs cards stranded in pr_open after a failed
+   * PR creation (pr_number is set atomically with pr_url only on success).
+   * Cards with no linked stack are left unchanged — the stack may be gone and moving back
+   * could be wrong.
+   */
+  reconcilePrOpenStuckTickets(): void {
+    const rows = this.db.prepare(
+      `SELECT tb.ticket_id, tb.project_dir
+       FROM ticket_board tb
+       JOIN stacks s ON s.ticket = tb.ticket_id AND s.project_dir = tb.project_dir
+       WHERE tb.column = 'pr_open' AND s.pr_number IS NULL`
+    ).all() as { ticket_id: string; project_dir: string }[];
+    for (const row of rows) {
+      this.setBoardTicketColumn(row.ticket_id, row.project_dir, 'in_stack');
+    }
+  }
+
+  /**
    * Backfill: for every stack with status='pr_created' and a non-null ticket,
    * advance the linked ticket from in_stack → pr_open (forward-only, idempotent).
    */

--- a/src/main/control-plane/startup-reconciler.ts
+++ b/src/main/control-plane/startup-reconciler.ts
@@ -92,6 +92,11 @@ export async function runStartupReconciliation(
     workspaceExistsFn = defaultWorkspaceExists,
   } = deps;
 
+  // Repair cards stuck in pr_open after a failed PR creation (runs before stack reconciliation
+  // so the board is consistent when the renderer loads).
+  registry.reconcilePrOpenStuckTickets();
+  notifyUpdate();
+
   const staleStacks = registry.listStacks().filter((s) => RECONCILE_STATUSES.has(s.status));
 
   for (const stack of staleStacks) {

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -29,6 +29,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     mergeTicket,
     mergeInFlight,
     prCreateInFlight,
+    prCreateErrors,
     refineInFlight,
     refineStartErrors,
   } = useAppStore();
@@ -54,6 +55,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   };
 
   const prInFlight = stack ? (prCreateInFlight[stack.id] ?? false) : false;
+  const prCreateError = stack ? (prCreateErrors[stack.id] ?? null) : null;
 
   const handleCreatePR = () => {
     if (stack && !prInFlight) {
@@ -208,6 +210,14 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               {stackCreateError}
             </div>
           )}
+          {prCreateError && (
+            <div
+              className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-2 py-1.5 break-words"
+              data-testid={`ticket-card-pr-create-error-${ticket.ticket_id}`}
+            >
+              {prCreateError}
+            </div>
+          )}
           {stack && (
             <div className="flex items-center gap-1.5">
               <span
@@ -264,14 +274,16 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               PR #{stack.pr_number}
             </a>
           )}
-          <button
-            onClick={handleMerge}
-            disabled={mergeInflight}
-            className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-state-propen/10 text-sandstorm-state-propen border border-sandstorm-state-propen/30 hover:bg-sandstorm-state-propen/20 transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed"
-            data-testid={`ticket-card-merge-${ticket.ticket_id}`}
-          >
-            {mergeInflight ? 'Merging…' : 'Merge'}
-          </button>
+          {stack?.pr_number != null && (
+            <button
+              onClick={handleMerge}
+              disabled={mergeInflight}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-state-propen/10 text-sandstorm-state-propen border border-sandstorm-state-propen/30 hover:bg-sandstorm-state-propen/20 transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+              data-testid={`ticket-card-merge-${ticket.ticket_id}`}
+            >
+              {mergeInflight ? 'Merging…' : 'Merge'}
+            </button>
+          )}
         </div>
       )}
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -542,7 +542,9 @@ interface AppState {
   mergeTicket: (ticketId: string, projectDir: string) => Promise<void>;
   /** Per-stack in-flight flag for background PR creation, keyed by stackId. */
   prCreateInFlight: Record<string, boolean>;
-  /** One-click PR creation: draft + create in background; opens fallback dialog on failure. */
+  /** Per-stack inline PR-creation error, keyed by stackId. Set on draft_failed/create_failed/thrown error; cleared on retry. */
+  prCreateErrors: Record<string, string>;
+  /** One-click PR creation: draft + create in background; stays in in_stack with inline error on failure. */
   createPRAutomatic: (stackId: string, ticketId: string, projectDir: string, previousColumn: KanbanColumn) => Promise<void>;
 
   // Schedules (per-project)
@@ -1063,6 +1065,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   stackCreateInFlight: {},
   mergeInFlight: {},
   prCreateInFlight: {},
+  prCreateErrors: {},
   refineInFlight: {},
   refineStartErrors: {},
 
@@ -1294,22 +1297,25 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   createPRAutomatic: async (stackId, ticketId, projectDir, previousColumn) => {
     if (get().prCreateInFlight[stackId]) return;
-    set((state) => ({ prCreateInFlight: { ...state.prCreateInFlight, [stackId]: true } }));
-    // Optimistic move: advance to pr_open immediately so the card moves without waiting
-    // for the IPC round-trip. If the call fails and the user cancels the fallback dialog,
-    // setShowCreatePRDialog reverts to previousColumn.
-    void get().moveTicketColumn(ticketId, projectDir, 'pr_open');
+    set((state) => ({
+      prCreateInFlight: { ...state.prCreateInFlight, [stackId]: true },
+      prCreateErrors: (() => { const { [stackId]: _, ...rest } = state.prCreateErrors; return rest; })(),
+    }));
     try {
       const result = await window.sandstorm.pr.createAuto(stackId);
-      if (result.status === 'draft_failed') {
-        get().openCreatePRDialogForTicket(stackId, ticketId, projectDir, previousColumn);
+      if (result.status === 'created') {
+        // Only advance to pr_open on confirmed success
+        void get().moveTicketColumn(ticketId, projectDir, 'pr_open');
+      } else if (result.status === 'draft_failed') {
+        set((state) => ({ prCreateErrors: { ...state.prCreateErrors, [stackId]: 'PR draft failed. Please try again.' } }));
       } else if (result.status === 'create_failed') {
         get().setPrDraft(stackId, result.draft);
-        get().openCreatePRDialogForTicket(stackId, ticketId, projectDir, previousColumn, result.error);
+        const msg = result.error ?? 'PR creation failed. Please try again.';
+        set((state) => ({ prCreateErrors: { ...state.prCreateErrors, [stackId]: msg } }));
       }
-      // On 'created': card is already at pr_open; stacks:updated refreshes the stack record
-    } catch {
-      get().openCreatePRDialogForTicket(stackId, ticketId, projectDir, previousColumn);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'PR creation failed. Please try again.';
+      set((state) => ({ prCreateErrors: { ...state.prCreateErrors, [stackId]: msg } }));
     } finally {
       set((state) => {
         const { [stackId]: _, ...rest } = state.prCreateInFlight;

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -416,21 +416,27 @@ describe('TicketCard', () => {
     expect(useAppStore.getState().showCreatePRDialog).toBeNull();
   });
 
-  it('in_stack: clicking Create PR moves ticket to pr_open immediately (optimistic)', async () => {
+  it('in_stack: clicking Create PR moves ticket to pr_open only after confirmed success', async () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     let resolveAuto!: (v: any) => void;
     api.pr.createAuto.mockReturnValue(new Promise((r) => { resolveAuto = r; }));
     useAppStore.setState({ boardTickets: [makeTicket('in_stack') as any] });
     render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     fireEvent.click(screen.getByTestId('ticket-card-create-pr-42'));
-    // Optimistic move happens synchronously before createAuto resolves
+    // Card must NOT move to pr_open before createAuto resolves
+    await act(async () => { await Promise.resolve(); });
+    const entryBefore = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entryBefore?.column).toBe('in_stack');
+    // Now resolve with success — card should advance
+    await act(async () => {
+      resolveAuto({ status: 'created', url: 'https://github.com/o/r/pull/1', number: 1 });
+      await Promise.resolve();
+    });
     await waitFor(() => {
       const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
       expect(entry?.column).toBe('pr_open');
     });
     expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'pr_open');
-    resolveAuto({ status: 'created', url: 'https://github.com/o/r/pull/1', number: 1 });
-    await waitFor(() => expect(useAppStore.getState().prCreateInFlight['s1']).toBeFalsy());
   });
 
   it('in_stack: shows Creating PR... spinner while prCreateInFlight is set', async () => {
@@ -463,42 +469,65 @@ describe('TicketCard', () => {
     expect(api.pr.createAuto).toHaveBeenCalledTimes(1);
   });
 
-  it('in_stack: opens dialog with no cache when draft fails (Q3 fallback)', async () => {
+  it('in_stack: shows inline error and keeps card in in_stack when draft fails', async () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     api.pr.createAuto.mockResolvedValue({ status: 'draft_failed' });
-    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    useAppStore.setState({ boardTickets: [makeTicket('in_stack') as any] });
+    const { container } = render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     fireEvent.click(screen.getByTestId('ticket-card-create-pr-42'));
     await waitFor(() => {
-      expect(useAppStore.getState().showCreatePRDialog).toEqual({ stackId: 's1', initialError: undefined });
+      expect(useAppStore.getState().prCreateErrors['s1']).toBeTruthy();
     });
-    expect(useAppStore.getState().prDraftCache['s1']).toBeUndefined();
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('in_stack');
+    expect(container.querySelector('[data-testid="ticket-card-pr-create-error-42"]')).not.toBeNull();
   });
 
-  it('in_stack: opens dialog pre-populated with draft and error when create fails (Q4 fallback)', async () => {
+  it('in_stack: shows inline error with draft saved and keeps card in in_stack when create fails', async () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     api.pr.createAuto.mockResolvedValue({
       status: 'create_failed',
       draft: { title: 'pre-drafted', body: 'pre-body' },
       error: 'gh pr create failed after 5 attempts',
     });
-    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    useAppStore.setState({ boardTickets: [makeTicket('in_stack') as any] });
+    const { container } = render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     fireEvent.click(screen.getByTestId('ticket-card-create-pr-42'));
     await waitFor(() => {
-      expect(useAppStore.getState().showCreatePRDialog?.stackId).toBe('s1');
-      expect(useAppStore.getState().showCreatePRDialog?.initialError).toBe('gh pr create failed after 5 attempts');
+      expect(useAppStore.getState().prCreateErrors['s1']).toBe('gh pr create failed after 5 attempts');
     });
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
     expect(useAppStore.getState().prDraftCache['s1']).toEqual({ title: 'pre-drafted', body: 'pre-body' });
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('in_stack');
+    expect(container.querySelector('[data-testid="ticket-card-pr-create-error-42"]')).not.toBeNull();
   });
 
-  it('in_stack: spinner clears and dialog opens when createAuto rejects unexpectedly', async () => {
+  it('in_stack: shows inline error and keeps card in in_stack when createAuto rejects unexpectedly', async () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     api.pr.createAuto.mockRejectedValue(new Error('IPC crash'));
-    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    useAppStore.setState({ boardTickets: [makeTicket('in_stack') as any] });
+    const { container } = render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     fireEvent.click(screen.getByTestId('ticket-card-create-pr-42'));
     await waitFor(() => {
-      expect(useAppStore.getState().showCreatePRDialog?.stackId).toBe('s1');
+      expect(useAppStore.getState().prCreateErrors['s1']).toBe('IPC crash');
       expect(useAppStore.getState().prCreateInFlight['s1']).toBeFalsy();
     });
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('in_stack');
+    expect(container.querySelector('[data-testid="ticket-card-pr-create-error-42"]')).not.toBeNull();
+  });
+
+  it('in_stack: Create PR button stays available after a failure (pr_url not set)', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
+    api.pr.createAuto.mockResolvedValue({ status: 'draft_failed' });
+    useAppStore.setState({ boardTickets: [makeTicket('in_stack') as any] });
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-create-pr-42'));
+    await waitFor(() => expect(useAppStore.getState().prCreateErrors['s1']).toBeTruthy());
+    expect(screen.queryByTestId('ticket-card-create-pr-42')).not.toBeNull();
   });
 
   it('in_stack: Create PR button absent when no matching stack', () => {
@@ -570,20 +599,21 @@ describe('TicketCard', () => {
     expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
   });
 
-  it('pr_open: shows Merge button', () => {
-    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+  it('pr_open: shows Merge button when stack has pr_number set', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
     expect(screen.getByTestId('ticket-card-merge-42')).toBeDefined();
   });
 
-  it('pr_open: clicking Merge with no stack calls ticketBoard.setColumn without teardown or GitHub merge', async () => {
-    useAppStore.setState({ boardTickets: [makeTicket('pr_open') as any], stacks: [] });
+  it('pr_open: Merge button is absent when stack has pr_number == null (stuck card fix)', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-merge-42')).toBeNull();
+  });
+
+  it('pr_open: Merge button is absent when there is no linked stack', () => {
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
-    fireEvent.click(screen.getByTestId('ticket-card-merge-42'));
-    await waitFor(() => {
-      expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'merged');
-    });
-    expect(api.pr.merge).not.toHaveBeenCalled();
-    expect(api.stacks.teardown).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('ticket-card-merge-42')).toBeNull();
   });
 
   it('pr_open: clicking Merge with a stack calls pr.merge → teardown → setColumn in order', async () => {

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -225,6 +225,50 @@ describe('registry.reconcilePrCreatedTickets', () => {
   });
 });
 
+// --- reconcilePrOpenStuckTickets (bug #450 repair) ---
+
+describe('registry.reconcilePrOpenStuckTickets', () => {
+  it('moves pr_open ticket back to in_stack when linked stack has pr_number == null', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'completed', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'pr_open');
+    registry.reconcilePrOpenStuckTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('in_stack');
+  });
+
+  it('leaves pr_open ticket at pr_open when linked stack has a non-null pr_number', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'pr_created', runtime: 'docker' });
+    registry.setPullRequest('s1', 'https://github.com/o/r/pull/5', 5);
+    registry.setBoardTicketColumn('T-1', '/proj', 'pr_open');
+    registry.reconcilePrOpenStuckTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('leaves pr_open ticket unchanged when there is no linked stack', () => {
+    registry.setBoardTicketColumn('T-orphan', '/proj', 'pr_open');
+    registry.reconcilePrOpenStuckTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('pr_open');
+  });
+
+  it('is idempotent — running twice leaves cards in in_stack', () => {
+    registry.createStack({ id: 's1', project: 'p', project_dir: '/proj', ticket: 'T-1', branch: null, description: null, status: 'completed', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-1', '/proj', 'pr_open');
+    registry.reconcilePrOpenStuckTickets();
+    registry.reconcilePrOpenStuckTickets();
+    expect(registry.listBoardTickets('/proj')[0].column).toBe('in_stack');
+  });
+
+  it('does not touch in_stack or merged tickets', () => {
+    registry.createStack({ id: 's2', project: 'p', project_dir: '/proj', ticket: 'T-2', branch: null, description: null, status: 'running', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-2', '/proj', 'in_stack');
+    registry.createStack({ id: 's3', project: 'p', project_dir: '/proj', ticket: 'T-3', branch: null, description: null, status: 'completed', runtime: 'docker' });
+    registry.setBoardTicketColumn('T-3', '/proj', 'merged');
+    registry.reconcilePrOpenStuckTickets();
+    const rows = registry.listBoardTickets('/proj');
+    expect(rows.find(r => r.ticket_id === 'T-2')?.column).toBe('in_stack');
+    expect(rows.find(r => r.ticket_id === 'T-3')?.column).toBe('merged');
+  });
+});
+
 // --- deleteClosedEarlyColumnTickets ---
 
 describe('deleteClosedEarlyColumnTickets', () => {
@@ -803,7 +847,7 @@ describe('store: resolveRefinementTargets (#393)', () => {
   });
 });
 
-describe('store: createPRAutomatic revert-on-cancel (#417)', () => {
+describe('store: createPRAutomatic failure handling (#450)', () => {
   beforeEach(() => {
     setupSandstormMock();
     useAppStore.setState({
@@ -813,10 +857,11 @@ describe('store: createPRAutomatic revert-on-cancel (#417)', () => {
       stacks: [],
       _prDialogContext: null,
       prCreateInFlight: {},
+      prCreateErrors: {},
     });
   });
 
-  it('reverts ticket to in_stack when dialog canceled after draft_failed', async () => {
+  it('on draft_failed: card stays in in_stack, inline error set, no dialog', async () => {
     Object.defineProperty(window, 'sandstorm', {
       value: {
         tickets: { list: vi.fn().mockResolvedValue([]) },
@@ -829,22 +874,13 @@ describe('store: createPRAutomatic revert-on-cancel (#417)', () => {
 
     await useAppStore.getState().createPRAutomatic('s1', '42', PROJECT_DIR, 'in_stack');
 
-    // After draft_failed the ticket should be at pr_open (optimistic move) and dialog should open
-    const afterFail = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
-    expect(afterFail?.column).toBe('pr_open');
-    expect(useAppStore.getState().showCreatePRDialog).toEqual({ stackId: 's1', initialError: undefined });
-
-    // User cancels dialog
-    useAppStore.getState().setShowCreatePRDialog(null);
-    await new Promise(resolve => setTimeout(resolve, 0));
-
-    // Ticket must revert to in_stack
-    const afterCancel = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
-    expect(afterCancel?.column).toBe('in_stack');
-    expect(useAppStore.getState()._prDialogContext).toBeNull();
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('in_stack');
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    expect(useAppStore.getState().prCreateErrors['s1']).toBeTruthy();
   });
 
-  it('reverts ticket to in_stack when dialog canceled after create_failed', async () => {
+  it('on create_failed: card stays in in_stack, inline error set, draft cached, no dialog', async () => {
     const draft = { title: 'My PR', body: 'Description' };
     Object.defineProperty(window, 'sandstorm', {
       value: {
@@ -858,20 +894,50 @@ describe('store: createPRAutomatic revert-on-cancel (#417)', () => {
 
     await useAppStore.getState().createPRAutomatic('s1', '42', PROJECT_DIR, 'in_stack');
 
-    // After create_failed the ticket should be at pr_open (optimistic move) and dialog should open with error
-    const afterFail = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
-    expect(afterFail?.column).toBe('pr_open');
-    expect(useAppStore.getState().showCreatePRDialog).toEqual({ stackId: 's1', initialError: 'gh failed' });
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('in_stack');
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    expect(useAppStore.getState().prCreateErrors['s1']).toBe('gh failed');
     expect(useAppStore.getState().prDraftCache['s1']).toEqual(draft);
+  });
 
-    // User cancels dialog
-    useAppStore.getState().setShowCreatePRDialog(null);
+  it('on status created: card advances to pr_open, no error set', async () => {
+    Object.defineProperty(window, 'sandstorm', {
+      value: {
+        tickets: { list: vi.fn().mockResolvedValue([]) },
+        ticketBoard: { setColumn: vi.fn().mockResolvedValue(undefined) },
+        pr: { createAuto: vi.fn().mockResolvedValue({ status: 'created', url: 'https://github.com/o/r/pull/5', number: 5 }) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    await useAppStore.getState().createPRAutomatic('s1', '42', PROJECT_DIR, 'in_stack');
+
     await new Promise(resolve => setTimeout(resolve, 0));
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('pr_open');
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    expect(useAppStore.getState().prCreateErrors['s1']).toBeUndefined();
+  });
 
-    // Ticket must revert to in_stack
-    const afterCancel = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
-    expect(afterCancel?.column).toBe('in_stack');
-    expect(useAppStore.getState()._prDialogContext).toBeNull();
+  it('on thrown error: card stays in in_stack, inline error set, no dialog', async () => {
+    Object.defineProperty(window, 'sandstorm', {
+      value: {
+        tickets: { list: vi.fn().mockResolvedValue([]) },
+        ticketBoard: { setColumn: vi.fn().mockResolvedValue(undefined) },
+        pr: { createAuto: vi.fn().mockRejectedValue(new Error('IPC crash')) },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    await useAppStore.getState().createPRAutomatic('s1', '42', PROJECT_DIR, 'in_stack');
+
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
+    expect(entry?.column).toBe('in_stack');
+    expect(useAppStore.getState().showCreatePRDialog).toBeNull();
+    expect(useAppStore.getState().prCreateErrors['s1']).toBe('IPC crash');
   });
 });
 


### PR DESCRIPTION
## Summary
- Stop optimistically moving a ticket to `pr_open` when Create PR is clicked; the card now advances only on a confirmed `status === 'created'` result, so a failed draft/create no longer strands it in the wrong column.
- Replace the fallback dialog on PR-creation failure with an inline per-stack error on the card, and only show the Merge button once the stack actually has a `pr_number`.
- Add a startup repair pass (`reconcilePrOpenStuckTickets`) that moves any `pr_open` ticket whose linked stack has a null `pr_number` back to `in_stack`, fixing cards left stranded by earlier failed PR creations.

## Test plan
- [ ] `npm test` — unit suites for `TicketCard` and `ticketBoard` pass
- [ ] Trigger a failing PR creation and confirm the card stays in `in_stack` with an inline error, no dialog
- [ ] Confirm the Merge button only appears after `pr_number` is set
- [ ] Seed a `pr_open` ticket whose stack has null `pr_number`, restart, and confirm startup reconciliation moves it back to `in_stack`

Closes #450