### PR TITLE
feat: add discard action for in-progress and pr-open tickets

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -1221,6 +1221,14 @@ export class Registry {
     ).run(normalizedDir, ...openTicketIds).changes;
   }
 
+  /** Hard-deletes exactly one ticket_board row. No-op when the row is absent. */
+  deleteBoardTicket(ticketId: string, projectDir: string): void {
+    const normalizedDir = path.resolve(projectDir);
+    this.db.prepare(
+      `DELETE FROM ticket_board WHERE ticket_id = ? AND project_dir = ?`
+    ).run(ticketId, normalizedDir);
+  }
+
   /**
    * Resolve the effective model for a project.
    * Resolution order: per-project override > global default > hardcoded fallback

--- a/src/main/control-plane/ticket-config.ts
+++ b/src/main/control-plane/ticket-config.ts
@@ -146,6 +146,21 @@ export async function githubListTickets(cwd: string, label?: string): Promise<Ti
   }
 }
 
+export async function githubCloseTicket(ticketId: string, cwd: string): Promise<void> {
+  try {
+    await execFileAsync(
+      'gh',
+      ['issue', 'close', ticketId],
+      { cwd, timeout: 30000, maxBuffer: 2 * 1024 * 1024 }
+    );
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    const text = `${e.stderr ?? ''} ${e.message ?? ''}`;
+    if (/already closed/i.test(text)) return;
+    throw new Error(`gh issue close failed: ${e.stderr?.trim() || (err as Error).message}`);
+  }
+}
+
 export async function githubCreateTicket(title: string, body: string, cwd: string): Promise<CreatedTicket> {
   const { stdout } = await execFileAsync(
     'gh',
@@ -354,6 +369,26 @@ export async function jiraUpdateTicket(
   });
 }
 
+export async function jiraCloseTicket(
+  ticketId: string,
+  config: ProjectTicketConfig,
+): Promise<void> {
+  if (!config.jira_url || !config.jira_username || !config.jira_api_token) {
+    throw new Error(
+      'Jira credentials are missing. Configure JIRA_URL, JIRA_USERNAME, and JIRA_API_TOKEN in Project Settings.'
+    );
+  }
+  const url = `${config.jira_url.replace(/\/$/, '')}/rest/api/3/issue/${ticketId}/archive`;
+  try {
+    await jiraRequest({ url, method: 'PUT', auth: jiraAuth(config) });
+  } catch (err: unknown) {
+    const e = err as { status?: number; body?: string; message?: string };
+    const body = e.body ?? e.message ?? '';
+    if (/already archived/i.test(body)) return;
+    throw err;
+  }
+}
+
 export async function jiraCreateTicket(
   title: string,
   body: string,
@@ -433,6 +468,17 @@ export async function updateTicketWithConfig(
     return githubUpdateTicket(ticketId, body, cwd);
   }
   return jiraUpdateTicket(ticketId, body, config);
+}
+
+export async function closeTicketWithConfig(
+  ticketId: string,
+  config: ProjectTicketConfig,
+  cwd: string,
+): Promise<void> {
+  if (config.provider === 'github') {
+    return githubCloseTicket(ticketId, cwd);
+  }
+  return jiraCloseTicket(ticketId, config);
 }
 
 export async function createTicketWithConfig(opts: {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -77,7 +77,7 @@ import {
   createPullRequest,
 } from './control-plane/pr-creator';
 import { showNotification } from './tray';
-import { createTicketWithConfig, updateTicketWithConfig, fetchRawBodyWithConfig, testJiraConnection } from './control-plane/ticket-config';
+import { createTicketWithConfig, updateTicketWithConfig, fetchRawBodyWithConfig, testJiraConnection, closeTicketWithConfig } from './control-plane/ticket-config';
 import type { TicketListError } from './control-plane/ticket-config';
 import type { ProjectTicketConfig } from './control-plane/registry';
 import type { EphemeralStreamEvent } from './agent/types';
@@ -1317,6 +1317,22 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     if (dirError) throw new Error(dirError.error);
     if (!VALID_KANBAN_COLUMNS.includes(column)) throw new Error(`Invalid kanban column: "${column}"`);
     registry.setBoardTicketColumn(ticketId, path.resolve(projectDir), column);
+  });
+
+  ipcMain.handle('ticket:close', async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
+    if (!ticketId?.trim()) throw new Error('ticketId is required');
+    const dirError = validateProjectDir(projectDir);
+    if (dirError) throw new Error(dirError.error);
+    const config = registry.getProjectTicketConfig(projectDir);
+    if (!config) throw new Error(`No ticket provider configured for project: ${projectDir}`);
+    await closeTicketWithConfig(ticketId, config, path.resolve(projectDir));
+  });
+
+  ipcMain.handle('ticket-board:delete', async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
+    if (!ticketId?.trim()) throw new Error('ticketId is required');
+    const dirError = validateProjectDir(projectDir);
+    if (dirError) throw new Error(dirError.error);
+    registry.deleteBoardTicket(ticketId, path.resolve(projectDir));
   });
 
   // --- PR creation (deterministic UI for make-PR workflow, #310) ---

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -213,9 +213,11 @@ export interface SandstormAPI {
       auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };
       jql: { ok: true; count: number } | { ok: false; status?: number; message: string } | null;
     }>;
+    close: (ticketId: string, projectDir: string) => Promise<void>;
   };
   ticketBoard: {
     setColumn: (ticketId: string, projectDir: string, column: string) => Promise<void>;
+    delete: (ticketId: string, projectDir: string) => Promise<void>;
   };
   pr: {
     draftBody: (stackId: string) => Promise<{ title: string; body: string }>;
@@ -401,10 +403,14 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('tickets:update', projectDir, ticketId, body),
     testJiraConnection: (params) =>
       ipcRenderer.invoke('tickets:testJiraConnection', params),
+    close: (ticketId, projectDir) =>
+      ipcRenderer.invoke('ticket:close', { ticketId, projectDir }),
   },
   ticketBoard: {
     setColumn: (ticketId, projectDir, column) =>
       ipcRenderer.invoke('ticket-board:set-column', ticketId, projectDir, column),
+    delete: (ticketId, projectDir) =>
+      ipcRenderer.invoke('ticket-board:delete', { ticketId, projectDir }),
   },
   pr: {
     draftBody: (stackId) => ipcRenderer.invoke('pr:draftBody', stackId),

--- a/src/renderer/components/DiscardStackDialog.tsx
+++ b/src/renderer/components/DiscardStackDialog.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+interface DiscardStackDialogProps {
+  onBackToBacklog: () => void;
+  onCloseTicket: () => void;
+  onCancel: () => void;
+  'data-testid'?: string;
+}
+
+export function DiscardStackDialog({
+  onBackToBacklog,
+  onCloseTicket,
+  onCancel,
+  'data-testid': testId = 'discard-stack-dialog',
+}: DiscardStackDialogProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-[60] animate-fade-in"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      data-testid={testId}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Discard stack"
+    >
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[480px] shadow-dialog animate-slide-up">
+        <div className="px-6 py-4 border-b border-sandstorm-border">
+          <h2 className="text-base font-semibold text-sandstorm-text">Discard stack</h2>
+        </div>
+        <div className="px-6 py-5">
+          <p className="text-xs text-sandstorm-text-secondary">
+            This will tear down the local stack and all changes it made. Any already-created remote PR will not be closed — you can close it on GitHub or Jira manually. What would you like to do with the ticket?
+          </p>
+        </div>
+        <div className="px-6 py-4 border-t border-sandstorm-border flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-xs font-medium text-sandstorm-muted hover:text-sandstorm-text transition-colors rounded-lg hover:bg-sandstorm-surface-hover"
+            data-testid="discard-dialog-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onCloseTicket}
+            className="px-4 py-2 text-xs font-medium text-sandstorm-muted hover:text-sandstorm-text transition-colors rounded-lg hover:bg-sandstorm-surface-hover border border-sandstorm-border"
+            data-testid="discard-dialog-close-ticket"
+          >
+            Close ticket
+          </button>
+          <button
+            onClick={onBackToBacklog}
+            className="px-5 py-2 bg-red-600 hover:bg-red-700 text-white text-xs font-medium rounded-lg transition-all active:scale-[0.98]"
+            data-testid="discard-dialog-back-to-backlog"
+          >
+            Back to backlog
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAppStore, KanbanColumn, TicketBoardEntry, Stack } from '../store';
 import { makePrEligible } from '../utils/duration';
 import { suggestStackName } from '../lib/stack-name';
+import { DiscardStackDialog } from './DiscardStackDialog';
 
 interface TicketCardProps {
   ticket: TicketBoardEntry;
@@ -31,13 +32,20 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     prCreateInFlight,
     refineInFlight,
     refineStartErrors,
+    discardStack,
+    discardInFlight,
+    discardErrors,
   } = useAppStore();
+
+  const [showDiscardDialog, setShowDiscardDialog] = useState(false);
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
   const stackKey = `${ticket.ticket_id}|${ticket.project_dir}`;
   const stackCreateError = stackCreateErrors[stackKey];
   const stackInFlight = stackCreateInFlight[stackKey] ?? false;
   const mergeInflight = mergeInFlight[stackKey] ?? false;
+  const discardInflight = discardInFlight[stackKey] ?? false;
+  const discardError = discardErrors[stackKey];
 
   const handleRefine = () => {
     openRefineDialogFromCard(ticket.ticket_id, ticket.project_dir, ticket.column as KanbanColumn);
@@ -70,6 +78,41 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
       void resumeStackWithContinuation(stack.id, true);
     }
   };
+
+  const handleDiscardBackToBacklog = () => {
+    setShowDiscardDialog(false);
+    void discardStack(ticket.ticket_id, ticket.project_dir, 'backlog');
+  };
+
+  const handleDiscardCloseTicket = () => {
+    setShowDiscardDialog(false);
+    void discardStack(ticket.ticket_id, ticket.project_dir, 'close');
+  };
+
+  const discardSection = (
+    <>
+      {discardError && (
+        <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-2 py-1.5 break-words">
+          {discardError}
+        </div>
+      )}
+      <button
+        onClick={() => setShowDiscardDialog(true)}
+        disabled={discardInflight}
+        className="w-full text-xs py-1.5 px-3 rounded-md bg-red-500/5 text-red-400/70 border border-red-500/20 hover:bg-red-500/10 hover:text-red-400 transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+        data-testid={`ticket-card-discard-${ticket.ticket_id}`}
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0">
+          <polyline points="3 6 5 6 21 6"/>
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+          <path d="M10 11v6"/>
+          <path d="M14 11v6"/>
+          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+        </svg>
+        Discard
+      </button>
+    </>
+  );
 
   const refinementSession = refinementSessions.find(
     (s) => s.ticketId === ticket.ticket_id && s.projectDir === ticket.project_dir
@@ -248,6 +291,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               )}
             </button>
           )}
+          {discardSection}
         </div>
       )}
 
@@ -272,11 +316,21 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
           >
             {mergeInflight ? 'Merging…' : 'Merge'}
           </button>
+          {discardSection}
         </div>
       )}
 
       {ticket.column === 'merged' && (
         <span className="text-xs text-sandstorm-state-merged font-medium">Merged</span>
+      )}
+
+      {showDiscardDialog && (
+        <DiscardStackDialog
+          onBackToBacklog={handleDiscardBackToBacklog}
+          onCloseTicket={handleDiscardCloseTicket}
+          onCancel={() => setShowDiscardDialog(false)}
+          data-testid={`discard-stack-dialog-${ticket.ticket_id}`}
+        />
       )}
     </div>
   );

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -544,6 +544,12 @@ interface AppState {
   prCreateInFlight: Record<string, boolean>;
   /** One-click PR creation: draft + create in background; opens fallback dialog on failure. */
   createPRAutomatic: (stackId: string, ticketId: string, projectDir: string, previousColumn: KanbanColumn) => Promise<void>;
