### PR TITLE
Pin userData dir name so app rename can't strand user data

### DIFF
--- a/src/main/app-identity.ts
+++ b/src/main/app-identity.ts
@@ -1,0 +1,16 @@
+/**
+ * The Electron app name used to resolve `app.getPath('userData')`.
+ *
+ * MUST remain `'sandstorm-desktop'`. Electron derives the userData directory
+ * (`~/.config/<name>` on Linux, equivalents elsewhere) from `app.getName()`,
+ * which defaults to the package.json `name` field. In #485 the package was
+ * renamed `sandstorm-desktop` -> `sandstorm` to change the product/artifact
+ * name; that silently moved userData to `~/.config/sandstorm`, so every
+ * existing project and ticket-provider config became invisible (a fresh,
+ * empty SQLite DB was created instead).
+ *
+ * Pinning the name here via `app.setName(APP_USER_DATA_NAME)` decouples the
+ * data directory from the package/product name, so a future rename can never
+ * strand user data again. Do not change this value.
+ */
+export const APP_USER_DATA_NAME = 'sandstorm-desktop';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,14 @@ import { syncAllProjectsCrontab } from './scheduler/scheduler-manager';
 import { runScheduledScript } from './scheduler/script-runner';
 import { runStartupReconciliation } from './control-plane/startup-reconciler';
 import { DarkFactoryOrchestrator } from './control-plane/dark-factory-orchestrator';
+import { APP_USER_DATA_NAME } from './app-identity';
+
+// Pin the userData directory name independent of the package.json `name` /
+// electron-builder productName. Electron resolves app.getPath('userData') from
+// app.getName(); renaming the package to 'sandstorm' (#485) moved userData and
+// hid every existing project/ticket-config. Must run before whenReady and any
+// getPath('userData') call. See app-identity.ts.
+app.setName(APP_USER_DATA_NAME);
 
 // Enable remote debugging via env var (used by integration tests and ad-hoc CDP connections)
 if (process.env.REMOTE_DEBUGGING_PORT) {

--- a/tests/unit/main/app-identity.test.ts
+++ b/tests/unit/main/app-identity.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { APP_USER_DATA_NAME } from '../../../src/main/app-identity';
+
+/**
+ * Regression guard for #485: renaming the package.json `name` to 'sandstorm'
+ * moved Electron's userData dir from ~/.config/sandstorm-desktop to
+ * ~/.config/sandstorm, hiding every existing project and ticket config behind
+ * a fresh empty DB. The main process pins app.setName(APP_USER_DATA_NAME) to
+ * decouple the data directory from the package/product name. Locking the value
+ * here means any future rename of this constant fails CI loudly instead of
+ * silently stranding user data.
+ */
+describe('APP_USER_DATA_NAME', () => {
+  it("is pinned to 'sandstorm-desktop' so userData never moves on rename", () => {
+    expect(APP_USER_DATA_NAME).toBe('sandstorm-desktop');
+  });
+});


### PR DESCRIPTION
## Problem

After #485 renamed the package `sandstorm-desktop` → `sandstorm` (to change the product/artifact name), all projects and their ticket configs vanished from the app.

**Root cause:** Electron derives `app.getPath('userData')` from `app.getName()`, which defaults to the package.json `name` field. Changing `name` silently moved the data directory from `~/.config/sandstorm-desktop` to `~/.config/sandstorm`, so the app opened a fresh empty `sandstorm.db` instead of the populated one. No data was lost — the app was just looking in the wrong folder.

## Fix

Pin the data-dir name via `app.setName('sandstorm-desktop')` before `whenReady` (and before any `getPath('userData')` call), sourced from a dedicated `app-identity` module. This decouples the userData location from the package/product name, so a future rename can't move user data again.

For everyone on the current (pre-rename) release this is transparent — it points at the same `~/.config/sandstorm-desktop` folder they've always used; their data reappears on upgrade with zero action.

## Changes

- `src/main/app-identity.ts` — `APP_USER_DATA_NAME = 'sandstorm-desktop'` with a documented rationale
- `src/main/index.ts` — `app.setName(APP_USER_DATA_NAME)` at the top of the main process
- `tests/unit/main/app-identity.test.ts` — regression test locking the value so a future rename fails CI loudly

## Testing

`npx vitest run tests/unit/main/app-identity.test.ts` → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)