### PR TITLE
#457: Auto-resolve merge conflicts

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -1,4 +1,5 @@
-import { spawn, execSync } from 'child_process';
+import { spawn, execSync, execFile } from 'child_process';
+import { promisify } from 'util';
 import path from 'path';
 import fs from 'fs';
 import { Registry, Stack, StackHistoryRecord, Task, TokenUsage } from './registry';
@@ -9,6 +10,9 @@ import { ContainerRuntime, Container, ContainerStats } from '../runtime/types';
 import { SandstormError, ErrorCode } from '../errors';
 import { fetchTicketWithConfig } from './ticket-config';
 import { referencesTicket } from './ticket-fetcher';
+import { workspacePathFor } from './pr-creator';
+
+const execFileAsync = promisify(execFile);
 
 declare const __GIT_COMMIT__: string;
 
@@ -55,6 +59,13 @@ export interface TaskStatusResult {
 
 /** Byte caps for MCP tool response payloads. See #255. */
 export const TASK_OUTPUT_MAX_BYTES = 4096;
+
+/** Result type returned by `autoResolveConflicts`. */
+export type AutoResolveResult =
+  | { status: 'resolved' }
+  | { status: 'no_conflicts' }
+  | { status: 'unknown_state' }
+  | { status: 'failed'; error: string };
 export const LOGS_PER_CONTAINER_MAX_BYTES = 8192;
 export const LOGS_TOTAL_MAX_BYTES = 32768;
 
@@ -1676,6 +1687,214 @@ export class StackManager {
       return false;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Wait for a specific dispatched task to reach a terminal state.
+   * Event-driven via TaskWatcher, with a 2-second polling backstop and a
+   * bounded timeout (default 30 minutes).
+   */
+  awaitTaskCompletion(
+    stackId: string,
+    taskId: number,
+    opts?: { timeoutMs?: number }
+  ): Promise<Task> {
+    const timeoutMs = opts?.timeoutMs ?? 30 * 60 * 1000;
+
+    return new Promise<Task>((resolve, reject) => {
+      let settled = false;
+      let pollInterval: ReturnType<typeof setInterval> | null = null;
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+      const settle = (task?: Task, err?: Error) => {
+        if (settled) return;
+        settled = true;
+        this.taskWatcher.removeListener('task:completed', onCompleted);
+        this.taskWatcher.removeListener('task:failed', onFailed);
+        if (pollInterval !== null) clearInterval(pollInterval);
+        if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+        if (err) reject(err);
+        else resolve(task!);
+      };
+
+      const isTerminal = (t: Task) =>
+        t.status === 'completed' || t.status === 'failed' || t.status === 'needs_human';
+
+      const onCompleted = ({ stackId: sid, task }: { stackId: string; task: Task }) => {
+        if (sid === stackId && task.id === taskId) settle(task);
+      };
+      const onFailed = ({ stackId: sid, task }: { stackId: string; task: Task }) => {
+        if (sid === stackId && task.id === taskId) settle(task);
+      };
+
+      this.taskWatcher.on('task:completed', onCompleted);
+      this.taskWatcher.on('task:failed', onFailed);
+
+      // Backstop: poll every 2 s in case the terminal event was emitted before
+      // the listener was registered.
+      pollInterval = setInterval(() => {
+        try {
+          const tasks = this.registry.getTasksForStack(stackId);
+          const task = tasks.find(t => t.id === taskId);
+          if (task && isTerminal(task)) settle(task);
+        } catch { /* best effort */ }
+      }, 2000);
+
+      timeoutHandle = setTimeout(() => {
+        settle(
+          undefined,
+          new SandstormError(
+            ErrorCode.TASK_DISPATCH_FAILED,
+            'Auto-resolve timed out waiting for task completion'
+          )
+        );
+      }, timeoutMs);
+
+      // Immediate backstop: task may already be terminal before we set up listeners.
+      try {
+        const tasks = this.registry.getTasksForStack(stackId);
+        const task = tasks.find(t => t.id === taskId);
+        if (task && isTerminal(task)) { settle(task); return; }
+      } catch { /* ignore */ }
+    });
+  }
+
+  /**
+   * Resolve merge conflicts for the PR associated with `ticketId` / `projectDir`.
+   * Queries GitHub for the PR's merge state, dispatches the inner agent to merge
+   * the base branch and resolve conflicts, waits for the task to complete, and
+   * pushes the result on success.
+   *
+   * The associated stack is reused if it exists; if it was torn down, it is
+   * recreated from the branch stored in history and torn down again afterwards.
+   */
+  async autoResolveConflicts(ticketId: string, projectDir: string): Promise<AutoResolveResult> {
+    // Find live stack for this ticket
+    const liveStack = this.registry.listStacks().find(
+      s => s.ticket === ticketId && s.project_dir === projectDir
+    ) ?? null;
+
+    let stackId: string | null = liveStack?.id ?? null;
+    let autoCreated = false;
+
+    // Workspace dir for gh commands: use the stack workspace if it exists, else projectDir
+    const ghCwd = liveStack
+      ? workspacePathFor(projectDir, liveStack.id)
+      : projectDir;
+
+    // === Determine PR info ===
+    let mergeable: string;
+    let baseRefName: string;
+
+    if (liveStack && liveStack.pr_number != null) {
+      // Live stack with a known PR number
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'view', String(liveStack.pr_number), '--json', 'mergeable,mergeStateStatus,baseRefName'],
+        { cwd: ghCwd, timeout: 30000, maxBuffer: 1024 * 1024 }
+      );
+      const pr = JSON.parse(stdout.trim()) as { mergeable: string; mergeStateStatus: string; baseRefName: string };
+      mergeable = pr.mergeable ?? 'UNKNOWN';
+      baseRefName = pr.baseRefName;
+    } else if (!liveStack) {
+      // Stack torn down — look in history for the branch
+      const history = this.registry.listStackHistory()
+        .filter(h => h.ticket === ticketId && h.project_dir === projectDir)
+        .sort((a, b) => new Date(b.finished_at).getTime() - new Date(a.finished_at).getTime())[0];
+
+      if (!history?.branch) {
+        throw new SandstormError(
+          ErrorCode.STACK_NOT_FOUND,
+          `No stack found for ticket ${ticketId} in project ${projectDir}`
+        );
+      }
+
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'list', '--head', history.branch, '--json', 'number,mergeable,mergeStateStatus,baseRefName', '--state', 'open', '--limit', '1'],
+        { cwd: projectDir, timeout: 30000, maxBuffer: 1024 * 1024 }
+      );
+      const prList = JSON.parse(stdout.trim()) as Array<{ number: number; mergeable: string; mergeStateStatus: string; baseRefName: string }>;
+
+      if (prList.length === 0) {
+        throw new SandstormError(
+          ErrorCode.STACK_NOT_FOUND,
+          `No open PR found for branch '${history.branch}'`
+        );
+      }
+
+      const pr = prList[0];
+      mergeable = pr.mergeable ?? 'UNKNOWN';
+      baseRefName = pr.baseRefName;
+
+      // Early-exit non-conflicting states before creating a new stack
+      if (mergeable === 'MERGEABLE') return { status: 'no_conflicts' };
+      if (mergeable !== 'CONFLICTING') return { status: 'unknown_state' };
+
+      // CONFLICTING — recreate the stack from the branch
+      const name = `auto-${ticketId.replace(/[^a-z0-9]/gi, '-').slice(0, 20)}-${Date.now().toString(36)}`;
+      this.createStack({
+        name,
+        projectDir,
+        ticket: ticketId,
+        branch: history.branch,
+        runtime: history.runtime,
+        gateApproved: true,
+      });
+      stackId = name;
+      autoCreated = true;
+
+      // Wait for the build to complete (up to 3 min) before dispatching
+      const buildDeadline = Date.now() + 180_000;
+      while (Date.now() < buildDeadline) {
+        const s = this.registry.getStack(stackId);
+        if (!s || s.status === 'failed') {
+          throw new SandstormError(ErrorCode.COMPOSE_FAILED, s?.error || 'Stack creation failed');
+        }
+        if (['up', 'idle', 'running', 'completed', 'pushed', 'pr_created'].includes(s.status)) break;
+        await new Promise(r => setTimeout(r, 2000));
+      }
+    } else {
+      // Live stack exists but has no pr_number
+      return { status: 'failed', error: 'Stack has no associated PR number' };
+    }
+
+    // === Handle non-conflicting states ===
+    if (mergeable === 'MERGEABLE') return { status: 'no_conflicts' };
+    if (mergeable !== 'CONFLICTING') return { status: 'unknown_state' };
+
+    // === Dispatch resolution task ===
+    const resolvePrompt = [
+      'Resolve merge conflicts with the base branch.',
+      '',
+      'Steps:',
+      '1. Run `git fetch origin`',
+      `2. Merge the base branch into the current branch: \`git merge origin/${baseRefName}\``,
+      '3. Resolve any merge conflicts',
+      '4. Ensure the working tree builds and all tests pass',
+      '',
+      'Do not force-push. Produce a clean merge commit.',
+    ].join('\n');
+
+    try {
+      const dispatchResult = await this.dispatchTask(stackId!, resolvePrompt, undefined, {
+        gateApproved: true,
+        skipTicketFetch: true,
+      });
+
+      const terminalTask = await this.awaitTaskCompletion(stackId!, dispatchResult.id);
+
+      if (terminalTask.exit_code !== 0) {
+        return { status: 'failed', error: 'Auto-resolve failed: inner agent could not resolve conflicts or verify failed' };
+      }
+
+      await this.push(stackId!, 'Auto-resolve merge conflicts');
+      return { status: 'resolved' };
+    } finally {
+      if (autoCreated && stackId) {
+        await this.teardownStack(stackId).catch(() => {});
+      }
     }
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1473,4 +1473,8 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
+  ipcMain.handle('pr:autoResolve', async (_event, ticketId: string, projectDir: string) => {
+    return stackManager.autoResolveConflicts(ticketId, projectDir);
+  });
+
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -229,6 +229,12 @@ export interface SandstormAPI {
       | { status: 'draft_failed' }
       | { status: 'create_failed'; draft: { title: string; body: string }; error: string }
     >;
+    autoResolve: (ticketId: string, projectDir: string) => Promise<
+      | { status: 'resolved' }
+      | { status: 'no_conflicts' }
+      | { status: 'unknown_state' }
+      | { status: 'failed'; error: string }
+    >;
   };
   on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
 }
