### PR TITLE
[489] fix: surface merge conflicts and gate auto-resolve button

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1418,14 +1418,28 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         ['pr', 'merge', String(prNumber), '--squash'],
         { cwd: workspace, timeout: 60000, maxBuffer: 1024 * 1024 },
       );
+      return { status: 'merged' } as const;
     } catch (err) {
-      // An already-merged PR is the desired end state, not a failure: swallow it so the
-      // caller still proceeds to tear down the stack and advance the card. gh reports this
-      // on stderr (e.g. "GraphQL: Pull request is already merged"); the generic execFile
-      // error message may instead read "Command failed: …", so check both.
+      // An already-merged PR is the desired end state, not a failure.
       const detail = err as { stderr?: unknown; message?: unknown };
       const text = `${String(detail?.stderr ?? '')} ${String(detail?.message ?? '')}`;
-      if (!/already merged/i.test(text)) throw err;
+      if (/already merged/i.test(text)) return { status: 'merged' } as const;
+      // Re-query mergeability to distinguish conflict failures from other failures.
+      const originalError = err instanceof Error ? err.message : String(err);
+      try {
+        const { stdout } = await execFileAsync(
+          'gh',
+          ['pr', 'view', String(prNumber), '--json', 'mergeable'],
+          { cwd: workspace, timeout: 30000, maxBuffer: 1024 * 1024 },
+        );
+        const pr = JSON.parse(stdout.trim()) as { mergeable?: string };
+        if ((pr.mergeable ?? 'UNKNOWN') === 'CONFLICTING') {
+          return { status: 'conflict' } as const;
+        }
+      } catch {
+        // Re-query failed; fall through to return failed with the original error.
+      }
+      return { status: 'failed', error: originalError } as const;
     }
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -225,7 +225,7 @@ export interface SandstormAPI {
   pr: {
     draftBody: (stackId: string) => Promise<{ title: string; body: string }>;
     create: (stackId: string, title: string, body: string) => Promise<{ url: string; number: number }>;
-    merge: (stackId: string, prNumber: number) => Promise<void>;
+    merge: (stackId: string, prNumber: number) => Promise<{ status: 'merged' } | { status: 'conflict' } | { status: 'failed'; error: string }>;
     createAuto: (stackId: string) => Promise<
       | { status: 'created'; url: string; number: number }
       | { status: 'draft_failed' }

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -40,6 +40,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     autoResolveConflicts,
     autoResolveInFlight,
     autoResolveErrors,
+    mergeConflicts,
   } = useAppStore();
 
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
@@ -54,6 +55,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const discardError = discardErrors[stackKey];
   const autoResolveInflight = autoResolveInFlight[stackKey] ?? false;
   const autoResolveError = autoResolveErrors[stackKey];
+  const hasConflict = mergeConflicts[stackKey] ?? false;
 
   const handleRefine = () => {
     openRefineDialogFromCard(ticket.ticket_id, ticket.project_dir, ticket.column as KanbanColumn);
@@ -346,7 +348,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               PR #{stack.pr_number}
             </a>
           )}