+  /** Per-ticket in-flight flag for discard operation, keyed by `${ticketId}|${projectDir}`. */
+  discardInFlight: Record<string, boolean>;
+  /** Per-ticket discard error message, keyed by `${ticketId}|${projectDir}`. Cleared at the start of the next discard attempt. */
+  discardErrors: Record<string, string>;
+  /** Best-effort teardown → card disposition (backlog or close+delete). Surfaces close failure via discardErrors (R2). */
+  discardStack: (ticketId: string, projectDir: string, disposition: 'backlog' | 'close') => Promise<void>;
 
   // Schedules (per-project)
   schedules: ScheduleEntry[];
@@ -783,9 +789,11 @@ declare global {
           auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };
           jql: { ok: true; count: number } | { ok: false; status?: number; message: string } | null;
         }>;
+        close: (ticketId: string, projectDir: string) => Promise<void>;
       };
       ticketBoard: {
         setColumn: (ticketId: string, projectDir: string, column: string) => Promise<void>;
+        delete: (ticketId: string, projectDir: string) => Promise<void>;
       };
       pr: {
         draftBody: (stackId: string) => Promise<{ title: string; body: string }>;
@@ -1062,6 +1070,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   stackCreateInFlight: {},
   mergeInFlight: {},
   prCreateInFlight: {},
+  discardInFlight: {},
+  discardErrors: {},
   refineInFlight: {},
   refineStartErrors: {},
 
@@ -1287,6 +1297,50 @@ export const useAppStore = create<AppState>((set, get) => ({
       set((state) => {
         const { [key]: _, ...rest } = state.mergeInFlight;
         return { mergeInFlight: rest };
+      });
+    }
+  },
+
+  discardStack: async (ticketId: string, projectDir: string, disposition: 'backlog' | 'close') => {
+    const key = `${ticketId}|${projectDir}`;
+    if (get().discardInFlight[key]) return;
+    set((state) => ({
+      discardInFlight: { ...state.discardInFlight, [key]: true },
+      discardErrors: (() => { const { [key]: _, ...rest } = state.discardErrors; return rest; })(),
+    }));
+
+    const stack = get().stacks.find(s => s.ticket === ticketId && s.project_dir === projectDir);
+
+    try {
+      // Best-effort teardown: swallow all errors, including missing stacks
+      if (stack) {
+        try {
+          await window.sandstorm.stacks.teardown(stack.id);
+        } catch {
+          // intentional: teardown is best-effort and must not block disposition
+        }
+      }
+
+      if (disposition === 'backlog') {
+        await get().moveTicketColumn(ticketId, projectDir, 'backlog');
+      } else {
+        // Close/archive ticket — rejects on genuine failure (R2)
+        await window.sandstorm.tickets.close(ticketId, projectDir);
+        // On success or already-closed, delete the board row
+        await window.sandstorm.ticketBoard.delete(ticketId, projectDir);
+        set((state) => ({
+          boardTickets: state.boardTickets.filter(
+            t => !(t.ticket_id === ticketId && t.project_dir === projectDir)
+          ),
+        }));
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      set((state) => ({ discardErrors: { ...state.discardErrors, [key]: `Failed to discard ticket #${ticketId}: ${message}` } }));
+    } finally {
+      set((state) => {
+        const { [key]: _, ...rest } = state.discardInFlight;
+        return { discardInFlight: rest };
       });
     }
   },

--- a/tests/unit/components/DiscardStackDialog.test.tsx
+++ b/tests/unit/components/DiscardStackDialog.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
+import { DiscardStackDialog } from '../../../src/renderer/components/DiscardStackDialog';
+
+describe('DiscardStackDialog', () => {
+  it('renders title and warning body', () => {
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Discard stack')).toBeDefined();
+    expect(screen.getByText(/tear down the local stack/i)).toBeDefined();
+  });
+
+  it('renders three action buttons', () => {
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('discard-dialog-cancel')).toBeDefined();
+    expect(screen.getByTestId('discard-dialog-close-ticket')).toBeDefined();
+    expect(screen.getByTestId('discard-dialog-back-to-backlog')).toBeDefined();
+  });
+
+  it('calls onBackToBacklog when Back to backlog is clicked', () => {
+    const onBackToBacklog = vi.fn();
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={onBackToBacklog}
+        onCloseTicket={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByTestId('discard-dialog-back-to-backlog'));
+    expect(onBackToBacklog).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCloseTicket when Close ticket is clicked', () => {
+    const onCloseTicket = vi.fn();
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={onCloseTicket}
+        onCancel={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByTestId('discard-dialog-close-ticket'));
+    expect(onCloseTicket).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByTestId('discard-dialog-cancel'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('has accessible role=dialog, aria-modal, and aria-label', () => {
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-label')).toBe('Discard stack');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('applies custom data-testid', () => {
+    render(
+      <DiscardStackDialog
+        onBackToBacklog={vi.fn()}
+        onCloseTicket={vi.fn()}
+        onCancel={vi.fn()}
+        data-testid="my-discard-dialog"
+      />
+    );
+    expect(screen.getByTestId('my-discard-dialog')).toBeDefined();
+  });
+});

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -8,6 +8,22 @@ import { TicketCard } from '../../../src/renderer/components/TicketCard';
 import { useAppStore } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
 
+// Mock DiscardStackDialog to avoid full dialog rendering in all tests
+vi.mock('../../../src/renderer/components/DiscardStackDialog', () => ({
+  DiscardStackDialog: ({ onBackToBacklog, onCloseTicket, onCancel, 'data-testid': testId }: {
+    onBackToBacklog: () => void;
+    onCloseTicket: () => void;
+    onCancel: () => void;
+    'data-testid'?: string;
+  }) => (
+    <div data-testid={testId ?? 'discard-stack-dialog'} role="dialog">
+      <button data-testid="discard-dialog-back-to-backlog" onClick={onBackToBacklog}>Back to backlog</button>
+      <button data-testid="discard-dialog-close-ticket" onClick={onCloseTicket}>Close ticket</button>
+      <button data-testid="discard-dialog-cancel" onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}));
+
 const PROJECT_DIR = '/proj';
 
 const makeTicket = (column: string, overrides = {}) => ({
@@ -36,6 +52,8 @@ describe('TicketCard', () => {
       boardTickets: [],
       refineInFlight: {},
       refineStartErrors: {},
+      discardInFlight: {},
+      discardErrors: {},
       showRefineTicketDialog: false,
       refineTicketPrefill: null,
       currentRefinementSessionId: null,
@@ -876,5 +894,86 @@ describe('TicketCard', () => {
     });
     render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
     expect(screen.getByText('2 questions awaiting')).toBeDefined();
+  });
+
+  // =========================================================================
+  // Discard (trash) icon — #446
+  // =========================================================================
+
+  it('in_stack: shows Discard button', () => {
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-discard-42')).toBeDefined();
+  });
+
+  it('pr_open: shows Discard button', () => {
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-discard-42')).toBeDefined();
+  });
+
+  it('backlog: does NOT show Discard button', () => {
+    render(<TicketCard ticket={makeTicket('backlog') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-discard-42')).toBeNull();
+  });
+
+  it('refining: does NOT show Discard button', () => {
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-discard-42')).toBeNull();
+  });
+
+  it('spec_ready: does NOT show Discard button', () => {
+    render(<TicketCard ticket={makeTicket('spec_ready') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-discard-42')).toBeNull();
+  });
+
+  it('merged: does NOT show Discard button', () => {
+    render(<TicketCard ticket={makeTicket('merged') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-discard-42')).toBeNull();
+  });
+
+  it('in_stack: clicking Discard opens the discard dialog', () => {
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    expect(screen.queryByTestId('discard-stack-dialog-42')).toBeNull();
+    fireEvent.click(screen.getByTestId('ticket-card-discard-42'));
+    expect(screen.getByTestId('discard-stack-dialog-42')).toBeDefined();
+  });
+
+  it('pr_open: clicking Discard opens the discard dialog', () => {
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    expect(screen.queryByTestId('discard-stack-dialog-42')).toBeNull();
+    fireEvent.click(screen.getByTestId('ticket-card-discard-42'));
+    expect(screen.getByTestId('discard-stack-dialog-42')).toBeDefined();
+  });
+
+  it('in_stack: clicking Cancel in discard dialog closes the dialog', () => {
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-discard-42'));
+    expect(screen.getByTestId('discard-stack-dialog-42')).toBeDefined();
+    fireEvent.click(screen.getByTestId('discard-dialog-cancel'));
+    expect(screen.queryByTestId('discard-stack-dialog-42')).toBeNull();
+  });
+
+  it('in_stack: clicking Back to backlog calls discardStack with backlog disposition', async () => {
+    const discardSpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ discardStack: discardSpy } as any);
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-discard-42'));
+    fireEvent.click(screen.getByTestId('discard-dialog-back-to-backlog'));
+    await waitFor(() => expect(discardSpy).toHaveBeenCalledWith('42', PROJECT_DIR, 'backlog'));
+  });
+
+  it('in_stack: clicking Close ticket calls discardStack with close disposition', async () => {
+    const discardSpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ discardStack: discardSpy } as any);
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-discard-42'));
+    fireEvent.click(screen.getByTestId('discard-dialog-close-ticket'));
+    await waitFor(() => expect(discardSpy).toHaveBeenCalledWith('42', PROJECT_DIR, 'close'));
+  });
+
+  it('in_stack: Discard button is disabled while discardInFlight is set', () => {
+    useAppStore.setState({ discardInFlight: { '42|/proj': true } } as any);
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    const btn = screen.getByTestId('ticket-card-discard-42') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
   });
 });

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -176,9 +176,11 @@ export function mockSandstormApi() {
         auth: { ok: true, displayName: 'Test User' },
         jql: { ok: true, count: 5 },
       }),
+      close: vi.fn().mockResolvedValue(undefined),
     },
     ticketBoard: {
       setColumn: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
     },
     pr: {
       draftBody: vi.fn().mockResolvedValue({ title: 'Test PR', body: '## Summary\n- thing\n\n## Test plan\n- [ ] check' }),

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -23,6 +23,7 @@ const {
   mockRemoveProjectFromCrontab,
   mockListTicketsWithConfig,
   mockCreateTicketWithConfig,
+  mockCloseTicketWithConfig,
   mockTestJiraConnection,
   mockSessionMonitor,
   mockSpawnSpecCheck,
@@ -46,6 +47,7 @@ const {
     listBoardTickets: vi.fn().mockReturnValue([]),
     setBoardTicketColumn: vi.fn(),
     deleteClosedEarlyColumnTickets: vi.fn().mockReturnValue(0),
+    deleteBoardTicket: vi.fn(),
   };
 
   const mockStackManager = {
@@ -114,6 +116,7 @@ const {
   const mockRemoveProjectFromCrontab = vi.fn();
   const mockListTicketsWithConfig = vi.fn().mockResolvedValue({ ok: false, error: { reason: 'network', message: 'Failed to fetch GitHub tickets' } });
   const mockCreateTicketWithConfig = vi.fn().mockResolvedValue({ url: 'https://github.com/o/r/issues/1', ticketId: '1' });
+  const mockCloseTicketWithConfig = vi.fn().mockResolvedValue(undefined);
   const mockTestJiraConnection = vi.fn().mockResolvedValue({
     auth: { ok: true, displayName: 'Test User' },
     jql: { ok: true, count: 5 },
@@ -141,6 +144,7 @@ const {
     mockRemoveProjectFromCrontab,
     mockListTicketsWithConfig,
     mockCreateTicketWithConfig,
+    mockCloseTicketWithConfig,
     mockTestJiraConnection,
     mockSessionMonitor,
     mockSpawnSpecCheck,
@@ -222,6 +226,7 @@ vi.mock('../../src/main/control-plane/ticket-lister', () => ({
 
 vi.mock('../../src/main/control-plane/ticket-config', () => ({
   createTicketWithConfig: (...args: unknown[]) => mockCreateTicketWithConfig(...args),
+  closeTicketWithConfig: (...args: unknown[]) => mockCloseTicketWithConfig(...args),
   testJiraConnection: (...args: unknown[]) => mockTestJiraConnection(...args),
 }));
 
@@ -1806,7 +1811,9 @@ describe('IPC Handlers', () => {
       'tickets:update',
       'tickets:list',
       'tickets:testJiraConnection',
+      'ticket:close',
       'ticket-board:set-column',
+      'ticket-board:delete',
       'pr:draftBody',
       'pr:create',
       'pr:merge',
@@ -1823,6 +1830,68 @@ describe('IPC Handlers', () => {
 
     it('registers exactly the expected number of handlers', () => {
       expect(Object.keys(registeredHandlers).length).toBe(expectedChannels.length);
+    });
+  });
+
+  // =========================================================================
+  // ticket:close (#446)
+  // =========================================================================
+  describe('ticket:close', () => {
+    beforeEach(() => {
+      mockRegistry.getProjectTicketConfig.mockReturnValue({ provider: 'github' });
+    });
+
+    it('calls closeTicketWithConfig with ticketId, config, and projectDir', async () => {
+      await invokeHandler('ticket:close', { ticketId: '42', projectDir: '/proj' });
+      expect(mockCloseTicketWithConfig).toHaveBeenCalledWith('42', { provider: 'github' }, '/proj');
+    });
+
+    it('resolves successfully when closeTicketWithConfig resolves', async () => {
+      await expect(
+        invokeHandler('ticket:close', { ticketId: '42', projectDir: '/proj' })
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects when no ticket config is configured for the project', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValue(null);
+      await expect(
+        invokeHandler('ticket:close', { ticketId: '42', projectDir: '/proj' })
+      ).rejects.toThrow(/No ticket provider configured/);
+    });
+
+    it('rejects when ticketId is empty', async () => {
+      await expect(
+        invokeHandler('ticket:close', { ticketId: '', projectDir: '/proj' })
+      ).rejects.toThrow(/ticketId is required/);
+    });
+
+    it('propagates rejection from closeTicketWithConfig', async () => {
+      mockCloseTicketWithConfig.mockRejectedValueOnce(new Error('403 Forbidden'));
+      await expect(
+        invokeHandler('ticket:close', { ticketId: '42', projectDir: '/proj' })
+      ).rejects.toThrow('403 Forbidden');
+    });
+  });
+
+  // =========================================================================
+  // ticket-board:delete (#446)
+  // =========================================================================
+  describe('ticket-board:delete', () => {
+    it('calls registry.deleteBoardTicket with ticketId and resolved projectDir', async () => {
+      await invokeHandler('ticket-board:delete', { ticketId: '42', projectDir: '/proj' });
+      expect(mockRegistry.deleteBoardTicket).toHaveBeenCalledWith('42', '/proj');
+    });
+
+    it('resolves successfully (no-op when row absent)', async () => {
+      await expect(
+        invokeHandler('ticket-board:delete', { ticketId: 'nonexistent', projectDir: '/proj' })
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects when ticketId is empty', async () => {
+      await expect(
+        invokeHandler('ticket-board:delete', { ticketId: '', projectDir: '/proj' })
+      ).rejects.toThrow(/ticketId is required/);
     });
   });
 });

--- a/tests/unit/store.discardStack.test.ts
+++ b/tests/unit/store.discardStack.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the discardStack store action (#446).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from '../../src/renderer/store';
+
+const PROJECT_DIR = '/proj';
+const TICKET_ID = '42';
+
+// Minimal sandstorm API mock
+function makeSandstormApi(overrides: Record<string, unknown> = {}) {
+  const api = {
+    stacks: {
+      teardown: vi.fn().mockResolvedValue(undefined),
+    },
+    tickets: {
+      close: vi.fn().mockResolvedValue(undefined),
+    },
+    ticketBoard: {
+      setColumn: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
+    ...overrides,
+  };
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+  return api;
+}
+
+const makeTicket = (column: string) => ({
+  ticket_id: TICKET_ID,
+  project_dir: PROJECT_DIR,
+  column,
+  title: 'Test ticket',
+  updated_at: '',
+});
+
+const makeStack = (overrides = {}) => ({
+  id: 's1',
+  ticket: TICKET_ID,
+  project_dir: PROJECT_DIR,
+  status: 'completed',
+  pr_url: null,
+  pr_number: null,
+  ...overrides,
+});
+
+describe('discardStack', () => {
+  let api: ReturnType<typeof makeSandstormApi>;
+
+  beforeEach(() => {
+    api = makeSandstormApi();
+    useAppStore.setState({
+      boardTickets: [makeTicket('in_stack') as any],
+      stacks: [],
+      discardInFlight: {},
+      discardErrors: {},
+      moveTicketColumnError: null,
+    } as any);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Option A: back to backlog
+  // ---------------------------------------------------------------------------
+
+  it('option A: best-effort teardown then moves card to backlog', async () => {
+    useAppStore.setState({ stacks: [makeStack() as any] } as any);
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'backlog');
+    expect(api.stacks.teardown).toHaveBeenCalledWith('s1');
+    expect(api.ticketBoard.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'backlog');
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === TICKET_ID);
+    expect(entry?.column).toBe('backlog');
+  });
+
+  it('option A: skips teardown when no live stack record (the #446 case)', async () => {
+    // No stack in store → teardown not called
+    useAppStore.setState({ stacks: [] } as any);
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'backlog');
+    expect(api.stacks.teardown).not.toHaveBeenCalled();
+    expect(api.ticketBoard.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'backlog');
+  });
+
+  it('option A: teardown Stack-not-found is swallowed', async () => {
+    useAppStore.setState({ stacks: [makeStack() as any] } as any);
+    api.stacks.teardown.mockRejectedValueOnce(new Error('Stack "s1" not found'));
+    await expect(
+      useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'backlog')
+    ).resolves.not.toThrow();
+    expect(api.ticketBoard.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'backlog');
+  });
+
+  it('option A: all teardown errors are swallowed (best-effort)', async () => {
+    useAppStore.setState({ stacks: [makeStack() as any] } as any);
+    api.stacks.teardown.mockRejectedValueOnce(new Error('docker daemon not running'));
+    await expect(
+      useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'backlog')
+    ).resolves.not.toThrow();
+    expect(api.ticketBoard.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'backlog');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Option B: close ticket
+  // ---------------------------------------------------------------------------
+
+  it('option B: best-effort teardown → ticket:close → ticket-board:delete → removes card', async () => {
+    useAppStore.setState({ stacks: [makeStack() as any] } as any);
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+    expect(api.stacks.teardown).toHaveBeenCalledWith('s1');
+    expect(api.tickets.close).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+    expect(api.ticketBoard.delete).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === TICKET_ID);
+    expect(entry).toBeUndefined();
+  });
+
+  it('option B regression #446: no stack record + already-closed ticket → success, card removed', async () => {
+    // No live stack, ticket.close resolves (already-closed treated as success)
+    useAppStore.setState({ stacks: [] } as any);
+    api.tickets.close.mockResolvedValueOnce(undefined); // already-closed resolves
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+    expect(api.stacks.teardown).not.toHaveBeenCalled();
+    expect(api.tickets.close).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+    expect(api.ticketBoard.delete).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === TICKET_ID);
+    expect(entry).toBeUndefined();
+  });
+
+  it('option B R2 regression: genuine close failure keeps the card and sets discardErrors', async () => {
+    useAppStore.setState({ stacks: [] } as any);
+    api.tickets.close.mockRejectedValueOnce(new Error('403 Forbidden: archive unsupported on plan'));
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+    // Card must still be present
+    const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === TICKET_ID);
+    expect(entry).toBeDefined();
+    expect(entry?.column).toBe('in_stack');
+    // deleteBoardTicket must NOT have been called
+    expect(api.ticketBoard.delete).not.toHaveBeenCalled();
+    // Error is surfaced in the dedicated discardErrors field (not moveTicketColumnError)
+    expect(useAppStore.getState().discardErrors[`${TICKET_ID}|${PROJECT_DIR}`]).toContain('403 Forbidden');
+    expect(useAppStore.getState().moveTicketColumnError).toBeNull();
+  });
+
+  it('option B: teardown error is swallowed even for close path', async () => {
+    useAppStore.setState({ stacks: [makeStack() as any] } as any);
+    api.stacks.teardown.mockRejectedValueOnce(new Error('docker unavailable'));
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+    // Teardown error swallowed — close still runs
+    expect(api.tickets.close).toHaveBeenCalled();
+    expect(api.ticketBoard.delete).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // In-flight guard
+  // ---------------------------------------------------------------------------
+
+  it('in-flight guard prevents concurrent discards', async () => {
+    let resolveFirst!: () => void;
+    const firstPromise = new Promise<void>(r => { resolveFirst = r; });
+    api.tickets.close.mockReturnValueOnce(firstPromise);
+
+    const p1 = useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+    const p2 = useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+
+    resolveFirst();
+    await p1;
+    await p2;
+
+    // tickets.close called only once
+    expect(api.tickets.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('discardInFlight is cleared after the action completes', async () => {
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'backlog');
+    expect(useAppStore.getState().discardInFlight[`${TICKET_ID}|${PROJECT_DIR}`]).toBeFalsy();
+  });
+
+  it('discardInFlight is cleared even after a close failure', async () => {
+    api.tickets.close.mockRejectedValueOnce(new Error('network error'));
+    await useAppStore.getState().discardStack(TICKET_ID, PROJECT_DIR, 'close');
+    expect(useAppStore.getState().discardInFlight[`${TICKET_ID}|${PROJECT_DIR}`]).toBeFalsy();
+  });
+});

--- a/tests/unit/ticket-config.test.ts
+++ b/tests/unit/ticket-config.test.ts
@@ -6,16 +6,19 @@ import {
   githubUpdateTicket,
   githubCreateTicket,
   githubListTickets,
+  githubCloseTicket,
   jiraFetchTicket,
   jiraFetchRawBody,
   jiraUpdateTicket,
   jiraCreateTicket,
   jiraListTickets,
+  jiraCloseTicket,
   fetchTicketWithConfig,
   fetchRawBodyWithConfig,
   updateTicketWithConfig,
   createTicketWithConfig,
   listTicketsWithConfig,
+  closeTicketWithConfig,
   testJiraConnection,
 } from '../../src/main/control-plane/ticket-config';
 import type { ProjectTicketConfig } from '../../src/main/control-plane/registry';
@@ -716,4 +719,146 @@ describe('testJiraConnection', () => {
     }
   });
 
+});
+
+// ---------------------------------------------------------------------------
+// githubCloseTicket (#446)
+// ---------------------------------------------------------------------------
+
+describe('githubCloseTicket', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls gh issue close with the ticket id', async () => {
+    mockExecFileSuccess('');
+    await githubCloseTicket('42', '/proj');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'close', '42'],
+      expect.objectContaining({ cwd: '/proj' }),
+      expect.any(Function)
+    );
+  });
+
+  it('resolves when gh succeeds', async () => {
+    mockExecFileSuccess('');
+    await expect(githubCloseTicket('42', '/proj')).resolves.toBeUndefined();
+  });
+
+  it('resolves when issue is already closed (stderr contains already closed)', async () => {
+    const err = Object.assign(new Error('Command failed'), { stderr: 'Issue is already closed.' });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(err, '', 'Issue is already closed.');
+      return {} as ReturnType<typeof import('child_process').execFile>;
+    });
+    await expect(githubCloseTicket('42', '/proj')).resolves.toBeUndefined();
+  });
+
+  it('throws a meaningful error on genuine gh failure', async () => {
+    mockExecFileError('authentication failed');
+    await expect(githubCloseTicket('42', '/proj')).rejects.toThrow(/gh issue close failed.*authentication failed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jiraCloseTicket (#446)
+// ---------------------------------------------------------------------------
+
+describe('jiraCloseTicket', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('throws when credentials are missing', async () => {
+    const cfg: ProjectTicketConfig = { provider: 'jira' };
+    await expect(jiraCloseTicket('ACME-1', cfg)).rejects.toThrow(/credentials are missing/);
+  });
+
+  it('sends PUT request to the archive endpoint', async () => {
+    const req = mockJiraRequest('', 204);
+    await jiraCloseTicket('ACME-42', JIRA_CONFIG);
+    expect(req.end).toHaveBeenCalled();
+    // Check that the URL path used was the archive endpoint
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.stringContaining('/archive') }),
+      expect.any(Function)
+    );
+  });
+
+  it('resolves on 204 success', async () => {
+    mockJiraRequest('', 204);
+    await expect(jiraCloseTicket('ACME-42', JIRA_CONFIG)).resolves.toBeUndefined();
+  });
+
+  it('resolves when already archived (body contains already archived)', async () => {
+    const mockRequest = {
+      on: vi.fn().mockReturnThis(),
+      write: vi.fn(),
+      end: vi.fn(),
+      setTimeout: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+    };
+    const mockResponse = {
+      statusCode: 400,
+      on: vi.fn((event: string, handler: Function) => {
+        if (event === 'data') handler('{"errorMessages":["Issue is already archived"]}');
+        if (event === 'end') handler();
+      }),
+    };
+    mockHttpsRequest.mockImplementation((_opts: unknown, callback?: Function) => {
+      if (callback) callback(mockResponse);
+      return mockRequest as unknown as ReturnType<typeof import('https').request>;
+    });
+    await expect(jiraCloseTicket('ACME-42', JIRA_CONFIG)).resolves.toBeUndefined();
+  });
+
+  it('rejects when archive returns a genuine error (e.g. 403 Forbidden)', async () => {
+    mockJiraRequest('Forbidden: archive not available on your plan', 403);
+    await expect(jiraCloseTicket('ACME-42', JIRA_CONFIG)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// closeTicketWithConfig (#446)
+// ---------------------------------------------------------------------------
+
+describe('closeTicketWithConfig', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes GitHub → githubCloseTicket', async () => {
+    mockExecFileSuccess('');
+    await closeTicketWithConfig('42', GITHUB_CONFIG, '/proj');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['issue', 'close', '42'],
+      expect.objectContaining({ cwd: '/proj' }),
+      expect.any(Function)
+    );
+  });
+
+  it('routes JIRA → jiraCloseTicket (archive endpoint)', async () => {
+    mockJiraRequest('', 204);
+    await closeTicketWithConfig('ACME-42', JIRA_CONFIG, '/proj');
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.stringContaining('/archive') }),
+      expect.any(Function)
+    );
+  });
+
+  it('resolves when GitHub issue is already closed', async () => {
+    const err = Object.assign(new Error('Command failed'), { stderr: 'Issue is already closed.' });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as Function)(err, '', 'Issue is already closed.');
+      return {} as ReturnType<typeof import('child_process').execFile>;
+    });
+    await expect(closeTicketWithConfig('42', GITHUB_CONFIG, '/proj')).resolves.toBeUndefined();
+  });
+
+  it('rejects on genuine GitHub failure', async () => {
+    mockExecFileError('repository not found');
+    await expect(closeTicketWithConfig('42', GITHUB_CONFIG, '/proj')).rejects.toThrow(/gh issue close failed/);
+  });
+
+  it('rejects on JIRA archive failure', async () => {
+    mockJiraRequest('Forbidden', 403);
+    await expect(closeTicketWithConfig('ACME-42', JIRA_CONFIG, '/proj')).rejects.toThrow();
+  });
 });

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -912,3 +912,38 @@ describe('store: commitRefinementContext (#393)', () => {
     expect(entry?.column).toBe('backlog');
   });
 });
+
+
+// --- deleteBoardTicket (#446) ---
+
+describe('deleteBoardTicket', () => {
+  it('removes exactly the targeted row', () => {
+    registry.seedBoardTicket('del-1', '/proj', 'To be deleted');
+    registry.seedBoardTicket('keep-1', '/proj', 'To keep');
+    registry.deleteBoardTicket('del-1', '/proj');
+    const rows = registry.listBoardTickets('/proj');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ticket_id).toBe('keep-1');
+  });
+
+  it('is a no-op when the row is absent', () => {
+    registry.seedBoardTicket('keep-1', '/proj', 'Keep this');
+    expect(() => registry.deleteBoardTicket('nonexistent', '/proj')).not.toThrow();
+    expect(registry.listBoardTickets('/proj')).toHaveLength(1);
+  });
+
+  it('is scoped to the given project_dir — does not affect other projects', () => {
+    registry.seedBoardTicket('t1', '/alpha', 'Alpha ticket');
+    registry.seedBoardTicket('t1', '/beta', 'Beta ticket');
+    registry.deleteBoardTicket('t1', '/alpha');
+    expect(registry.listBoardTickets('/alpha')).toHaveLength(0);
+    expect(registry.listBoardTickets('/beta')).toHaveLength(1);
+  });
+
+  it('is idempotent — deleting the same row twice does not throw', () => {
+    registry.seedBoardTicket('t1', '/proj', 'T');
+    registry.deleteBoardTicket('t1', '/proj');
+    expect(() => registry.deleteBoardTicket('t1', '/proj')).not.toThrow();
+    expect(registry.listBoardTickets('/proj')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- adds a "Discard" action to ticket cards in the `in_stack` and `pr_open` columns, opening a dialog that lets the user either send the ticket back to backlog or close/archive it and remove the board row
- wires `closeTicketWithConfig` end to end (`gh issue close` for GitHub, Jira archive via REST) plus a `deleteBoardTicket` registry method, exposed through `ticket:close` / `ticket-board:delete` IPC handlers and the preload API
- `discardStack` tears down any associated stack best-effort (failures never block disposition) and surfaces genuine close failures inline via a dedicated per-ticket `discardErrors` field, keeping `moveTicketColumnError` untouched

## Test plan
- [ ] run `npm test` and confirm the full suite passes
- [ ] start a stack from a ticket, click Discard, choose "Back to backlog" and verify the card returns to backlog and the stack is torn down
- [ ] click Discard, choose "Close ticket" and verify the GitHub issue closes (or Jira issue archives) and the board row disappears
- [ ] simulate a close failure and confirm the error renders inline under the discard button and the card stays put
- [ ] verify discarding a ticket with no live stack still completes without error (best-effort teardown)

Closes #446