@@ -422,6 +428,8 @@ const api: SandstormAPI = {
     merge: (stackId, prNumber) =>
       ipcRenderer.invoke('pr:merge', stackId, prNumber),
     createAuto: (stackId) => ipcRenderer.invoke('pr:createAuto', stackId),
+    autoResolve: (ticketId, projectDir) =>
+      ipcRenderer.invoke('pr:autoResolve', ticketId, projectDir),
   },
   on: (channel, callback) => {
     const handler = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -35,6 +35,9 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     discardStack,
     discardInFlight,
     discardErrors,
+    autoResolveConflicts,
+    autoResolveInFlight,
+    autoResolveErrors,
   } = useAppStore();
 
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
@@ -46,6 +49,8 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const mergeInflight = mergeInFlight[stackKey] ?? false;
   const discardInflight = discardInFlight[stackKey] ?? false;
   const discardError = discardErrors[stackKey];
+  const autoResolveInflight = autoResolveInFlight[stackKey] ?? false;
+  const autoResolveError = autoResolveErrors[stackKey];
 
   const handleRefine = () => {
     openRefineDialogFromCard(ticket.ticket_id, ticket.project_dir, ticket.column as KanbanColumn);
@@ -72,6 +77,10 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
 
   const handleMerge = () => {
     void mergeTicket(ticket.ticket_id, ticket.project_dir);
+  };
+
+  const handleAutoResolve = () => {
+    void autoResolveConflicts(ticket.ticket_id, ticket.project_dir);
   };
 
   const handleResume = () => {
@@ -327,6 +336,31 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               {mergeInflight ? 'Merging…' : 'Merge'}
             </button>
           )}
