### PR TITLE
Rename app to 'sandstorm'; one-command build; drop stale release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-![Sandstorm Desktop](resources/icon.png)
+![Sandstorm](resources/icon.png)
 
-# Sandstorm Desktop
+# Sandstorm
 
 **Deploy a fleet of AI agents. Ship 10x faster.**
 
-Sandstorm Desktop is a local orchestration platform that spins up isolated AI coding agents in parallel. Each agent gets its own Docker environment with a full repo clone, running services, and a dedicated Claude Code instance. You dispatch work, review diffs, and push code — all from one interface.
+Sandstorm is a local orchestration platform that spins up isolated AI coding agents in parallel. Each agent gets its own Docker environment with a full repo clone, running services, and a dedicated Claude Code instance. You dispatch work, review diffs, and push code — all from one interface.
 
 No cloud. No waiting. No seat limits. Just you and as many agents as your machine can run.
 
@@ -41,20 +41,18 @@ You  --->  Outer Claude (orchestrator)
 
 ---
 
-## Install
+## Build from source
 
-### Linux
+Requires Node.js, Docker, and Git.
 
-Download `sandstorm-desktop-0.1.0-linux.AppImage` from the [latest release](https://github.com/onomojo/sandstorm-desktop/releases/latest).
+    git clone https://github.com/onomojo/sandstorm-desktop.git
+    cd sandstorm-desktop
+    npm run build
 
-```bash
-chmod +x sandstorm-desktop-0.1.0-linux.AppImage
-./sandstorm-desktop-0.1.0-linux.AppImage
-```
+`npm run build` runs the whole pipeline (install, compile, native-module rebuild, package) and is self-sufficient from a clean clone. When it finishes:
 
-### macOS
-
-Download `sandstorm-desktop-0.1.0-mac.dmg` from the [latest release](https://github.com/onomojo/sandstorm-desktop/releases/latest). Open it and drag Sandstorm Desktop to Applications.
+- **Linux:** run `release/sandstorm.AppImage`
+- **macOS:** open `release/sandstorm.dmg` and drag Sandstorm to Applications
 
 ---
 
@@ -71,7 +69,7 @@ Download `sandstorm-desktop-0.1.0-mac.dmg` from the [latest release](https://git
 
 ## Quick start
 
-1. Launch Sandstorm Desktop
+1. Launch Sandstorm
 2. **Open Project** — select a directory with a `docker-compose.yml`
 3. **Initialize** — if the project hasn't been set up, click "Initialize Sandstorm"
 4. **New Stack** — create an isolated workspace
@@ -100,28 +98,7 @@ npm test             # run tests
 npx tsc --noEmit     # type check
 ```
 
-### Build & package
-
-```bash
-npm run build
-npx electron-rebuild
-npm run package -- --config.npmRebuild=false
-```
-
-### Building for macOS
-
-macOS builds require macOS (for code signing):
-
-```bash
-git clone git@github.com:onomojo/sandstorm-desktop.git
-cd sandstorm-desktop
-npm install
-npm run build
-npx electron-rebuild
-npm run package -- --config.npmRebuild=false
-```
-
-Produces a `.dmg` in `release/`.
+The one full-build command is `npm run build`, which produces `release/sandstorm.AppImage` on Linux and `release/sandstorm.dmg` on macOS.
 
 ---
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,7 +1,7 @@
 appId: com.sandstorm.desktop
-productName: Sandstorm Desktop
+productName: Sandstorm
 npmRebuild: false
-artifactName: "sandstorm-desktop-${version}.${ext}"
+artifactName: "sandstorm.${ext}"
 directories:
   output: release
   buildResources: resources
@@ -24,16 +24,16 @@ mac:
   target: [dmg]
   icon: resources/icon.icns
   category: public.app-category.developer-tools
-  artifactName: "sandstorm-desktop-${version}-mac.${ext}"
+  artifactName: "sandstorm.${ext}"
 win:
   target: [nsis]
   icon: resources/icon.ico
-  artifactName: "sandstorm-desktop-${version}-win.${ext}"
+  artifactName: "sandstorm.${ext}"
 linux:
   target: [AppImage]
   icon: resources/icon.png
   category: Development
-  artifactName: "sandstorm-desktop-${version}-linux.${ext}"
+  artifactName: "sandstorm.${ext}"
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandstorm-desktop",
+  "name": "sandstorm",
   "version": "0.1.0",
   "type": "module",
   "description": "Desktop control plane for Sandstorm agent orchestration",
@@ -10,8 +10,11 @@
   "main": "dist/main/index.cjs",
   "scripts": {
     "dev": "electron-vite dev",
-    "prebuild": "git config --global --add safe.directory /app 2>/dev/null; git rev-parse --short HEAD > src/renderer/build-version.txt 2>/dev/null || echo unknown > src/renderer/build-version.txt",
-    "build": "electron-vite build",
+    "build-version": "git config --global --add safe.directory /app 2>/dev/null; git rev-parse --short HEAD > src/renderer/build-version.txt 2>/dev/null || echo unknown > src/renderer/build-version.txt",
+    "prebuild": "npm run build-version",
+    "prebuild:vite": "npm run build-version",
+    "build:vite": "electron-vite build",
+    "build": "bash scripts/build.sh",
     "preview": "electron-vite preview",
     "package": "electron-builder",
     "package:all": "electron-builder -mwl",
@@ -21,8 +24,7 @@
     "test:integration": "PLAYWRIGHT_TEST=1 xvfb-run --server-num=50 playwright test --config playwright.integration.config.ts",
     "test:e2e": "playwright test",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit",
-    "release": "bash scripts/build.sh"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,7 +25,7 @@ git rev-parse --short HEAD > src/renderer/build-version.txt
 echo "    Commit: $(cat src/renderer/build-version.txt)"
 
 echo "==> Building app..."
-npm run build
+npm run build:vite
 
 echo "==> Rebuilding native modules for Electron..."
 # electron-rebuild recompiles native Node modules for Electron's Node version.

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -28,8 +28,8 @@ function resolvePackagedBinary(): string {
     );
   }
 
-  // Look for the executable — productName is "Sandstorm Desktop" → binary is "sandstorm-desktop"
-  const expectedBinary = path.join(unpackedDir, 'sandstorm-desktop');
+  // Look for the executable — productName is "Sandstorm" → binary is "sandstorm"
+  const expectedBinary = path.join(unpackedDir, 'sandstorm');
   if (fs.existsSync(expectedBinary)) {
     return expectedBinary;
   }


### PR DESCRIPTION
## What

- **Rename** the app and packaged binary to `sandstorm`. `productName: Sandstorm`; artifacts are now `sandstorm.AppImage` / `sandstorm.dmg` / `sandstorm.exe` — no version, no platform suffix.
- **One command to build everything:** `npm run build` now runs the full pipeline (`bash scripts/build.sh`: install → compile → electron-rebuild → package). The electron-vite compile step is split out as `build:vite`; the redundant `release` script is removed.
- **Keep `build-version.txt` regenerated** on every path via a shared `build-version` script with `prebuild` + `prebuild:vite` hooks (the file is gitignored, so the verify gate's `build:vite` must still trigger it).
- **README:** replaced the stale 'Download from latest release' Install section with **Build from source** (clone + `npm run build`); rebranded 'Sandstorm Desktop' → 'Sandstorm'; collapsed the duplicate build/package dev subsections.
- **Integration fixture** `tests/integration/fixtures.ts` updated to expect the `sandstorm` binary name.

## Out of scope / unchanged
- `appId` (`com.sandstorm.desktop`) unchanged.
- Generic verify generator in `src/main/ipc.ts` and its tests/evals left as-is (`build`=compile is still the correct default for other projects).
- Full repo rename is a separate future task.

## Verification (in stack)
- `npm run build` from a clean state produced **`release/sandstorm.AppImage`** (118 MB), unpacked binary `release/linux-unpacked/sandstorm`.
- Verify gate: unit suite clean, integration **43 passed / 1 skipped / 0 failed**.

## Note
The stale GitHub release `v0.1.0` and its tag have already been deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)