### PR TITLE
[451] fix: show ticket title in refine dialog header

### DIFF
--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -52,6 +52,7 @@ export function RefineTicketDialog() {
     moveTicketColumn,
     resolveRefinementTargets,
     commitRefinementContext,
+    boardTickets,
   } = useAppStore();
   const project = activeProject();
 
@@ -372,11 +373,24 @@ export function RefineTicketDialog() {
             )}
 
             {/* Show ticket ID read-only when a session exists */}
-            {session && (
-              <div className="text-xs text-sandstorm-muted">
-                Ticket: <span className="font-mono text-sandstorm-text">#{session.ticketId}</span>
-              </div>
-            )}
+            {session && (() => {
+              const boardEntry = boardTickets.find(
+                (t) => t.ticket_id === session.ticketId && t.project_dir === session.projectDir
+              );
+              const title = boardEntry?.title?.trim() || '';
+              return (
+                <div className="text-xs text-sandstorm-muted flex items-baseline gap-1.5 min-w-0">
+                  <span className="shrink-0">Ticket:</span>
+                  <span className="font-mono text-sandstorm-text shrink-0">#{session.ticketId}</span>
+                  {title && (
+                    <>
+                      <span className="shrink-0">—</span>
+                      <span className="text-sandstorm-text truncate min-w-0" data-testid="refine-ticket-title">{title}</span>
+                    </>
+                  )}
+                </div>
+              );
+            })()}
 
             {isRunning && (
               <div className="space-y-2" data-testid="refine-running">

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -1306,6 +1306,79 @@ describe('RefineTicketDialog', () => {
     });
   });
 
+  describe('ticket title display (#451)', () => {
+    const sessionBase = {
+      id: 'session-1', ticketId: '310', projectDir: '/proj',
+      status: 'running' as const, phase: 'check' as const, startedAt: Date.now(),
+    };
+
+    it('shows ticket title when board entry has a non-empty title', () => {
+      useAppStore.setState({
+        refinementSessions: [sessionBase],
+        currentRefinementSessionId: 'session-1',
+        boardTickets: [
+          { ticket_id: '310', project_dir: '/proj', column: 'refining', title: 'Add dark mode', updated_at: '' },
+        ],
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByText('#310')).toBeDefined();
+      expect(screen.getByTestId('refine-ticket-title').textContent).toBe('Add dark mode');
+    });
+
+    it('falls back to bare #N when board entry has empty title', () => {
+      useAppStore.setState({
+        refinementSessions: [sessionBase],
+        currentRefinementSessionId: 'session-1',
+        boardTickets: [
+          { ticket_id: '310', project_dir: '/proj', column: 'refining', title: '', updated_at: '' },
+        ],
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByText('#310')).toBeDefined();
+      expect(screen.queryByTestId('refine-ticket-title')).toBeNull();
+    });
+
+    it('falls back to bare #N when no board entry exists', () => {
+      useAppStore.setState({
+        refinementSessions: [sessionBase],
+        currentRefinementSessionId: 'session-1',
+        boardTickets: [],
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByText('#310')).toBeDefined();
+      expect(screen.queryByTestId('refine-ticket-title')).toBeNull();
+    });
+
+    it('treats whitespace-only title as empty and falls back to bare #N', () => {
+      useAppStore.setState({
+        refinementSessions: [sessionBase],
+        currentRefinementSessionId: 'session-1',
+        boardTickets: [
+          { ticket_id: '310', project_dir: '/proj', column: 'refining', title: '   ', updated_at: '' },
+        ],
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByText('#310')).toBeDefined();
+      expect(screen.queryByTestId('refine-ticket-title')).toBeNull();
+    });
+
+    it('applies truncation class to title element for long titles', () => {
+      useAppStore.setState({
+        refinementSessions: [sessionBase],
+        currentRefinementSessionId: 'session-1',
+        boardTickets: [
+          {
+            ticket_id: '310', project_dir: '/proj', column: 'refining', updated_at: '',
+            title: 'This is an extremely long ticket title that would overflow the 768px modal if not properly truncated with CSS ellipsis',
+          },
+        ],
+      });
+      render(<RefineTicketDialog />);
+      const titleEl = screen.getByTestId('refine-ticket-title');
+      expect(titleEl.className).toContain('truncate');
+    });
+  });
+
   describe('upsertRefinementSession clears streamingOutput on completion', () => {
     it('clears streamingOutput when status transitions to ready', () => {
       useAppStore.setState({


### PR DESCRIPTION
## Summary

The refine ticket dialog header previously showed only the ticket ID. It now also displays the ticket's title, looked up from the board entry matching `ticket_id` and `project_dir`, rendered as `— <title>` next to the ID. The title is trimmed and only shown when a non-empty value is found, so tickets with missing, empty, or whitespace-only titles fall back cleanly to showing just the ID. Long titles truncate with an ellipsis to keep the header layout intact.

## QA plan

1. Open the refine ticket dialog for a ticket that has a title on the board — confirm the header shows the ticket ID followed by `— <title>`.
2. Open the dialog for a ticket whose board entry has an empty or whitespace-only title — confirm only the ticket ID is shown, with no trailing dash.
3. Open the dialog for a ticket that has no matching board entry — confirm it falls back to showing just the ticket ID.
4. Open the dialog for a ticket with a very long title — confirm the title truncates with an ellipsis rather than overflowing the header.

Closes #451