### PR TITLE
#461: Stack human intervention — answer questions and resume

### DIFF
--- a/sandstorm-cli/docker/SANDSTORM_INNER.md
+++ b/sandstorm-cli/docker/SANDSTORM_INNER.md
@@ -76,13 +76,32 @@ The in-scope files list the *primary* targets. You are authorized — and expect
 
 ### STOP_AND_ASK — deadlock break
 
-If you determine that verify cannot pass **without** making out-of-scope changes (e.g., a pre-existing broken test unrelated to your ticket keeps failing), do NOT silently drift. Instead, output exactly:
+If you determine that verify cannot pass **without** making out-of-scope changes (e.g., a pre-existing broken test unrelated to your ticket keeps failing), do NOT silently drift. Instead:
+
+**Step 1 — write structured questions to `/tmp/claude-stop-questions.json`** (MUST be done before the STOP_AND_ASK line). The file MUST contain a JSON array of `RefineQuestion` objects:
+
+```json
+[
+  {
+    "id": "q1",
+    "question": "What should we do about the pre-existing broken test in foo.test.ts?",
+    "options": [
+      { "id": "skip", "label": "Skip it for now and re-dispatch after fixing", "recommended": true },
+      { "id": "fix", "label": "Fix it as part of this task (out-of-scope exception)" }
+    ]
+  }
+]
+```
+
+Required fields: `id` (string), `question` (string), `options` (array). Each option needs `id` and `label`; mark one with `"recommended": true` to pre-select it.
+
+**Step 2 — output exactly:**
 
 ```
 STOP_AND_ASK: <one-sentence reason naming the out-of-scope file or problem>
 ```
 
-on its own line, then stop immediately without making further changes. The harness will halt the loop, set the stack status to `needs_human`, and surface your reason to the human operator. The human will then fix the pre-existing issue separately and re-dispatch your ticket.
+on its own line, then stop immediately without making further changes. The harness will halt the loop, set the stack status to `needs_human`, and surface your questions to the human operator. The human will answer your questions in the UI and re-dispatch your ticket with the answers as context.
 
 ## What you should NOT do
 

--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -42,6 +42,11 @@ check_for_stop_and_ask() {
     reason=$(echo "$stop_line" | sed 's/.*STOP_AND_ASK:[[:space:]]*//')
     echo "$reason" > /tmp/claude-stop-reason.txt
     log_loop "Agent signaled STOP_AND_ASK: $reason"
+    if [ -f /tmp/claude-stop-questions.json ]; then
+      local questions_content
+      questions_content=$(cat /tmp/claude-stop-questions.json 2>/dev/null || echo "")
+      log_loop "Structured questions: $questions_content"
+    fi
     return 0
   fi
   return 1

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -65,6 +65,7 @@ export interface Task {
   review_verdicts: string | null;
   verify_outputs: string | null;
   execution_summary: string | null;
+  needs_human_questions: string | null;
   execution_started_at: string | null;
   execution_finished_at: string | null;
   review_started_at: string | null;
@@ -534,6 +535,13 @@ export class Registry {
       this.setSchemaVersion(16);
     }
 
+    if (currentVersion < 17) {
+      // Structured questions emitted by the agent at STOP_AND_ASK time.
+      // Stored as a JSON string (RefineQuestion[]) so the renderer can render them.
+      try { this.db.exec('ALTER TABLE tasks ADD COLUMN needs_human_questions TEXT'); } catch { /* exists */ }
+      this.setSchemaVersion(17);
+    }
+
   }
 
   // --- Projects ---
@@ -636,10 +644,10 @@ export class Registry {
     }
   }
 
