### PR TITLE
[463] fix: auto-recover stalled running tasks via liveness watcher

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -704,6 +704,50 @@ export class StackManager {
   }
 
   /**
+   * Dispatch an investigation-and-finish session for a stalled task.
+   * Called by the TaskWatcher liveness check when a running task's process
+   * has died without writing a terminal status. Uses --resume <session_id>
+   * so the original session can inspect its own prior work and either finish
+   * or write a terminal status. Distinct from dispatchContinuation (token-limit
+   * resume) — this path delivers the INVESTIGATE_AND_FINISH_PROMPT.
+   */
+  async dispatchInvestigation(stackId: string, task: Task, investigationPrompt: string): Promise<void> {
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    const runtime = this.getRuntimeForStack(stack);
+    let claudeContainer = await this.findClaudeContainer(stack, runtime);
+
+    if (claudeContainer.status !== 'running') {
+      await this.ensureStackContainersRunning(stack, stackId);
+      claudeContainer = await this.findClaudeContainer(stack, runtime);
+    }
+
+    await this.waitForClaudeReady(claudeContainer.id, runtime);
+
+    this.registry.setTaskResumedAt(task.id, new Date().toISOString());
+    this.registry.updateStackStatus(stackId, 'running');
+    this.notifyUpdate();
+
+    const cliArgs = ['task', stackId, '--resume', task.session_id!];
+    if (task.model) cliArgs.push('--model', task.model);
+    cliArgs.push(investigationPrompt);
+
+    const result = await this.runCli(stack.project_dir, cliArgs);
+    if (result.exitCode !== 0) {
+      this.registry.updateStackStatus(stackId, 'needs_human');
+      this.notifyUpdate();
+      throw new SandstormError(
+        ErrorCode.TASK_DISPATCH_FAILED,
+        result.stderr.trim() || result.stdout.trim() || 'Investigation dispatch failed'
+      );
+    }
+
+    this.taskWatcher.watch(stackId, claudeContainer.id);
+    this.taskWatcher.streamOutput(stackId, claudeContainer.id, () => {}).catch(() => {});
+  }
+
+  /**
    * Resume a needs_human stack by providing answers to the agent's questions.
    * Uses --resume <session_id> if available; falls back to fresh dispatch if not.
    */

--- a/src/main/control-plane/startup-reconciler.ts
+++ b/src/main/control-plane/startup-reconciler.ts
@@ -24,6 +24,21 @@ const INVESTIGATE_PROMPT =
   'Also write the exit code to /tmp/claude-task.exit: "0" for completed, "1" for all others. ' +
   'Stop immediately after writing these files — do not perform any other work.';
 
