### PR TITLE
[459] fix: preserve refine answers across dialog close/reopen

### DIFF
--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -53,6 +53,8 @@ export function RefineTicketDialog() {
     resolveRefinementTargets,
     commitRefinementContext,
     boardTickets,
+    setRefineAnswerDraft,
+    clearRefineAnswerDraft,
   } = useAppStore();
   const project = activeProject();
 
@@ -75,7 +77,7 @@ export function RefineTicketDialog() {
   const gate: SpecGateResult | null = session?.result ?? null;
   const sessionError = session?.error ?? null;
 
-  // Initialise answers when gate questions change.
+  // Initialise answers when gate questions change, restoring from draft if available.
   // Defensively coerce legacy string[] items (old persisted sessions) to RefineQuestion.
   useEffect(() => {
     if (gate && !gate.passed && gate.questions.length > 0) {
@@ -84,12 +86,20 @@ export function RefineTicketDialog() {
           ? { id: 'q', question: q as string, options: [] }
           : (!Array.isArray((q as RefineQuestion).options) ? { ...(q as RefineQuestion), options: [] } : q as RefineQuestion)
       );
-      setAnswers(normalized.map((q) => {
+      // Read draft imperatively to avoid adding refineAnswerDrafts as a reactive dep.
+      // Questions are not re-fetched on reopen (same gate.questions), so position is stable;
+      // draft[i] corresponds to normalized[i] (id-first match degenerates to positional here).
+      const sessionId = useAppStore.getState().currentRefinementSessionId;
+      const draft = sessionId ? (useAppStore.getState().refineAnswerDrafts[sessionId] ?? null) : null;
+      setAnswers(normalized.map((q, i) => {
+        const saved = draft?.[i];
+        if (saved !== undefined) return saved;
         const firstRecommended = q.options.find((o) => o.recommended === true);
         return { optionId: firstRecommended ? firstRecommended.id : null, text: '' };
       }));
     }
-  }, [gate]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gate, currentRefinementSessionId]);
 
   // Suggest stack name when gate passes
   useEffect(() => {
@@ -221,8 +231,9 @@ export function RefineTicketDialog() {
       projectDir,
       combined,
     );
+    clearRefineAnswerDraft(session.id);
     setShowRefineTicketDialog(false);
-  }, [session, gate, answers, projectDir, upsertRefinementSession, setShowRefineTicketDialog]);
+  }, [session, gate, answers, projectDir, upsertRefinementSession, setShowRefineTicketDialog, clearRefineAnswerDraft]);
 
   const handleStartStack = useCallback(async () => {
     if (!session || !projectDir) return;
@@ -500,6 +511,7 @@ export function RefineTicketDialog() {
                                         const next = [...answers];
                                         next[i] = { ...ans, optionId: ans.optionId === opt.id ? null : opt.id };
                                         setAnswers(next);
+                                        if (session) setRefineAnswerDraft(session.id, next);
                                       }}
                                       className="accent-sandstorm-accent"
                                       data-testid={`refine-option-${i}-${opt.id}`}
@@ -524,6 +536,7 @@ export function RefineTicketDialog() {
                               const next = [...answers];
                               next[i] = { ...ans, text: e.target.value };
                               setAnswers(next);
+                              if (session) setRefineAnswerDraft(session.id, next);
                             }}
                             rows={2}
                             placeholder="Add more detail…"

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -422,6 +422,10 @@ interface AppState {
   refinementSessions: RefinementSession[];
   /** ID of the session currently shown in the refine dialog (null = new refinement). */
   currentRefinementSessionId: string | null;
+  /** In-memory draft answers keyed by sessionId — survives dialog close/reopen (#459). Not persisted to disk. */
+  refineAnswerDrafts: Record<string, { optionId: string | null; text: string }[]>;
+  setRefineAnswerDraft: (sessionId: string, answers: { optionId: string | null; text: string }[]) => void;
+  clearRefineAnswerDraft: (sessionId: string) => void;
   showCreateTicketDialog: boolean;
   showEditTicketDialog: boolean;
   editTicketTarget: { ticketId: string; projectDir: string } | null;
@@ -896,6 +900,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   refineTicketPrefill: null,
   refinementSessions: [],
   currentRefinementSessionId: null,
+  refineAnswerDrafts: {},
   showCreateTicketDialog: false,
   showEditTicketDialog: false,
   editTicketTarget: null,
@@ -1541,12 +1546,16 @@ export const useAppStore = create<AppState>((set, get) => ({
     next[idx] = { ...session, streamingOutput: (session.streamingOutput ?? '') + delta };
     return { refinementSessions: next };
   }),
-  removeRefinementSession: (sessionId) => set((state) => ({
-    refinementSessions: state.refinementSessions.filter((s) => s.id !== sessionId),
-    currentRefinementSessionId: state.currentRefinementSessionId === sessionId
-      ? null
-      : state.currentRefinementSessionId,
-  })),
+  removeRefinementSession: (sessionId) => set((state) => {
+    const { [sessionId]: _, ...draftsNext } = state.refineAnswerDrafts;
+    return {
+      refinementSessions: state.refinementSessions.filter((s) => s.id !== sessionId),
+      currentRefinementSessionId: state.currentRefinementSessionId === sessionId
+        ? null
+        : state.currentRefinementSessionId,
+      refineAnswerDrafts: draftsNext,
+    };
+  }),
   setCurrentRefinementSessionId: (id) => set({ currentRefinementSessionId: id }),
   retryRefinementForTicket: async (ticketId, projectDir) => {
     const key = `${ticketId}|${projectDir}`;
@@ -1619,6 +1628,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       const next = { ...state.prDraftCache };
       delete next[stackId];
       return { prDraftCache: next };
+    }),
+  setRefineAnswerDraft: (sessionId, answers) =>
+    set((state) => ({
+      refineAnswerDrafts: { ...state.refineAnswerDrafts, [sessionId]: answers },
+    })),
+  clearRefineAnswerDraft: (sessionId) =>
+    set((state) => {
+      const { [sessionId]: _, ...next } = state.refineAnswerDrafts;
+      return { refineAnswerDrafts: next };
     }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -52,7 +52,8 @@ describe('RefineTicketDialog', () => {
       refinementSessions: [],
       currentRefinementSessionId: null,
       stacks: [],
-    });
+      refineAnswerDrafts: {},
+    } as any);
     // Default: specCheckAsync returns a sessionId immediately
     api.tickets.specCheckAsync = vi.fn().mockResolvedValue({ sessionId: 'session-1' });
     api.tickets.specRefineAsync = vi.fn().mockResolvedValue(undefined);
@@ -1402,6 +1403,260 @@ describe('RefineTicketDialog', () => {
       render(<RefineTicketDialog />);
       const titleEl = screen.getByTestId('refine-ticket-title');
       expect(titleEl.className).toContain('truncate');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Draft preservation (#459)
+  // ---------------------------------------------------------------------------
+  describe('refine answer draft preservation (#459)', () => {
+    const makeFailSession = (id = 'session-1', questions = MULTI_OPT_QUESTIONS) => ({
+      id,
+      ticketId: '310',
+      projectDir: '/proj',
+      status: 'ready' as const,
+      phase: 'check' as const,
+      startedAt: Date.now(),
+      result: {
+        passed: false,
+        questions,
+        gateSummary: 'Gate=FAIL',
+        ticketUrl: null,
+        cached: false,
+      },
+    });
+
+    const setFailState = (id = 'session-1', questions = MULTI_OPT_QUESTIONS) => {
+      useAppStore.setState({
+        refinementSessions: [makeFailSession(id, questions)],
+        currentRefinementSessionId: id,
+        refineAnswerDrafts: {},
+      } as any);
+    };
+
+    it('backdrop click preserves answers — reopening restores option and text', async () => {
+      const user = userEvent.setup();
+      setFailState();
+
+      const { unmount } = render(<RefineTicketDialog />);
+
+      // Select option and type text
+      await user.click(screen.getByTestId('refine-option-0-a'));
+      await user.type(screen.getByTestId('refine-answer-0'), 'some context');
+
+      // Simulate backdrop click (closes dialog but keeps session)
+      const backdrop = screen.getByTestId('refine-ticket-dialog');
+      fireEvent.click(backdrop);
+      unmount();
+
+      // Draft must be persisted in the store even after unmount
+      expect(useAppStore.getState().refineAnswerDrafts['session-1']).toBeDefined();
+      expect(useAppStore.getState().refineAnswerDrafts['session-1'][0].optionId).toBe('a');
+      expect(useAppStore.getState().refineAnswerDrafts['session-1'][0].text).toBe('some context');
+
+      // Reopen the dialog
+      useAppStore.setState({ showRefineTicketDialog: true } as any);
+      render(<RefineTicketDialog />);
+
+      // Assert option is still selected and textarea retains value
+      const radio = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+      expect(radio.checked).toBe(true);
+      const textarea = screen.getByTestId('refine-answer-0') as HTMLTextAreaElement;
+      expect(textarea.value).toBe('some context');
+    });
+
+    it('switching sessions shows each session draft independently', async () => {
+      const user = userEvent.setup();
+
+      const session2 = {
+        id: 'session-2',
+        ticketId: '311',
+        projectDir: '/proj',
+        status: 'ready' as const,
+        phase: 'check' as const,
+        startedAt: Date.now(),
+        result: {
+          passed: false,
+          questions: SINGLE_OPT_QUESTION,
+          gateSummary: 'Gate=FAIL',
+          ticketUrl: null,
+          cached: false,
+        },
+      };
+
+      useAppStore.setState({
+        refinementSessions: [makeFailSession('session-1'), session2],
+        currentRefinementSessionId: 'session-1',
+        refineAnswerDrafts: {},
+      } as any);
+
+      render(<RefineTicketDialog />);
+
+      // Enter answer for session-1
+      await user.click(screen.getByTestId('refine-option-0-a'));
+      await user.type(screen.getByTestId('refine-answer-0'), 'session1 note');
+
+      // Switch to session-2 — answers should be empty/default
+      act(() => {
+        useAppStore.getState().setCurrentRefinementSessionId('session-2');
+      });
+
+      await waitFor(() => {
+        const radio = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+        // No draft for session-2 yet, so no option pre-selected
+        expect(radio.checked).toBe(false);
+        const textarea = screen.getByTestId('refine-answer-0') as HTMLTextAreaElement;
+        expect(textarea.value).toBe('');
+      });
+
+      // Switch back to session-1 — drafts restored
+      act(() => {
+        useAppStore.getState().setCurrentRefinementSessionId('session-1');
+      });
+
+      await waitFor(() => {
+        const radio = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+        expect(radio.checked).toBe(true);
+        const textarea = screen.getByTestId('refine-answer-0') as HTMLTextAreaElement;
+        expect(textarea.value).toBe('session1 note');
+      });
+    });
+
+    it('submit answers clears the draft for that session', async () => {
+      const user = userEvent.setup();
+      setFailState('session-1', SINGLE_OPT_QUESTION);
+
+      render(<RefineTicketDialog />);
+      await user.click(screen.getByTestId('refine-option-0-a'));
+      await user.type(screen.getByTestId('refine-answer-0'), 'before submit');
+
+      // Confirm draft saved
+      expect(useAppStore.getState().refineAnswerDrafts['session-1']).toBeDefined();
+
+      fireEvent.click(screen.getByTestId('refine-submit-answers'));
+
+      await waitFor(() => {
+        expect(api.tickets.specRefineAsync).toHaveBeenCalled();
+        expect(useAppStore.getState().refineAnswerDrafts['session-1']).toBeUndefined();
+      });
+    });
+
+    it('retry (handleRetry) discards old session draft and new session starts empty', async () => {
+      // Use errored state to show the refine-retry button
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1',
+          ticketId: '310',
+          projectDir: '/proj',
+          status: 'errored' as const,
+          phase: 'check' as const,
+          startedAt: Date.now(),
+          error: 'gate error',
+        }],
+        currentRefinementSessionId: 'session-1',
+        refineAnswerDrafts: {},
+      } as any);
+      // Pre-populate draft for session-1
+      useAppStore.getState().setRefineAnswerDraft('session-1', [{ optionId: 'a', text: 'old note' }]);
+
+      // New session returned by specCheckAsync
+      api.tickets.specCheckAsync = vi.fn().mockResolvedValue({ sessionId: 'session-2' });
+
+      render(<RefineTicketDialog />);
+      fireEvent.click(screen.getByTestId('refine-retry'));
+
+      await waitFor(() => {
+        expect(useAppStore.getState().currentRefinementSessionId).toBe('session-2');
+      });
+
+      // Old session draft must be gone
+      expect(useAppStore.getState().refineAnswerDrafts['session-1']).toBeUndefined();
+      // New session has no draft
+      expect(useAppStore.getState().refineAnswerDrafts['session-2']).toBeUndefined();
+    });
+
+    it('restores guarded against length mismatch (more questions than saved answers)', async () => {
+      // Pre-save draft with only 1 answer for a 2-question session
+      useAppStore.setState({
+        refinementSessions: [makeFailSession('session-1', MULTI_OPT_QUESTIONS)],
+        currentRefinementSessionId: 'session-1',
+        refineAnswerDrafts: {
+          'session-1': [{ optionId: 'b', text: 'only first' }],
+        },
+      } as any);
+
+      // Should not crash
+      expect(() => render(<RefineTicketDialog />)).not.toThrow();
+
+      // First question answer restored from draft
+      const radio = screen.getByTestId('refine-option-0-b') as HTMLInputElement;
+      expect(radio.checked).toBe(true);
+      const textarea0 = screen.getByTestId('refine-answer-0') as HTMLTextAreaElement;
+      expect(textarea0.value).toBe('only first');
+
+      // Second question falls back to default (no optionId, empty text)
+      const textarea1 = screen.getByTestId('refine-answer-1') as HTMLTextAreaElement;
+      expect(textarea1.value).toBe('');
+    });
+
+    it('legacy string questions use positional fallback on restore', async () => {
+      const legacyQuestions = [
+        'What approach should we use?' as unknown as ReturnType<typeof Object>,
+        'Any performance concerns?' as unknown as ReturnType<typeof Object>,
+      ];
+      // These will be coerced to RefineQuestion with id 'q' and empty options
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1',
+          ticketId: '310',
+          projectDir: '/proj',
+          status: 'ready' as const,
+          phase: 'check' as const,
+          startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: legacyQuestions as any,
+            gateSummary: 'Gate=FAIL',
+            ticketUrl: null,
+            cached: false,
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+        refineAnswerDrafts: {
+          'session-1': [
+            { optionId: null, text: 'approach note' },
+            { optionId: null, text: 'perf note' },
+          ],
+        },
+      } as any);
+
+      render(<RefineTicketDialog />);
+
+      const textarea0 = screen.getByTestId('refine-answer-0') as HTMLTextAreaElement;
+      const textarea1 = screen.getByTestId('refine-answer-1') as HTMLTextAreaElement;
+      expect(textarea0.value).toBe('approach note');
+      expect(textarea1.value).toBe('perf note');
+    });
+
+    it('no draft on first open — default recommended option pre-selected', () => {
+      const recommendedQuestions = [{
+        id: 'q1',
+        question: 'Pick one',
+        options: [
+          { id: 'a', label: 'Option A', recommended: true },
+          { id: 'b', label: 'Option B' },
+        ],
+      }];
+      useAppStore.setState({
+        refinementSessions: [makeFailSession('session-1', recommendedQuestions)],
+        currentRefinementSessionId: 'session-1',
+        refineAnswerDrafts: {},
+      } as any);
+
+      render(<RefineTicketDialog />);
+
+      const radioA = screen.getByTestId('refine-option-0-a') as HTMLInputElement;
+      expect(radioA.checked).toBe(true);
     });
   });
 