-          {stack?.pr_number != null && (
+          {stack?.pr_number != null && !hasConflict && (
             <button
               onClick={handleMerge}
               disabled={mergeInflight}
@@ -364,23 +366,25 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               {autoResolveError}
             </div>
           )}
-          <button
-            onClick={handleAutoResolve}
-            disabled={autoResolveInflight}
-            className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-surface-hover text-sandstorm-muted border border-sandstorm-border hover:border-sandstorm-accent/30 hover:text-sandstorm-text transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
-            data-testid={`ticket-card-auto-resolve-${ticket.ticket_id}`}
-          >
-            {autoResolveInflight ? (
-              <>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" className="animate-spin flex-shrink-0">
-                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
-                </svg>
-                Resolving…
-              </>
-            ) : (
-              'Auto-resolve conflicts'
-            )}
-          </button>
+          {hasConflict && (
+            <button
+              onClick={handleAutoResolve}
+              disabled={autoResolveInflight}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-surface-hover text-sandstorm-muted border border-sandstorm-border hover:border-sandstorm-accent/30 hover:text-sandstorm-text transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+              data-testid={`ticket-card-auto-resolve-${ticket.ticket_id}`}
+            >
+              {autoResolveInflight ? (
+                <>
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" className="animate-spin flex-shrink-0">
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+                  </svg>
+                  Resolving…
+                </>
+              ) : (
+                'Auto-resolve conflicts'
+              )}
+            </button>
+          )}
           {discardSection}
         </div>
       )}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -546,6 +546,8 @@ interface AppState {
   startStackForTicket: (ticketId: string, projectDir: string) => Promise<void>;
   /** Per-ticket merge in-flight flag, keyed by `${ticketId}|${projectDir}`. Guards against double-clicks on Merge. */
   mergeInFlight: Record<string, boolean>;
+  /** Per-ticket conflict flag, keyed by `${ticketId}|${projectDir}`. Set when a merge attempt fails due to confirmed CONFLICTING mergeability; cleared when auto-resolve returns resolved or no_conflicts. Ephemeral — resets on page reload. */
+  mergeConflicts: Record<string, boolean>;
   /** GitHub PR merge → stack teardown → card move to 'merged', in that order. Aborts on any failure and surfaces via moveTicketColumnError. */
   mergeTicket: (ticketId: string, projectDir: string) => Promise<void>;
   /** Per-stack in-flight flag for background PR creation, keyed by stackId. */
@@ -818,7 +820,7 @@ declare global {
       pr: {
         draftBody: (stackId: string) => Promise<{ title: string; body: string }>;
         create: (stackId: string, title: string, body: string) => Promise<{ url: string; number: number }>;
-        merge: (stackId: string, prNumber: number) => Promise<void>;
+        merge: (stackId: string, prNumber: number) => Promise<{ status: 'merged' } | { status: 'conflict' } | { status: 'failed'; error: string }>;
         createAuto: (stackId: string) => Promise<
           | { status: 'created'; url: string; number: number }
           | { status: 'draft_failed' }
@@ -1109,6 +1111,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   stackCreateErrors: {},
   stackCreateInFlight: {},
   mergeInFlight: {},
+  mergeConflicts: {},
   prCreateInFlight: {},
   prCreateErrors: {},
   discardInFlight: {},
@@ -1311,16 +1314,30 @@ export const useAppStore = create<AppState>((set, get) => ({
     // "Stack not found" from pr.merge or teardown means the backend record is already gone
     // (e.g. torn down externally, or a test-injected fake stack). Treat as non-fatal so the
     // column still advances to 'merged'. Real failures (branch protection, docker error, etc.)
-    // re-throw and surface via moveTicketColumnError.
+    // surface via moveTicketColumnError.
     const isStackNotFound = (err: unknown) =>
       /Stack ".+" not found/.test(err instanceof Error ? err.message : String(err));
 
     try {
       if (stack?.pr_number != null) {
+        let mergeResult: { status: 'merged' } | { status: 'conflict' } | { status: 'failed'; error: string };
         try {
-          await window.sandstorm.pr.merge(stack.id, stack.pr_number);
+          mergeResult = await window.sandstorm.pr.merge(stack.id, stack.pr_number);
         } catch (err) {
           if (!isStackNotFound(err)) throw err;
+          mergeResult = { status: 'merged' };
+        }
+
+        if (mergeResult.status === 'conflict') {
+          set((state) => ({
+            mergeConflicts: { ...state.mergeConflicts, [key]: true },
+            autoResolveErrors: { ...state.autoResolveErrors, [key]: 'Merge failed — conflicts must be resolved' },
+          }));
+          return;
+        }
+        if (mergeResult.status === 'failed') {
+          set({ moveTicketColumnError: `Failed to merge ticket #${ticketId}: ${mergeResult.error}` });
+          return;
         }
       }
       if (stack) {
@@ -1429,14 +1446,20 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     try {
       const result = await window.sandstorm.pr.autoResolve(ticketId, projectDir);
-      if (result.status === 'no_conflicts') {
-        set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: 'No conflicts to resolve.' } }));
+      if (result.status === 'resolved') {
+        set((state) => ({
+          mergeConflicts: (() => { const { [key]: _, ...rest } = state.mergeConflicts; return rest; })(),
+        }));
+      } else if (result.status === 'no_conflicts') {
+        set((state) => ({
+          autoResolveErrors: { ...state.autoResolveErrors, [key]: 'No conflicts to resolve.' },
+          mergeConflicts: (() => { const { [key]: _, ...rest } = state.mergeConflicts; return rest; })(),
+        }));
       } else if (result.status === 'unknown_state') {
         set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: 'Mergeability unknown, try again.' } }));
       } else if (result.status === 'failed') {
         set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: result.error } }));
       }