+          {autoResolveError && (
+            <div
+              className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-2 py-1.5 break-words"
+              data-testid={`ticket-card-auto-resolve-error-${ticket.ticket_id}`}
+            >
+              {autoResolveError}
+            </div>
+          )}
+          <button
+            onClick={handleAutoResolve}
+            disabled={autoResolveInflight}
+            className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-surface-hover text-sandstorm-muted border border-sandstorm-border hover:border-sandstorm-accent/30 hover:text-sandstorm-text transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+            data-testid={`ticket-card-auto-resolve-${ticket.ticket_id}`}
+          >
+            {autoResolveInflight ? (
+              <>
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" className="animate-spin flex-shrink-0">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+                </svg>
+                Resolving…
+              </>
+            ) : (
+              'Auto-resolve conflicts'
+            )}
+          </button>
           {discardSection}
         </div>
       )}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -553,6 +553,13 @@ interface AppState {
   /** Best-effort teardown → card disposition (backlog or close+delete). Surfaces close failure via discardErrors (R2). */
   discardStack: (ticketId: string, projectDir: string, disposition: 'backlog' | 'close') => Promise<void>;
 
+  /** Per-ticket in-flight flag for auto-resolve, keyed by `${ticketId}|${projectDir}`. Guards against double-clicks. */
+  autoResolveInFlight: Record<string, boolean>;
+  /** Per-ticket error message for auto-resolve, keyed by `${ticketId}|${projectDir}`. Cleared at the start of the next attempt. */
+  autoResolveErrors: Record<string, string>;
+  /** Query PR merge state and dispatch the inner agent to resolve conflicts if conflicting. */
+  autoResolveConflicts: (ticketId: string, projectDir: string) => Promise<void>;
+
   // Schedules (per-project)
   schedules: ScheduleEntry[];
   schedulesLoading: boolean;
@@ -806,6 +813,12 @@ declare global {
           | { status: 'created'; url: string; number: number }
           | { status: 'draft_failed' }
           | { status: 'create_failed'; draft: { title: string; body: string }; error: string }
+        >;
+        autoResolve: (ticketId: string, projectDir: string) => Promise<
+          | { status: 'resolved' }
+          | { status: 'no_conflicts' }
+          | { status: 'unknown_state' }
+          | { status: 'failed'; error: string }
         >;
       };
       on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
@@ -1374,6 +1387,39 @@ export const useAppStore = create<AppState>((set, get) => ({
       set((state) => {
         const { [stackId]: _, ...rest } = state.prCreateInFlight;
         return { prCreateInFlight: rest };
+      });
+    }
+  },
+
+  autoResolveInFlight: {},
+  autoResolveErrors: {},
+
+  autoResolveConflicts: async (ticketId: string, projectDir: string) => {
+    const key = `${ticketId}|${projectDir}`;
+    if (get().autoResolveInFlight[key]) return;
+
+    set((state) => ({
+      autoResolveInFlight: { ...state.autoResolveInFlight, [key]: true },
+      autoResolveErrors: (() => { const { [key]: _, ...rest } = state.autoResolveErrors; return rest; })(),
+    }));
+
+    try {
+      const result = await window.sandstorm.pr.autoResolve(ticketId, projectDir);
+      if (result.status === 'no_conflicts') {
+        set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: 'No conflicts to resolve.' } }));
+      } else if (result.status === 'unknown_state') {
+        set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: 'Mergeability unknown, try again.' } }));
+      } else if (result.status === 'failed') {
+        set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: result.error } }));
+      }
+      // status === 'resolved': no error to set
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: message } }));
+    } finally {
+      set((state) => {
+        const { [key]: _, ...rest } = state.autoResolveInFlight;
+        return { autoResolveInFlight: rest };
       });
     }
   },

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -54,6 +54,8 @@ describe('TicketCard', () => {
       refineStartErrors: {},
       discardInFlight: {},
       discardErrors: {},
+      autoResolveInFlight: {},
+      autoResolveErrors: {},
       showRefineTicketDialog: false,
       refineTicketPrefill: null,
       currentRefinementSessionId: null,
@@ -755,6 +757,59 @@ describe('TicketCard', () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
     expect(screen.getByTestId('ticket-card-pr-link-42').textContent).toContain('99');
+  });
+
+  it('pr_open: Auto-resolve conflicts button is always visible', () => {
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-auto-resolve-42')).toBeDefined();
+  });
+
+  it('pr_open: Auto-resolve conflicts button is visible even when stack has no pr_number', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-auto-resolve-42')).toBeDefined();
+  });
+
+  it('pr_open: clicking Auto-resolve calls pr.autoResolve with ticketId and projectDir', async () => {
+    api.pr.autoResolve.mockResolvedValue({ status: 'resolved' });
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-auto-resolve-42'));
+    await waitFor(() => expect(api.pr.autoResolve).toHaveBeenCalledWith('42', PROJECT_DIR));
+  });
+
+  it('pr_open: Auto-resolve button shows spinner while in-flight', () => {
+    useAppStore.setState({ autoResolveInFlight: { [`42|${PROJECT_DIR}`]: true } } as any);
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    const btn = screen.getByTestId('ticket-card-auto-resolve-42');
+    expect(btn.textContent).toContain('Resolving');
+    expect(btn).toHaveProperty('disabled', true);
+  });
+
+  it('pr_open: Auto-resolve button is disabled while in-flight', () => {
+    useAppStore.setState({ autoResolveInFlight: { [`42|${PROJECT_DIR}`]: true } } as any);
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    const btn = screen.getByTestId('ticket-card-auto-resolve-42');
+    expect(btn).toHaveProperty('disabled', true);
+  });
+
+  it('pr_open: shows auto-resolve error badge when autoResolveErrors is set', () => {
+    useAppStore.setState({ autoResolveErrors: { [`42|${PROJECT_DIR}`]: 'Auto-resolve failed' } } as any);
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-auto-resolve-error-42');
+    expect(badge.textContent).toContain('Auto-resolve failed');
+  });
+
+  it('pr_open: double-click on Auto-resolve does not call pr.autoResolve twice', async () => {
+    let resolveFirst!: () => void;
+    const firstPromise = new Promise<{ status: string }>((r) => { resolveFirst = r as () => void; });
+    api.pr.autoResolve.mockReturnValueOnce(firstPromise);
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    const btn = screen.getByTestId('ticket-card-auto-resolve-42');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    resolveFirst({ status: 'resolved' } as any);
+    await waitFor(() => expect(useAppStore.getState().autoResolveInFlight[`42|${PROJECT_DIR}`]).toBeFalsy());
+    expect(api.pr.autoResolve).toHaveBeenCalledTimes(1);
   });
 
   it('merged: card is dimmed', () => {

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -188,6 +188,7 @@ export function mockSandstormApi() {
       create: vi.fn().mockResolvedValue({ url: 'https://github.com/o/r/pull/1', number: 1 }),
       merge: vi.fn().mockResolvedValue(undefined),
       createAuto: vi.fn().mockResolvedValue({ status: 'created', url: 'https://github.com/o/r/pull/1', number: 1 }),
+      autoResolve: vi.fn().mockResolvedValue({ status: 'resolved' }),
     },
     on: vi.fn().mockReturnValue(() => {}),
   };

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -80,6 +80,7 @@ const {
     getRateLimitState: vi.fn(),
     getWorkflowProgress: vi.fn(),
     resumeStackWithContinuation: vi.fn(),
+    autoResolveConflicts: vi.fn(),
   };
 
   const mockDockerRuntime = {
@@ -1643,6 +1644,54 @@ describe('IPC Handlers', () => {
   });
 
   // =========================================================================
+  // PR Auto-Resolve
+  // =========================================================================
+  describe('pr:autoResolve', () => {
+    it('delegates to stackManager.autoResolveConflicts and returns the result', async () => {
+      mockStackManager.autoResolveConflicts.mockResolvedValue({ status: 'resolved' });
+
+      const result = await invokeHandler('pr:autoResolve', 'T-1', '/proj');
+
+      expect(mockStackManager.autoResolveConflicts).toHaveBeenCalledWith('T-1', '/proj');
+      expect(result).toEqual({ status: 'resolved' });
+    });
+
+    it('propagates errors thrown by autoResolveConflicts', async () => {
+      mockStackManager.autoResolveConflicts.mockRejectedValue(new Error('Stack "T-1" not found'));
+
+      await expect(invokeHandler('pr:autoResolve', 'T-1', '/proj')).rejects.toThrow('Stack "T-1" not found');
+    });
+
+    it('returns no_conflicts when PR is already mergeable', async () => {
+      mockStackManager.autoResolveConflicts.mockResolvedValue({ status: 'no_conflicts' });
+
+      const result = await invokeHandler('pr:autoResolve', 'T-2', '/proj');
+
+      expect(result).toEqual({ status: 'no_conflicts' });
+    });
+
+    it('returns unknown_state when mergeable is UNKNOWN', async () => {
+      mockStackManager.autoResolveConflicts.mockResolvedValue({ status: 'unknown_state' });
+
+      const result = await invokeHandler('pr:autoResolve', 'T-3', '/proj');
+
+      expect(result).toEqual({ status: 'unknown_state' });
+    });
+
+    it('returns failed when agent could not resolve', async () => {
+      mockStackManager.autoResolveConflicts.mockResolvedValue({
+        status: 'failed',
+        error: 'Auto-resolve failed: inner agent could not resolve conflicts or verify failed',
+      });
+
+      const result = await invokeHandler('pr:autoResolve', 'T-4', '/proj') as { status: string; error: string };
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/inner agent/);
+    });
+  });
+
+  // =========================================================================
   // Phase-aware retryRefinementAsync
   // =========================================================================
   describe('tickets:retryRefinementAsync', () => {
@@ -1900,6 +1949,7 @@ describe('IPC Handlers', () => {
       'pr:create',
       'pr:merge',
       'pr:createAuto',
+      'pr:autoResolve',
       'projectTicketConfig:get',
       'projectTicketConfig:set',
     ];

--- a/tests/unit/stack-manager-auto-resolve.test.ts
+++ b/tests/unit/stack-manager-auto-resolve.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Unit tests for StackManager.autoResolveConflicts internals.
+ *
+ * Stubs dispatchTask, awaitTaskCompletion, push, createStack, teardownStack,
+ * and execFileAsync (via child_process.execFile mock) to verify orchestration
+ * invariants without real Docker or gh CLI.
+ *
+ * Covers:
+ * - gateApproved: true is passed to dispatchTask (both reuse and recreate paths)
+ * - push skipped when task exit_code is non-zero
+ * - push skipped when awaitTaskCompletion times out
+ * - teardown only when auto-created (not on pre-existing stack)
+ * - recreate path when stack is absent (stack torn down)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { SandstormError, ErrorCode } from '../../src/main/errors';
+import type { Task } from '../../src/main/control-plane/registry';
+
+// ---------------------------------------------------------------------------
+// Hoist the gh mock so it's available in the vi.mock factory.
+// execFileAsync = promisify(execFile); to intercept it we set
+// [util.promisify.custom] on the mocked execFile, so promisify picks it up.
+// ---------------------------------------------------------------------------
+const { mockGhFn } = vi.hoisted(() => {
+  const mockGhFn = vi.fn<[], Promise<{ stdout: string; stderr: string }>>();
+  return { mockGhFn };
+});
+
+vi.mock('child_process', async () => {
+  const util = await import('util');
+  const execFile = vi.fn();
+  (execFile as any)[util.promisify.custom] = mockGhFn;
+  return {
+    execFile,
+    execSync: vi.fn().mockReturnValue('abc123sha'),
+    spawn: vi.fn(),
+  };
+});
+
+import { StackManager } from '../../src/main/control-plane/stack-manager';
+import { Registry } from '../../src/main/control-plane/registry';
+import { PortAllocator } from '../../src/main/control-plane/port-allocator';
+import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
+import type { ContainerRuntime } from '../../src/main/runtime/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `sm-autoresolve-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function createMockRuntime(): ContainerRuntime {
+  return {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn().mockResolvedValue({}),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
+    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+const TICKET = 'T-1';
+const PROJECT_DIR = '/proj';
+const BRANCH = 'feat/T-1';
+const PR_NUMBER = 42;
+const PR_URL = 'https://github.com/org/repo/pull/42';
+
+function makeTerminalTask(exit_code: number): Task {
+  return {
+    id: 101,
+    stack_id: 'stack-1',
+    status: exit_code === 0 ? 'completed' : 'failed',
+    exit_code,
+    prompt: '',
+    model: null,
+    resolved_model: null,
+    warnings: null,
+    session_id: null,
+    input_tokens: 0,
+    output_tokens: 0,
+    execution_input_tokens: 0,
+    execution_output_tokens: 0,
+    review_input_tokens: 0,
+    review_output_tokens: 0,
+    review_iterations: 0,
+    verify_retries: 0,
+    review_verdicts: null,
+    verify_outputs: null,
+    execution_summary: null,
+    execution_started_at: null,
+    execution_finished_at: null,
+    review_started_at: null,
+    review_finished_at: null,
+    verify_started_at: null,
+    verify_finished_at: null,
+    started_at: new Date().toISOString(),
+    finished_at: new Date().toISOString(),
+    resumed_at: null,
+  };
+}
+
+function ghViewJson(mergeable: string, baseRefName = 'main') {
+  return {
+    stdout: JSON.stringify({ mergeable, mergeStateStatus: 'DIRTY', baseRefName }),
+    stderr: '',
+  };
+}
+
+function ghListJson(mergeable: string, baseRefName = 'main') {
+  return {
+    stdout: JSON.stringify([{ number: PR_NUMBER, mergeable, mergeStateStatus: 'DIRTY', baseRefName }]),
+    stderr: '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe('StackManager.autoResolveConflicts internals', () => {
+  let registry: Registry;
+  let portAllocator: PortAllocator;
+  let taskWatcher: TaskWatcher;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+
+  let dispatchTaskSpy: ReturnType<typeof vi.spyOn>;
+  let awaitTaskCompletionSpy: ReturnType<typeof vi.spyOn>;
+  let pushSpy: ReturnType<typeof vi.spyOn>;
+  let createStackSpy: ReturnType<typeof vi.spyOn>;
+  let teardownStackSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    portAllocator = new PortAllocator(registry, [40000, 40099]);
+    taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+
+    mockGhFn.mockReset();
+
+    dispatchTaskSpy = vi.spyOn(manager, 'dispatchTask').mockResolvedValue({ id: 101, stack_id: 'stack-1', status: 'running' });
+    awaitTaskCompletionSpy = vi.spyOn(manager, 'awaitTaskCompletion').mockResolvedValue(makeTerminalTask(0));
+    pushSpy = vi.spyOn(manager, 'push').mockResolvedValue({ stdout: '', stderr: '' });
+    createStackSpy = vi.spyOn(manager, 'createStack');
+    teardownStackSpy = vi.spyOn(manager, 'teardownStack').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    taskWatcher.unwatchAll();
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // Live stack path: stack exists and has pr_number
+  // ==========================================================================
+  describe('live stack path', () => {
+    beforeEach(() => {
+      registry.createStack({
+        id: 'stack-1',
+        project: 'test',
+        project_dir: PROJECT_DIR,
+        ticket: TICKET,
+        branch: BRANCH,
+        description: null,
+        status: 'pr_created',
+        runtime: 'docker',
+      });
+      registry.setPullRequest('stack-1', PR_URL, PR_NUMBER);
+      mockGhFn.mockResolvedValue(ghViewJson('CONFLICTING'));
+    });
+
+    it('passes gateApproved: true to dispatchTask', async () => {
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(dispatchTaskSpy).toHaveBeenCalledWith(
+        'stack-1',
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ gateApproved: true })
+      );
+    });
+
+    it('includes baseRefName from gh response in the dispatch prompt', async () => {
+      mockGhFn.mockResolvedValue(ghViewJson('CONFLICTING', 'develop'));
+
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      const [, prompt] = dispatchTaskSpy.mock.calls[0] as [string, string, ...unknown[]];
+      expect(prompt).toContain('develop');
+    });
+
+    it('pushes and returns resolved when task exit_code is 0', async () => {
+      const result = await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(pushSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual({ status: 'resolved' });
+    });
+
+    it('skips push and returns failed when task exit_code is non-zero', async () => {
+      awaitTaskCompletionSpy.mockResolvedValue(makeTerminalTask(1));
+
+      const result = await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(pushSpy).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ status: 'failed' });
+    });
+
+    it('skips push and throws when awaitTaskCompletion times out', async () => {
+      awaitTaskCompletionSpy.mockRejectedValue(
+        new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, 'Auto-resolve timed out waiting for task completion')
+      );
+
+      await expect(manager.autoResolveConflicts(TICKET, PROJECT_DIR)).rejects.toThrow('timed out');
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not teardown a pre-existing stack on success', async () => {
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(teardownStackSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not teardown a pre-existing stack when task fails', async () => {
+      awaitTaskCompletionSpy.mockResolvedValue(makeTerminalTask(1));
+
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(teardownStackSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not teardown a pre-existing stack when awaitTaskCompletion times out', async () => {
+      awaitTaskCompletionSpy.mockRejectedValue(
+        new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, 'Auto-resolve timed out waiting for task completion')
+      );
+
+      await expect(manager.autoResolveConflicts(TICKET, PROJECT_DIR)).rejects.toThrow();
+      expect(teardownStackSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch and returns no_conflicts when PR is MERGEABLE', async () => {
+      mockGhFn.mockResolvedValue(ghViewJson('MERGEABLE'));
+
+      const result = await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(dispatchTaskSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: 'no_conflicts' });
+    });
+
+    it('does not dispatch and returns unknown_state when PR is UNKNOWN', async () => {
+      mockGhFn.mockResolvedValue(ghViewJson('UNKNOWN'));
+
+      const result = await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(dispatchTaskSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: 'unknown_state' });
+    });
+  });
+
+  // ==========================================================================
+  // Recreate path: stack was torn down, found only in history
+  // ==========================================================================
+  describe('recreate path (stack absent)', () => {
+    beforeEach(() => {
+      // Seed history by creating a stack, archiving it, then deleting it from live stacks
+      registry.createStack({
+        id: 'old-stack',
+        project: 'test',
+        project_dir: PROJECT_DIR,
+        ticket: TICKET,
+        branch: BRANCH,
+        description: null,
+        status: 'pr_created',
+        runtime: 'docker',
+      });
+      registry.archiveStack('old-stack', 'torn_down');
+      registry.deleteStack('old-stack');
+
+      // gh pr list response for the torn-down case
+      mockGhFn.mockResolvedValue(ghListJson('CONFLICTING'));
+
+      // createStack spy: insert a stack with 'up' status so the build-wait loop
+      // exits immediately on the first registry.getStack check.
+      createStackSpy.mockImplementation((opts) => {
+        return registry.createStack({
+          id: opts.name,
+          project: 'test',
+          project_dir: opts.projectDir,
+          ticket: opts.ticket ?? null,
+          branch: opts.branch ?? null,
+          description: opts.description ?? null,
+          status: 'up',
+          runtime: opts.runtime ?? 'docker',
+        });
+      });
+    });
+
+    it('calls createStack when no live stack exists', async () => {
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(createStackSpy).toHaveBeenCalledOnce();
+    });
+
+    it('passes gateApproved: true to dispatchTask on the recreate path', async () => {
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(dispatchTaskSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ gateApproved: true })
+      );
+    });
+
+    it('tears down the recreated stack after successful resolution', async () => {
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(teardownStackSpy).toHaveBeenCalledOnce();
+    });
+
+    it('tears down the recreated stack even when task fails (finally block)', async () => {
+      awaitTaskCompletionSpy.mockResolvedValue(makeTerminalTask(1));
+
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(teardownStackSpy).toHaveBeenCalledOnce();
+    });
+
+    it('tears down the recreated stack even when awaitTaskCompletion times out', async () => {
+      awaitTaskCompletionSpy.mockRejectedValue(
+        new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, 'Auto-resolve timed out waiting for task completion')
+      );
+
+      await expect(manager.autoResolveConflicts(TICKET, PROJECT_DIR)).rejects.toThrow();
+      expect(teardownStackSpy).toHaveBeenCalledOnce();
+    });
+
+    it('skips push when task exit_code is non-zero on recreate path', async () => {
+      awaitTaskCompletionSpy.mockResolvedValue(makeTerminalTask(1));
+
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not call createStack when gh reports MERGEABLE (early exit before recreate)', async () => {
+      mockGhFn.mockResolvedValue(ghListJson('MERGEABLE'));
+
+      const result = await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      expect(createStackSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: 'no_conflicts' });
+    });
+
+    it('throws STACK_NOT_FOUND when no history record exists for the ticket', async () => {
+      vi.spyOn(registry, 'listStackHistory').mockReturnValue([]);
+
+      await expect(manager.autoResolveConflicts(TICKET, PROJECT_DIR)).rejects.toThrow();
+    });
+  });
+});

