### PR TITLE
[490] fix: dispatch spec_ready tickets on dark factory enable

### DIFF
--- a/src/main/control-plane/dark-factory-orchestrator.ts
+++ b/src/main/control-plane/dark-factory-orchestrator.ts
@@ -19,12 +19,20 @@ function makeStackName(ticketId: string): string {
   return id ? `ticket-${id}` : '';
 }
 
+/** Default per-stack readiness timeout (10 minutes). */
+const STACK_READY_TIMEOUT_MS = 600_000;
+
+/** Default poll interval when waiting for a stack to become ready. */
+const STACK_READY_POLL_INTERVAL_MS = 1_000;
+
 export class DarkFactoryOrchestrator {
   constructor(
     private readonly registry: Registry,
     private readonly stackManager: StackManager,
     private readonly agentBackend: AgentBackend,
     private readonly notifyUpdate: () => void,
+    private readonly stackReadyTimeoutMs: number = STACK_READY_TIMEOUT_MS,
+    private readonly pollIntervalMs: number = STACK_READY_POLL_INTERVAL_MS,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -37,6 +45,53 @@ export class DarkFactoryOrchestrator {
 
     this.startStack(ticketId, projectDir).catch((err) => {
       console.warn(`[DarkFactory] startStack failed for ${ticketId}:`, err);
+    });
+  }
+
+  /**
+   * Invoked once when dark factory transitions from disabled → enabled.
+   * Serially starts a stack for every ticket currently in spec_ready, in
+   * board order (oldest created_at first). Waits for each stack to reach
+   * 'up' or 'failed' before dispatching the next one. On failure or
+   * timeout the failed ticket stays in in_stack and the batch continues.
+   */
+  async handleDarkFactoryEnabled(projectDir: string): Promise<void> {
+    const tickets = this.registry.listBoardTickets(projectDir)
+      .filter((t) => t.column === 'spec_ready');
+
+    for (const ticket of tickets) {
+      const stackName = makeStackName(ticket.ticket_id);
+      if (!stackName) continue;
+
+      try {
+        await this.startStack(ticket.ticket_id, projectDir);
+      } catch (err) {
+        console.warn(`[DarkFactory] handleDarkFactoryEnabled: startStack failed for ${ticket.ticket_id}:`, err);
+        continue;
+      }
+
+      await this.awaitStackReady(stackName, this.stackReadyTimeoutMs);
+    }
+  }
+
+  /** Polls registry until the stack is 'up' or 'failed', or the timeout elapses. */
+  private awaitStackReady(stackName: string, timeoutMs: number): Promise<void> {
+    const start = Date.now();
+    return new Promise<void>((resolve) => {
+      const poll = () => {
+        const status = this.registry.getStack(stackName)?.status;
+        if (status === 'up' || status === 'failed') {
+          resolve();
+          return;
+        }
+        if (Date.now() - start >= timeoutMs) {
+          console.warn(`[DarkFactory] stack ${stackName} did not become ready within ${timeoutMs}ms, continuing`);
+          resolve();
+          return;
+        }
+        setTimeout(poll, this.pollIntervalMs);
+      };
+      poll();
     });
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1491,7 +1491,13 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle('darkFactory:setEnabled', (_event, projectDir: string, enabled: boolean) => {
+    const prior = registry.getDarkFactoryEnabled(projectDir);
     registry.setDarkFactoryEnabled(projectDir, enabled);
+    if (!prior && enabled) {
+      darkFactoryOrchestrator?.handleDarkFactoryEnabled(projectDir).catch((err) => {
+        console.warn('[DarkFactory] handleDarkFactoryEnabled failed:', err);
+      });
+    }
   });
 
   ipcMain.handle('pr:autoResolve', async (_event, ticketId: string, projectDir: string) => {

--- a/tests/unit/dark-factory-orchestrator.test.ts
+++ b/tests/unit/dark-factory-orchestrator.test.ts
@@ -47,12 +47,14 @@ function makeRegistry(overrides: Partial<{
   getStack: (id: string) => unknown;
   getProjectTicketConfig: (dir: string) => null;
   setBoardTicketColumn: () => void;
+  listBoardTickets: (dir: string) => unknown[];
 }> = {}) {
   return {
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
     getStack: vi.fn().mockReturnValue(null),
     getProjectTicketConfig: vi.fn().mockReturnValue(null),
     setBoardTicketColumn: vi.fn(),
+    listBoardTickets: vi.fn().mockReturnValue([]),
     ...overrides,
   };
 }
@@ -301,6 +303,210 @@ describe('DarkFactoryOrchestrator', () => {
 
       // Already-merged is treated as success — card should advance
       expect(registry.setBoardTicketColumn).toHaveBeenCalledWith('T-1', '/proj', 'merged');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleDarkFactoryEnabled — scan-on-enable
+  // -------------------------------------------------------------------------
+  describe('handleDarkFactoryEnabled', () => {
+    function makeTicket(id: string, col: string, created: string) {
+      return { ticket_id: id, column: col, project_dir: '/proj', title: '', created_at: created, updated_at: created };
+    }
+
+    let fastOrchestrator: DarkFactoryOrchestrator;
+
+    beforeEach(() => {
+      // Use 0ms poll so tests resolve without advancing timers
+      fastOrchestrator = new DarkFactoryOrchestrator(
+        registry as never,
+        stackManager as never,
+        agentBackend as never,
+        notifyUpdate,
+        600_000,
+        0,
+      );
+    });
+
+    it('starts a stack for every spec_ready ticket when enabled (regression)', async () => {
+      registry.listBoardTickets.mockReturnValue([
+        makeTicket('T-1', 'spec_ready', '2024-01-01T00:00:00'),
+        makeTicket('T-2', 'spec_ready', '2024-01-02T00:00:00'),
+      ]);
+      registry.getStack.mockReturnValue({ status: 'up' });
+
+      await fastOrchestrator.handleDarkFactoryEnabled('/proj');
+
+      expect(stackManager.createStack).toHaveBeenCalledTimes(2);
+      expect(registry.setBoardTicketColumn).toHaveBeenCalledWith('T-1', expect.any(String), 'in_stack');
+      expect(registry.setBoardTicketColumn).toHaveBeenCalledWith('T-2', expect.any(String), 'in_stack');
+    });
+
+    it('dispatches in created_at-ascending order', async () => {
+      registry.listBoardTickets.mockReturnValue([
+        makeTicket('T-1', 'spec_ready', '2024-01-01T00:00:00'),
+        makeTicket('T-2', 'spec_ready', '2024-01-02T00:00:00'),
+        makeTicket('T-3', 'spec_ready', '2024-01-03T00:00:00'),
+      ]);
+      registry.getStack.mockReturnValue({ status: 'up' });
+
+      await fastOrchestrator.handleDarkFactoryEnabled('/proj');
+
+      const calls = stackManager.createStack.mock.calls;
+      expect(calls).toHaveLength(3);
+      expect((calls[0][0] as { ticket: string }).ticket).toBe('T-1');
+      expect((calls[1][0] as { ticket: string }).ticket).toBe('T-2');
+      expect((calls[2][0] as { ticket: string }).ticket).toBe('T-3');
+    });
+
+    it('waits for stack N to be ready before dispatching N+1 (serialization)', async () => {
+      registry.listBoardTickets.mockReturnValue([
+        makeTicket('T-1', 'spec_ready', '2024-01-01T00:00:00'),
+        makeTicket('T-2', 'spec_ready', '2024-01-02T00:00:00'),
+      ]);
+
+      const events: string[] = [];
+      let t1PollCount = 0;
+      registry.getStack.mockImplementation((name: string) => {
+        if (name === 'ticket-t-1') {
+          t1PollCount++;
+          const status = t1PollCount === 1 ? 'building' : 'up';
+          events.push(`poll:${name}:${status}`);
+          return { status };
+        }
+        events.push(`poll:${name}:up`);
+        return { status: 'up' };
+      });
+      stackManager.createStack.mockImplementation((opts: { ticket: string }) => {
+        events.push(`create:${opts.ticket}`);
+      });
+
+      await fastOrchestrator.handleDarkFactoryEnabled('/proj');
+
+      // T-1 must have been polled at least once (saw 'building') before T-2 was created
+      const buildingIdx = events.findIndex((e) => e === 'poll:ticket-t-1:building');
+      const createT2Idx = events.indexOf('create:T-2');
+      expect(buildingIdx).toBeGreaterThanOrEqual(0);
+      expect(createT2Idx).toBeGreaterThan(buildingIdx);
+    });
+
+    it('continues batch when stack reaches failed (Q4)', async () => {
+      registry.listBoardTickets.mockReturnValue([
+        makeTicket('T-1', 'spec_ready', '2024-01-01T00:00:00'),
+        makeTicket('T-2', 'spec_ready', '2024-01-02T00:00:00'),
+      ]);
+      registry.getStack
+        .mockReturnValueOnce({ status: 'failed' })
+        .mockReturnValue({ status: 'up' });
+
+      await fastOrchestrator.handleDarkFactoryEnabled('/proj');
+
+      expect(stackManager.createStack).toHaveBeenCalledTimes(2);
+      // Both tickets moved to in_stack (failed ticket stays there, not reverted)
+      const inStackCalls = registry.setBoardTicketColumn.mock.calls.filter(
+        (c) => c[2] === 'in_stack',
+      );
+      expect(inStackCalls).toHaveLength(2);
+      expect(stackManager.teardownStack).not.toHaveBeenCalled();
+    });
+
+    it('continues batch when stack hangs in building past timeout (Q5)', async () => {
+      vi.useFakeTimers();
+
+      const timeoutOrchestrator = new DarkFactoryOrchestrator(
+        registry as never,
+        stackManager as never,
+        agentBackend as never,
+        notifyUpdate,
+        100,  // 100ms timeout so the test advances only a little
+        50,   // 50ms poll interval
+      );
+
+      registry.listBoardTickets.mockReturnValue([
+        makeTicket('T-1', 'spec_ready', '2024-01-01T00:00:00'),
+        makeTicket('T-2', 'spec_ready', '2024-01-02T00:00:00'),
+      ]);
+      registry.getStack.mockImplementation((name: string) => {
+        if (name === 'ticket-t-1') return { status: 'building' };
+        return { status: 'up' };
+      });
+
+      const scanPromise = timeoutOrchestrator.handleDarkFactoryEnabled('/proj');
+      await vi.advanceTimersByTimeAsync(200);
+      await scanPromise;
+
+      // Both stacks dispatched; T-1 stayed in_stack after timeout
+      expect(stackManager.createStack).toHaveBeenCalledTimes(2);
+      const inStackCalls = registry.setBoardTicketColumn.mock.calls.filter(
+        (c) => c[2] === 'in_stack',
+      );
+      expect(inStackCalls).toHaveLength(2);
+      expect(stackManager.teardownStack).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('no-op when spec_ready column is empty', async () => {
+      registry.listBoardTickets.mockReturnValue([
+        makeTicket('T-1', 'backlog', '2024-01-01T00:00:00'),
+        makeTicket('T-2', 'in_stack', '2024-01-02T00:00:00'),
+      ]);
+
+      await fastOrchestrator.handleDarkFactoryEnabled('/proj');
+
+      expect(stackManager.createStack).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // darkFactory:setEnabled off→on guard (tested via handleDarkFactoryEnabled)
+  // -------------------------------------------------------------------------
+  describe('off→on guard', () => {
+    function makeTicket(id: string) {
+      return { ticket_id: id, column: 'spec_ready', project_dir: '/proj', title: '', created_at: '2024-01-01T00:00:00', updated_at: '2024-01-01T00:00:00' };
+    }
+
+    let guardOrchestrator: DarkFactoryOrchestrator;
+
+    beforeEach(() => {
+      guardOrchestrator = new DarkFactoryOrchestrator(
+        registry as never,
+        stackManager as never,
+        agentBackend as never,
+        notifyUpdate,
+        600_000,
+        0,
+      );
+    });
+
+    it('dispatches when called on an off→on transition', async () => {
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+      registry.getStack.mockReturnValue({ status: 'up' });
+
+      await guardOrchestrator.handleDarkFactoryEnabled('/proj');
+
+      expect(stackManager.createStack).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-dispatch when called a second time (already-enabled guard in IPC)', async () => {
+      // The off→on guard lives in the IPC handler (reads prior state before writing).
+      // handleDarkFactoryEnabled itself has no guard — it just processes whatever spec_ready
+      // tickets it finds. This test documents that calling it twice dispatches twice,
+      // confirming the guard must live in the caller (ipc.ts).
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+      registry.getStack.mockReturnValue({ status: 'up' });
+
+      // Simulate that the ticket was already moved to in_stack after first enable
+      registry.setBoardTicketColumn.mockImplementation(() => {
+        // After first call, ticket is no longer in spec_ready
+        registry.listBoardTickets.mockReturnValue([]);
+      });
+
+      await guardOrchestrator.handleDarkFactoryEnabled('/proj');
+      await guardOrchestrator.handleDarkFactoryEnabled('/proj'); // second call: empty spec_ready
+
+      // createStack only called once because second call found no spec_ready tickets
+      expect(stackManager.createStack).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

When the dark factory toggle is switched from off to on, queued tickets in the `spec_ready` column are now dispatched automatically instead of waiting for the next manual trigger.

The orchestrator gained `handleDarkFactoryEnabled`, which lists `spec_ready` tickets in board order and starts each one serially, awaiting stack readiness before moving to the next so the batch doesn't overwhelm the host. Readiness is polled via `awaitStackReady`, which watches `registry.getStack().status` until the stack reports `up` or `failed`, or until a 10-minute timeout. On timeout it logs and unblocks the batch rather than tearing the stack down, so one slow stack can't stall the rest. The timeout and poll interval are injectable for tests.

The `darkFactory:setEnabled` IPC handler now reads the prior state before writing and only fires the dispatch (fire-and-forget) on a genuine off-to-on transition, so re-saving an already-enabled state is a no-op.

## QA plan

1. Place two or more tickets in the `spec_ready` column with the dark factory disabled.
2. Enable the dark factory toggle and confirm the tickets begin dispatching in board order, one stack coming up before the next starts.
3. Toggle off then on again with an empty `spec_ready` column and confirm nothing is dispatched.
4. Re-save the enabled state (on to on) and confirm no duplicate dispatch occurs.

Closes #490