+/**
+ * Recovery prompt for the live liveness check. Unlike INVESTIGATE_PROMPT (which
+ * is used for fresh-dispatch investigation), this is delivered via --resume
+ * <session_id> so the original session can inspect its own prior context.
+ * The key difference: if work is incomplete, this prompt instructs the session
+ * to finish the remaining work rather than just writing a terminal status.
+ */
+export const INVESTIGATE_AND_FINISH_PROMPT =
+  'Your task\'s status was stuck at "running" — the process died before writing a terminal status. ' +
+  'Inspect your prior work: run "git status", "git log --oneline -10", check test results, and review the tail of /tmp/claude-raw.log. ' +
+  'If all intended work is complete and tests pass, write "completed" to /tmp/claude-task.status and "0" to /tmp/claude-task.exit, then stop. ' +
+  'If work was attempted but tests fail or an error occurred, write "failed" to /tmp/claude-task.status and "1" to /tmp/claude-task.exit, then stop. ' +
+  'If the task is genuinely incomplete, finish the remaining work — do NOT write to the status files yourself; ' +
+  'let the normal task lifecycle write the terminal status when you are done.';
+
 export interface ReconcilerDeps {
   fetchTicketStateFn?: (ticketId: string, cwd: string) => Promise<'OPEN' | 'CLOSED'>;
   workspaceExistsFn?: (stack: Stack) => boolean;

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -36,6 +36,16 @@ const SUSPICIOUS_DURATION_MS = 30_000;
 const BACKOFF_BASE_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
 
+/** How often the background liveness check runs while a task is 'running' (ms) */
+export const LIVENESS_CHECK_INTERVAL_MS = 60_000;
+/** No raw-log growth for this long ⇒ candidate stall (pending process-liveness confirmation) */
+export const LIVENESS_STALL_THRESHOLD_MS = 5 * 60_000;
+
+/** Terminal statuses used by the liveness check's idempotency guard */
+const LIVENESS_TERMINAL_STATUSES = new Set([
+  'completed', 'failed', 'needs_human', 'verify_blocked_environmental', 'token_limited',
+]);
+
 export class TaskWatcher extends EventEmitter {
   private watchers = new Map<string, NodeJS.Timeout>();
   private errorCounts = new Map<string, number>();
@@ -58,15 +68,41 @@ export class TaskWatcher extends EventEmitter {
   /** Track container IDs for each watched stack (for on-demand progress queries) */
   private containerIds = new Map<string, string>();
 
+  /** Liveness tracking — last known /tmp/claude-raw.log size per stack */
+  private livenessLogSize = new Map<string, number>();
+  /** Liveness tracking — timestamp of last observed log growth per stack */
+  private livenessLastActivityAt = new Map<string, number>();
+  /** Liveness tracking — setInterval handles for the periodic liveness checks */
+  private livenessTimers = new Map<string, ReturnType<typeof setInterval>>();
+  /** Effective liveness check interval (overridable in tests) */
+  private livenessCheckIntervalMs: number;
+  /** Effective stall threshold (overridable in tests) */
+  private livenessStallThresholdMs: number;
+
+  /** Callback invoked when a stall is confirmed and investigation should be dispatched */
+  private onDispatchInvestigation?: (stackId: string, task: Task) => Promise<void>;
+
   constructor(
     private registry: Registry,
     private dockerRuntime: ContainerRuntime,
     private podmanRuntime: ContainerRuntime,
-    options?: { pollInterval?: number; tokenPollInterval?: number }
+    options?: {
+      pollInterval?: number;
+      tokenPollInterval?: number;
+      livenessCheckInterval?: number;
+      livenessStallThreshold?: number;
+    }
   ) {
     super();
     this.pollInterval = options?.pollInterval ?? 2000;
     this.tokenPollInterval = options?.tokenPollInterval ?? 5_000;
+    this.livenessCheckIntervalMs = options?.livenessCheckInterval ?? LIVENESS_CHECK_INTERVAL_MS;
+    this.livenessStallThresholdMs = options?.livenessStallThreshold ?? LIVENESS_STALL_THRESHOLD_MS;
+  }
+
+  /** Register a callback invoked when a stalled task needs investigation dispatch */
+  setDispatchInvestigation(callback: (stackId: string, task: Task) => Promise<void>): void {
+    this.onDispatchInvestigation = callback;
   }
 
   /**
@@ -96,6 +132,16 @@ export class TaskWatcher extends EventEmitter {
     this.stalePollCounts.set(stackId, 0);
     this.containerIds.set(stackId, containerId);
 
+    // Initialize liveness tracking — assume active at watch start
+    this.livenessLogSize.set(stackId, 0);
+    this.livenessLastActivityAt.set(stackId, Date.now());
+    const livenessTimer = setInterval(() => {
+      this.checkLiveness(stackId, containerId).catch((err) => {
+        console.warn(`[TaskWatcher] Liveness check error for ${stackId}:`, (err as Error)?.message ?? err);
+      });
+    }, this.livenessCheckIntervalMs);
+    this.livenessTimers.set(stackId, livenessTimer);
+
     this.schedulePoll(stackId, containerId, this.pollInterval);
   }
 
@@ -117,6 +163,15 @@ export class TaskWatcher extends EventEmitter {
       controller.abort();
       this.activeOutputStreams.delete(stackId);
     }
+
+    // Clean up liveness tracking
+    const livenessTimer = this.livenessTimers.get(stackId);
+    if (livenessTimer) {
+      clearInterval(livenessTimer);
+      this.livenessTimers.delete(stackId);
+    }
+    this.livenessLogSize.delete(stackId);
+    this.livenessLastActivityAt.delete(stackId);
   }
 
   unwatchAll(): void {
@@ -503,6 +558,97 @@ export class TaskWatcher extends EventEmitter {
       this.readTaskIterations(taskId, stackId, containerId).catch(() => {}),
       this.readTaskMetadata(taskId, stackId, containerId).catch(() => {}),
     ]);
+  }
+
+  /**
+   * Background liveness check for a running task. Fires every LIVENESS_CHECK_INTERVAL_MS.
+   * Uses /tmp/claude-raw.log size growth as the activity signal. If no growth is seen
+   * for LIVENESS_STALL_THRESHOLD_MS AND pgrep confirms the claude process is dead,
+   * triggers automatic investigation-and-recovery.
+   */
+  private async checkLiveness(stackId: string, containerId: string): Promise<void> {
+    // Guard: abort if no longer watching (e.g. unwatch was called concurrently)
+    if (!this.watchers.has(stackId)) return;
+
+    const runtime = this.getRuntimeForStack(stackId);
+
+    // 1. Read current raw log size — do NOT update lastActivityAt on exec failure
+    try {
+      const sizeResult = await runtime.exec(containerId, ['stat', '-c', '%s', '/tmp/claude-raw.log']);
+      const currentSize = parseInt(sizeResult.stdout.trim(), 10);
+      if (!isNaN(currentSize)) {
+        const lastSize = this.livenessLogSize.get(stackId) ?? 0;
+        if (currentSize > lastSize) {
+          // Log grew — reset stall clock
+          this.livenessLogSize.set(stackId, currentSize);
+          this.livenessLastActivityAt.set(stackId, Date.now());
+        }
+      }
+      // NaN size: treat like transient error — don't update anything
+    } catch {
+      // Exec error (container gone, daemon down) — skip this cycle entirely
+      // to avoid falsely declaring a stall (issue spec: transient errors must
+      // not count as no-log-growth and must not reset lastActivityAt)
+      return;
+    }
+
+    // 2. Not yet stalled
+    const lastActivity = this.livenessLastActivityAt.get(stackId) ?? Date.now();
+    if (Date.now() - lastActivity < this.livenessStallThresholdMs) return;
+
+    // 3. Candidate stall — confirm process is actually dead before recovering
+    try {
+      const pgrepResult = await runtime.exec(containerId, ['pgrep', '-f', 'claude']);
+      if (pgrepResult.stdout.trim()) return; // Process alive — long quiet tool call, not stalled
+    } catch {
+      // pgrep exec failed — skip recovery to avoid false positive
+      return;
+    }
+
+    // 4. Process dead + stalled — stop liveness timer to prevent double-recovery
+    const livenessTimer = this.livenessTimers.get(stackId);
+    if (livenessTimer) {
+      clearInterval(livenessTimer);
+      this.livenessTimers.delete(stackId);
+    }
+
+    // 5. Idempotency guard: re-read status file before dispatching recovery
+    try {
+      const statusResult = await runtime.exec(containerId, ['cat', '/tmp/claude-task.status']);
+      const status = statusResult.stdout.trim();
+      if (LIVENESS_TERMINAL_STATUSES.has(status)) {
+        // Status became terminal concurrently — normal poll will handle it
+        return;
+      }
+    } catch {
+      // Can't read status — skip recovery to avoid false positive
+      return;
+    }
+
+    // 6. Still 'running' — look up task and dispatch investigation
+    const task = this.registry.getRunningTask(stackId);
+    if (!task) return; // Already resolved by another path
+
+    if (!task.session_id) {
+      // No session_id — cannot resume; mark needs_human (edge case 2)
+      this.registry.completeTaskNeedsHuman(
+        task.id,
+        'Task stalled with no resumable session — needs human review'
+      );
+      this.onStatusChange?.();
+      this.unwatch(stackId);
+      return;
+    }
+
+    // 7. Dispatch investigation via callback (fire-and-forget; errors logged by caller)
+    if (this.onDispatchInvestigation) {
+      this.onDispatchInvestigation(stackId, task).catch((err) => {
+        console.warn(
+          `[TaskWatcher] Investigation dispatch failed for ${stackId}:`,
+          (err as Error)?.message ?? err
+        );
+      });
+    }
   }
 
   /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,7 +25,7 @@ import {
 } from './scheduler';
 import { syncAllProjectsCrontab } from './scheduler/scheduler-manager';
 import { runScheduledScript } from './scheduler/script-runner';
-import { runStartupReconciliation } from './control-plane/startup-reconciler';
+import { runStartupReconciliation, INVESTIGATE_AND_FINISH_PROMPT } from './control-plane/startup-reconciler';
 import { DarkFactoryOrchestrator } from './control-plane/dark-factory-orchestrator';
 import { APP_USER_DATA_NAME } from './app-identity';
 
@@ -149,6 +149,13 @@ async function initializeApp(): Promise<void> {
     cliDir
   );
   stackManager.setPortProxy(portProxy);
+
+  // Wire liveness-check investigation dispatch: when TaskWatcher detects a stalled
+  // task (process dead + no log growth for 5 min), it calls back here to resume
+  // the original session with an investigate-and-finish prompt.
+  taskWatcher.setDispatchInvestigation(async (stackId, task) => {
+    await stackManager.dispatchInvestigation(stackId, task, INVESTIGATE_AND_FINISH_PROMPT);
+  });
 
   // Backfill: advance any tickets stuck in in_stack whose linked stack is already pr_created.
   registry.reconcilePrCreatedTickets();

--- a/tests/unit/main/control-plane/task-watcher-liveness.test.ts
+++ b/tests/unit/main/control-plane/task-watcher-liveness.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TaskWatcher, LIVENESS_CHECK_INTERVAL_MS, LIVENESS_STALL_THRESHOLD_MS } from '../../../../src/main/control-plane/task-watcher';
+import { Registry, Task } from '../../../../src/main/control-plane/registry';
+import { ContainerRuntime } from '../../../../src/main/runtime/types';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Fast intervals for tests — override production defaults
+const TEST_LIVENESS_INTERVAL = 500;
+const TEST_STALL_THRESHOLD = 1000;
+
+/**
+ * Create a mock ContainerRuntime for liveness tests.
+ * opts.logSize: stat return value for /tmp/claude-raw.log (default 0)
+ * opts.pgrepOut: pgrep stdout (default '' = no process)
+ * opts.statusSequence: successive reads of /tmp/claude-task.status
+ */
+function createLivenessMockRuntime(opts: {
+  logSize?: number | (() => number);
+  pgrepOut?: string;
+  statusSequence?: string[];
+  statShouldThrow?: boolean;
+  pgrepShouldThrow?: boolean;
+} = {}): ContainerRuntime {
+  let statusCallIdx = 0;
+  return {
+    name: 'mock',
+    composeUp: vi.fn(),
+    composeDown: vi.fn(),
+    listContainers: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn(),
+    logs: vi.fn().mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true, value: '' }) }),
+    }),
+    exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+      // /tmp/claude-task.status read (main poll + idempotency re-read)
+      if (cmd.includes('/tmp/claude-task.status')) {
+        const seq = opts.statusSequence ?? ['running'];
+        const idx = Math.min(statusCallIdx++, seq.length - 1);
+        return { exitCode: 0, stdout: seq[idx], stderr: '' };
+      }
+
+      // stat for liveness log size
+      if (cmd[0] === 'stat' && cmd.includes('/tmp/claude-raw.log')) {
+        if (opts.statShouldThrow) throw new Error('stat exec error');
+        const size = typeof opts.logSize === 'function' ? opts.logSize() : (opts.logSize ?? 0);
+        return { exitCode: 0, stdout: String(size), stderr: '' };
+      }
+
+      // pgrep for process liveness
+      if (cmd[0] === 'pgrep') {
+        if (opts.pgrepShouldThrow) throw new Error('pgrep exec error');
+        const out = opts.pgrepOut ?? '';
+        return { exitCode: out ? 0 : 1, stdout: out, stderr: '' };
+      }
+
+      // /tmp/claude-task.exit
+      if (cmd.includes('/tmp/claude-task.exit')) {
+        return { exitCode: 0, stdout: '0', stderr: '' };
+      }
+
+      // Everything else (token files, iteration files, metadata)
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+describe('TaskWatcher — liveness check', () => {
+  let registry: Registry;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    dbPath = path.join(os.tmpdir(), `sandstorm-liveness-test-${Date.now()}.db`);
+    registry = await Registry.create(dbPath);
+
+    registry.createStack({
+      id: 'live-stack',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'running',
+      runtime: 'docker',
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    registry.close();
+    try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+    try { fs.unlinkSync(`${dbPath}-wal`); } catch { /* ignore */ }
+    try { fs.unlinkSync(`${dbPath}-shm`); } catch { /* ignore */ }
+  });
+
+  // ─── Wiring tests ──────────────────────────────────────────────────────────
+
+  it('watch() initializes liveness tracking; unwatch() tears it down', () => {
+    const runtime = createLivenessMockRuntime();
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+    registry.createTask('live-stack', 'test task');
+
+    watcher.watch('live-stack', 'c1');
+    // @ts-expect-error — accessing private field to verify initialization
+    expect(watcher.livenessTimers.has('live-stack')).toBe(true);
+    // @ts-expect-error
+    expect(watcher.livenessLogSize.has('live-stack')).toBe(true);
+    // @ts-expect-error
+    expect(watcher.livenessLastActivityAt.has('live-stack')).toBe(true);
+
+    watcher.unwatch('live-stack');
+    // @ts-expect-error
+    expect(watcher.livenessTimers.has('live-stack')).toBe(false);
+    // @ts-expect-error
+    expect(watcher.livenessLogSize.has('live-stack')).toBe(false);
+    // @ts-expect-error
+    expect(watcher.livenessLastActivityAt.has('live-stack')).toBe(false);
+  });
+
+  it('re-watch cleans up previous liveness timer and starts fresh', () => {
+    const runtime = createLivenessMockRuntime();
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+    });
+    registry.createTask('live-stack', 'test task');
+
+    watcher.watch('live-stack', 'c1');
+    // @ts-expect-error
+    const firstTimer = watcher.livenessTimers.get('live-stack');
+
+    watcher.watch('live-stack', 'c2');
+    // @ts-expect-error
+    const secondTimer = watcher.livenessTimers.get('live-stack');
+
+    expect(secondTimer).not.toBe(firstTimer);
+    watcher.unwatch('live-stack');
+  });
+
+  // ─── Headline regression ────────────────────────────────────────────────────
+
+  it('triggers recovery exactly once when stalled + process dead', async () => {
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,      // log never grows
+      pgrepOut: '',    // claude process dead
+      statusSequence: ['running'],  // status stays running
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000, // large — keep main poll from interfering
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'session-abc');
+
+    const dispatchCalls: Array<{ stackId: string; task: Task }> = [];
+    watcher.setDispatchInvestigation(async (stackId, t) => {
+      dispatchCalls.push({ stackId, task: t });
+    });
+
+    watcher.watch('live-stack', 'c1');
+
+    // Advance past stall threshold — liveness fires, stall detected, recovery triggered
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+
+    expect(dispatchCalls).toHaveLength(1);
+    expect(dispatchCalls[0].stackId).toBe('live-stack');
+    expect(dispatchCalls[0].task.session_id).toBe('session-abc');
+
+    watcher.unwatchAll();
+  });
+
+  // ─── False-positive guard ───────────────────────────────────────────────────
+
+  it('does NOT trigger recovery when log is quiet but process is alive', async () => {
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,        // log never grows
+      pgrepOut: '12345', // claude process alive — long build/test
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'session-xyz');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => {
+      dispatchCalls.push(stackId);
+    });
+
+    watcher.watch('live-stack', 'c1');
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+
+    expect(dispatchCalls).toHaveLength(0); // no recovery triggered
+
+    watcher.unwatchAll();
+  });
+
+  // ─── Activity resets clock ──────────────────────────────────────────────────
+
+  it('resets stall clock when log grows within the window', async () => {
+    let logSizeValue = 100;
+    const runtime = createLivenessMockRuntime({
+      logSize: () => logSizeValue,
+      pgrepOut: '',
+      statusSequence: ['running'],
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'session-grow');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+
+    // First liveness check fires — log size is 100, grew from 0 → resets clock
+    await vi.advanceTimersByTimeAsync(TEST_LIVENESS_INTERVAL + 50);
+
+    // After reset, stall threshold resets: even if we advance another stall period,
+    // if the log keeps growing no stall is declared
+    logSizeValue = 200; // log grew again
+    await vi.advanceTimersByTimeAsync(TEST_LIVENESS_INTERVAL);
+
+    logSizeValue = 300;
+    await vi.advanceTimersByTimeAsync(TEST_LIVENESS_INTERVAL);
+
+    // 3 intervals elapsed, each with log growth → clock reset each time → no stall
+    expect(dispatchCalls).toHaveLength(0);
+
+    watcher.unwatchAll();
+  });
+
+  it('stall IS triggered when log stops growing after initial growth', async () => {
+    let logSizeValue = 0;
+    const runtime = createLivenessMockRuntime({
+      logSize: () => logSizeValue,
+      pgrepOut: '',
+      statusSequence: ['running'],
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'session-stall');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+
+    // Log grows on first check → clock reset at T=500ms
+    logSizeValue = 500;
+    await vi.advanceTimersByTimeAsync(TEST_LIVENESS_INTERVAL + 50);
+    expect(dispatchCalls).toHaveLength(0);
+
+    // Log stops growing — advance past stall threshold from T=500ms
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+    expect(dispatchCalls).toHaveLength(1);
+
+    watcher.unwatchAll();
+  });
+
+  // ─── Transient exec error ───────────────────────────────────────────────────
+
+  it('does not declare stall when stat exec fails (transient error)', async () => {
+    // stat always throws — liveness check returns early each cycle
+    const runtime = createLivenessMockRuntime({
+      statShouldThrow: true,
+      pgrepOut: '',
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    registry.createTask('live-stack', 'test task');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 3);
+
+    // No stall declared because every stat call threw
+    expect(dispatchCalls).toHaveLength(0);
+
+    watcher.unwatchAll();
+  });
+
+  it('does not falsely stall when pgrep exec fails', async () => {
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,
+      pgrepShouldThrow: true, // pgrep errors out
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    registry.createTask('live-stack', 'test task');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+
+    // pgrep threw → returned early, no recovery
+    expect(dispatchCalls).toHaveLength(0);
+
+    watcher.unwatchAll();
+  });
+
+  // ─── Idempotency / terminal-wins ────────────────────────────────────────────
+
+  it('aborts recovery when status becomes terminal before dispatch', async () => {
+    // With a large pollInterval, the first /tmp/claude-task.status read happens during
+    // the liveness check's idempotency re-read. Returning 'completed' here simulates
+    // the task writing a terminal status concurrently — recovery should abort.
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,
+      pgrepOut: '',
+      statusSequence: ['completed'], // idempotency re-read returns terminal immediately
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000, // large — main poll does not fire during our test window
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'session-idem');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+
+    // Terminal status was seen in idempotency re-read → no dispatch
+    expect(dispatchCalls).toHaveLength(0);
+
+    watcher.unwatchAll();
+  });
+
+  // ─── Recovery dispatch mechanism ────────────────────────────────────────────
+
+  it('dispatches investigation with correct stackId and session_id', async () => {
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,
+      pgrepOut: '',
+      statusSequence: ['running'],
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'do the work');
+    registry.setTaskSessionId(task.id, 'resume-session-id-999');
+
+    let capturedStackId: string | null = null;
+    let capturedTask: Task | null = null;
+    watcher.setDispatchInvestigation(async (stackId, t) => {
+      capturedStackId = stackId;
+      capturedTask = t;
+    });
+
+    watcher.watch('live-stack', 'c1');
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+
+    expect(capturedStackId).toBe('live-stack');
+    expect(capturedTask).not.toBeNull();
+    expect(capturedTask!.session_id).toBe('resume-session-id-999');
+    // Verify the token-limit continuation prompt is NOT passed here (separate code path)
+    // The investigate callback is NOT the dispatchContinuation path
+    expect(capturedTask!.prompt).toBe('do the work');
+
+    watcher.unwatchAll();
+  });
+
+  it('does NOT trigger recovery more than once for the same stall', async () => {
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,
+      pgrepOut: '',
+      statusSequence: ['running'],
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'session-once');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+
+    // Advance well past stall threshold — multiple liveness checks would fire
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD * 3 + TEST_LIVENESS_INTERVAL * 5);
+
+    // Liveness timer was cleared after first stall detection — recovery dispatched exactly once
+    expect(dispatchCalls).toHaveLength(1);
+
+    watcher.unwatchAll();
+  });
+
+  // ─── No session_id → needs_human ────────────────────────────────────────────
+
+  it('marks task needs_human when stalled with no session_id', async () => {
+    const runtime = createLivenessMockRuntime({
+      logSize: 0,
+      pgrepOut: '',
+      statusSequence: ['running'],
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 10_000,
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    // Deliberately no session_id set
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    let statusChangeCalled = false;
+    watcher.setOnStatusChange(() => { statusChangeCalled = true; });
+
+    watcher.watch('live-stack', 'c1');
+    await vi.advanceTimersByTimeAsync(TEST_STALL_THRESHOLD + TEST_LIVENESS_INTERVAL * 2);
+
+    // No dispatch — falls back to needs_human
+    expect(dispatchCalls).toHaveLength(0);
+
+    // Task should be in needs_human state
+    const updatedTask = registry.getMostRecentTask('live-stack');
+    expect(updatedTask?.status).toBe('needs_human');
+    expect(updatedTask?.warnings).toContain('no resumable session');
+    expect(statusChangeCalled).toBe(true);
+
+    // Watcher should be gone after needs_human
+    // @ts-expect-error
+    expect(watcher.livenessTimers.has('live-stack')).toBe(false);
+
+    watcher.unwatchAll();
+  });
+
+  // ─── Token_limited recovery fallback (edge case 2) ─────────────────────────
+
+  it('existing token_limited → session_paused path is NOT disrupted by liveness', async () => {
+    // Sequence: running → token_limited (normal watcher path, not liveness)
+    const runtime = createLivenessMockRuntime({
+      logSize: 500, // log has content, not stalled
+      pgrepOut: '9999', // process alive
+      statusSequence: ['running', 'token_limited'],
+    });
+    const watcher = new TaskWatcher(registry, runtime, runtime, {
+      pollInterval: 50, // fast poll so token_limited is seen quickly
+      livenessCheckInterval: TEST_LIVENESS_INTERVAL,
+      livenessStallThreshold: TEST_STALL_THRESHOLD,
+    });
+
+    const task = registry.createTask('live-stack', 'test task');
+    registry.setTaskSessionId(task.id, 'token-session');
+
+    const dispatchCalls: string[] = [];
+    watcher.setDispatchInvestigation(async (stackId) => { dispatchCalls.push(stackId); });
+
+    watcher.watch('live-stack', 'c1');
+
+    // Advance enough for token_limited to be seen by the main poll
+    await vi.advanceTimersByTimeAsync(200);
+
+    // Stack should be session_paused (normal token_limited path)
+    const stack = registry.getStack('live-stack');
+    expect(stack?.status).toBe('session_paused');
+
+    // No liveness dispatch triggered
+    expect(dispatchCalls).toHaveLength(0);
+
+    watcher.unwatchAll();
+  });
+
+  // ─── Module-level constant values ───────────────────────────────────────────
+
+  it('exports correct production threshold constants', () => {
+    expect(LIVENESS_CHECK_INTERVAL_MS).toBe(60_000);
+    expect(LIVENESS_STALL_THRESHOLD_MS).toBe(5 * 60_000);
+  });
+});

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -650,7 +650,13 @@ describe('TaskWatcher', () => {
     expect(taskFailed).toBe(true);
 
     const execFn = runtime.exec as ReturnType<typeof vi.fn>;
-    expect(execFn.mock.calls.length).toBe(30);
+    // Count only the status-poll calls (backoff cycles) — liveness checks add
+    // additional exec calls (stat /tmp/claude-raw.log) that are not part of
+    // the backoff loop.
+    const backoffCalls = execFn.mock.calls.filter(
+      ([_id, cmd]: [string, string[]]) => Array.isArray(cmd) && cmd.includes('/tmp/claude-task.status')
+    );
+    expect(backoffCalls.length).toBe(30);
 
     watcher.unwatchAll();
     vi.useRealTimers();


### PR DESCRIPTION
## Summary

Stacks whose inner agent stalled while a task was still in the `running` state had no way to recover automatically — the task would sit indefinitely until a human intervened. This adds a liveness watcher that detects stalled `running` tasks and either dispatches an investigation to finish the work or, when that is not possible, marks the task `needs_human`.

The task watcher now tracks per-stack log growth and last-activity time. Every 60s it checks each watched stack: if the agent's log has not grown past the stall threshold (5 min) and `pgrep` confirms the agent process is dead, it re-reads the task status for idempotency and then resumes the agent session with a new investigate-then-finish prompt (delivered via `--resume <session_id>`). When no session is available to resume, the task is marked `needs_human` instead.

Recovery is wired as a distinct code path from the existing token-limit continuation flow: `stack-manager` exposes `dispatchInvestigation()` (mirroring `dispatchContinuation`'s container-ready + `--resume` handling), and `index.ts` wires the watcher's `setDispatchInvestigation()` callback with the new `INVESTIGATE_AND_FINISH_PROMPT`. Thresholds are constructor-overridable so tests can drive them deterministically.

## QA plan

1. Start a stack and dispatch a task so it enters the `running` state.
2. Simulate a stalled agent — kill the inner agent process while its task is still `running` (so the log stops growing but the status is never updated).
3. Wait past the 5-minute stall threshold (the watcher polls every 60s) and confirm the watcher detects the dead process and resumes the session with the investigate-then-finish prompt, allowing the task to complete.
4. Repeat with a stalled task that has no resumable session and confirm it is marked `needs_human` rather than left running.
5. Confirm a healthy, actively-logging `running` task is never falsely flagged — its activity clock should reset as the log grows.

Closes #463