-  completeTaskNeedsHuman(taskId: number, reason: string): void {
+  completeTaskNeedsHuman(taskId: number, reason: string, questionsJson?: string | null): void {
     this.db.prepare(
-      "UPDATE tasks SET status = 'needs_human', exit_code = 1, warnings = ?, finished_at = datetime('now') WHERE id = ?"
-    ).run(reason, taskId);
+      "UPDATE tasks SET status = 'needs_human', exit_code = 1, warnings = ?, needs_human_questions = ?, finished_at = datetime('now') WHERE id = ?"
+    ).run(reason, questionsJson ?? null, taskId);
 
     const task = this.db.prepare(
       'SELECT stack_id FROM tasks WHERE id = ?'
@@ -647,6 +655,18 @@ export class Registry {
     if (task) {
       this.updateStackStatus(task.stack_id, 'needs_human');
     }
+  }
+
+  reopenTaskForResume(taskId: number): void {
+    this.db.prepare(
+      "UPDATE tasks SET status = 'running', finished_at = NULL, exit_code = NULL WHERE id = ?"
+    ).run(taskId);
+  }
+
+  getNeedsHumanQuestions(stackId: string): string | null {
+    const task = this.getMostRecentTask(stackId);
+    if (!task || task.status !== 'needs_human') return null;
+    return task.needs_human_questions ?? null;
   }
 
   completeTaskVerifyBlockedEnvironmental(taskId: number, reason: string): void {

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -657,7 +657,8 @@ export class StackManager {
   private async dispatchContinuation(
     stack: Stack,
     stackId: string,
-    task: Task
+    task: Task,
+    continuationPrompt: string = 'Continue the work that was halted by token limits. Keep going from where you left off.'
   ): Promise<void> {
     const runtime = this.getRuntimeForStack(stack);
     let claudeContainer = await this.findClaudeContainer(stack, runtime);
@@ -672,9 +673,6 @@ export class StackManager {
     this.registry.setTaskResumedAt(task.id, new Date().toISOString());
     this.registry.updateStackStatus(stackId, 'running');
     this.notifyUpdate();
-
-    const continuationPrompt =
-      'Continue the work that was halted by token limits. Keep going from where you left off.';
 
     const cliArgs = ['task', stackId, '--resume', task.session_id!];
     if (task.model) cliArgs.push('--model', task.model);
@@ -692,6 +690,67 @@ export class StackManager {
 
     this.taskWatcher.watch(stackId, claudeContainer.id);
     this.taskWatcher.streamOutput(stackId, claudeContainer.id, () => {}).catch(() => {});
+  }
+
+  /**
+   * Resume a needs_human stack by providing answers to the agent's questions.
+   * Uses --resume <session_id> if available; falls back to fresh dispatch if not.
+   */
+  async resumeNeedsHumanStack(stackId: string, answers: string): Promise<void> {
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    if (stack.status !== 'needs_human') {
+      throw new SandstormError(ErrorCode.INVALID_INPUT, `Stack "${stackId}" is not in needs_human state`);
+    }
+
+    const task = this.registry.getMostRecentTask(stackId);
+    if (!task) throw new SandstormError(ErrorCode.INTERNAL_ERROR, `No task found for stack "${stackId}"`);
+
+    // Bring containers up
+    this.registry.updateStackStatus(stackId, 'building');
+    this.notifyUpdate();
+    try {
+      await this.ensureStackContainersRunning(stack, stackId);
+    } catch (err) {
+      this.registry.updateStackStatus(stackId, 'needs_human');
+      this.notifyUpdate();
+      throw err;
+    }
+
+    const continuationPrompt =
+      `The agent was waiting for human input. Here are the answers to the questions:\n\n${answers}\n\nPlease continue the work from where you left off.`;
+
+    try {
+      if (task.session_id) {
+        // Case A: resume with existing Claude session — reopen task then dispatch continuation
+        this.registry.reopenTaskForResume(task.id);
+        await this.dispatchContinuation(stack, stackId, { ...task, status: 'running' }, continuationPrompt);
+      } else {
+        // Case B: no session_id — close the original task and redispatch fresh with original prompt + answers
+        this.registry.interruptTask(task.id);
+        const freshPrompt = `${task.prompt}\n\n---\nAdditional context from human:\n${answers}`;
+        try {
+          await this.dispatchTask(stackId, freshPrompt, task.model ?? undefined, {
+            skipTicketFetch: true,
+          });
+        } catch (err) {
+          // Revert task to terminal needs_human state so it doesn't strand in interrupted
+          this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+          this.registry.updateStackStatus(stackId, 'needs_human');
+          this.notifyUpdate();
+          throw err;
+        }
+      }
+    } catch (err) {
+      if (task.session_id) {
+        // Revert task to terminal needs_human state so it doesn't strand in running
+        this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+        this.registry.updateStackStatus(stackId, 'needs_human');
+        this.notifyUpdate();
+      }
+      throw err;
+    }
   }
 
   async teardownStack(stackId: string): Promise<void> {

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -131,10 +131,11 @@ export class TaskWatcher extends EventEmitter {
     status: 'completed' | 'failed' | 'needs_human',
     exitCode: number,
     containerId?: string,
-    stopReason?: string
+    stopReason?: string,
+    questionsJson?: string | null
   ): void {
     if (status === 'needs_human') {
-      this.registry.completeTaskNeedsHuman(task.id, stopReason ?? 'Agent signaled STOP_AND_ASK — needs human intervention');
+      this.registry.completeTaskNeedsHuman(task.id, stopReason ?? 'Agent signaled STOP_AND_ASK — needs human intervention', questionsJson);
     } else {
       this.registry.completeTask(task.id, exitCode);
     }
@@ -624,13 +625,27 @@ export class TaskWatcher extends EventEmitter {
 
         if (status === 'needs_human') {
           let stopReason = 'Agent signaled STOP_AND_ASK — needs human intervention';
+          let questionsJson: string | null = null;
           try {
             const reasonResult = await runtime.exec(containerId, ['cat', '/tmp/claude-stop-reason.txt']);
             if (reasonResult.stdout.trim()) {
               stopReason = reasonResult.stdout.trim();
             }
           } catch { /* best effort */ }
-          this.completeTaskAndNotify(task, stackId, 'needs_human', 1, containerId, stopReason);
+          try {
+            const questionsResult = await runtime.exec(containerId, ['cat', '/tmp/claude-stop-questions.json']);
+            if (questionsResult.stdout.trim()) {
+              const parsed = JSON.parse(questionsResult.stdout.trim());
+              if (Array.isArray(parsed) && parsed.every(
+                (q: unknown) => q && typeof q === 'object' &&
+                  typeof (q as Record<string, unknown>).id === 'string' &&
+                  typeof (q as Record<string, unknown>).question === 'string'
+              )) {
+                questionsJson = questionsResult.stdout.trim();
+              }
+            }
+          } catch { /* best effort — malformed/absent JSON falls back to null */ }
+          this.completeTaskAndNotify(task, stackId, 'needs_human', 1, containerId, stopReason, questionsJson);
           return;
         }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -919,6 +919,14 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return sessionMonitor.forcePoll();
   });
 
+  ipcMain.handle('stacks:getNeedsHumanQuestions', (_event, stackId: string) => {
+    return registry.getNeedsHumanQuestions(stackId);
+  });
+
+  ipcMain.handle('stacks:resumeNeedsHuman', async (_event, stackId: string, answers: string) => {
+    await stackManager.resumeNeedsHumanStack(stackId, answers);
+  });
+
   ipcMain.on('session:activity', () => {
     sessionMonitor.reportActivity();
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,6 +71,8 @@ export interface SandstormAPI {
     setPr: (id: string, prUrl: string, prNumber: number) => Promise<void>;
     detectStale: () => Promise<unknown[]>;
     cleanupStale: (workspacePaths: string[]) => Promise<unknown[]>;
+    getNeedsHumanQuestions: (stackId: string) => Promise<string | null>;
+    resumeNeedsHuman: (stackId: string, answers: string) => Promise<void>;
   };
   tasks: {
     dispatch: (stackId: string, prompt: string, model?: string) => Promise<unknown>;
@@ -263,6 +265,10 @@ const api: SandstormAPI = {
     detectStale: () => ipcRenderer.invoke('stacks:detectStale'),
     cleanupStale: (workspacePaths: string[]) =>
       ipcRenderer.invoke('stacks:cleanupStale', workspacePaths),
+    getNeedsHumanQuestions: (stackId: string) =>
+      ipcRenderer.invoke('stacks:getNeedsHumanQuestions', stackId),
+    resumeNeedsHuman: (stackId: string, answers: string) =>
+      ipcRenderer.invoke('stacks:resumeNeedsHuman', stackId, answers),
   },
   tasks: {
     dispatch: (stackId, prompt, model?) =>

--- a/src/renderer/components/AnswerQuestionsModal.tsx
+++ b/src/renderer/components/AnswerQuestionsModal.tsx
@@ -1,0 +1,151 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { RefineQuestion } from '../store';
+import { QuestionList, QuestionAnswer, normalizeQuestion, combineAnswers, defaultAnswers, isSubmitDisabled } from './QuestionList';
+
+interface AnswerQuestionsModalProps {
+  stackId: string;
+  onClose: () => void;
+  onResumed: () => void;
+}
+
+export function AnswerQuestionsModal({ stackId, onClose, onResumed }: AnswerQuestionsModalProps) {
+  const [questions, setQuestions] = useState<RefineQuestion[] | null>(null);
+  const [fallbackMessage, setFallbackMessage] = useState<string | null>(null);
+  const [answers, setAnswers] = useState<QuestionAnswer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.sandstorm.stacks.getNeedsHumanQuestions(stackId)
+      .then((raw) => {
+        if (cancelled) return;
+        if (!raw) {
+          setFallbackMessage('Agent requested human input but provided no structured questions.');
+          setLoading(false);
+          return;
+        }
+        try {
+          const parsed = JSON.parse(raw) as unknown[];
+          const normalized = parsed.map((q, i) => normalizeQuestion(q, i));
+          if (normalized.length === 0) {
+            setFallbackMessage(raw);
+            setLoading(false);
+            return;
+          }
+          setQuestions(normalized);
+          setAnswers(defaultAnswers(normalized));
+        } catch {
+          setFallbackMessage(raw);
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setFallbackMessage(`Could not load questions: ${err instanceof Error ? err.message : String(err)}`);
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [stackId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!questions) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const combined = combineAnswers(questions, answers);
+      await window.sandstorm.stacks.resumeNeedsHuman(stackId, combined);
+      onResumed();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }, [stackId, questions, answers, onResumed]);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in"
+      onClick={(e) => { if (e.target === e.currentTarget && !submitting) onClose(); }}
+      data-testid="answer-questions-modal"
+    >
+      <div className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[640px] max-h-[80vh] overflow-y-auto shadow-dialog animate-slide-up">
+        <div className="px-6 py-4 border-b border-sandstorm-border flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-sandstorm-text">Answer Agent Questions</h2>
+            <p className="text-[11px] text-sandstorm-muted mt-0.5">
+              The agent needs your input to continue
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="text-sandstorm-muted hover:text-sandstorm-text transition-colors p-1.5 rounded-md hover:bg-sandstorm-surface-hover disabled:opacity-40"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          {error && (
+            <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2.5" data-testid="answer-modal-error">
+              {error}
+            </div>
+          )}
+
+          {loading && (
+            <div className="flex items-center gap-2 text-xs text-sandstorm-muted" data-testid="answer-modal-loading">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="animate-spin">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+              </svg>
+              Loading questions…
+            </div>
+          )}
+
+          {!loading && fallbackMessage && (
+            <div className="space-y-3" data-testid="answer-modal-fallback">
+              <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
+                The agent halted with the following message. Review it and re-dispatch manually if needed.
+              </div>
+              <div className="text-xs text-sandstorm-muted bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2.5 whitespace-pre-wrap font-mono">
+                {fallbackMessage}
+              </div>
+            </div>
+          )}
+
+          {!loading && questions && questions.length > 0 && (
+            <QuestionList
+              questions={questions}
+              answers={answers}
+              onAnswersChange={setAnswers}
+              testIdPrefix="answer"
+            />
+          )}
+        </div>
+
+        <div className="px-6 py-4 border-t border-sandstorm-border flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 text-xs font-medium text-sandstorm-muted hover:text-sandstorm-text transition-colors rounded-lg hover:bg-sandstorm-surface-hover disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          {!loading && questions && questions.length > 0 && (
+            <button
+              onClick={handleSubmit}
+              disabled={submitting || isSubmitDisabled(answers)}
+              className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
+              data-testid="answer-modal-submit"
+            >
+              {submitting ? 'Resuming…' : 'Submit & Resume'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/QuestionList.tsx
+++ b/src/renderer/components/QuestionList.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { RefineQuestion } from '../store';
+
+export interface QuestionAnswer {
+  optionId: string | null;
+  text: string;
+}
+
+export function normalizeQuestion(q: unknown, index: number): RefineQuestion {
+  if (typeof q === 'string') {
+    return { id: `q${index}`, question: q as string, options: [] };
+  }
+  const qObj = q as RefineQuestion;
+  if (!Array.isArray(qObj.options)) {
+    return { ...qObj, options: [] };
+  }
+  return qObj;
+}
+
+export function combineAnswers(questions: RefineQuestion[], answers: QuestionAnswer[]): string {
+  return questions
+    .map((q, i) => {
+      const ans = answers[i];
+      const selectedLabel =
+        ans?.optionId != null
+          ? q.options.find((o) => o.id === ans.optionId)?.label ?? null
+          : null;
+      return [
+        `Q${i + 1}: ${q.question}`,
+        `Selected: ${selectedLabel ?? '(none)'}`,
+        `Additional context: ${ans?.text.trim() || '(none)'}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+}
+
+export function defaultAnswers(questions: RefineQuestion[]): QuestionAnswer[] {
+  return questions.map((q) => {
+    const firstRecommended = q.options.find((o) => o.recommended === true);
+    return { optionId: firstRecommended ? firstRecommended.id : null, text: '' };
+  });
+}
+
+export function isSubmitDisabled(answers: QuestionAnswer[]): boolean {
+  return answers.some((a) => a.optionId === null && !a.text.trim());
+}
+
+interface QuestionListProps {
+  questions: RefineQuestion[];
+  answers: QuestionAnswer[];
+  onAnswersChange: (answers: QuestionAnswer[]) => void;
+  testIdPrefix?: string;
+}
+
+export function QuestionList({ questions, answers, onAnswersChange, testIdPrefix = 'question' }: QuestionListProps) {
+  return (
+    <div className="space-y-4">
+      {questions.map((q, i) => {
+        const ans = answers[i] ?? { optionId: null, text: '' };
+        return (
+          <div key={i} className="space-y-2">
+            <p className="text-xs text-sandstorm-text-secondary">
+              <span className="text-sandstorm-muted">{i + 1}.</span> {q.question}
+            </p>
+            {q.options.length > 0 && (
+              <div className="space-y-1 pl-3">
+                {q.options.map((opt, optIdx) => {
+                  const isFirstRecommended =
+                    opt.recommended === true &&
+                    optIdx === q.options.findIndex((o) => o.recommended === true);
+                  return (
+                    <label key={opt.id} className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name={`${testIdPrefix}-q-${i}`}
+                        value={opt.id}
+                        checked={ans.optionId === opt.id}
+                        onChange={() => {}}
+                        onClick={() => {
+                          const next = [...answers];
+                          next[i] = { ...ans, optionId: ans.optionId === opt.id ? null : opt.id };
+                          onAnswersChange(next);
+                        }}
+                        className="accent-sandstorm-accent"
+                        data-testid={`${testIdPrefix}-option-${i}-${opt.id}`}
+                      />
+                      <span className="text-xs text-sandstorm-text">{opt.label}</span>
+                      {isFirstRecommended && (
+                        <span
+                          className="text-xs font-medium text-sandstorm-accent border border-sandstorm-accent/40 rounded px-1.5 py-0.5 leading-none"
+                          data-testid={`${testIdPrefix}-option-recommended-${i}-${opt.id}`}
+                        >
+                          Recommended
+                        </span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+            <textarea
+              value={ans.text}
+              onChange={(e) => {
+                const next = [...answers];
+                next[i] = { ...ans, text: e.target.value };
+                onAnswersChange(next);
+              }}
+              rows={2}
+              placeholder="Add more detail…"
+              className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-xs text-sandstorm-text resize-none outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
+              data-testid={`${testIdPrefix}-answer-${i}`}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { useAppStore, SpecGateResult, RefinementSession, RefineQuestion } from '../store';
 import type { KanbanColumn } from '../store';
 import { ConfirmDialog } from './ConfirmDialog';
+import { QuestionList, QuestionAnswer, normalizeQuestion, combineAnswers, defaultAnswers, isSubmitDisabled } from './QuestionList';
 
 type LocalPhase = 'input' | 'starting';
 
@@ -58,7 +59,7 @@ export function RefineTicketDialog() {
 
   const [ticketId, setTicketId] = useState('');
   const [localPhase, setLocalPhase] = useState<LocalPhase>('input');
-  const [answers, setAnswers] = useState<{ optionId: string | null; text: string }[]>([]);
+  const [answers, setAnswers] = useState<QuestionAnswer[]>([]);
   const [localError, setLocalError] = useState<string | null>(null);
   const [stackName, setStackName] = useState('');
   const [confirmingCancel, setConfirmingCancel] = useState(false);
@@ -79,15 +80,8 @@ export function RefineTicketDialog() {
   // Defensively coerce legacy string[] items (old persisted sessions) to RefineQuestion.
   useEffect(() => {
     if (gate && !gate.passed && gate.questions.length > 0) {
-      const normalized = gate.questions.map((q): RefineQuestion =>
-        typeof q === 'string'
-          ? { id: 'q', question: q as string, options: [] }
-          : (!Array.isArray((q as RefineQuestion).options) ? { ...(q as RefineQuestion), options: [] } : q as RefineQuestion)
-      );
-      setAnswers(normalized.map((q) => {
-        const firstRecommended = q.options.find((o) => o.recommended === true);
-        return { optionId: firstRecommended ? firstRecommended.id : null, text: '' };
-      }));
+      const normalized = gate.questions.map((q, i) => normalizeQuestion(q, i));
+      setAnswers(defaultAnswers(normalized));
     }
   }, [gate]);
 
@@ -185,23 +179,9 @@ export function RefineTicketDialog() {
 
   const handleSubmitAnswers = useCallback(async () => {
     if (!session || !projectDir) return;
-    const questions = gate?.questions ?? [];
-    const combined = questions
-      .map((q, i) => {
-        const ans = answers[i];
-        const questionText = typeof q === 'string' ? q : q.question;
-        const selectedLabel =
-          ans?.optionId != null
-            ? (typeof q === 'string' ? null : q.options.find((o) => o.id === ans.optionId)?.label ?? null)
-            : null;
-        const lines = [
-          `Q${i + 1}: ${questionText}`,
-          `Selected: ${selectedLabel ?? '(none)'}`,
-          `Additional context: ${ans?.text.trim() || '(none)'}`,
-        ];
-        return lines.join('\n');
-      })
-      .join('\n\n');
+    const rawQuestions = gate?.questions ?? [];
+    const questions = rawQuestions.map((q, i) => normalizeQuestion(q, i));
+    const combined = combineAnswers(questions, answers);
     setLocalError(null);
     // Update session optimistically to 'running' while we wait
     upsertRefinementSession({ ...session, status: 'running', phase: 'refine' });
@@ -473,67 +453,12 @@ export function RefineTicketDialog() {
                     No structured questions parsed. The full report was committed to the ticket — open it on GitHub to read it.
                   </div>
                 ) : (
-                  <div className="space-y-4">
-                    {gate.questions.map((q, i) => {
-                      const qItem: RefineQuestion = typeof q === 'string'
-                        ? { id: `q${i}`, question: q as string, options: [] }
-                        : (!Array.isArray((q as RefineQuestion).options) ? { ...(q as RefineQuestion), options: [] } : q as RefineQuestion);
-                      const ans = answers[i] ?? { optionId: null, text: '' };
-                      return (
-                        <div key={i} className="space-y-2">
-                          <p className="text-xs text-sandstorm-text-secondary">
-                            <span className="text-sandstorm-muted">{i + 1}.</span> {qItem.question}
-                          </p>
-                          {qItem.options.length > 0 && (
-                            <div className="space-y-1 pl-3">
-                              {qItem.options.map((opt, optIdx) => {
-                                const isFirstRecommended = opt.recommended === true && optIdx === qItem.options.findIndex((o) => o.recommended === true);
-                                return (
-                                  <label key={opt.id} className="flex items-center gap-2 cursor-pointer">
-                                    <input
-                                      type="radio"
-                                      name={`refine-q-${i}`}
-                                      value={opt.id}
-                                      checked={ans.optionId === opt.id}
-                                      onChange={() => {}}
-                                      onClick={() => {
-                                        const next = [...answers];
-                                        next[i] = { ...ans, optionId: ans.optionId === opt.id ? null : opt.id };
-                                        setAnswers(next);
-                                      }}
-                                      className="accent-sandstorm-accent"
-                                      data-testid={`refine-option-${i}-${opt.id}`}
-                                    />
-                                    <span className="text-xs text-sandstorm-text">{opt.label}</span>
-                                    {isFirstRecommended && (
-                                      <span
-                                        className="text-xs font-medium text-sandstorm-accent border border-sandstorm-accent/40 rounded px-1.5 py-0.5 leading-none"
-                                        data-testid={`refine-option-recommended-${i}-${opt.id}`}
-                                      >
-                                        Recommended
-                                      </span>
-                                    )}
-                                  </label>
-                                );
-                              })}
-                            </div>
-                          )}
-                          <textarea
-                            value={ans.text}
-                            onChange={(e) => {
-                              const next = [...answers];
-                              next[i] = { ...ans, text: e.target.value };
-                              setAnswers(next);
-                            }}
-                            rows={2}
-                            placeholder="Add more detail…"
-                            className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2 text-xs text-sandstorm-text resize-none outline-none focus:border-sandstorm-accent/50 focus:ring-1 focus:ring-sandstorm-accent/20"
-                            data-testid={`refine-answer-${i}`}
-                          />
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <QuestionList
+                    questions={gate.questions.map((q, i) => normalizeQuestion(q, i))}
+                    answers={answers}
+                    onAnswersChange={setAnswers}
+                    testIdPrefix="refine"
+                  />
                 )}
               </div>
             )}
@@ -595,7 +520,7 @@ export function RefineTicketDialog() {
                 {showFailState && gate && gate.questions.length > 0 && (
                   <button
                     onClick={handleSubmitAnswers}
-                    disabled={answers.some((a) => a.optionId === null && !a.text.trim())}
+                    disabled={isSubmitDisabled(answers)}
                     className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-glow"
                     data-testid="refine-submit-answers"
                   >

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Stack, StackMetrics, useAppStore } from '../store';
 import { getStackDuration, isTerminalStatus, makePrEligible, DURATION_UPDATE_INTERVAL } from '../utils/duration';
 import { StackRowPopover } from './StackRowPopover';
+import { AnswerQuestionsModal } from './AnswerQuestionsModal';
 
 const STATUS_COLORS: Record<string, string> = {
   building: 'bg-amber-400',
@@ -50,6 +51,7 @@ export function StackTableRow({
     getStackDuration(stack.created_at, stack.updated_at, stack.status),
   );
   const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
+  const [showAnswerModal, setShowAnswerModal] = useState(false);
   const rowRef = useRef<HTMLTableRowElement>(null);
   const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -125,6 +127,16 @@ export function StackTableRow({
     } catch (err) {
       alert(`Failed to resume: ${err}`);
     }
+  };
+
+  const handleAnswer = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowAnswerModal(true);
+  };
+
+  const handleAnswerResumed = async () => {
+    setShowAnswerModal(false);
+    await refreshStacks();
   };
 
   const handlePrLink = (e: React.MouseEvent) => {
@@ -222,6 +234,16 @@ export function StackTableRow({
                 ▶ Resume
               </button>
             )}
+            {stack.status === 'needs_human' && (
+              <button
+                onClick={handleAnswer}
+                className="text-[10px] font-medium px-2 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20 transition-colors"
+                data-testid={`row-answer-${stack.id}`}
+                title="Answer the agent's questions and resume"
+              >
+                Answer
+              </button>
+            )}
             {makePrEligible(stack) && (
               <button
                 onClick={handleMakePr}
@@ -263,6 +285,17 @@ export function StackTableRow({
         <tr aria-hidden>
           <td colSpan={6} className="p-0">
             <StackRowPopover stack={stack} metrics={metrics} anchorRect={popoverRect} />
+          </td>
+        </tr>
+      )}
+      {showAnswerModal && (
+        <tr aria-hidden>
+          <td colSpan={6} className="p-0">
+            <AnswerQuestionsModal
+              stackId={stack.id}
+              onClose={() => setShowAnswerModal(false)}
+              onResumed={handleAnswerResumed}
+            />
           </td>
         </tr>
       )}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -670,6 +670,8 @@ declare global {
         setPr: (id: string, prUrl: string, prNumber: number) => Promise<void>;
         detectStale: () => Promise<StaleWorkspace[]>;
         cleanupStale: (workspacePaths: string[]) => Promise<CleanupResult[]>;
+        getNeedsHumanQuestions: (stackId: string) => Promise<string | null>;
+        resumeNeedsHuman: (stackId: string, answers: string) => Promise<void>;
       };
       tasks: {
         dispatch: (stackId: string, prompt: string, model?: string) => Promise<Task>;

--- a/src/renderer/utils/duration.ts
+++ b/src/renderer/utils/duration.ts
@@ -62,7 +62,6 @@ const PR_ELIGIBLE_STATUSES = new Set([
   'completed',
   'failed',
   'pushed',
-  'needs_human',
   'verify_blocked_environmental',
 ]);
 

--- a/tests/unit/components/AnswerQuestionsModal.test.tsx
+++ b/tests/unit/components/AnswerQuestionsModal.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { AnswerQuestionsModal } from '../../../src/renderer/components/AnswerQuestionsModal';
+import { mockSandstormApi } from './setup';
+
+const QUESTIONS_JSON = JSON.stringify([
+  {
+    id: 'q1',
+    question: 'How should we handle it?',
+    options: [
+      { id: 'a', label: 'Option A', recommended: true },
+      { id: 'b', label: 'Option B' },
+    ],
+  },
+]);
+
+function renderModal(overrides: Partial<{
+  stackId: string;
+  onClose: () => void;
+  onResumed: () => void;
+}> = {}) {
+  const onClose = overrides.onClose ?? vi.fn();
+  const onResumed = overrides.onResumed ?? vi.fn();
+  return render(
+    <AnswerQuestionsModal
+      stackId={overrides.stackId ?? 'test-stack'}
+      onClose={onClose}
+      onResumed={onResumed}
+    />
+  );
+}
+
+describe('AnswerQuestionsModal', () => {
+  beforeEach(() => {
+    mockSandstormApi();
+  });
+
+  it('shows loading state initially', () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(QUESTIONS_JSON);
+    renderModal();
+    expect(screen.getByTestId('answer-modal-loading')).toBeDefined();
+  });
+
+  it('renders structured questions after loading', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(QUESTIONS_JSON);
+    renderModal();
+    await waitFor(() => {
+      expect(screen.queryByTestId('answer-modal-loading')).toBeNull();
+    });
+    expect(screen.getByText('How should we handle it?')).toBeDefined();
+    expect(screen.getByText('Option A')).toBeDefined();
+    expect(screen.getByText('Option B')).toBeDefined();
+  });
+
+  it('pre-selects the recommended option', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(QUESTIONS_JSON);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    const radioA = screen.getByTestId('answer-option-0-a') as HTMLInputElement;
+    expect(radioA.checked).toBe(true);
+  });
+
+  it('shows submit button that is enabled when recommended option is preselected', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(QUESTIONS_JSON);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    const btn = screen.getByTestId('answer-modal-submit') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('shows fallback message when questions JSON is null', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(null);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    expect(screen.getByTestId('answer-modal-fallback')).toBeDefined();
+    expect(screen.queryByTestId('answer-modal-submit')).toBeNull();
+  });
+
+  it('shows fallback message when JSON is malformed', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue('not valid json {{');
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    expect(screen.getByTestId('answer-modal-fallback')).toBeDefined();
+  });
+
+  it('calls resumeNeedsHuman and onResumed on submit', async () => {
+    const onResumed = vi.fn();
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(QUESTIONS_JSON);
+    (window.sandstorm.stacks.resumeNeedsHuman as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(undefined);
+    renderModal({ onResumed });
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    await act(async () => {
+      screen.getByTestId('answer-modal-submit').click();
+    });
+    expect(window.sandstorm.stacks.resumeNeedsHuman).toHaveBeenCalledWith(
+      'test-stack',
+      expect.stringContaining('Q1: How should we handle it?')
+    );
+    expect(onResumed).toHaveBeenCalled();
+  });
+
+  it('shows error when resumeNeedsHuman fails', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(QUESTIONS_JSON);
+    (window.sandstorm.stacks.resumeNeedsHuman as ReturnType<typeof vi.fn>)
+      .mockRejectedValue(new Error('Network failure'));
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    await act(async () => {
+      screen.getByTestId('answer-modal-submit').click();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('answer-modal-error')).toBeDefined();
+    });
+    expect(screen.getByTestId('answer-modal-error').textContent).toContain('Network failure');
+  });
+});

--- a/tests/unit/components/QuestionList.test.tsx
+++ b/tests/unit/components/QuestionList.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+afterEach(() => { cleanup(); });
+import { QuestionList, normalizeQuestion, combineAnswers, defaultAnswers, isSubmitDisabled } from '../../../src/renderer/components/QuestionList';
+import type { QuestionAnswer } from '../../../src/renderer/components/QuestionList';
+import type { RefineQuestion } from '../../../src/renderer/store';
+
+const q1: RefineQuestion = {
+  id: 'q1',
+  question: 'What approach?',
+  options: [
+    { id: 'a', label: 'Option A', recommended: true },
+    { id: 'b', label: 'Option B' },
+  ],
+};
+
+const q2: RefineQuestion = {
+  id: 'q2',
+  question: 'Which library?',
+  options: [
+    { id: 'x', label: 'Library X' },
+    { id: 'y', label: 'Library Y', recommended: true },
+  ],
+};
+
+describe('normalizeQuestion', () => {
+  it('wraps a string into a RefineQuestion', () => {
+    const result = normalizeQuestion('some question', 0);
+    expect(result).toEqual({ id: 'q0', question: 'some question', options: [] });
+  });
+
+  it('fills in missing options array', () => {
+    const result = normalizeQuestion({ id: 'qx', question: 'What?' } as unknown, 0);
+    expect((result as RefineQuestion).options).toEqual([]);
+  });
+
+  it('passes through a valid RefineQuestion unchanged', () => {
+    expect(normalizeQuestion(q1, 0)).toEqual(q1);
+  });
+});
+
+describe('defaultAnswers', () => {
+  it('pre-selects the first recommended option', () => {
+    const ans = defaultAnswers([q1]);
+    expect(ans[0].optionId).toBe('a');
+    expect(ans[0].text).toBe('');
+  });
+
+  it('starts with null when no recommended option', () => {
+    const q: RefineQuestion = { id: 'q', question: 'Q?', options: [{ id: 'z', label: 'Z' }] };
+    const ans = defaultAnswers([q]);
+    expect(ans[0].optionId).toBeNull();
+  });
+
+  it('starts with null for questions with no options', () => {
+    const q: RefineQuestion = { id: 'q', question: 'Q?', options: [] };
+    const ans = defaultAnswers([q]);
+    expect(ans[0].optionId).toBeNull();
+  });
+});
+
+describe('isSubmitDisabled', () => {
+  it('returns true when any answer has no optionId and no text', () => {
+    const answers: QuestionAnswer[] = [{ optionId: 'a', text: '' }, { optionId: null, text: '' }];
+    expect(isSubmitDisabled(answers)).toBe(true);
+  });
+
+  it('returns false when each answer has optionId or text', () => {
+    const answers: QuestionAnswer[] = [{ optionId: 'a', text: '' }, { optionId: null, text: 'some text' }];
+    expect(isSubmitDisabled(answers)).toBe(false);
+  });
+
+  it('returns false when all have optionIds', () => {
+    const answers: QuestionAnswer[] = [{ optionId: 'a', text: '' }, { optionId: 'b', text: '' }];
+    expect(isSubmitDisabled(answers)).toBe(false);
+  });
+});
+
+describe('combineAnswers', () => {
+  it('formats questions and answers into structured text', () => {
+    const questions = [q1, q2];
+    const answers: QuestionAnswer[] = [
+      { optionId: 'a', text: 'more detail' },
+      { optionId: 'y', text: '' },
+    ];
+    const result = combineAnswers(questions, answers);
+    expect(result).toContain('Q1: What approach?');
+    expect(result).toContain('Selected: Option A');
+    expect(result).toContain('Additional context: more detail');
+    expect(result).toContain('Q2: Which library?');
+    expect(result).toContain('Selected: Library Y');
+    expect(result).toContain('Additional context: (none)');
+  });
+
+  it('uses (none) when no option selected', () => {
+    const questions = [q1];
+    const answers: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    const result = combineAnswers(questions, answers);
+    expect(result).toContain('Selected: (none)');
+  });
+});
+
+describe('QuestionList component', () => {
+  it('renders question text', () => {
+    const answers: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    render(
+      <QuestionList
+        questions={[q1]}
+        answers={answers}
+        onAnswersChange={() => {}}
+        testIdPrefix="test"
+      />
+    );
+    expect(screen.getByText('What approach?')).toBeDefined();
+  });
+
+  it('renders all options', () => {
+    const answers: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    render(
+      <QuestionList
+        questions={[q1]}
+        answers={answers}
+        onAnswersChange={() => {}}
+        testIdPrefix="test"
+      />
+    );
+    expect(screen.getByText('Option A')).toBeDefined();
+    expect(screen.getByText('Option B')).toBeDefined();
+  });
+
+  it('renders Recommended badge for the first recommended option', () => {
+    const answers: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    render(
+      <QuestionList
+        questions={[q1]}
+        answers={answers}
+        onAnswersChange={() => {}}
+        testIdPrefix="test"
+      />
+    );
+    expect(screen.getByTestId('test-option-recommended-0-a')).toBeDefined();
+  });
+
+  it('does not render Recommended badge for non-recommended options', () => {
+    const answers: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    render(
+      <QuestionList
+        questions={[q1]}
+        answers={answers}
+        onAnswersChange={() => {}}
+        testIdPrefix="test"
+      />
+    );
+    expect(screen.queryByTestId('test-option-recommended-0-b')).toBeNull();
+  });
+
+  it('calls onAnswersChange when an option is clicked', () => {
+    let captured: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    const { rerender } = render(
+      <QuestionList
+        questions={[q1]}
+        answers={captured}
+        onAnswersChange={(next) => { captured = next; }}
+        testIdPrefix="test"
+      />
+    );
+    fireEvent.click(screen.getByTestId('test-option-0-b'));
+    expect(captured[0].optionId).toBe('b');
+  });
+
+  it('renders textarea for additional context', () => {
+    const answers: QuestionAnswer[] = [{ optionId: null, text: '' }];
+    render(
+      <QuestionList
+        questions={[q1]}
+        answers={answers}
+        onAnswersChange={() => {}}
+        testIdPrefix="test"
+      />
+    );
+    expect(screen.getByTestId('test-answer-0')).toBeDefined();
+  });
+});

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -215,10 +215,10 @@ describe('StackTableRow primary-action chip (#315)', () => {
     expect(screen.getByTestId('row-make-pr-fail1')).toBeDefined();
   });
 
-  it('shows Make PR chip when status is needs_human and pr_url is null', () => {
+  it('does NOT show Make PR chip for needs_human (regression: stray PR button)', () => {
     vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
     renderRow(makeStack({ id: 'nh1', status: 'needs_human', pr_url: null }));
-    expect(screen.getByTestId('row-make-pr-nh1')).toBeDefined();
+    expect(screen.queryByTestId('row-make-pr-nh1')).toBeNull();
   });
 
   it('shows Make PR chip when status is verify_blocked_environmental and pr_url is null', () => {
@@ -332,6 +332,44 @@ describe('StackTableRow session_paused Resume button', () => {
     fireEvent.click(screen.getByTestId('row-resume-paused2'));
 
     expect(resumeFn).toHaveBeenCalledWith('paused2', true);
+  });
+});
+
+describe('StackTableRow needs_human Answer button (#461)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSandstormApi();
+    useAppStore.setState({ stacks: [], selectedStackId: null, stackMetrics: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows Answer button for needs_human stacks', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'nh1', status: 'needs_human', pr_url: null }));
+    expect(screen.getByTestId('row-answer-nh1')).toBeDefined();
+  });
+
+  it('does not show Answer button for other statuses', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'done', status: 'completed', pr_url: null }));
+    expect(screen.queryByTestId('row-answer-done')).toBeNull();
+  });
+
+  it('does not show PR button for needs_human (regression check)', () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    renderRow(makeStack({ id: 'nh2', status: 'needs_human', pr_url: null }));
+    expect(screen.queryByTestId('row-make-pr-nh2')).toBeNull();
+  });
+
+  it('opens AnswerQuestionsModal when Answer button is clicked', async () => {
+    vi.setSystemTime(new Date('2026-03-25T10:05:00Z'));
+    (window.sandstorm.stacks as Record<string, unknown>).getNeedsHumanQuestions = vi.fn().mockResolvedValue(null);
+    renderRow(makeStack({ id: 'nh3', status: 'needs_human', pr_url: null }));
+    fireEvent.click(screen.getByTestId('row-answer-nh3'));
+    expect(screen.getByTestId('answer-questions-modal')).toBeDefined();
   });
 });
 

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -558,8 +558,8 @@ describe('TicketCard', () => {
   });
 
   // All 14 StackStatus values — PR button visibility map
-  const ELIGIBLE_STATUSES = ['completed', 'failed', 'pushed', 'needs_human', 'verify_blocked_environmental'];
-  const INELIGIBLE_STATUSES = ['building', 'rebuilding', 'up', 'running', 'idle', 'stopped', 'pr_created', 'rate_limited', 'session_paused'];
+  const ELIGIBLE_STATUSES = ['completed', 'failed', 'pushed', 'verify_blocked_environmental'];
+  const INELIGIBLE_STATUSES = ['building', 'rebuilding', 'up', 'running', 'idle', 'stopped', 'pr_created', 'rate_limited', 'session_paused', 'needs_human'];
 
   ELIGIBLE_STATUSES.forEach((status) => {
     it(`in_stack: Create PR button is present for status="${status}"`, () => {

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -33,6 +33,8 @@ export function mockSandstormApi() {
       setPr: vi.fn().mockResolvedValue(undefined),
       detectStale: vi.fn().mockResolvedValue([]),
       cleanupStale: vi.fn().mockResolvedValue([]),
+      getNeedsHumanQuestions: vi.fn().mockResolvedValue(null),
+      resumeNeedsHuman: vi.fn().mockResolvedValue(undefined),
     },
     tasks: {
       dispatch: vi.fn().mockResolvedValue({ id: 1, stack_id: 'test', prompt: '', model: null, status: 'running' }),

--- a/tests/unit/duration.test.ts
+++ b/tests/unit/duration.test.ts
@@ -4,6 +4,7 @@ import {
   formatDuration,
   getStackDuration,
   isTerminalStatus,
+  makePrEligible,
   DURATION_UPDATE_INTERVAL,
 } from '../../src/renderer/utils/duration';
 
@@ -187,5 +188,37 @@ describe('getStackDuration', () => {
 describe('DURATION_UPDATE_INTERVAL', () => {
   it('is 5 seconds', () => {
     expect(DURATION_UPDATE_INTERVAL).toBe(5000);
+  });
+});
+
+describe('makePrEligible', () => {
+  const eligible = (status: string) => makePrEligible({ status, pr_url: null });
+
+  it('returns true for completed', () => {
+    expect(eligible('completed')).toBe(true);
+  });
+
+  it('returns true for pushed', () => {
+    expect(eligible('pushed')).toBe(true);
+  });
+
+  it('returns true for failed', () => {
+    expect(eligible('failed')).toBe(true);
+  });
+
+  it('returns true for verify_blocked_environmental', () => {
+    expect(eligible('verify_blocked_environmental')).toBe(true);
+  });
+
+  it('returns false for needs_human (regression: stray PR button)', () => {
+    expect(eligible('needs_human')).toBe(false);
+  });
+
+  it('returns false for running', () => {
+    expect(eligible('running')).toBe(false);
+  });
+
+  it('returns false when pr_url already set', () => {
+    expect(makePrEligible({ status: 'completed', pr_url: 'https://github.com/o/r/pull/1' })).toBe(false);
   });
 });

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -1902,6 +1902,8 @@ describe('IPC Handlers', () => {
       'pr:createAuto',
       'projectTicketConfig:get',
       'projectTicketConfig:set',
+      'stacks:getNeedsHumanQuestions',
+      'stacks:resumeNeedsHuman',
     ];
 
     it('registers all expected IPC channels', () => {

--- a/tests/unit/stack-lifecycle.test.ts
+++ b/tests/unit/stack-lifecycle.test.ts
@@ -761,4 +761,139 @@ describe('Stack Lifecycle Integration', () => {
       expect(updateCallback.mock.calls.length).toBeGreaterThan(callsAfterPR);
     });
   });
+
+  describe('registry: completeTaskNeedsHuman + reopenTaskForResume (#461)', () => {
+    it('persists questionsJson in needs_human_questions column', async () => {
+      registry.createStack(makeStack('nh-questions'));
+      const task = registry.createTask('nh-questions', 'Fix the bug');
+      const questionsJson = JSON.stringify([{ id: 'q1', question: 'How?', options: [] }]);
+      registry.completeTaskNeedsHuman(task.id, 'Agent stopped', questionsJson);
+      const stored = registry.getNeedsHumanQuestions('nh-questions');
+      expect(stored).toBe(questionsJson);
+    });
+
+    it('stores null when questionsJson is omitted (fallback to plain-text)', async () => {
+      registry.createStack(makeStack('nh-no-questions'));
+      const task = registry.createTask('nh-no-questions', 'Task');
+      registry.completeTaskNeedsHuman(task.id, 'Agent stopped');
+      const stored = registry.getNeedsHumanQuestions('nh-no-questions');
+      expect(stored).toBeNull();
+    });
+
+    it('getNeedsHumanQuestions returns null when task is not needs_human', async () => {
+      registry.createStack(makeStack('nh-running'));
+      registry.createTask('nh-running', 'Still running');
+      const stored = registry.getNeedsHumanQuestions('nh-running');
+      expect(stored).toBeNull();
+    });
+
+    it('reopenTaskForResume clears finished_at and exit_code and sets status to running', async () => {
+      registry.createStack(makeStack('nh-reopen'));
+      const task = registry.createTask('nh-reopen', 'Task to reopen');
+      registry.completeTaskNeedsHuman(task.id, 'STOP_AND_ASK reason');
+      const before = registry.getMostRecentTask('nh-reopen')!;
+      expect(before.status).toBe('needs_human');
+      expect(before.exit_code).toBe(1);
+
+      registry.reopenTaskForResume(task.id);
+      const after = registry.getMostRecentTask('nh-reopen')!;
+      expect(after.status).toBe('running');
+      expect(after.exit_code).toBeNull();
+      expect(after.finished_at).toBeNull();
+    });
+  });
+
+  describe('resumeNeedsHumanStack (#461)', () => {
+    it('throws STACK_NOT_FOUND for unknown stack', async () => {
+      await expect(
+        manager.resumeNeedsHumanStack('no-such', 'answers')
+      ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.STACK_NOT_FOUND }));
+    });
+
+    it('throws INVALID_INPUT for stack not in needs_human state', async () => {
+      registry.createStack(makeStack('not-nh', 'completed'));
+      await expect(
+        manager.resumeNeedsHumanStack('not-nh', 'answers')
+      ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.INVALID_INPUT }));
+    });
+
+    it('Case A: resumes with --resume when session_id is present', async () => {
+      registry.createStack(makeStack('nh-case-a', 'needs_human'));
+      const task = registry.createTask('nh-case-a', 'Task that stopped');
+      registry.setTaskSessionId(task.id, 'session-abc');
+      registry.completeTaskNeedsHuman(task.id, 'STOP_AND_ASK: needs input');
+      registry.updateStackStatus('nh-case-a', 'needs_human');
+
+      vi.spyOn(manager, 'ensureStackContainersRunning' as any).mockResolvedValue(undefined);
+      const dispatchSpy = vi.spyOn(manager, 'dispatchContinuation' as any).mockResolvedValue(undefined);
+
+      await manager.resumeNeedsHumanStack('nh-case-a', 'My answers here');
+
+      expect(dispatchSpy).toHaveBeenCalledOnce();
+      const callArgs = dispatchSpy.mock.calls[0];
+      expect(callArgs[3]).toContain('My answers here');
+    });
+
+    it('Case B: fresh dispatch when session_id is absent', async () => {
+      registry.createStack(makeStack('nh-case-b', 'needs_human'));
+      const task = registry.createTask('nh-case-b', 'Original prompt');
+      registry.completeTaskNeedsHuman(task.id, 'STOP_AND_ASK: needs input');
+      registry.updateStackStatus('nh-case-b', 'needs_human');
+
+      vi.spyOn(manager, 'ensureStackContainersRunning' as any).mockResolvedValue(undefined);
+      const dispatchTaskSpy = vi.spyOn(manager, 'dispatchTask').mockResolvedValue({
+        id: 99, stack_id: 'nh-case-b', status: 'running',
+      });
+
+      await manager.resumeNeedsHumanStack('nh-case-b', 'answers to questions');
+
+      expect(dispatchTaskSpy).toHaveBeenCalledOnce();
+      const callArgs = dispatchTaskSpy.mock.calls[0];
+      expect(callArgs[1]).toContain('Original prompt');
+      expect(callArgs[1]).toContain('answers to questions');
+    });
+
+    it('reverts to needs_human on container failure', async () => {
+      registry.createStack(makeStack('nh-revert', 'needs_human'));
+      const task = registry.createTask('nh-revert', 'Task');
+      registry.completeTaskNeedsHuman(task.id, 'Stop reason');
+      registry.updateStackStatus('nh-revert', 'needs_human');
+
+      vi.spyOn(manager, 'ensureStackContainersRunning' as any).mockRejectedValueOnce(
+        new Error('Container start failed')
+      );
+
+      await expect(
+        manager.resumeNeedsHumanStack('nh-revert', 'answers')
+      ).rejects.toThrow('Container start failed');
+
+      expect(registry.getStack('nh-revert')!.status).toBe('needs_human');
+    });
+
+    it('Case A: re-terminates task and reverts stack to needs_human when dispatchContinuation fails', async () => {
+      registry.createStack(makeStack('nh-dispatch-fail', 'needs_human'));
+      const task = registry.createTask('nh-dispatch-fail', 'Task that stopped');
+      registry.setTaskSessionId(task.id, 'session-xyz');
+      const questionsJson = JSON.stringify([{ id: 'q1', question: 'Which approach?', options: [{ id: 'a', label: 'Option A', recommended: true }] }]);
+      registry.completeTaskNeedsHuman(task.id, 'STOP_AND_ASK: needs input', questionsJson);
+      registry.updateStackStatus('nh-dispatch-fail', 'needs_human');
+
+      vi.spyOn(manager, 'ensureStackContainersRunning' as any).mockResolvedValue(undefined);
+      vi.spyOn(manager, 'dispatchContinuation' as any).mockRejectedValueOnce(
+        new Error('Dispatch failed after reopen')
+      );
+
+      await expect(
+        manager.resumeNeedsHumanStack('nh-dispatch-fail', 'My answers')
+      ).rejects.toThrow('Dispatch failed after reopen');
+
+      // Task must not be stranded in 'running' — it should be reverted to needs_human
+      const tasks = registry.getTasksForStack('nh-dispatch-fail');
+      expect(tasks[0].status).toBe('needs_human');
+      // Stack must also revert to needs_human
+      expect(registry.getStack('nh-dispatch-fail')!.status).toBe('needs_human');
+      // Structured questions must be preserved so the Answer modal can re-render them on retry
+      expect(tasks[0].needs_human_questions).toBe(questionsJson);
+    });
+  });
 });

--- a/tests/unit/task-runner-scope-smoke.sh
+++ b/tests/unit/task-runner-scope-smoke.sh
@@ -76,10 +76,14 @@ LOG
 # ---------------------------------------------------------------------------
 
 # Extract everything up to (not including) the "# ─── Main Loop" line
+STOP_QUESTIONS_FILE="$tmpdir/claude-stop-questions.json"
+
 FUNC_SOURCE=$(sed -n '1,/^# ─── Main Loop/p' "$TASK_RUNNER" | head -n -1)
 
 # Override the stop-reason path inside the function before eval
 FUNC_SOURCE="${FUNC_SOURCE//\/tmp\/claude-stop-reason.txt/$STOP_REASON_FILE}"
+# Override the stop-questions path inside the function before eval
+FUNC_SOURCE="${FUNC_SOURCE//\/tmp\/claude-stop-questions.json/$STOP_QUESTIONS_FILE}"
 
 eval "$FUNC_SOURCE"
 
@@ -131,8 +135,22 @@ if [ "$BEFORE_INT_DIFF" != "$AFTER_INT_DIFF" ]; then
   FAIL=1
 fi
 
+# ---------------------------------------------------------------------------
+# Additional: verify questions JSON file detection is logged when present.
+# ---------------------------------------------------------------------------
+SAMPLE_QUESTIONS='[{"id":"q1","question":"Fix out-of-scope file?","options":[{"id":"skip","label":"Skip","recommended":true}]}]'
+echo "$SAMPLE_QUESTIONS" > "$STOP_QUESTIONS_FILE"
+
+LOG_OUTPUT=$(check_for_stop_and_ask "$TASK_LOG" 2>&1 || true)
+if ! echo "$LOG_OUTPUT" | grep -q '"q1"'; then
+  echo "FAIL: check_for_stop_and_ask did not forward questions JSON content" >&2
+  FAIL=1
+fi
+
+rm -f "$STOP_QUESTIONS_FILE"
+
 if [ $FAIL -eq 0 ]; then
-  echo "PASS: status=needs_human, reason captured, no tests/integration/ diff"
+  echo "PASS: status=needs_human, reason captured, questions JSON forwarded, no tests/integration/ diff"
   exit 0
 else
   echo ""


### PR DESCRIPTION
Implements #461 — surfaces the inner agent's `STOP_AND_ASK` questions in the UI and provides a path to answer and resume, instead of stranding the stack at `needs_human` with a stray "Create PR" button.

## Changes
- New `AnswerQuestionsModal` + `QuestionList` renderer components (with tests) to display structured questions and collect answers.
- Backend wiring for needs-human questions: `registry.ts` (persist `needs_human_questions`), `task-watcher.ts`, `stack-manager.ts` (resume path), `ipc.ts`/`preload`.
- `task-runner.sh` surfaces the structured questions payload alongside the plain-text stop reason.
- Removes the PR button for `needs_human` stacks; adds the answer/resume affordance.

## Recovery note
This stack had completed its dual-loop (review-clean) but was marked `failed` only because the verify gate hit the pre-existing broken `kanban-column-transitions.spec.ts` — now fixed on main via #471. Recovered by merging current main (clean, no conflicts) and re-running the full verify suite **green** (typecheck, unit, build, package, integration — 41 integration tests pass).

Closes #461.