--- a/tests/unit/stack-manager-await.test.ts
+++ b/tests/unit/stack-manager-await.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for StackManager.awaitTaskCompletion
+ *
+ * Uses a mocked TaskWatcher EventEmitter and a minimal registry stub to
+ * exercise the event-driven + polling-backstop + timeout paths.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { SandstormError, ErrorCode } from '../../src/main/errors';
+
+// ---------------------------------------------------------------------------
+// Minimal stub types
+// ---------------------------------------------------------------------------
+interface StubTask {
+  id: number;
+  stack_id: string;
+  status: 'running' | 'completed' | 'failed' | 'needs_human' | 'interrupted';
+  exit_code: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Build a minimal StackManager-like object with only awaitTaskCompletion
+// exposed, so we can test it in isolation without bringing up the full class.
+// ---------------------------------------------------------------------------
+
+function makeAwaitFn(taskWatcher: EventEmitter, getTasksForStack: (stackId: string) => StubTask[]) {
+  function awaitTaskCompletion(
+    stackId: string,
+    taskId: number,
+    opts?: { timeoutMs?: number }
+  ): Promise<StubTask> {
+    const timeoutMs = opts?.timeoutMs ?? 30 * 60 * 1000;
+
+    return new Promise<StubTask>((resolve, reject) => {
+      let settled = false;
+      let pollInterval: ReturnType<typeof setInterval> | null = null;
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+      const settle = (task?: StubTask, err?: Error) => {
+        if (settled) return;
+        settled = true;
+        taskWatcher.removeListener('task:completed', onCompleted);
+        taskWatcher.removeListener('task:failed', onFailed);
+        if (pollInterval !== null) clearInterval(pollInterval);
+        if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+        if (err) reject(err);
+        else resolve(task!);
+      };
+
+      const isTerminal = (t: StubTask) =>
+        t.status === 'completed' || t.status === 'failed' || t.status === 'needs_human';
+
+      const onCompleted = ({ stackId: sid, task }: { stackId: string; task: StubTask }) => {
+        if (sid === stackId && task.id === taskId) settle(task);
+      };
+      const onFailed = ({ stackId: sid, task }: { stackId: string; task: StubTask }) => {
+        if (sid === stackId && task.id === taskId) settle(task);
+      };
+
+      taskWatcher.on('task:completed', onCompleted);
+      taskWatcher.on('task:failed', onFailed);
+
+      pollInterval = setInterval(() => {
+        try {
+          const tasks = getTasksForStack(stackId);
+          const task = tasks.find(t => t.id === taskId);
+          if (task && isTerminal(task)) settle(task);
+        } catch { /* best effort */ }
+      }, 2000);
+
+      timeoutHandle = setTimeout(() => {
+        settle(
+          undefined,
+          new SandstormError(
+            ErrorCode.TASK_DISPATCH_FAILED,
+            'Auto-resolve timed out waiting for task completion'
+          )
+        );
+      }, timeoutMs);
+
+      // Immediate backstop check
+      try {
+        const tasks = getTasksForStack(stackId);
+        const task = tasks.find(t => t.id === taskId);
+        if (task && isTerminal(task)) { settle(task); return; }
+      } catch { /* ignore */ }
+    });
+  }
+
+  return awaitTaskCompletion;
+}
+
+describe('awaitTaskCompletion', () => {
+  let emitter: EventEmitter;
+  let tasks: StubTask[];
+  let getTasksForStack: ReturnType<typeof vi.fn>;
+  let awaitTask: ReturnType<typeof makeAwaitFn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    emitter = new EventEmitter();
+    tasks = [];
+    getTasksForStack = vi.fn(() => tasks);
+    awaitTask = makeAwaitFn(emitter, getTasksForStack);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    emitter.removeAllListeners();
+  });
+
+  it('resolves when task:completed event fires for matching stackId and taskId', async () => {
+    const completedTask: StubTask = { id: 1, stack_id: 's1', status: 'completed', exit_code: 0 };
+
+    const promise = awaitTask('s1', 1);
+    emitter.emit('task:completed', { stackId: 's1', task: completedTask });
+
+    await expect(promise).resolves.toEqual(completedTask);
+  });
+
+  it('resolves when task:failed event fires for matching stackId and taskId', async () => {
+    const failedTask: StubTask = { id: 2, stack_id: 's1', status: 'failed', exit_code: 1 };
+
+    const promise = awaitTask('s1', 2);
+    emitter.emit('task:failed', { stackId: 's1', task: failedTask });
+
+    await expect(promise).resolves.toEqual(failedTask);
+  });
+
+  it('ignores task:completed events for a different stackId', async () => {
+    const otherTask: StubTask = { id: 1, stack_id: 's2', status: 'completed', exit_code: 0 };
+    const targetTask: StubTask = { id: 1, stack_id: 's1', status: 'completed', exit_code: 0 };
+
+    const promise = awaitTask('s1', 1);
+    // Different stack
+    emitter.emit('task:completed', { stackId: 's2', task: otherTask });
+    // Correct stack
+    emitter.emit('task:completed', { stackId: 's1', task: targetTask });
+
+    await expect(promise).resolves.toEqual(targetTask);
+  });
+
+  it('ignores task:completed events for a different taskId', async () => {
+    const siblingTask: StubTask = { id: 99, stack_id: 's1', status: 'completed', exit_code: 0 };
+    const targetTask: StubTask = { id: 1, stack_id: 's1', status: 'completed', exit_code: 0 };
+
+    const promise = awaitTask('s1', 1);
+    emitter.emit('task:completed', { stackId: 's1', task: siblingTask });
+    emitter.emit('task:completed', { stackId: 's1', task: targetTask });
+
+    await expect(promise).resolves.toEqual(targetTask);
+  });
+
+  it('settles via polling backstop when task is already terminal before any event fires', async () => {
+    const completedTask: StubTask = { id: 5, stack_id: 's1', status: 'completed', exit_code: 0 };
+    tasks = [completedTask];
+
+    const promise = awaitTask('s1', 5, { timeoutMs: 10000 });
+
+    // The immediate backstop check should resolve synchronously
+    await expect(promise).resolves.toEqual(completedTask);
+  });
+
+  it('settles via the polling interval when task becomes terminal after a poll tick', async () => {
+    const targetTask: StubTask = { id: 7, stack_id: 's1', status: 'completed', exit_code: 0 };
+
+    const promise = awaitTask('s1', 7, { timeoutMs: 10000 });
+
+    // Task not terminal yet
+    tasks = [];
+    vi.advanceTimersByTime(1999);
+    // Still not there
+
+    // Now task becomes terminal
+    tasks = [targetTask];
+    vi.advanceTimersByTime(2001);
+
+    await expect(promise).resolves.toEqual(targetTask);
+  });
+
+  it('rejects on timeout when no terminal event arrives', async () => {
+    const promise = awaitTask('s1', 3, { timeoutMs: 5000 });
+
+    vi.advanceTimersByTime(5001);
+
+    await expect(promise).rejects.toThrow('Auto-resolve timed out');
+  });
+
+  it('removes listeners on settle (no leak)', async () => {
+    const completedTask: StubTask = { id: 10, stack_id: 's1', status: 'completed', exit_code: 0 };
+
+    const promise = awaitTask('s1', 10);
+    emitter.emit('task:completed', { stackId: 's1', task: completedTask });
+    await promise;
+
+    // After settle, emitter should have no remaining listeners
+    expect(emitter.listenerCount('task:completed')).toBe(0);
+    expect(emitter.listenerCount('task:failed')).toBe(0);
+  });
+});

