### PR TITLE
[494] fix: dispatch stranded spec_ready tickets via watcher

### DIFF
--- a/src/main/control-plane/dark-factory-orchestrator.ts
+++ b/src/main/control-plane/dark-factory-orchestrator.ts
@@ -25,7 +25,13 @@ const STACK_READY_TIMEOUT_MS = 600_000;
 /** Default poll interval when waiting for a stack to become ready. */
 const STACK_READY_POLL_INTERVAL_MS = 1_000;
 
+/** How often the periodic safety-net watcher rescans for stranded spec_ready tickets (ms). */
+export const SPEC_READY_RECONCILE_INTERVAL_MS = 60_000;
+
 export class DarkFactoryOrchestrator {
+  private readonly _reconcileInProgress = new Set<string>();
+  private _watcherTimer: ReturnType<typeof setInterval> | null = null;
+
   constructor(
     private readonly registry: Registry,
     private readonly stackManager: StackManager,
@@ -33,6 +39,7 @@ export class DarkFactoryOrchestrator {
     private readonly notifyUpdate: () => void,
     private readonly stackReadyTimeoutMs: number = STACK_READY_TIMEOUT_MS,
     private readonly pollIntervalMs: number = STACK_READY_POLL_INTERVAL_MS,
+    private readonly reconcileIntervalMs: number = SPEC_READY_RECONCILE_INTERVAL_MS,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -71,6 +78,54 @@ export class DarkFactoryOrchestrator {
       }
 
       await this.awaitStackReady(stackName, this.stackReadyTimeoutMs);
+    }
+  }
+
+  /**
+   * Scans spec_ready tickets for a project and starts stacks for any that
+   * don't already have one. Safe to call concurrently: a per-project
+   * re-entrancy guard prevents overlapping passes from double-dispatching.
+   */
+  async reconcileSpecReady(projectDir: string): Promise<void> {
+    if (!this.registry.getDarkFactoryEnabled(projectDir)) return;
+    if (this._reconcileInProgress.has(projectDir)) return;
+    this._reconcileInProgress.add(projectDir);
+    try {
+      const tickets = this.registry.listBoardTickets(projectDir)
+        .filter((t) => t.column === 'spec_ready');
+
+      for (const ticket of tickets) {
+        const stackName = makeStackName(ticket.ticket_id);
+        if (!stackName) continue;
+        if (this.registry.getStack(stackName)) continue; // skip: stack already exists
+        try {
+          await this.startStack(ticket.ticket_id, projectDir);
+        } catch (err) {
+          console.warn(`[DarkFactory] reconcileSpecReady: startStack failed for ${ticket.ticket_id}:`, err);
+        }
+      }
+    } finally {
+      this._reconcileInProgress.delete(projectDir);
+    }
+  }
+
+  /** Starts the periodic safety-net watcher that rescans all enabled projects for stranded tickets. */
+  startPeriodicWatcher(): void {
+    if (this._watcherTimer !== null) return;
+    this._watcherTimer = setInterval(() => {
+      for (const project of this.registry.listProjects()) {
+        this.reconcileSpecReady(project.directory).catch((err) => {
+          console.warn('[DarkFactory] periodic reconcile failed for', project.directory, ':', err);
+        });
+      }
+    }, this.reconcileIntervalMs);
+  }
+
+  /** Clears the periodic watcher. Call on app quit. */
+  destroy(): void {
+    if (this._watcherTimer !== null) {
+      clearInterval(this._watcherTimer);
+      this._watcherTimer = null;
     }
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -355,6 +355,7 @@ async function initializeApp(): Promise<void> {
     agentBackend,
     () => mainWindow?.webContents.send('stacks:updated'),
   );
+  darkFactoryOrchestrator.startPeriodicWatcher();
 
   // Listen for task events to send to renderer
   taskWatcher.on('task:completed', ({ stackId, task }) => {
@@ -420,6 +421,14 @@ app.whenReady().then(async () => {
     ).catch((err) => {
       console.warn('[StartupReconciler] Background reconciliation error:', err);
     });
+
+    // Dispatch any spec_ready tickets with no stack across all Dark-Factory-enabled
+    // projects. Catches tickets that were stranded before the last app restart.
+    for (const project of registry.listProjects()) {
+      darkFactoryOrchestrator.reconcileSpecReady(project.directory).catch((err) => {
+        console.warn('[DarkFactory] Startup reconcile failed for', project.directory, ':', err);
+      });
+    }
   });
 
   app.on('activate', () => {
@@ -446,6 +455,7 @@ app.on('before-quit', () => {
   agentBackend?.destroy();
   stackManager?.destroy();
   taskWatcher?.unwatchAll();
+  darkFactoryOrchestrator?.destroy();
   if (dockerRuntime instanceof DockerRuntime) {
     (dockerRuntime as DockerRuntime).destroy();
   }

--- a/tests/unit/dark-factory-orchestrator.test.ts
+++ b/tests/unit/dark-factory-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DarkFactoryOrchestrator } from '../../src/main/control-plane/dark-factory-orchestrator';
 
 // ---------------------------------------------------------------------------
@@ -15,6 +15,10 @@ vi.mock('../../src/main/control-plane/pr-creator', () => ({
   ),
   draftPullRequest: vi.fn(),
   createPullRequest: vi.fn(),
+}));
+
+vi.mock('../../src/main/control-plane/ticket-config', () => ({
+  fetchTicketWithConfig: vi.fn().mockResolvedValue(''),
 }));
 
 // execFile mock needs [util.promisify.custom] so promisify() resolves { stdout, stderr }
@@ -39,6 +43,7 @@ vi.mock('child_process', async () => {
 
 import { showNotification } from '../../src/main/tray';
 import { draftPullRequest, createPullRequest, workspacePathFor } from '../../src/main/control-plane/pr-creator';
+import { fetchTicketWithConfig } from '../../src/main/control-plane/ticket-config';
 
 const mockExecFile = mockExecFileInner;
 
@@ -48,6 +53,7 @@ function makeRegistry(overrides: Partial<{
   getProjectTicketConfig: (dir: string) => null;
   setBoardTicketColumn: () => void;
   listBoardTickets: (dir: string) => unknown[];
+  listProjects: () => { directory: string }[];
 }> = {}) {
   return {
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
@@ -55,6 +61,7 @@ function makeRegistry(overrides: Partial<{
     getProjectTicketConfig: vi.fn().mockReturnValue(null),
     setBoardTicketColumn: vi.fn(),
     listBoardTickets: vi.fn().mockReturnValue([]),
+    listProjects: vi.fn().mockReturnValue([]),
     ...overrides,
   };
 }
@@ -506,6 +513,150 @@ describe('DarkFactoryOrchestrator', () => {
       await guardOrchestrator.handleDarkFactoryEnabled('/proj'); // second call: empty spec_ready
 
       // createStack only called once because second call found no spec_ready tickets
+      expect(stackManager.createStack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reconcileSpecReady — startup dispatch and periodic safety-net
+  // -------------------------------------------------------------------------
+  describe('reconcileSpecReady', () => {
+    function makeTicket(id: string, col: string = 'spec_ready') {
+      return { ticket_id: id, column: col, project_dir: '/proj', title: '', created_at: '2024-01-01T00:00:00', updated_at: '2024-01-01T00:00:00' };
+    }
+
+    let fastOrchestrator: DarkFactoryOrchestrator;
+
+    beforeEach(() => {
+      fastOrchestrator = new DarkFactoryOrchestrator(
+        registry as never,
+        stackManager as never,
+        agentBackend as never,
+        notifyUpdate,
+        600_000,
+        0,
+      );
+    });
+
+    afterEach(() => {
+      fastOrchestrator.destroy();
+    });
+
+    it('regression: dispatches a stranded spec_ready ticket with no existing stack on startup', async () => {
+      registry.getDarkFactoryEnabled.mockReturnValue(true);
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+      registry.getStack.mockReturnValue(null); // no stack exists
+
+      await fastOrchestrator.reconcileSpecReady('/proj');
+
+      expect(stackManager.createStack).toHaveBeenCalledTimes(1);
+      expect(stackManager.createStack).toHaveBeenCalledWith(
+        expect.objectContaining({ ticket: 'T-1', projectDir: '/proj', gateApproved: true }),
+      );
+      expect(registry.setBoardTicketColumn).toHaveBeenCalledWith('T-1', expect.any(String), 'in_stack');
+    });
+
+    it('dedup: skips a spec_ready ticket whose stack already exists in the registry', async () => {
+      registry.getDarkFactoryEnabled.mockReturnValue(true);
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+      registry.getStack.mockReturnValue({ status: 'up' }); // stack already exists
+
+      await fastOrchestrator.reconcileSpecReady('/proj');
+
+      expect(stackManager.createStack).not.toHaveBeenCalled();
+    });
+
+    it('skips a project with Dark Factory disabled', async () => {
+      registry.getDarkFactoryEnabled.mockReturnValue(false);
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+
+      await fastOrchestrator.reconcileSpecReady('/proj');
+
+      expect(stackManager.createStack).not.toHaveBeenCalled();
+    });
+
+    it('multi-project: only dispatches for Dark-Factory-enabled projects', async () => {
+      registry.getDarkFactoryEnabled.mockImplementation((dir: string) => dir === '/proj-a');
+      registry.listBoardTickets.mockImplementation((dir: string) => {
+        if (dir === '/proj-a') return [makeTicket('T-1')];
+        if (dir === '/proj-b') return [makeTicket('T-2')];
+        return [];
+      });
+      registry.getStack.mockReturnValue(null);
+      registry.listProjects.mockReturnValue([{ directory: '/proj-a' }, { directory: '/proj-b' }]);
+
+      await fastOrchestrator.reconcileSpecReady('/proj-a');
+      await fastOrchestrator.reconcileSpecReady('/proj-b');
+
+      expect(stackManager.createStack).toHaveBeenCalledTimes(1);
+      expect(stackManager.createStack).toHaveBeenCalledWith(
+        expect.objectContaining({ ticket: 'T-1', projectDir: '/proj-a' }),
+      );
+    });
+
+    it('periodic watcher: dispatches a ticket that appears in spec_ready between ticks', async () => {
+      vi.useFakeTimers();
+
+      const watcherOrchestrator = new DarkFactoryOrchestrator(
+        registry as never,
+        stackManager as never,
+        agentBackend as never,
+        notifyUpdate,
+        600_000,
+        0,
+        100, // 100ms watcher interval
+      );
+
+      registry.getDarkFactoryEnabled.mockReturnValue(true);
+      registry.listProjects.mockReturnValue([{ directory: '/proj' }]);
+      registry.getStack.mockReturnValue(null);
+      // No tickets initially
+      registry.listBoardTickets.mockReturnValue([]);
+
+      watcherOrchestrator.startPeriodicWatcher();
+
+      // Advance past first tick — nothing dispatched yet
+      await vi.advanceTimersByTimeAsync(110);
+      expect(stackManager.createStack).not.toHaveBeenCalled();
+
+      // Ticket appears in spec_ready
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+
+      // Advance past second tick — ticket should be dispatched
+      await vi.advanceTimersByTimeAsync(110);
+      expect(stackManager.createStack).toHaveBeenCalledTimes(1);
+      expect(stackManager.createStack).toHaveBeenCalledWith(
+        expect.objectContaining({ ticket: 'T-1' }),
+      );
+
+      watcherOrchestrator.destroy();
+      vi.useRealTimers();
+    });
+
+    it('re-entrancy: concurrent reconcile calls do not double-dispatch the same ticket', async () => {
+      registry.getDarkFactoryEnabled.mockReturnValue(true);
+      registry.getStack.mockReturnValue(null);
+
+      let resolveStartStack!: () => void;
+      const startStackBlocker = new Promise<void>((resolve) => { resolveStartStack = resolve; });
+
+      // Make fetchTicketWithConfig hang so startStack is slow
+      registry.listBoardTickets.mockReturnValue([makeTicket('T-1')]);
+      registry.getProjectTicketConfig.mockReturnValue({ provider: 'test' } as never);
+
+      vi.mocked(fetchTicketWithConfig).mockImplementation(() => startStackBlocker.then(() => ''));
+
+      // Start first reconcile (won't complete until startStackBlocker resolves)
+      const first = fastOrchestrator.reconcileSpecReady('/proj');
+
+      // Second reconcile should be blocked by re-entrancy guard
+      const second = fastOrchestrator.reconcileSpecReady('/proj');
+
+      // Resolve the blocker so first call can finish
+      resolveStartStack();
+      await Promise.all([first, second]);
+
+      // Only one stack should have been created
       expect(stackManager.createStack).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
## Summary

Dark Factory could leave `spec_ready` tickets without a running stack when dispatch was missed — for example if the ticket entered `spec_ready` while the app was closed, or an event was dropped. This adds a safety net so those tickets get picked up automatically.

- `reconcileSpecReady(projectDir)` scans a project's `spec_ready` tickets and starts a stack for any that don't already have one. A per-project re-entrancy guard prevents overlapping passes from double-dispatching.
- `startPeriodicWatcher()` rescans all Dark-Factory-enabled projects on a 60s interval; `destroy()` clears the timer on quit.
- On app startup, every enabled project is reconciled once to catch tickets stranded before the last restart.
- Wired into the app lifecycle in `index.ts`: watcher starts after the orchestrator is built, a startup sweep runs once the app is ready, and the watcher is torn down on `before-quit`.

## QA plan

1. Enable Dark Factory for a project and move a ticket to `spec_ready` while the app is running — confirm a stack is created for it.
2. Move a ticket to `spec_ready`, fully quit the app, then relaunch — confirm the stranded ticket gets a stack shortly after startup.
3. Leave a `spec_ready` ticket without a stack and wait ~60s — confirm the periodic watcher dispatches it without manual action.
4. Confirm tickets that already have a stack are not re-dispatched (no duplicate stacks) across repeated watcher passes.
5. Quit the app and confirm no lingering timers/errors (clean shutdown via `before-quit`).

Closes #494