-      // status === 'resolved': no error to set
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       set((state) => ({ autoResolveErrors: { ...state.autoResolveErrors, [key]: message } }));

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -54,8 +54,10 @@ describe('TicketCard', () => {
       refineStartErrors: {},
       discardInFlight: {},
       discardErrors: {},
+      mergeInFlight: {},
       autoResolveInFlight: {},
       autoResolveErrors: {},
+      mergeConflicts: {},
       showRefineTicketDialog: false,
       refineTicketPrefill: null,
       currentRefinementSessionId: null,
@@ -644,7 +646,7 @@ describe('TicketCard', () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
     useAppStore.setState({ boardTickets: [makeTicket('pr_open') as any], stacks: [stack] });
     const callOrder: string[] = [];
-    api.pr.merge.mockImplementation(async () => { callOrder.push('merge'); });
+    api.pr.merge.mockImplementation(async () => { callOrder.push('merge'); return { status: 'merged' }; });
     api.stacks.teardown.mockImplementation(async () => { callOrder.push('teardown'); });
     api.ticketBoard.setColumn.mockImplementation(async () => { callOrder.push('setColumn'); });
 
@@ -658,10 +660,10 @@ describe('TicketCard', () => {
     expect(callOrder).toEqual(['merge', 'teardown', 'setColumn']);
   });
 
-  it('pr_open: GitHub merge failure aborts teardown and column move, surfaces error', async () => {
+  it('pr_open: GitHub merge failure (non-conflict) aborts teardown and column move, surfaces error', async () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
     useAppStore.setState({ boardTickets: [makeTicket('pr_open') as any], stacks: [stack] });
-    api.pr.merge.mockRejectedValueOnce(new Error('branch protection'));
+    api.pr.merge.mockResolvedValueOnce({ status: 'failed', error: 'branch protection' });
 
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
     fireEvent.click(screen.getByTestId('ticket-card-merge-42'));
@@ -672,6 +674,20 @@ describe('TicketCard', () => {
     expect(api.ticketBoard.setColumn).not.toHaveBeenCalled();
     const entry = useAppStore.getState().boardTickets.find(t => t.ticket_id === '42');
     expect(entry?.column).toBe('pr_open');
+  });
+
+  it('pr_open: GitHub merge failure (non-conflict) does not set conflict flag or show auto-resolve button', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
+    useAppStore.setState({ boardTickets: [makeTicket('pr_open') as any], stacks: [stack] });
+    api.pr.merge.mockResolvedValueOnce({ status: 'failed', error: 'branch protection' });
+
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-merge-42'));
+    await waitFor(() => {
+      expect(useAppStore.getState().moveTicketColumnError).toContain('branch protection');
+    });
+    expect(useAppStore.getState().mergeConflicts['42|/proj']).toBeFalsy();
+    expect(screen.queryByTestId('ticket-card-auto-resolve-42')).toBeNull();
   });
 
   it('pr_open: teardown failure after successful merge surfaces error and keeps card in pr_open', async () => {
@@ -726,8 +742,8 @@ describe('TicketCard', () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
     useAppStore.setState({ boardTickets: [makeTicket('pr_open') as any], stacks: [stack] });
 
-    let resolveMerge!: () => void;
-    const mergePromise = new Promise<void>((r) => { resolveMerge = r; });
+    let resolveMerge!: (v: { status: string }) => void;
+    const mergePromise = new Promise<{ status: string }>((r) => { resolveMerge = r; });
     api.pr.merge.mockReturnValueOnce(mergePromise);
 
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
@@ -736,7 +752,7 @@ describe('TicketCard', () => {
     fireEvent.click(btn);
 
     await act(async () => {
-      resolveMerge();
+      resolveMerge({ status: 'merged' });
       await Promise.resolve();
     });
 
@@ -759,18 +775,55 @@ describe('TicketCard', () => {
     expect(screen.getByTestId('ticket-card-pr-link-42').textContent).toContain('99');
   });
 
-  it('pr_open: Auto-resolve conflicts button is always visible', () => {
+  it('pr_open: Auto-resolve conflicts button is absent when there is no conflict (regression)', () => {
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-auto-resolve-42')).toBeNull();
+  });
+
+  it('pr_open: Auto-resolve conflicts button is absent when stack has no pr_number and no conflict flag', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-auto-resolve-42')).toBeNull();
+  });
+
+  it('pr_open: conflict flag set → Merge button absent, auto-resolve button present', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
+    useAppStore.setState({ mergeConflicts: { [`42|${PROJECT_DIR}`]: true } } as any);
+    render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-merge-42')).toBeNull();
     expect(screen.getByTestId('ticket-card-auto-resolve-42')).toBeDefined();
   });
 
-  it('pr_open: Auto-resolve conflicts button is visible even when stack has no pr_number', () => {
-    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_number: null } as any;
+  it('pr_open: conflict flag set → conflict message visible in error area', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
+    useAppStore.setState({
+      mergeConflicts: { [`42|${PROJECT_DIR}`]: true },
+      autoResolveErrors: { [`42|${PROJECT_DIR}`]: 'Merge failed — conflicts must be resolved' },
+    } as any);
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    const badge = screen.getByTestId('ticket-card-auto-resolve-error-42');
+    expect(badge.textContent).toContain('Merge failed — conflicts must be resolved');
+  });
+
+  it('pr_open: merge returns conflict → conflict flag set, auto-resolve button shown, merge button hidden', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/99', pr_number: 99 } as any;
+    useAppStore.setState({ boardTickets: [makeTicket('pr_open') as any], stacks: [stack] });
+    api.pr.merge.mockResolvedValueOnce({ status: 'conflict' });
+
+    const { rerender } = render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-merge-42'));
+    await waitFor(() => {
+      expect(useAppStore.getState().mergeConflicts['42|/proj']).toBe(true);
+    });
+    rerender(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-merge-42')).toBeNull();
     expect(screen.getByTestId('ticket-card-auto-resolve-42')).toBeDefined();
+    expect(api.stacks.teardown).not.toHaveBeenCalled();
+    expect(api.ticketBoard.setColumn).not.toHaveBeenCalled();
   });
 
   it('pr_open: clicking Auto-resolve calls pr.autoResolve with ticketId and projectDir', async () => {
+    useAppStore.setState({ mergeConflicts: { [`42|${PROJECT_DIR}`]: true } } as any);
     api.pr.autoResolve.mockResolvedValue({ status: 'resolved' });
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
     fireEvent.click(screen.getByTestId('ticket-card-auto-resolve-42'));
@@ -778,7 +831,10 @@ describe('TicketCard', () => {
   });
 
   it('pr_open: Auto-resolve button shows spinner while in-flight', () => {
-    useAppStore.setState({ autoResolveInFlight: { [`42|${PROJECT_DIR}`]: true } } as any);
+    useAppStore.setState({
+      autoResolveInFlight: { [`42|${PROJECT_DIR}`]: true },
+      mergeConflicts: { [`42|${PROJECT_DIR}`]: true },
+    } as any);
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
     const btn = screen.getByTestId('ticket-card-auto-resolve-42');
     expect(btn.textContent).toContain('Resolving');
@@ -786,7 +842,10 @@ describe('TicketCard', () => {
   });
 
   it('pr_open: Auto-resolve button is disabled while in-flight', () => {
-    useAppStore.setState({ autoResolveInFlight: { [`42|${PROJECT_DIR}`]: true } } as any);
+    useAppStore.setState({
+      autoResolveInFlight: { [`42|${PROJECT_DIR}`]: true },
+      mergeConflicts: { [`42|${PROJECT_DIR}`]: true },
+    } as any);
     render(<TicketCard ticket={makeTicket('pr_open') as any} stacks={[]} />);
     const btn = screen.getByTestId('ticket-card-auto-resolve-42');
     expect(btn).toHaveProperty('disabled', true);
@@ -800,6 +859,7 @@ describe('TicketCard', () => {
   });
 
   it('pr_open: double-click on Auto-resolve does not call pr.autoResolve twice', async () => {
+    useAppStore.setState({ mergeConflicts: { [`42|${PROJECT_DIR}`]: true } } as any);
     let resolveFirst!: () => void;
     const firstPromise = new Promise<{ status: string }>((r) => { resolveFirst = r as () => void; });
     api.pr.autoResolve.mockReturnValueOnce(firstPromise);

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -188,7 +188,7 @@ export function mockSandstormApi() {
     pr: {
       draftBody: vi.fn().mockResolvedValue({ title: 'Test PR', body: '## Summary\n- thing\n\n## Test plan\n- [ ] check' }),
       create: vi.fn().mockResolvedValue({ url: 'https://github.com/o/r/pull/1', number: 1 }),
-      merge: vi.fn().mockResolvedValue(undefined),
+      merge: vi.fn().mockResolvedValue({ status: 'merged' }),
       createAuto: vi.fn().mockResolvedValue({ status: 'created', url: 'https://github.com/o/r/pull/1', number: 1 }),
       autoResolve: vi.fn().mockResolvedValue({ status: 'resolved' }),
     },

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -1605,7 +1605,7 @@ describe('IPC Handlers', () => {
         },
       );
 
-      await invokeHandler('pr:merge', 'stack-1', 99);
+      const result = await invokeHandler('pr:merge', 'stack-1', 99);
 
       expect(execFile).toHaveBeenCalledWith(
         'gh',
@@ -1617,6 +1617,7 @@ describe('IPC Handlers', () => {
       const ghArgs = callArgs[1] as string[];
       expect(ghArgs).not.toContain('--merge');
       expect(ghArgs).not.toContain('--delete-branch');
+      expect(result).toEqual({ status: 'merged' });
     });
 
     it('throws when stack is not found', async () => {
@@ -1624,19 +1625,71 @@ describe('IPC Handlers', () => {
       await expect(invokeHandler('pr:merge', 'missing-stack', 1)).rejects.toThrow('Stack "missing-stack" not found');
     });
 
-    it('propagates gh CLI error to caller', async () => {
+    it('returns { status: "conflict" } when merge fails and re-query reports CONFLICTING', async () => {
       const stack = { id: 'stack-1', project_dir: '/proj', pr_number: 42, status: 'pr_created', services: [] };
       mockStackManager.getStackWithServices.mockResolvedValue(stack);
-      (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+      // First call: gh pr merge fails
+      mockExecFile.mockImplementationOnce(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(new Error('pull request has conflicts'), '', '');
+        },
+      );
+      // Second call: gh pr view --json mergeable returns CONFLICTING.
+      // Note: execFile is mocked as vi.fn() without util.promisify.custom, so promisify resolves
+      // with the first non-error argument directly. Pass the { stdout } object as that first arg.
+      mockExecFile.mockImplementationOnce(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(null, { stdout: JSON.stringify({ mergeable: 'CONFLICTING' }), stderr: '' } as any);
+        },
+      );
+
+      const result = await invokeHandler('pr:merge', 'stack-1', 42);
+
+      expect(result).toEqual({ status: 'conflict' });
+    });
+
+    it('returns { status: "failed" } when merge fails and re-query reports UNKNOWN', async () => {
+      const stack = { id: 'stack-1', project_dir: '/proj', pr_number: 42, status: 'pr_created', services: [] };
+      mockStackManager.getStackWithServices.mockResolvedValue(stack);
+      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+      mockExecFile.mockImplementationOnce(
         (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
           callback(new Error('branch protection rule'), '', '');
         },
       );
+      mockExecFile.mockImplementationOnce(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(null, { stdout: JSON.stringify({ mergeable: 'UNKNOWN' }), stderr: '' } as any);
+        },
+      );
 
-      await expect(invokeHandler('pr:merge', 'stack-1', 42)).rejects.toThrow('branch protection rule');
+      const result = await invokeHandler('pr:merge', 'stack-1', 42);
+
+      expect(result).toEqual({ status: 'failed', error: 'branch protection rule' });
     });
 
-    it('treats an already-merged PR as success (does not throw) — error message form', async () => {
+    it('returns { status: "failed" } when merge fails and re-query itself throws', async () => {
+      const stack = { id: 'stack-1', project_dir: '/proj', pr_number: 42, status: 'pr_created', services: [] };
+      mockStackManager.getStackWithServices.mockResolvedValue(stack);
+      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+      mockExecFile.mockImplementationOnce(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(new Error('network error'), '', '');
+        },
+      );
+      mockExecFile.mockImplementationOnce(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(new Error('gh not found'), '', '');
+        },
+      );
+
+      const result = await invokeHandler('pr:merge', 'stack-1', 42);
+
+      expect(result).toEqual({ status: 'failed', error: 'network error' });
+    });
+
+    it('treats an already-merged PR as success — returns { status: "merged" } (error message form)', async () => {
       const stack = { id: 'stack-1', project_dir: '/proj', pr_number: 99, status: 'pr_created', services: [] };
       mockStackManager.getStackWithServices.mockResolvedValue(stack);
       (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
@@ -1645,10 +1698,11 @@ describe('IPC Handlers', () => {
         },
       );
 
-      await expect(invokeHandler('pr:merge', 'stack-1', 99)).resolves.toBeUndefined();
+      const result = await invokeHandler('pr:merge', 'stack-1', 99);
+      expect(result).toEqual({ status: 'merged' });
     });
 
-    it('treats an already-merged PR as success when the detail is on stderr', async () => {
+    it('treats an already-merged PR as success — returns { status: "merged" } when detail is on stderr', async () => {
       const stack = { id: 'stack-1', project_dir: '/proj', pr_number: 99, status: 'pr_created', services: [] };
       mockStackManager.getStackWithServices.mockResolvedValue(stack);
       (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
@@ -1660,7 +1714,8 @@ describe('IPC Handlers', () => {
         },
       );
 
-      await expect(invokeHandler('pr:merge', 'stack-1', 99)).resolves.toBeUndefined();
+      const result = await invokeHandler('pr:merge', 'stack-1', 99);
+      expect(result).toEqual({ status: 'merged' });
     });
   });
 

--- a/tests/unit/store-auto-resolve.test.ts
+++ b/tests/unit/store-auto-resolve.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  *
- * Store-level unit tests for the autoResolveConflicts action.
+ * Store-level unit tests for autoResolveConflicts and mergeTicket (conflict path).
  * Mirrors the pattern in tests/unit/ticketBoard.test.ts for store-facing tests.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -35,10 +35,51 @@ function mockAutoResolveIpcError(err: Error) {
   return api;
 }
 
+function mockMergeIpc(result: unknown) {
+  const api = {
+    pr: {
+      merge: vi.fn().mockResolvedValue(result),
+      autoResolve: vi.fn(),
+    },
+    stacks: { teardown: vi.fn().mockResolvedValue(undefined) },
+    ticketBoard: { setColumn: vi.fn().mockResolvedValue(undefined) },
+  };
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+  return api;
+}
+
+function mockMergeIpcThrow(err: Error) {
+  const api = {
+    pr: {
+      merge: vi.fn().mockRejectedValue(err),
+      autoResolve: vi.fn(),
+    },
+    stacks: { teardown: vi.fn().mockResolvedValue(undefined) },
+    ticketBoard: { setColumn: vi.fn().mockResolvedValue(undefined) },
+  };
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+  return api;
+}
+
+const STACK = { id: 's1', ticket: TICKET_ID, project_dir: PROJECT_DIR, pr_number: 99, status: 'pr_created', services: [] };
+
 beforeEach(() => {
   useAppStore.setState({
     autoResolveInFlight: {},
     autoResolveErrors: {},
+    mergeConflicts: {},
+    mergeInFlight: {},
+    moveTicketColumnError: null,
+    stacks: [STACK],
+    boardTickets: [{ ticket_id: TICKET_ID, project_dir: PROJECT_DIR, column: 'pr_open', title: 'T', updated_at: '' }],
   } as any);
 });
 
@@ -52,12 +93,30 @@ describe('autoResolveConflicts store action', () => {
     expect(useAppStore.getState().autoResolveInFlight[KEY]).toBeFalsy();
   });
 
+  it('resolved: clears conflict flag', async () => {
+    useAppStore.setState({ mergeConflicts: { [KEY]: true } } as any);
+    mockAutoResolveIpc({ status: 'resolved' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBeFalsy();
+  });
+
   it('no-op path (MERGEABLE): sets "No conflicts to resolve." error', async () => {
     mockAutoResolveIpc({ status: 'no_conflicts' });
 
     await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
 
     expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('No conflicts to resolve.');
+  });
+
+  it('no_conflicts: clears conflict flag', async () => {
+    useAppStore.setState({ mergeConflicts: { [KEY]: true } } as any);
+    mockAutoResolveIpc({ status: 'no_conflicts' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBeFalsy();
   });
 
   it('unknown path (UNKNOWN): sets "Mergeability unknown, try again." error', async () => {
@@ -68,12 +127,30 @@ describe('autoResolveConflicts store action', () => {
     expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('Mergeability unknown, try again.');
   });
 
+  it('unknown_state: retains conflict flag', async () => {
+    useAppStore.setState({ mergeConflicts: { [KEY]: true } } as any);
+    mockAutoResolveIpc({ status: 'unknown_state' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBe(true);
+  });
+
   it('failure path: sets the error message from the result', async () => {
     mockAutoResolveIpc({ status: 'failed', error: 'inner agent could not resolve' });
 
     await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
 
     expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('inner agent could not resolve');
+  });
+
+  it('failed: retains conflict flag', async () => {
+    useAppStore.setState({ mergeConflicts: { [KEY]: true } } as any);
+    mockAutoResolveIpc({ status: 'failed', error: 'conflict agent error' });
+
+    await useAppStore.getState().autoResolveConflicts(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBe(true);
   });
 
   it('error thrown by IPC: sets the error message in the store', async () => {
@@ -128,5 +205,50 @@ describe('autoResolveConflicts store action', () => {
     await actionPromise;
 
     expect(useAppStore.getState().autoResolveInFlight[KEY]).toBeFalsy();
+  });
+});
+
+describe('mergeTicket store action — conflict classification', () => {
+  it('merged result: advances to merged, no conflict flag', async () => {
+    const api = mockMergeIpc({ status: 'merged' });
+
+    await useAppStore.getState().mergeTicket(TICKET_ID, PROJECT_DIR);
+
+    expect(api.ticketBoard.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'merged');
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBeFalsy();
+    expect(useAppStore.getState().moveTicketColumnError).toBeNull();
+  });
+
+  it('conflict result: sets conflict flag and conflict message, no teardown, no column move', async () => {
+    const api = mockMergeIpc({ status: 'conflict' });
+
+    await useAppStore.getState().mergeTicket(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBe(true);
+    expect(useAppStore.getState().autoResolveErrors[KEY]).toBe('Merge failed — conflicts must be resolved');
+    expect(api.stacks.teardown).not.toHaveBeenCalled();
+    expect(api.ticketBoard.setColumn).not.toHaveBeenCalled();
+    expect(useAppStore.getState().moveTicketColumnError).toBeNull();
+  });
+
+  it('failed result: sets moveTicketColumnError, no conflict flag, no teardown, no column move', async () => {
+    const api = mockMergeIpc({ status: 'failed', error: 'branch protection rule' });
+
+    await useAppStore.getState().mergeTicket(TICKET_ID, PROJECT_DIR);
+
+    expect(useAppStore.getState().moveTicketColumnError).toContain('branch protection rule');
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBeFalsy();
+    expect(api.stacks.teardown).not.toHaveBeenCalled();
+    expect(api.ticketBoard.setColumn).not.toHaveBeenCalled();
+  });
+
+  it('Stack not found throw: swallowed, advances to merged (regression guard)', async () => {
+    const api = mockMergeIpcThrow(new Error('Stack "s1" not found'));
+
+    await useAppStore.getState().mergeTicket(TICKET_ID, PROJECT_DIR);
+
+    expect(api.ticketBoard.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'merged');
+    expect(useAppStore.getState().mergeConflicts[KEY]).toBeFalsy();
+    expect(useAppStore.getState().moveTicketColumnError).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

The merge flow now distinguishes a conflict failure from a generic failure instead of swallowing both. Previously `pr.merge` returned `void` and only re-threw on unexpected errors, so the UI could not tell when a merge was blocked by conflicts versus some other problem, and the "Auto-resolve conflicts" button was always shown on every card with a PR.

The `pr.merge` IPC handler now returns a discriminated result: `merged`, `conflict`, or `failed`. When a merge fails, it re-queries the PR's mergeability with `gh pr view --json mergeable` and reports `conflict` only when GitHub confirms a `CONFLICTING` state; anything else surfaces as `failed` with the original error.

The renderer store tracks an ephemeral per-ticket `mergeConflicts` flag. A `conflict` result sets the flag and an explanatory message; a `failed` result surfaces the underlying error. Auto-resolve clears the flag when it returns `resolved` or `no_conflicts`. The ticket card now hides the Merge button and only renders the "Auto-resolve conflicts" button when a conflict is actually present, so the action only appears when it applies.

## QA plan

1. Open a ticket whose PR merges cleanly and click Merge — the card should advance to the merged column with no auto-resolve button appearing.
2. Create a ticket whose PR genuinely conflicts with the base branch, then click Merge — the Merge button should disappear, an error message about resolving conflicts should show, and the "Auto-resolve conflicts" button should appear.
3. Click "Auto-resolve conflicts" and let it resolve — the conflict state should clear and the Merge button should return.
4. Trigger a non-conflict merge failure (e.g. branch protection) and confirm the card shows the failure error rather than the conflict/auto-resolve UI.
5. Reload the page mid-conflict and confirm the conflict flag resets (it is ephemeral).

Closes #489