--- a/tests/unit/store.refineAnswerDrafts.test.ts
+++ b/tests/unit/store.refineAnswerDrafts.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the refineAnswerDrafts store feature (#459).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../../src/renderer/store';
+
+const SESSION_A = 'session-a';
+const SESSION_B = 'session-b';
+
+const ANSWERS_A = [
+  { optionId: 'opt1', text: 'context for q1' },
+  { optionId: null, text: 'free text only' },
+];
+
+const ANSWERS_B = [
+  { optionId: 'opt2', text: '' },
+];
+
+describe('refineAnswerDrafts', () => {
+  beforeEach(() => {
+    useAppStore.setState({ refineAnswerDrafts: {} } as any);
+  });
+
+  it('setRefineAnswerDraft stores answers and can be read back', () => {
+    useAppStore.getState().setRefineAnswerDraft(SESSION_A, ANSWERS_A);
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_A]).toEqual(ANSWERS_A);
+  });
+
+  it('drafts for two distinct session ids are independent', () => {
+    useAppStore.getState().setRefineAnswerDraft(SESSION_A, ANSWERS_A);
+    useAppStore.getState().setRefineAnswerDraft(SESSION_B, ANSWERS_B);
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_A]).toEqual(ANSWERS_A);
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_B]).toEqual(ANSWERS_B);
+  });
+
+  it('clearRefineAnswerDraft removes the entry for that session', () => {
+    useAppStore.getState().setRefineAnswerDraft(SESSION_A, ANSWERS_A);
+    useAppStore.getState().setRefineAnswerDraft(SESSION_B, ANSWERS_B);
+    useAppStore.getState().clearRefineAnswerDraft(SESSION_A);
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_A]).toBeUndefined();
+    // Other session unaffected
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_B]).toEqual(ANSWERS_B);
+  });
+
+  it('clearRefineAnswerDraft on non-existent session is a no-op', () => {
+    useAppStore.getState().setRefineAnswerDraft(SESSION_B, ANSWERS_B);
+    useAppStore.getState().clearRefineAnswerDraft('does-not-exist');
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_B]).toEqual(ANSWERS_B);
+  });
+
+  it('removeRefinementSession clears that session draft and only that one', () => {
+    useAppStore.setState({
+      refineAnswerDrafts: {
+        [SESSION_A]: ANSWERS_A,
+        [SESSION_B]: ANSWERS_B,
+      },
+      refinementSessions: [
+        { id: SESSION_A, ticketId: '1', projectDir: '/p', status: 'ready', phase: 'check', startedAt: 0 },
+        { id: SESSION_B, ticketId: '2', projectDir: '/p', status: 'ready', phase: 'check', startedAt: 0 },
+      ],
+      currentRefinementSessionId: SESSION_A,
+    } as any);
+
+    useAppStore.getState().removeRefinementSession(SESSION_A);
+
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_A]).toBeUndefined();
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_B]).toEqual(ANSWERS_B);
+  });
+
+  it('removeRefinementSession also clears currentRefinementSessionId if it matches', () => {
+    useAppStore.setState({
+      refineAnswerDrafts: { [SESSION_A]: ANSWERS_A },
+      refinementSessions: [
+        { id: SESSION_A, ticketId: '1', projectDir: '/p', status: 'ready', phase: 'check', startedAt: 0 },
+      ],
+      currentRefinementSessionId: SESSION_A,
+    } as any);
+
+    useAppStore.getState().removeRefinementSession(SESSION_A);
+
+    expect(useAppStore.getState().currentRefinementSessionId).toBeNull();
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_A]).toBeUndefined();
+  });
+
+  it('draft is part of store state (not referenced by localStorage or persist)', () => {
+    // Verify refineAnswerDrafts exists as a key on the store state
+    useAppStore.getState().setRefineAnswerDraft(SESSION_A, ANSWERS_A);
+    const state = useAppStore.getState();
+    expect(Object.prototype.hasOwnProperty.call(state, 'refineAnswerDrafts')).toBe(true);
+    // Confirm nothing was written to localStorage
+    expect(localStorage.getItem('refineAnswerDrafts')).toBeNull();
+  });
+
+  it('updating an existing draft overwrites the previous value', () => {
+    useAppStore.getState().setRefineAnswerDraft(SESSION_A, ANSWERS_A);
+    const updated = [{ optionId: 'new-opt', text: 'updated text' }];
+    useAppStore.getState().setRefineAnswerDraft(SESSION_A, updated);
+    expect(useAppStore.getState().refineAnswerDrafts[SESSION_A]).toEqual(updated);
+  });
+});


### PR DESCRIPTION
## Summary

Answers entered in the Refine Ticket dialog were lost whenever the dialog was closed and reopened, forcing users to re-fill the spec gate questions from scratch. This adds an in-memory draft store (`refineAnswerDrafts`) keyed by refinement session ID that captures answers as they are typed or selected, then restores them when the dialog is reopened for the same session.

Drafts are held in the renderer store only (not persisted to disk). They are cleared when the refinement is committed (`commitRefinementContext`) and when the underlying session is removed, so stale answers never leak into a new or unrelated refinement. The restore happens positionally against the unchanged gate questions, falling back to the recommended option when no draft entry exists.

## QA plan

1. Open a ticket and start refinement until the spec gate shows questions.
2. Select options and type free-text detail for several questions.
3. Close the dialog (without committing) and reopen it for the same ticket — confirm the previously entered options and text are still present.
4. Commit the refinement, then reopen — confirm answers reset (draft cleared).
5. Start a fresh refinement on a different ticket — confirm no answers carry over.

Closes #459