--- a/tests/unit/store-auto-resolve.test.ts
+++ b/tests/unit/store-auto-resolve.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Store-level unit tests for the autoResolveConflicts action.
+ * Mirrors the pattern in tests/unit/ticketBoard.test.ts for store-facing tests.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from '../../src/renderer/store';
+
+const TICKET_ID = '42';
+const PROJECT_DIR = '/proj';
+const KEY = `${TICKET_ID}|${PROJECT_DIR}`;
+
+function mockAutoResolveIpc(result: unknown) {
+  const api = {
+    pr: { autoResolve: vi.fn().mockResolvedValue(result) },
+  };
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+  return api;
+}
+
+function mockAutoResolveIpcError(err: Error) {
+  const api = {
+    pr: { autoResolve: vi.fn().mockRejectedValue(err) },
+  };
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+  return api;
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    autoResolveInFlight: {},
+    autoResolveErrors: {},
+  } as any);
+});
+
+describe('autoResolveConflicts store action', () => {
+  it('success path (CONFLICTING → resolved): no error set in store', async () => {
+    mockAutoResolveIpc({ status: 'resolved' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBeUndefined();
+    expect(useAppStore.getState().autoResolveInFlight[KEY]).toBeFalsy();
+  });
+
+  it('no-op path (MERGEABLE): sets "No conflicts to resolve." error', async () => {
+    mockAutoResolveIpc({ status: 'no_conflicts' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('No conflicts to resolve.');
+  });
+
+  it('unknown path (UNKNOWN): sets "Mergeability unknown, try again." error', async () => {
+    mockAutoResolveIpc({ status: 'unknown_state' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('Mergeability unknown, try again.');
+  });
+
+  it('failure path: sets the error message from the result', async () => {
+    mockAutoResolveIpc({ status: 'failed', error: 'inner agent could not resolve' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('inner agent could not resolve');
+  });
+
+  it('error thrown by IPC: sets the error message in the store', async () => {
+    mockAutoResolveIpcError(new Error('Stack not found'));
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('Stack not found');
+  });
+
+  it('in-flight guard: second call while first is in-flight is a no-op', async () => {
+    let resolveFirst!: () => void;
+    const firstProm = new Promise<void>((r) => { resolveFirst = r; });
+    const api = {
+      pr: { autoResolve: vi.fn().mockReturnValueOnce(firstProm.then(() => ({ status: 'resolved' }))) },
+    };
+    Object.defineProperty(window, 'sandstorm', { value: api, writable: true, configurable: true });
+
+    const first = useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+    // second call before first resolves
+    const second = useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    resolveFirst();
+    await first;
+    await second;
+
+    expect(api.pr.autoResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears previous error at the start of a new attempt', async () => {
+    useAppStore.setState({ autoResolveErrors: { [KEY]: 'old error' } } as any);
+    mockAutoResolveIpc({ status: 'resolved' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBeUndefined();
+  });
+
+  it('inFlight flag is set during the call and cleared after', async () => {
+    let resolveFn!: () => void;
+    const promise = new Promise<void>((r) => { resolveFn = r; });
+    const api = {
+      pr: { autoResolve: vi.fn().mockReturnValue(promise.then(() => ({ status: 'resolved' }))) },
+    };
+    Object.defineProperty(window, 'sandstorm', { value: api, writable: true, configurable: true });
+
+    const actionPromise = useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().autoResolveInFlight[KEY]).toBe(true);
+
+    resolveFn();
+    await actionPromise;
+
+    expect(useAppStore.getState().autoResolveInFlight[KEY]).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Implements #457 — auto-resolve merge conflicts for stacks.

## Changes
- `stack-manager.ts`: auto-resolve flow + await handling (with `stack-manager-auto-resolve` / `stack-manager-await` tests).
- `store.ts`: `autoResolveInFlight` / `autoResolveErrors` / `autoResolveConflicts` state (with `store-auto-resolve` tests).
- `ipc.ts` / `preload`: IPC surface for the auto-resolve action.
- `TicketCard.tsx`: UI affordance (with component tests).

## Recovery note
This stack had halted at `needs_human` via `STOP_AND_ASK` — not because its feature work was incomplete, but because the pre-existing broken `kanban-column-transitions.spec.ts` contradicted the unit tests and it (correctly) refused to modify out-of-scope tests. That test is now fixed on main via #471. Recovered by merging current main (clean, no conflicts); full verify suite passes **green** (typecheck, unit, build, package, integration — 41 integration tests).

Closes #457.