### PR TITLE
[466] feat: per-ticket cost and token attribution

### DIFF
--- a/sandstorm-cli/docker/token-counter.sh
+++ b/sandstorm-cli/docker/token-counter.sh
@@ -23,8 +23,10 @@ OUTPUT_FILE="${1:?Usage: token-counter.sh <output-file> [iteration] [phase]}"
 ITERATION="${2:-}"
 PHASE="${3:-}"
 
-# Track current turn's input tokens (set by message_start, used by message_delta)
+# Track current turn's input and cache tokens (set by message_start, used by message_delta)
 current_input=0
+current_cache_creation=0
+current_cache_read=0
 
 # Build jq metadata suffix for output objects
 if [ -n "$ITERATION" ] && [ -n "$PHASE" ]; then
@@ -48,16 +50,20 @@ while IFS= read -r line; do
       case "$event_type" in
         message_start)
           in_tokens=$(echo "$event" | jq -r '(.message.usage.input_tokens // 0)' 2>/dev/null)
+          cc_tokens=$(echo "$event" | jq -r '(.message.usage.cache_creation_input_tokens // 0)' 2>/dev/null)
+          cr_tokens=$(echo "$event" | jq -r '(.message.usage.cache_read_input_tokens // 0)' 2>/dev/null)
           current_input="${in_tokens:-0}"
+          current_cache_creation="${cc_tokens:-0}"
+          current_cache_read="${cr_tokens:-0}"
           if [ "${current_input:-0}" -gt 0 ] 2>/dev/null; then
-            tokens=$(echo "$event" | jq -c "{in: (.message.usage.input_tokens // 0), out: 0${META}, partial: true}" 2>/dev/null)
+            tokens=$(echo "$event" | jq -c "{in: (.message.usage.input_tokens // 0), out: 0, cc: (.message.usage.cache_creation_input_tokens // 0), cr: (.message.usage.cache_read_input_tokens // 0)${META}, partial: true}" 2>/dev/null)
             [ -n "$tokens" ] && echo "$tokens" >> "$OUTPUT_FILE"
           fi
           ;;
         message_delta)
           out_tokens=$(echo "$event" | jq -r '(.usage.output_tokens // 0)' 2>/dev/null)
           if [ "${out_tokens:-0}" -gt 0 ] 2>/dev/null; then
-            tokens=$(echo "$event" | jq -c "{in: ${current_input:-0}, out: (.usage.output_tokens // 0)${META}, partial: true}" 2>/dev/null)
+            tokens=$(echo "$event" | jq -c "{in: ${current_input:-0}, out: (.usage.output_tokens // 0), cc: ${current_cache_creation:-0}, cr: ${current_cache_read:-0}${META}, partial: true}" 2>/dev/null)
             [ -n "$tokens" ] && echo "$tokens" >> "$OUTPUT_FILE"
           fi
           ;;
@@ -67,9 +73,11 @@ while IFS= read -r line; do
           in_tokens=$(echo "$event" | jq -r '(.usage.input_tokens // 0)' 2>/dev/null)
           out_tokens=$(echo "$event" | jq -r '(.usage.output_tokens // 0)' 2>/dev/null)
           if [ "${in_tokens:-0}" -gt 0 ] || [ "${out_tokens:-0}" -gt 0 ]; then
-            tokens=$(echo "$event" | jq -c "{in: (.usage.input_tokens // 0), out: (.usage.output_tokens // 0)${META}}" 2>/dev/null)
+            tokens=$(echo "$event" | jq -c "{in: (.usage.input_tokens // 0), out: (.usage.output_tokens // 0), cc: (.usage.cache_creation_input_tokens // 0), cr: (.usage.cache_read_input_tokens // 0)${META}}" 2>/dev/null)
             [ -n "$tokens" ] && echo "$tokens" >> "$OUTPUT_FILE"
             current_input=0
+            current_cache_creation=0
+            current_cache_read=0
           fi
           ;;
       esac

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -22,6 +22,8 @@ export interface Stack {
   total_execution_output_tokens: number;
   total_review_input_tokens: number;
   total_review_output_tokens: number;
+  total_cache_read_tokens: number;
+  total_cache_creation_tokens: number;
   rate_limit_reset_at: string | null;
   created_at: string;
   updated_at: string;
@@ -60,6 +62,8 @@ export interface Task {
   execution_output_tokens: number;
   review_input_tokens: number;
   review_output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
   review_iterations: number;
   verify_retries: number;
   review_verdicts: string | null;
@@ -550,6 +554,47 @@ export class Registry {
       this.setSchemaVersion(17);
     }
 
+    if (currentVersion < 18) {
+      // Add per-task cache token columns for per-ticket cacheHit attribution.
+      // DEFAULT 0 means historical tasks (pre-capture) naturally produce cacheHit = 0%.
+      try { this.db.exec('ALTER TABLE tasks ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
+      try { this.db.exec('ALTER TABLE tasks ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
+
+      // Aggregate cache columns on stacks to mirror existing phase-token pattern
+      try { this.db.exec('ALTER TABLE stacks ADD COLUMN total_cache_read_tokens INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
+      try { this.db.exec('ALTER TABLE stacks ADD COLUMN total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
+
+      this.setSchemaVersion(18);
+    }
+
+    if (currentVersion < 19) {
+      // Rollup cache tables for per-ticket cost/token attribution.
+      // ticket_rollups caches the aggregated per-ticket cost/token rollup.
+      // rollup_dirty_stacks tracks stacks needing re-derivation.
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS ticket_rollups (
+          ticket_id            TEXT PRIMARY KEY,
+          title                TEXT NOT NULL DEFAULT '',
+          column               TEXT,
+          total_cost           REAL NOT NULL DEFAULT 0,
+          total_input_tokens   INTEGER NOT NULL DEFAULT 0,
+          total_output_tokens  INTEGER NOT NULL DEFAULT 0,
+          total_cache_read     INTEGER NOT NULL DEFAULT 0,
+          total_cache_creation INTEGER NOT NULL DEFAULT 0,
+          primary_model        TEXT,
+          unpriced             INTEGER NOT NULL DEFAULT 0,
+          computed_at          TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS rollup_dirty_stacks (
+          stack_id  TEXT PRIMARY KEY,
+          marked_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      this.setSchemaVersion(19);
+    }
+
   }
 
   // --- Projects ---
@@ -577,7 +622,7 @@ export class Registry {
 
   // --- Stacks ---
 
-  createStack(stack: Omit<Stack, 'created_at' | 'updated_at' | 'error' | 'pr_url' | 'pr_number' | 'total_input_tokens' | 'total_output_tokens' | 'total_execution_input_tokens' | 'total_execution_output_tokens' | 'total_review_input_tokens' | 'total_review_output_tokens' | 'rate_limit_reset_at' | 'current_model'>): Stack {
+  createStack(stack: Omit<Stack, 'created_at' | 'updated_at' | 'error' | 'pr_url' | 'pr_number' | 'total_input_tokens' | 'total_output_tokens' | 'total_execution_input_tokens' | 'total_execution_output_tokens' | 'total_review_input_tokens' | 'total_review_output_tokens' | 'total_cache_read_tokens' | 'total_cache_creation_tokens' | 'rate_limit_reset_at' | 'current_model'>): Stack {
     if (!stack.id) {
       throw new Error('Stack id is required and cannot be null or empty');
     }
@@ -722,6 +767,16 @@ export class Registry {
 
   // --- Token Usage ---
 
+  /** Optional callback invoked after archiveStack — used by rollup store for cache invalidation. */
+  onStackArchived?: (stackId: string) => void;
+  /** Optional callback invoked after setBoardTicketColumn — used by rollup store for cache invalidation. */
+  onBoardTicketMoved?: (ticketId: string, column: string) => void;
+
+  /** Exposes the underlying Database instance for modules that need direct SQL access (e.g. rollup store). */
+  getDb(): Database.Database {
+    return this.db;
+  }
+
   updateTaskTokens(
     taskId: number,
     inputTokens: number,
@@ -731,13 +786,17 @@ export class Registry {
       executionOutput: number;
       reviewInput: number;
       reviewOutput: number;
+    },
+    cacheTokens?: {
+      cacheRead: number;
+      cacheCreation: number;
     }
   ): void {
     // Wrap in a transaction to prevent race conditions from concurrent task completions
     const updateFn = this.db.transaction(() => {
       // Read old values first so we can compute the delta for the stack aggregate
       const old = this.db.prepare(
-        'SELECT stack_id, input_tokens, output_tokens, execution_input_tokens, execution_output_tokens, review_input_tokens, review_output_tokens FROM tasks WHERE id = ?'
+        'SELECT stack_id, input_tokens, output_tokens, execution_input_tokens, execution_output_tokens, review_input_tokens, review_output_tokens, cache_read_tokens, cache_creation_tokens FROM tasks WHERE id = ?'
       ).get(taskId) as {
         stack_id: string;
         input_tokens: number;
@@ -746,11 +805,15 @@ export class Registry {
         execution_output_tokens: number;
         review_input_tokens: number;
         review_output_tokens: number;
+        cache_read_tokens: number;
+        cache_creation_tokens: number;
       } | undefined;
       if (!old) return;
 
       const inputDelta = inputTokens - old.input_tokens;
       const outputDelta = outputTokens - old.output_tokens;
+      const cacheReadDelta = (cacheTokens?.cacheRead ?? old.cache_read_tokens) - old.cache_read_tokens;
+      const cacheCreationDelta = (cacheTokens?.cacheCreation ?? old.cache_creation_tokens) - old.cache_creation_tokens;
 
       if (phaseBreakdown) {
         const execInDelta = phaseBreakdown.executionInput - old.execution_input_tokens;
@@ -760,16 +823,18 @@ export class Registry {
 
         // SET (not increment) — phase totals are cumulative values
         this.db.prepare(
-          'UPDATE tasks SET input_tokens = ?, output_tokens = ?, execution_input_tokens = ?, execution_output_tokens = ?, review_input_tokens = ?, review_output_tokens = ? WHERE id = ?'
+          'UPDATE tasks SET input_tokens = ?, output_tokens = ?, execution_input_tokens = ?, execution_output_tokens = ?, review_input_tokens = ?, review_output_tokens = ?, cache_read_tokens = ?, cache_creation_tokens = ? WHERE id = ?'
         ).run(
           inputTokens, outputTokens,
           phaseBreakdown.executionInput, phaseBreakdown.executionOutput,
           phaseBreakdown.reviewInput, phaseBreakdown.reviewOutput,
+          cacheTokens?.cacheRead ?? old.cache_read_tokens,
+          cacheTokens?.cacheCreation ?? old.cache_creation_tokens,
           taskId
         );
 
         // Update stack aggregate by the delta
-        if (inputDelta !== 0 || outputDelta !== 0 || execInDelta !== 0 || execOutDelta !== 0 || revInDelta !== 0 || revOutDelta !== 0) {
+        if (inputDelta !== 0 || outputDelta !== 0 || execInDelta !== 0 || execOutDelta !== 0 || revInDelta !== 0 || revOutDelta !== 0 || cacheReadDelta !== 0 || cacheCreationDelta !== 0) {
           this.db.prepare(
             `UPDATE stacks SET
               total_input_tokens = total_input_tokens + ?,
@@ -777,21 +842,23 @@ export class Registry {
               total_execution_input_tokens = total_execution_input_tokens + ?,
               total_execution_output_tokens = total_execution_output_tokens + ?,
               total_review_input_tokens = total_review_input_tokens + ?,
-              total_review_output_tokens = total_review_output_tokens + ?
+              total_review_output_tokens = total_review_output_tokens + ?,
+              total_cache_read_tokens = total_cache_read_tokens + ?,
+              total_cache_creation_tokens = total_cache_creation_tokens + ?
             WHERE id = ?`
-          ).run(inputDelta, outputDelta, execInDelta, execOutDelta, revInDelta, revOutDelta, old.stack_id);
+          ).run(inputDelta, outputDelta, execInDelta, execOutDelta, revInDelta, revOutDelta, cacheReadDelta, cacheCreationDelta, old.stack_id);
         }
       } else {
         // Legacy path — no phase breakdown
         this.db.prepare(
-          'UPDATE tasks SET input_tokens = ?, output_tokens = ? WHERE id = ?'
-        ).run(inputTokens, outputTokens, taskId);
+          'UPDATE tasks SET input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_creation_tokens = ? WHERE id = ?'
+        ).run(inputTokens, outputTokens, cacheTokens?.cacheRead ?? old.cache_read_tokens, cacheTokens?.cacheCreation ?? old.cache_creation_tokens, taskId);
 
         // Update stack aggregate by the delta
-        if (inputDelta !== 0 || outputDelta !== 0) {
+        if (inputDelta !== 0 || outputDelta !== 0 || cacheReadDelta !== 0 || cacheCreationDelta !== 0) {
           this.db.prepare(
-            'UPDATE stacks SET total_input_tokens = total_input_tokens + ?, total_output_tokens = total_output_tokens + ? WHERE id = ?'
-          ).run(inputDelta, outputDelta, old.stack_id);
+            'UPDATE stacks SET total_input_tokens = total_input_tokens + ?, total_output_tokens = total_output_tokens + ?, total_cache_read_tokens = total_cache_read_tokens + ?, total_cache_creation_tokens = total_cache_creation_tokens + ? WHERE id = ?'
+          ).run(inputDelta, outputDelta, cacheReadDelta, cacheCreationDelta, old.stack_id);
         }
       }
     });
@@ -1031,6 +1098,8 @@ export class Registry {
       stack.created_at,
       durationSeconds,
     );
+
+    this.onStackArchived?.(id);
   }
 
   listStackHistory(): StackHistoryRecord[] {
@@ -1202,6 +1271,7 @@ export class Registry {
        VALUES (?, ?, ?, '')
        ON CONFLICT(ticket_id, project_dir) DO UPDATE SET column = excluded.column, updated_at = datetime('now')`
     ).run(ticketId, normalizedDir, column);
+    this.onBoardTicketMoved?.(ticketId, column);
   }
 
   /**

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -198,6 +198,11 @@ export class StackManager {
     this.appVersion = StackManager.resolveAppVersion();
   }
 
+  /** Register a callback invoked when a task completes (used by rollup store for cache invalidation). */
+  setOnTaskCompleted(cb: (stackId: string) => void): void {
+    this.taskWatcher.onTaskCompleted = cb;
+  }
+
   /**
    * Resolve the app's git commit hash.
    * Prefers the build-time define; falls back to git at runtime (dev mode).

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -58,6 +58,8 @@ export class TaskWatcher extends EventEmitter {
   private stalePollCounts = new Map<string, number>();
   private pollInterval: number;
   private onStatusChange?: () => void;
+  /** Optional callback invoked after a task completes — used by rollup store for cache invalidation. */
+  onTaskCompleted?: (stackId: string) => void;
   /** Tracks the last time we polled tokens for each stack (to throttle reads) */
   private lastTokenPoll = new Map<string, number>();
   /** How often to poll tokens while a task is running (ms) */
@@ -206,10 +208,16 @@ export class TaskWatcher extends EventEmitter {
     }
 
     // Read token usage, session ID, loop iterations, and execution metadata (async, best-effort)
+    // onTaskCompleted fires after readTaskTokens completes so the dirty signal is set
+    // only once the new token values are actually written to the DB.
     if (containerId) {
-      this.readTaskTokens(task.id, stackId, containerId).catch(() => {});
+      this.readTaskTokens(task.id, stackId, containerId)
+        .catch(() => {})
+        .then(() => this.onTaskCompleted?.(stackId));
       this.readTaskIterations(task.id, stackId, containerId).catch(() => {});
       this.readTaskMetadata(task.id, stackId, containerId).catch(() => {});
+    } else {
+      this.onTaskCompleted?.(stackId);
     }
 
     const updatedTask = {
@@ -246,19 +254,24 @@ export class TaskWatcher extends EventEmitter {
         runtime.exec(containerId, ['cat', '/tmp/claude-raw.log']).catch(() => ({ stdout: '' })),
       ]);
 
-      // Parse phase token totals
+      // Parse phase token totals (including cache fields from token-counter.sh cc/cr)
       const execTokens = parsePhaseTokenTotals(execResult.stdout);
       const reviewTokens = parsePhaseTokenTotals(reviewResult.stdout);
 
       const totalInput = execTokens.input_tokens + reviewTokens.input_tokens;
       const totalOutput = execTokens.output_tokens + reviewTokens.output_tokens;
+      const totalCacheRead = execTokens.cache_read_tokens + reviewTokens.cache_read_tokens;
+      const totalCacheCreation = execTokens.cache_creation_tokens + reviewTokens.cache_creation_tokens;
 
-      if (totalInput > 0 || totalOutput > 0) {
+      if (totalInput > 0 || totalOutput > 0 || totalCacheRead > 0 || totalCacheCreation > 0) {
         this.registry.updateTaskTokens(taskId, totalInput, totalOutput, {
           executionInput: execTokens.input_tokens,
           executionOutput: execTokens.output_tokens,
           reviewInput: reviewTokens.input_tokens,
           reviewOutput: reviewTokens.output_tokens,
+        }, {
+          cacheRead: totalCacheRead,
+          cacheCreation: totalCacheCreation,
         });
       }
 

--- a/src/main/control-plane/token-parser.ts
+++ b/src/main/control-plane/token-parser.ts
@@ -16,6 +16,8 @@ export interface ParsedTokenUsage {
 export interface PhaseTokenTotals {
   input_tokens: number;
   output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
 }
 
 export interface TokenStep {
@@ -23,6 +25,8 @@ export interface TokenStep {
   phase: string;
   input_tokens: number;
   output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
 }
 
 /**
@@ -34,6 +38,8 @@ export interface TokenStep {
 export function parsePhaseTokenTotals(output: string): PhaseTokenTotals {
   let input_tokens = 0;
   let output_tokens = 0;
+  let cache_creation_tokens = 0;
+  let cache_read_tokens = 0;
 
   for (const line of output.split('\n')) {
     if (!line.trim()) continue;
@@ -43,12 +49,14 @@ export function parsePhaseTokenTotals(output: string): PhaseTokenTotals {
       if (parsed.partial === true) continue;
       input_tokens += parsed.in ?? 0;
       output_tokens += parsed.out ?? 0;
+      cache_creation_tokens += parsed.cc ?? 0;
+      cache_read_tokens += parsed.cr ?? 0;
     } catch {
       // Not JSON — skip
     }
   }
 
-  return { input_tokens, output_tokens };
+  return { input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens };
 }
 
 /**
@@ -70,9 +78,9 @@ export function parsePhaseTokenSteps(
   reviewOutput: string
 ): TokenStep[] {
   // Sum of completed (non-partial) result entries per key
-  const stepTotals = new Map<string, { iteration: number; phase: string; input_tokens: number; output_tokens: number }>();
+  const stepTotals = new Map<string, { iteration: number; phase: string; input_tokens: number; output_tokens: number; cache_creation_tokens: number; cache_read_tokens: number }>();
   // Latest partial entry per key — running total for in-progress API turn
-  const latestPartial = new Map<string, { input_tokens: number; output_tokens: number }>();
+  const latestPartial = new Map<string, { input_tokens: number; output_tokens: number; cache_creation_tokens: number; cache_read_tokens: number }>();
 
   function processLines(output: string, defaultPhase: string): void {
     for (const line of output.split('\n')) {
@@ -83,25 +91,29 @@ export function parsePhaseTokenSteps(
         const phase = parsed.phase ?? defaultPhase;
         const inTokens = parsed.in ?? 0;
         const outTokens = parsed.out ?? 0;
+        const ccTokens = parsed.cc ?? 0;
+        const crTokens = parsed.cr ?? 0;
         const isPartial = parsed.partial === true;
 
         const key = `${iteration}:${phase}`;
 
         if (isPartial) {
           // Track only the latest partial per key — it's a running total, not an increment
-          if (inTokens > 0 || outTokens > 0) {
-            latestPartial.set(key, { input_tokens: inTokens, output_tokens: outTokens });
+          if (inTokens > 0 || outTokens > 0 || ccTokens > 0 || crTokens > 0) {
+            latestPartial.set(key, { input_tokens: inTokens, output_tokens: outTokens, cache_creation_tokens: ccTokens, cache_read_tokens: crTokens });
           }
         } else {
           // Non-partial (result) entry: add to completed totals for this key
-          if (inTokens === 0 && outTokens === 0) continue;
+          if (inTokens === 0 && outTokens === 0 && ccTokens === 0 && crTokens === 0) continue;
 
           const existing = stepTotals.get(key);
           if (existing) {
             existing.input_tokens += inTokens;
             existing.output_tokens += outTokens;
+            existing.cache_creation_tokens += ccTokens;
+            existing.cache_read_tokens += crTokens;
           } else {
-            stepTotals.set(key, { iteration, phase, input_tokens: inTokens, output_tokens: outTokens });
+            stepTotals.set(key, { iteration, phase, input_tokens: inTokens, output_tokens: outTokens, cache_creation_tokens: ccTokens, cache_read_tokens: crTokens });
           }
           // Result supersedes its preceding partials — reset to avoid double-counting
           latestPartial.delete(key);
@@ -128,12 +140,14 @@ export function parsePhaseTokenSteps(
       // Phase has completed turns + an in-progress turn — add the partial
       existing.input_tokens += partial.input_tokens;
       existing.output_tokens += partial.output_tokens;
+      existing.cache_creation_tokens += partial.cache_creation_tokens;
+      existing.cache_read_tokens += partial.cache_read_tokens;
     } else {
       // Phase has only partial data — no completed turn yet
       const colonIdx = key.indexOf(':');
       const iteration = parseInt(key.slice(0, colonIdx), 10);
       const phase = key.slice(colonIdx + 1);
-      stepMap.set(key, { iteration, phase, input_tokens: partial.input_tokens, output_tokens: partial.output_tokens });
+      stepMap.set(key, { iteration, phase, input_tokens: partial.input_tokens, output_tokens: partial.output_tokens, cache_creation_tokens: partial.cache_creation_tokens, cache_read_tokens: partial.cache_read_tokens });
     }
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -90,6 +90,7 @@ import { KANBAN_COLUMNS } from '../shared/kanban';
 import os from 'os';
 import { createUsageEngine } from './telemetry/usage-engine';
 import type { DateRange } from './telemetry/usage-engine';
+import { TicketRollupStore } from './telemetry/rollup-store';
 
 // Set __sandstorm at module-load time so app.evaluate() works immediately
 // after electron.launch() resolves — which happens during createWindow(),
@@ -760,14 +761,30 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return fetchAccountUsage();
   });
 
-  // --- Telemetry (host orchestrator usage) ---
+  // --- Telemetry (host orchestrator usage + per-ticket attribution) ---
 
   const hostEngine = createUsageEngine(
     os.homedir() + '/.claude/projects'
   );
 
+  const rollupStore = new TicketRollupStore(registry.getDb());
+
+  // Wire auto-invalidation hooks so the rollup cache stays fresh
+  registry.onStackArchived = (stackId) => rollupStore.markStackDirty(stackId);
+  registry.onBoardTicketMoved = (_ticketId, column) => {
+    if (column === 'merged') rollupStore.markDirty();
+  };
+  stackManager.setOnTaskCompleted((stackId) => rollupStore.markStackDirty(stackId));
+
   ipcMain.handle('stats:telemetry:summary', async (_event, range: DateRange) => {
-    return hostEngine.getSummary(range);
+    const summary = hostEngine.getSummary(range);
+    const shipped = rollupStore.ticketsShipped();
+    const totalCost = rollupStore.totalTicketCost();
+    return {
+      ...summary,
+      ticketsShipped: shipped,
+      costPerTicket: shipped > 0 ? totalCost / shipped : null,
+    };
   });
 
   ipcMain.handle('stats:telemetry:daily', async (_event, range: DateRange) => {
@@ -780,6 +797,15 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   ipcMain.handle('stats:telemetry:session', async (_event, range: DateRange) => {
     return hostEngine.getSessions(range);
+  });
+
+  ipcMain.handle('stats:telemetry:byTicket', async () => {
+    return rollupStore.getByTicket();
+  });
+
+  ipcMain.handle('stats:telemetry:refresh', async () => {
+    rollupStore.refresh();
+    return { ok: true };
   });
 
   // --- Custom Context ---

--- a/src/main/telemetry/attribution.ts
+++ b/src/main/telemetry/attribution.ts
@@ -1,0 +1,208 @@
+import Database from 'better-sqlite3';
+import { computeCost } from './pricing';
+import type { ByTicketEntry } from './types';
+
+export const ORCHESTRATOR_TICKET_ID = '__orchestrator__';
+
+interface TaskCostRow {
+  ticket: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  resolved_model: string | null;
+}
+
+interface HistoryRow {
+  ticket: string | null;
+  task_history: string;
+}
+
+interface BoardRow {
+  ticket_id: string;
+  column: string;
+  title: string;
+}
+
+interface TicketBucket {
+  title: string;
+  column: string | null;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  modelOutputs: Map<string, number>;
+  cost: number;
+  unpriced: boolean;
+}
+
+interface HistoricalTask {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_tokens?: number;
+  cache_creation_tokens?: number;
+  resolved_model?: string | null;
+}
+
+function accumulate(bucket: TicketBucket, task: HistoricalTask): void {
+  const input = task.input_tokens ?? 0;
+  const output = task.output_tokens ?? 0;
+  const cacheRead = task.cache_read_tokens ?? 0;
+  const cacheCreation = task.cache_creation_tokens ?? 0;
+  const model = task.resolved_model ?? null;
+
+  bucket.input += input;
+  bucket.output += output;
+  bucket.cacheRead += cacheRead;
+  bucket.cacheCreation += cacheCreation;
+
+  if (model) {
+    const { cost, unpriced } = computeCost(model, {
+      input,
+      output,
+      cacheCreate: cacheCreation,
+      cacheRead,
+    });
+    bucket.cost += cost;
+    if (unpriced) bucket.unpriced = true;
+    bucket.modelOutputs.set(model, (bucket.modelOutputs.get(model) ?? 0) + output);
+  }
+}
+
+/**
+ * Computes per-ticket cost rollups from live tasks and archived stack history.
+ * Tasks on stacks with no ticket roll up under ORCHESTRATOR_TICKET_ID.
+ * Aggregates globally by ticketId (tickets are expected to be unique across projects).
+ */
+export function computeTicketRollups(db: Database.Database): ByTicketEntry[] {
+  const buckets = new Map<string, TicketBucket>();
+
+  function getOrCreate(ticketId: string): TicketBucket {
+    let bucket = buckets.get(ticketId);
+    if (!bucket) {
+      bucket = {
+        title: ticketId === ORCHESTRATOR_TICKET_ID ? 'Orchestrator / ad-hoc' : ticketId,
+        column: null,
+        input: 0, output: 0, cacheRead: 0, cacheCreation: 0,
+        modelOutputs: new Map(),
+        cost: 0,
+        unpriced: false,
+      };
+      buckets.set(ticketId, bucket);
+    }
+    return bucket;
+  }
+
+  // 1. Live tasks joined to stacks for ticket attribution
+  const liveTasks = db.prepare(`
+    SELECT s.ticket,
+           t.input_tokens, t.output_tokens,
+           t.cache_read_tokens, t.cache_creation_tokens,
+           t.resolved_model
+    FROM tasks t
+    JOIN stacks s ON t.stack_id = s.id
+  `).all() as TaskCostRow[];
+
+  for (const row of liveTasks) {
+    accumulate(getOrCreate(row.ticket ?? ORCHESTRATOR_TICKET_ID), row);
+  }
+
+  // 2. Historical tasks from stack_history.task_history JSON blob
+  const historyRows = db.prepare(`
+    SELECT ticket, task_history
+    FROM stack_history
+    WHERE task_history IS NOT NULL
+  `).all() as HistoryRow[];
+
+  for (const record of historyRows) {
+    const ticketId = record.ticket ?? ORCHESTRATOR_TICKET_ID;
+    let tasks: HistoricalTask[] = [];
+    try {
+      tasks = JSON.parse(record.task_history) as HistoricalTask[];
+    } catch {
+      continue;
+    }
+    for (const task of tasks) {
+      accumulate(getOrCreate(ticketId), task);
+    }
+  }
+
+  // 3. Enrich with ticket_board metadata (title, column)
+  const boardRows = db.prepare(
+    'SELECT ticket_id, column, title FROM ticket_board'
+  ).all() as BoardRow[];
+
+  for (const row of boardRows) {
+    const bucket = buckets.get(row.ticket_id);
+    if (bucket) {
+      if (row.title) bucket.title = row.title;
+      bucket.column = row.column;
+    }
+  }
+
+  // 4. Build ByTicketEntry[] from accumulated buckets
+  const result: ByTicketEntry[] = [];
+  for (const [ticketId, bucket] of buckets) {
+    const denom = bucket.input + bucket.cacheRead;
+    const cacheHit = denom > 0 ? (bucket.cacheRead / denom) * 100 : 0;
+
+    let primaryModel: string | null = null;
+    let maxOutput = 0;
+    for (const [model, outputTokens] of bucket.modelOutputs) {
+      if (outputTokens > maxOutput) {
+        maxOutput = outputTokens;
+        primaryModel = model;
+      }
+    }
+
+    result.push({
+      ticketId,
+      title: bucket.title,
+      column: bucket.column,
+      model: primaryModel,
+      cost: bucket.cost,
+      tokens: {
+        input: bucket.input,
+        output: bucket.output,
+        cacheRead: bucket.cacheRead,
+        cacheCreation: bucket.cacheCreation,
+      },
+      cacheHit,
+      lifecycle: null,
+      unpriced: bucket.unpriced,
+    });
+  }
+
+  // Sort: orchestrator last, others by cost descending
+  result.sort((a, b) => {
+    if (a.ticketId === ORCHESTRATOR_TICKET_ID) return 1;
+    if (b.ticketId === ORCHESTRATOR_TICKET_ID) return -1;
+    return b.cost - a.cost;
+  });
+
+  return result;
+}
+
+/**
+ * Count of distinct tickets that have been shipped.
+ * Shipped = ticket_board.column = 'merged' OR (no board row and stack/stack_history
+ * reached status/final_status of pr_created/pushed). Survives teardown via stack_history.
+ */
+export function countTicketsShipped(db: Database.Database): number {
+  const row = db.prepare(`
+    SELECT COUNT(DISTINCT ticket) AS n FROM (
+      SELECT ticket_id AS ticket FROM ticket_board WHERE column = 'merged'
+      UNION
+      SELECT s.ticket FROM stacks s
+      WHERE s.ticket IS NOT NULL
+        AND s.status IN ('pr_created', 'pushed')
+        AND s.ticket NOT IN (SELECT ticket_id FROM ticket_board)
+      UNION
+      SELECT sh.ticket FROM stack_history sh
+      WHERE sh.ticket IS NOT NULL
+        AND sh.final_status IN ('pr_created', 'pushed')
+        AND sh.ticket NOT IN (SELECT ticket_id FROM ticket_board)
+    )
+  `).get() as { n: number };
+  return row.n;
+}

--- a/src/main/telemetry/rollup-store.ts
+++ b/src/main/telemetry/rollup-store.ts
@@ -1,0 +1,195 @@
+import Database from 'better-sqlite3';
+import { computeTicketRollups, countTicketsShipped, ORCHESTRATOR_TICKET_ID } from './attribution';
+import type { ByTicketEntry } from './types';
+
+interface RollupRow {
+  ticket_id: string;
+  title: string;
+  column: string | null;
+  total_cost: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_read: number;
+  total_cache_creation: number;
+  primary_model: string | null;
+  unpriced: number;
+}
+
+/**
+ * Caches per-ticket cost rollups in SQLite so per-ticket / per-model views are fast
+ * and survive stack teardown. Auto-invalidates when stacks are dirtied by token updates,
+ * teardown, or board moves.
+ */
+export class TicketRollupStore {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+  }
+
+  /** Mark a stack dirty so the next getByTicket() call triggers a fresh rollup. */
+  markStackDirty(stackId: string): void {
+    this.db.prepare(
+      `INSERT OR REPLACE INTO rollup_dirty_stacks (stack_id, marked_at) VALUES (?, datetime('now'))`
+    ).run(stackId);
+  }
+
+  /** Mark all rollups dirty (used when ticket board state changes). */
+  markDirty(): void {
+    this.db.prepare(
+      `INSERT OR REPLACE INTO rollup_dirty_stacks (stack_id, marked_at) VALUES ('__board__', datetime('now'))`
+    ).run();
+  }
+
+  /**
+   * Returns per-ticket rollups, re-deriving from the DB if any stack is dirty.
+   * CacheHit for historical/pre-capture tasks is 0 (DEFAULT 0 on cache columns).
+   */
+  getByTicket(): ByTicketEntry[] {
+    this.reconcile();
+    const rows = this.db.prepare(
+      `SELECT * FROM ticket_rollups ORDER BY
+        CASE WHEN ticket_id = ? THEN 1 ELSE 0 END ASC,
+        total_cost DESC`
+    ).all(ORCHESTRATOR_TICKET_ID) as RollupRow[];
+
+    return rows.map((row) => {
+      const denom = row.total_input_tokens + row.total_cache_read;
+      const cacheHit = denom > 0 ? (row.total_cache_read / denom) * 100 : 0;
+      return {
+        ticketId: row.ticket_id,
+        title: row.title,
+        column: row.column,
+        model: row.primary_model,
+        cost: row.total_cost,
+        tokens: {
+          input: row.total_input_tokens,
+          output: row.total_output_tokens,
+          cacheRead: row.total_cache_read,
+          cacheCreation: row.total_cache_creation,
+        },
+        cacheHit,
+        lifecycle: null,
+        unpriced: row.unpriced === 1,
+      };
+    });
+  }
+
+  /**
+   * Force a full rebuild of all ticket rollups from the DB.
+   * Called by the stats:telemetry:refresh IPC handler.
+   */
+  refresh(): void {
+    const rollups = computeTicketRollups(this.db);
+    const upsert = this.db.prepare(`
+      INSERT OR REPLACE INTO ticket_rollups
+        (ticket_id, title, column, total_cost, total_input_tokens, total_output_tokens,
+         total_cache_read, total_cache_creation, primary_model, unpriced, computed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    `);
+
+    const rebuild = this.db.transaction((entries: ByTicketEntry[]) => {
+      this.db.exec('DELETE FROM ticket_rollups');
+      for (const entry of entries) {
+        upsert.run(
+          entry.ticketId,
+          entry.title,
+          entry.column,
+          entry.cost,
+          entry.tokens.input,
+          entry.tokens.output,
+          entry.tokens.cacheRead,
+          entry.tokens.cacheCreation,
+          entry.model,
+          entry.unpriced ? 1 : 0
+        );
+      }
+      this.db.exec('DELETE FROM rollup_dirty_stacks');
+    });
+
+    rebuild(rollups);
+  }
+
+  /**
+   * Count of distinct tickets that have been shipped (merged or pushed).
+   * Used to populate summary.ticketsShipped.
+   */
+  ticketsShipped(): number {
+    return countTicketsShipped(this.db);
+  }
+
+  /**
+   * Total estimated USD cost of all per-ticket tasks (excluding orchestrator bucket).
+   * Used to compute summary.costPerTicket.
+   */
+  totalTicketCost(): number {
+    this.reconcile();
+    const row = this.db.prepare(`
+      SELECT COALESCE(SUM(total_cost), 0) AS total
+      FROM ticket_rollups
+      WHERE ticket_id != ?
+    `).get(ORCHESTRATOR_TICKET_ID) as { total: number };
+    return row.total;
+  }
+
+  private reconcile(): void {
+    const dirtyRows = this.db.prepare(
+      'SELECT stack_id FROM rollup_dirty_stacks'
+    ).all() as { stack_id: string }[];
+
+    if (dirtyRows.length === 0) return;
+
+    const dirtyIds = dirtyRows.map(r => r.stack_id);
+
+    // __board__ means ticket board columns changed — full rebuild required
+    if (dirtyIds.includes('__board__')) {
+      this.refresh();
+      return;
+    }
+
+    const ph = dirtyIds.map(() => '?').join(', ');
+
+    // Find tickets touched by the specific dirty stacks (live + archived)
+    const liveRows = this.db.prepare(
+      `SELECT DISTINCT ticket FROM stacks WHERE id IN (${ph})`
+    ).all(...dirtyIds) as { ticket: string | null }[];
+
+    const histRows = this.db.prepare(
+      `SELECT DISTINCT ticket FROM stack_history WHERE stack_id IN (${ph})`
+    ).all(...dirtyIds) as { ticket: string | null }[];
+
+    const affectedTickets = new Set<string>();
+    for (const r of [...liveRows, ...histRows]) {
+      affectedTickets.add(r.ticket ?? ORCHESTRATOR_TICKET_ID);
+    }
+
+    if (affectedTickets.size === 0) {
+      // Stacks no longer exist anywhere — just clear dirty entries
+      this.db.prepare(`DELETE FROM rollup_dirty_stacks WHERE stack_id IN (${ph})`).run(...dirtyIds);
+      return;
+    }
+
+    // Recompute all rollups and filter to only the affected tickets
+    const allRollups = computeTicketRollups(this.db);
+    const affected = allRollups.filter(e => affectedTickets.has(e.ticketId));
+
+    const upsert = this.db.prepare(`
+      INSERT OR REPLACE INTO ticket_rollups
+        (ticket_id, title, column, total_cost, total_input_tokens, total_output_tokens,
+         total_cache_read, total_cache_creation, primary_model, unpriced, computed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    `);
+
+    this.db.transaction(() => {
+      for (const entry of affected) {
+        upsert.run(
+          entry.ticketId, entry.title, entry.column, entry.cost,
+          entry.tokens.input, entry.tokens.output,
+          entry.tokens.cacheRead, entry.tokens.cacheCreation,
+          entry.model, entry.unpriced ? 1 : 0
+        );
+      }
+      this.db.prepare(`DELETE FROM rollup_dirty_stacks WHERE stack_id IN (${ph})`).run(...dirtyIds);
+    })();
+  }
+}

--- a/src/main/telemetry/types.ts
+++ b/src/main/telemetry/types.ts
@@ -16,18 +16,35 @@ export interface TokenCounts {
 /**
  * Summary of host orchestrator usage over a date range.
  * Costs are estimated at list price.
- * ticketsShipped and costPerTicket are null pending attribution (#466).
  */
 export interface TelemetrySummary {
-  monthCost: number;        // current calendar month, estimated USD
-  prevMonthCost: number;    // previous calendar month, estimated USD
-  tokens: TokenCounts;      // over the requested range
-  cacheHitPct: number;      // cache_read / (input + cache_read) × 100, over range
-  sessions: number;         // distinct session IDs over range
-  ticketsShipped: null;     // pending attribution (#466)
-  costPerTicket: null;      // pending attribution (#466)
-  unpricedModels: string[]; // models with no bundled price (cost returned as 0)
-  skippedLines: number;     // malformed JSONL lines skipped across all files
+  monthCost: number;              // current calendar month, estimated USD
+  prevMonthCost: number;          // previous calendar month, estimated USD
+  tokens: TokenCounts;            // over the requested range
+  cacheHitPct: number;            // cache_read / (input + cache_read) × 100, over range
+  sessions: number;               // distinct session IDs over range
+  ticketsShipped: number | null;  // tickets in 'merged' column or pr_created/pushed; null when not yet computed
+  costPerTicket: number | null;   // total ticket cost ÷ ticketsShipped; null when no tickets shipped
+  unpricedModels: string[];       // models with no bundled price (cost returned as 0)
+  skippedLines: number;           // malformed JSONL lines skipped across all files
+}
+
+/** Per-ticket cost and token attribution derived from tasks/stacks token columns. */
+export interface ByTicketEntry {
+  ticketId: string;       // ticket ID, or '__orchestrator__' for tasks with no ticket
+  title: string;          // ticket title from ticket_board, or ticketId as fallback
+  column: string | null;  // current kanban column; null for orchestrator bucket
+  model: string | null;   // primary model (highest output tokens across all tasks)
+  cost: number;           // estimated USD cost across all tasks for this ticket
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheCreation: number;
+  };
+  cacheHit: number;       // cache_read / (input + cache_read) × 100; 0 when all-zero
+  lifecycle: null;        // pending sub-issue 4
+  unpriced: boolean;      // true when any task used a model with no known price
 }
 
 export interface DailyEntry {

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -33,6 +33,7 @@ const {
   mockPersistRefinement,
   mockLoadRefinements,
   mockUsageEngine,
+  mockRollupStoreInstance,
 } = vi.hoisted(() => {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
   const mockSpawnSpecCheck = vi.fn();
@@ -57,6 +58,7 @@ const {
     deleteBoardTicket: vi.fn(),
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
     setDarkFactoryEnabled: vi.fn(),
+    getDb: vi.fn().mockReturnValue({}),
   };
 
   const mockStackManager = {
@@ -84,6 +86,7 @@ const {
     getWorkflowProgress: vi.fn(),
     resumeStackWithContinuation: vi.fn(),
     autoResolveConflicts: vi.fn(),
+    setOnTaskCompleted: vi.fn(),
   };
 
   const mockDockerRuntime = {
@@ -147,6 +150,15 @@ const {
     getSessions: vi.fn(),
   };
 
+  const mockRollupStoreInstance = {
+    getByTicket: vi.fn().mockReturnValue([]),
+    refresh: vi.fn(),
+    markStackDirty: vi.fn(),
+    markDirty: vi.fn(),
+    ticketsShipped: vi.fn().mockReturnValue(0),
+    totalTicketCost: vi.fn().mockReturnValue(0),
+  };
+
   return {
     registeredHandlers,
     mockRegistry,
@@ -171,6 +183,7 @@ const {
     mockPersistRefinement,
     mockLoadRefinements,
     mockUsageEngine,
+    mockRollupStoreInstance,
   };
 });
 
@@ -220,6 +233,10 @@ vi.mock('os', async (importOriginal) => {
 
 vi.mock('../../src/main/telemetry/usage-engine', () => ({
   createUsageEngine: vi.fn(() => mockUsageEngine),
+}));
+
+vi.mock('../../src/main/telemetry/rollup-store', () => ({
+  TicketRollupStore: vi.fn().mockImplementation(() => mockRollupStoreInstance),
 }));
 
 vi.mock('child_process', () => ({
@@ -574,7 +591,7 @@ describe('IPC Handlers', () => {
   describe('telemetry', () => {
     const range = { since: '2024-01-01', until: '2024-01-31' };
 
-    it('stats:telemetry:summary delegates to usageEngine.getSummary', async () => {
+    it('stats:telemetry:summary delegates to usageEngine.getSummary and enriches attribution', async () => {
       const summary = {
         monthCost: 12.5,
         prevMonthCost: 8.0,
@@ -588,12 +605,15 @@ describe('IPC Handlers', () => {
       };
       mockUsageEngine.getSummary.mockReturnValue(summary);
 
-      const result = await invokeHandler('stats:telemetry:summary', range);
-      expect(result).toEqual(summary);
+      const result = await invokeHandler('stats:telemetry:summary', range) as typeof summary;
       expect(mockUsageEngine.getSummary).toHaveBeenCalledWith(range);
+      // Attribution values come from rollup store (mocked to return 0)
+      expect(result.monthCost).toBe(12.5);
+      expect(result.ticketsShipped).toBe(0); // from rollupStore.ticketsShipped()
+      expect(result.costPerTicket).toBeNull(); // null when ticketsShipped = 0
     });
 
-    it('stats:telemetry:summary returns null for ticketsShipped and costPerTicket', async () => {
+    it('stats:telemetry:summary returns null for costPerTicket when no tickets shipped', async () => {
       mockUsageEngine.getSummary.mockReturnValue({
         monthCost: 0,
         prevMonthCost: 0,
@@ -607,8 +627,8 @@ describe('IPC Handlers', () => {
       });
 
       const result = await invokeHandler('stats:telemetry:summary', range) as { ticketsShipped: unknown; costPerTicket: unknown };
-      expect(result.ticketsShipped).toBeNull();
-      expect(result.costPerTicket).toBeNull();
+      expect(result.ticketsShipped).toBe(0); // rollupStore returns 0 shipped
+      expect(result.costPerTicket).toBeNull(); // null when 0 shipped
     });
 
     it('stats:telemetry:daily delegates to usageEngine.getDaily', async () => {
@@ -652,6 +672,35 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('stats:telemetry:session', range);
       expect(result).toEqual(sessions);
       expect(mockUsageEngine.getSessions).toHaveBeenCalledWith(range);
+    });
+
+    it('stats:telemetry:byTicket delegates to rollupStore.getByTicket and returns the array', async () => {
+      const entries = [
+        {
+          ticketId: 'T-42',
+          title: 'Fix the bug',
+          column: 'merged',
+          model: 'claude-opus-4-5',
+          cost: 2.5,
+          tokens: { input: 500, output: 200, cacheRead: 100, cacheCreation: 50 },
+          cacheHit: 16.7,
+          lifecycle: null,
+          unpriced: false,
+        },
+      ];
+      mockRollupStoreInstance.getByTicket.mockReturnValueOnce(entries);
+
+      const result = await invokeHandler('stats:telemetry:byTicket');
+
+      expect(mockRollupStoreInstance.getByTicket).toHaveBeenCalledOnce();
+      expect(result).toEqual(entries);
+    });
+
+    it('stats:telemetry:refresh triggers rollup rebuild and returns { ok: true }', async () => {
+      const result = await invokeHandler('stats:telemetry:refresh');
+
+      expect(mockRollupStoreInstance.refresh).toHaveBeenCalledOnce();
+      expect(result).toEqual({ ok: true });
     });
   });
 
@@ -2171,6 +2220,8 @@ describe('IPC Handlers', () => {
       'stats:telemetry:daily',
       'stats:telemetry:byModel',
       'stats:telemetry:session',
+      'stats:telemetry:byTicket',
+      'stats:telemetry:refresh',
     ];
 
     it('registers all expected IPC channels', () => {

--- a/tests/unit/refinement-streaming.test.ts
+++ b/tests/unit/refinement-streaming.test.ts
@@ -43,6 +43,17 @@ vi.mock('electron', () => ({
   },
 }));
 
+vi.mock('../../src/main/telemetry/rollup-store', () => ({
+  TicketRollupStore: vi.fn().mockImplementation(() => ({
+    getByTicket: vi.fn().mockReturnValue([]),
+    refresh: vi.fn(),
+    markStackDirty: vi.fn(),
+    markDirty: vi.fn(),
+    ticketsShipped: vi.fn().mockReturnValue(0),
+    totalTicketCost: vi.fn().mockReturnValue(0),
+  })),
+}));
+
 vi.mock('../../src/main/index', () => ({
   registry: {
     listProjects: vi.fn(),
@@ -50,6 +61,7 @@ vi.mock('../../src/main/index', () => ({
     removeProject: vi.fn(),
     getProject: vi.fn(),
     getPorts: vi.fn(),
+    getDb: vi.fn().mockReturnValue({}),
   },
   stackManager: {
     setOnStackUpdate: vi.fn(),
@@ -75,6 +87,7 @@ vi.mock('../../src/main/index', () => ({
     getRateLimitState: vi.fn(),
     getWorkflowProgress: vi.fn(),
     resumeStackWithContinuation: vi.fn(),
+    setOnTaskCompleted: vi.fn(),
   },
   dockerRuntime: {
     isAvailable: vi.fn(),

--- a/tests/unit/telemetry/attribution.test.ts
+++ b/tests/unit/telemetry/attribution.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { computeTicketRollups, countTicketsShipped, ORCHESTRATOR_TICKET_ID } from '../../../src/main/telemetry/attribution';
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE stacks (
+      id          TEXT PRIMARY KEY,
+      ticket      TEXT,
+      project_dir TEXT NOT NULL DEFAULT '/proj',
+      status      TEXT NOT NULL DEFAULT 'completed'
+    );
+    CREATE TABLE tasks (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      stack_id             TEXT NOT NULL REFERENCES stacks(id) ON DELETE CASCADE,
+      input_tokens         INTEGER NOT NULL DEFAULT 0,
+      output_tokens        INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens    INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      resolved_model       TEXT
+    );
+    CREATE TABLE stack_history (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      stack_id     TEXT NOT NULL,
+      ticket       TEXT,
+      task_history TEXT,
+      final_status TEXT NOT NULL DEFAULT 'completed'
+    );
+    CREATE TABLE ticket_board (
+      ticket_id   TEXT NOT NULL,
+      project_dir TEXT NOT NULL,
+      column      TEXT NOT NULL DEFAULT 'backlog',
+      title       TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (ticket_id, project_dir)
+    );
+  `);
+  return db;
+}
+
+describe('computeTicketRollups', () => {
+  let db: Database.Database;
+
+  beforeEach(() => { db = makeDb(); });
+  afterEach(() => { db.close(); });
+
+  it('returns empty array when no tasks exist', () => {
+    expect(computeTicketRollups(db)).toEqual([]);
+  });
+
+  it('attributes live tasks to ticket via stacks join', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-1')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 1000, 500, 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].ticketId).toBe('TICKET-1');
+    expect(rollups[0].tokens.input).toBe(1000);
+    expect(rollups[0].tokens.output).toBe(500);
+    expect(rollups[0].cost).toBeGreaterThan(0);
+  });
+
+  it('rolls tasks with null ticket into orchestrator bucket', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', NULL)`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 500, 200, 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
+    expect(rollups[0].title).toBe('Orchestrator / ad-hoc');
+    expect(rollups[0].column).toBeNull();
+  });
+
+  it('attributes post-teardown tasks from stack_history.task_history', () => {
+    const taskHistory = JSON.stringify([{
+      input_tokens: 2000,
+      output_tokens: 1000,
+      cache_read_tokens: 500,
+      cache_creation_tokens: 100,
+      resolved_model: 'claude-sonnet-4-5',
+    }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s-archived', 'TICKET-2', '${taskHistory}')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].ticketId).toBe('TICKET-2');
+    expect(rollups[0].tokens.input).toBe(2000);
+    expect(rollups[0].tokens.cacheRead).toBe(500);
+  });
+
+  it('merges live and historical tasks for the same ticket', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-3')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 300, 100, 'claude-sonnet-4-5')`);
+    const hist = JSON.stringify([{ input_tokens: 700, output_tokens: 200, resolved_model: 'claude-sonnet-4-5' }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s2', 'TICKET-3', '${hist}')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].tokens.input).toBe(1000);
+  });
+
+  it('handles null ticket in stack_history — rolls up under orchestrator', () => {
+    const hist = JSON.stringify([{ input_tokens: 100, output_tokens: 50, resolved_model: 'claude-haiku-4-5' }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s-hist', NULL, '${hist}')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
+  });
+
+  it('computes cacheHit correctly', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-4')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, cache_read_tokens, resolved_model) VALUES ('s1', 900, 100, 100, 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    // cacheHit = 100 / (900 + 100) * 100 = 10%
+    expect(rollups[0].cacheHit).toBeCloseTo(10, 5);
+  });
+
+  it('returns cacheHit = 0 for all-zero-token ticket (division-by-zero guard)', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-5')`);
+    db.exec(`INSERT INTO tasks (stack_id, resolved_model) VALUES ('s1', 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].cacheHit).toBe(0);
+    expect(Number.isNaN(rollups[0].cacheHit)).toBe(false);
+  });
+
+  it('returns cacheHit = 0 for historical pre-capture tasks (cache columns at DEFAULT 0)', () => {
+    // Historical tasks have no cc/cr data — DEFAULT 0 means cacheHit = 0
+    const hist = JSON.stringify([{ input_tokens: 500, output_tokens: 200, resolved_model: 'claude-sonnet-4-5' }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s1', 'TICKET-PRE', '${hist}')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].cacheHit).toBe(0);
+  });
+
+  it('selects primary model as the one with highest output tokens', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-6')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-haiku-4-5')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 500, 300, 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].model).toBe('claude-sonnet-4-5');
+  });
+
+  it('enriches title and column from ticket_board', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-7')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-sonnet-4-5')`);
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('TICKET-7', '/proj', 'pr_open', 'My Feature')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].title).toBe('My Feature');
+    expect(rollups[0].column).toBe('pr_open');
+  });
+
+  it('places orchestrator bucket last in sorted output', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-A'), ('s2', NULL)`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 1000, 500, 'claude-sonnet-4-5')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s2', 500, 200, 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[rollups.length - 1].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
+  });
+
+  it('marks unpriced=true for unknown model', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-U')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'unknown-model-xyz')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].unpriced).toBe(true);
+    expect(rollups[0].cost).toBe(0);
+  });
+
+  it('lifecycle is null (pending sub-issue 4)', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-L')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-sonnet-4-5')`);
+    const rollups = computeTicketRollups(db);
+    expect(rollups[0].lifecycle).toBeNull();
+  });
+});
+
+describe('countTicketsShipped', () => {
+  let db: Database.Database;
+
+  beforeEach(() => { db = makeDb(); });
+  afterEach(() => { db.close(); });
+
+  it('returns 0 when no tickets are shipped', () => {
+    expect(countTicketsShipped(db)).toBe(0);
+  });
+
+  it('counts tickets with column=merged in ticket_board', () => {
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('T-1', '/proj', 'merged', 'Done')`);
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('T-2', '/proj', 'pr_open', 'In flight')`);
+    expect(countTicketsShipped(db)).toBe(1);
+  });
+
+  it('counts stacks with pr_created/pushed status that have no board row', () => {
+    db.exec(`INSERT INTO stacks (id, ticket, status) VALUES ('s1', 'T-PUSHED', 'pushed')`);
+    db.exec(`INSERT INTO stacks (id, ticket, status) VALUES ('s2', 'T-PR', 'pr_created')`);
+    expect(countTicketsShipped(db)).toBe(2);
+  });
+
+  it('does not double-count tickets that appear in both board and stacks', () => {
+    db.exec(`INSERT INTO stacks (id, ticket, status) VALUES ('s1', 'T-BOTH', 'pushed')`);
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('T-BOTH', '/proj', 'merged', 'Done')`);
+    expect(countTicketsShipped(db)).toBe(1);
+  });
+
+  it('counts archived stacks with pr_created/pushed final_status that have no board row', () => {
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s-old', 'T-ARCHIVED', 'pushed')`);
+    expect(countTicketsShipped(db)).toBe(1);
+  });
+
+  it('counts both pr_created and pushed final_status in stack_history', () => {
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s1', 'T-PUSHED', 'pushed')`);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s2', 'T-PR', 'pr_created')`);
+    expect(countTicketsShipped(db)).toBe(2);
+  });
+
+  it('does not count archived stacks with non-shipped final_status', () => {
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s1', 'T-FAIL', 'failed')`);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s2', 'T-COMP', 'completed')`);
+    expect(countTicketsShipped(db)).toBe(0);
+  });
+
+  it('does not double-count a ticket in stack_history that already has a merged board row', () => {
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s-old', 'T-BOARD', 'pushed')`);
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('T-BOARD', '/proj', 'merged', 'Done')`);
+    expect(countTicketsShipped(db)).toBe(1);
+  });
+
+  it('does not double-count a ticket in both live stacks and stack_history', () => {
+    db.exec(`INSERT INTO stacks (id, ticket, status) VALUES ('s-live', 'T-DUP', 'pushed')`);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, final_status) VALUES ('s-old', 'T-DUP', 'pushed')`);
+    expect(countTicketsShipped(db)).toBe(1);
+  });
+});

--- a/tests/unit/telemetry/rollup-store.test.ts
+++ b/tests/unit/telemetry/rollup-store.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { TicketRollupStore } from '../../../src/main/telemetry/rollup-store';
+import { ORCHESTRATOR_TICKET_ID } from '../../../src/main/telemetry/attribution';
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE stacks (
+      id          TEXT PRIMARY KEY,
+      ticket      TEXT,
+      project_dir TEXT NOT NULL DEFAULT '/proj',
+      status      TEXT NOT NULL DEFAULT 'completed'
+    );
+    CREATE TABLE tasks (
+      id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+      stack_id              TEXT NOT NULL REFERENCES stacks(id) ON DELETE CASCADE,
+      input_tokens          INTEGER NOT NULL DEFAULT 0,
+      output_tokens         INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      resolved_model        TEXT
+    );
+    CREATE TABLE stack_history (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      stack_id     TEXT NOT NULL,
+      ticket       TEXT,
+      task_history TEXT,
+      final_status TEXT NOT NULL DEFAULT 'completed'
+    );
+    CREATE TABLE ticket_board (
+      ticket_id   TEXT NOT NULL,
+      project_dir TEXT NOT NULL,
+      column      TEXT NOT NULL DEFAULT 'backlog',
+      title       TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (ticket_id, project_dir)
+    );
+    CREATE TABLE ticket_rollups (
+      ticket_id            TEXT PRIMARY KEY,
+      title                TEXT NOT NULL DEFAULT '',
+      column               TEXT,
+      total_cost           REAL NOT NULL DEFAULT 0,
+      total_input_tokens   INTEGER NOT NULL DEFAULT 0,
+      total_output_tokens  INTEGER NOT NULL DEFAULT 0,
+      total_cache_read     INTEGER NOT NULL DEFAULT 0,
+      total_cache_creation INTEGER NOT NULL DEFAULT 0,
+      primary_model        TEXT,
+      unpriced             INTEGER NOT NULL DEFAULT 0,
+      computed_at          TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE rollup_dirty_stacks (
+      stack_id  TEXT PRIMARY KEY,
+      marked_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  return db;
+}
+
+describe('TicketRollupStore', () => {
+  let db: Database.Database;
+  let store: TicketRollupStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new TicketRollupStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('works with rollup tables pre-created by registry migrations', () => {
+    const tables = (db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name IN ('ticket_rollups','rollup_dirty_stacks')
+    `).all() as { name: string }[]).map(r => r.name).sort();
+    expect(tables).toEqual(['rollup_dirty_stacks', 'ticket_rollups']);
+  });
+
+  it('returns empty array when no data exists', () => {
+    expect(store.getByTicket()).toEqual([]);
+  });
+
+  it('getByTicket triggers a refresh when dirty stacks exist', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-1')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 500, 200, 'claude-sonnet-4-5')`);
+    store.markStackDirty('s1');
+
+    const rollups = store.getByTicket();
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].ticketId).toBe('TICKET-1');
+  });
+
+  it('serves from cache after initial refresh (dirty_stacks is cleared)', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-2')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    // No dirty stacks — should serve from cache
+    const dirtyCount = (db.prepare('SELECT COUNT(*) AS n FROM rollup_dirty_stacks').get() as { n: number }).n;
+    expect(dirtyCount).toBe(0);
+
+    const rollups = store.getByTicket();
+    expect(rollups).toHaveLength(1);
+  });
+
+  it('refresh() rebuilds rollups from scratch', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-3')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 1000, 500, 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    const rollups = store.getByTicket();
+    expect(rollups[0].tokens.input).toBe(1000);
+  });
+
+  it('rollups persist across simulated teardown (stack_history)', () => {
+    // Simulate archival: stack_history has the historical tasks
+    const hist = JSON.stringify([{
+      input_tokens: 3000,
+      output_tokens: 1500,
+      cache_read_tokens: 500,
+      cache_creation_tokens: 0,
+      resolved_model: 'claude-sonnet-4-5',
+    }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s-old', 'TICKET-HIST', '${hist}')`);
+    store.refresh();
+
+    const rollups = store.getByTicket();
+    expect(rollups[0].ticketId).toBe('TICKET-HIST');
+    expect(rollups[0].tokens.input).toBe(3000);
+    expect(rollups[0].tokens.cacheRead).toBe(500);
+  });
+
+  it('incremental dirty-stack re-derive: only re-computes when dirty', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-INC')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 200, 100, 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    // Simulate new task tokens — mark dirty
+    store.markStackDirty('s1');
+    db.exec(`UPDATE tasks SET input_tokens = 400, output_tokens = 200 WHERE stack_id = 's1'`);
+
+    const rollups = store.getByTicket();
+    expect(rollups[0].tokens.input).toBe(400);
+  });
+
+  it('markDirty() (for board moves) triggers refresh on next getByTicket', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-B')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-sonnet-4-5')`);
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('TICKET-B', '/proj', 'pr_open', 'Board Ticket')`);
+    store.refresh();
+
+    // Simulate board move to merged
+    db.exec(`UPDATE ticket_board SET column = 'merged' WHERE ticket_id = 'TICKET-B'`);
+    store.markDirty();
+
+    const rollups = store.getByTicket();
+    expect(rollups[0].column).toBe('merged');
+  });
+
+  it('cacheHit is 0 for all-zero-token ticket (division-by-zero guard)', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-ZERO')`);
+    db.exec(`INSERT INTO tasks (stack_id, resolved_model) VALUES ('s1', 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    const rollups = store.getByTicket();
+    expect(rollups[0].cacheHit).toBe(0);
+    expect(Number.isNaN(rollups[0].cacheHit)).toBe(false);
+  });
+
+  it('cacheHit is 0 for historical pre-capture tasks (cache_read_tokens DEFAULT 0)', () => {
+    const hist = JSON.stringify([{ input_tokens: 500, output_tokens: 200, resolved_model: 'claude-sonnet-4-5' }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s1', 'TICKET-PRE', '${hist}')`);
+    store.refresh();
+
+    const rollups = store.getByTicket();
+    expect(rollups[0].cacheHit).toBe(0);
+  });
+
+  it('mixed ticket: pre-capture and post-capture tasks blend cacheHit correctly', () => {
+    // Historical task: no cache tokens
+    const hist = JSON.stringify([{ input_tokens: 500, output_tokens: 200, resolved_model: 'claude-sonnet-4-5' }]);
+    db.exec(`INSERT INTO stack_history (stack_id, ticket, task_history) VALUES ('s-old', 'TICKET-MIX', '${hist}')`);
+
+    // Live task: has cache tokens
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s-live', 'TICKET-MIX')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, cache_read_tokens, resolved_model) VALUES ('s-live', 500, 200, 200, 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    const rollups = store.getByTicket();
+    // Total input = 1000, total cache_read = 200
+    // cacheHit = 200 / (1000 + 200) * 100 ≈ 16.67%
+    expect(rollups[0].cacheHit).toBeCloseTo(200 / 1200 * 100, 3);
+  });
+
+  it('orchestrator bucket appears last', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-A'), ('s2', NULL)`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 1000, 500, 'claude-sonnet-4-5')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s2', 500, 200, 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    const rollups = store.getByTicket();
+    expect(rollups[rollups.length - 1].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
+  });
+
+  it('ticketsShipped() counts merged-column tickets', () => {
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('T-DONE', '/proj', 'merged', 'Done')`);
+    db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('T-WIP', '/proj', 'in_stack', 'WIP')`);
+    expect(store.ticketsShipped()).toBe(1);
+  });
+
+  it('totalTicketCost() excludes orchestrator bucket', () => {
+    db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-COST'), ('s2', NULL)`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 1000, 500, 'claude-sonnet-4-5')`);
+    db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s2', 500, 200, 'claude-sonnet-4-5')`);
+    store.refresh();
+
+    const orcCost = store.totalTicketCost();
+    // Only TICKET-COST's cost; orchestrator excluded
+    const allRollups = store.getByTicket();
+    const ticketCost = allRollups.find(r => r.ticketId === 'TICKET-COST')?.cost ?? 0;
+    expect(orcCost).toBeCloseTo(ticketCost, 10);
+  });
+});

--- a/tests/unit/token-parser.test.ts
+++ b/tests/unit/token-parser.test.ts
@@ -263,6 +263,8 @@ describe('parsePhaseTokenTotals', () => {
     const result = parsePhaseTokenTotals('');
     expect(result.input_tokens).toBe(0);
     expect(result.output_tokens).toBe(0);
+    expect(result.cache_creation_tokens).toBe(0);
+    expect(result.cache_read_tokens).toBe(0);
   });
 
   it('returns zeros for non-JSON input', () => {
@@ -275,6 +277,8 @@ describe('parsePhaseTokenTotals', () => {
     const result = parsePhaseTokenTotals('{"in":1500,"out":800}\n');
     expect(result.input_tokens).toBe(1500);
     expect(result.output_tokens).toBe(800);
+    expect(result.cache_creation_tokens).toBe(0);
+    expect(result.cache_read_tokens).toBe(0);
   });
 
   it('sums multiple token lines', () => {
@@ -287,6 +291,33 @@ describe('parsePhaseTokenTotals', () => {
     const result = parsePhaseTokenTotals(output);
     expect(result.input_tokens).toBe(3500);
     expect(result.output_tokens).toBe(1700);
+  });
+
+  it('parses cc and cr cache fields from token-counter.sh output', () => {
+    const output = [
+      '{"in":1000,"out":500,"cc":200,"cr":800}',
+      '{"in":500,"out":100,"cc":100,"cr":400}',
+    ].join('\n');
+    const result = parsePhaseTokenTotals(output);
+    expect(result.cache_creation_tokens).toBe(300);
+    expect(result.cache_read_tokens).toBe(1200);
+  });
+
+  it('ignores cc/cr on partial entries', () => {
+    const output = [
+      '{"in":100,"out":0,"cc":500,"cr":1000,"partial":true}',
+      '{"in":100,"out":50,"cc":500,"cr":1000}',
+    ].join('\n');
+    const result = parsePhaseTokenTotals(output);
+    // Only the non-partial result entry contributes
+    expect(result.cache_creation_tokens).toBe(500);
+    expect(result.cache_read_tokens).toBe(1000);
+  });
+
+  it('defaults cc/cr to 0 when absent (legacy lines)', () => {
+    const result = parsePhaseTokenTotals('{"in":100,"out":50}\n');
+    expect(result.cache_creation_tokens).toBe(0);
+    expect(result.cache_read_tokens).toBe(0);
   });
 
   it('handles mixed valid and invalid lines', () => {
@@ -330,6 +361,8 @@ describe('parsePhaseTokenSteps', () => {
       phase: 'execution',
       input_tokens: 1000,
       output_tokens: 500,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
     });
   });
 
@@ -342,6 +375,8 @@ describe('parsePhaseTokenSteps', () => {
       phase: 'review',
       input_tokens: 800,
       output_tokens: 300,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
     });
   });
 
@@ -368,10 +403,10 @@ describe('parsePhaseTokenSteps', () => {
     const result = parsePhaseTokenSteps(execOutput, reviewOutput);
     expect(result).toHaveLength(4);
     // Sorted: iter1-exec, iter1-review, iter2-exec, iter2-review
-    expect(result[0]).toEqual({ iteration: 1, phase: 'execution', input_tokens: 1000, output_tokens: 500 });
-    expect(result[1]).toEqual({ iteration: 1, phase: 'review', input_tokens: 600, output_tokens: 200 });
-    expect(result[2]).toEqual({ iteration: 2, phase: 'execution', input_tokens: 800, output_tokens: 400 });
-    expect(result[3]).toEqual({ iteration: 2, phase: 'review', input_tokens: 500, output_tokens: 150 });
+    expect(result[0]).toEqual({ iteration: 1, phase: 'execution', input_tokens: 1000, output_tokens: 500, cache_creation_tokens: 0, cache_read_tokens: 0 });
+    expect(result[1]).toEqual({ iteration: 1, phase: 'review', input_tokens: 600, output_tokens: 200, cache_creation_tokens: 0, cache_read_tokens: 0 });
+    expect(result[2]).toEqual({ iteration: 2, phase: 'execution', input_tokens: 800, output_tokens: 400, cache_creation_tokens: 0, cache_read_tokens: 0 });
+    expect(result[3]).toEqual({ iteration: 2, phase: 'review', input_tokens: 500, output_tokens: 150, cache_creation_tokens: 0, cache_read_tokens: 0 });
   });
 
   it('falls back to default phase and iteration 1 for legacy lines', () => {
@@ -379,8 +414,8 @@ describe('parsePhaseTokenSteps', () => {
     const reviewOutput = '{"in":600,"out":200}\n';
     const result = parsePhaseTokenSteps(execOutput, reviewOutput);
     expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ iteration: 1, phase: 'execution', input_tokens: 1000, output_tokens: 500 });
-    expect(result[1]).toEqual({ iteration: 1, phase: 'review', input_tokens: 600, output_tokens: 200 });
+    expect(result[0]).toEqual({ iteration: 1, phase: 'execution', input_tokens: 1000, output_tokens: 500, cache_creation_tokens: 0, cache_read_tokens: 0 });
+    expect(result[1]).toEqual({ iteration: 1, phase: 'review', input_tokens: 600, output_tokens: 200, cache_creation_tokens: 0, cache_read_tokens: 0 });
   });
 
   it('sorts by iteration then phase order (execution < review < verify)', () => {
@@ -462,6 +497,8 @@ describe('parsePhaseTokenSteps', () => {
       phase: 'execution',
       input_tokens: 2000,
       output_tokens: 0,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
     });
   });
 
@@ -488,8 +525,8 @@ describe('parsePhaseTokenSteps', () => {
     const reviewOutput = '{"in":800,"out":300,"iter":1,"phase":"review"}\n';
     const result = parsePhaseTokenSteps(execOutput, reviewOutput);
     expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ iteration: 1, phase: 'execution', input_tokens: 2500, output_tokens: 400 });
-    expect(result[1]).toEqual({ iteration: 1, phase: 'review', input_tokens: 800, output_tokens: 300 });
+    expect(result[0]).toEqual({ iteration: 1, phase: 'execution', input_tokens: 2500, output_tokens: 400, cache_creation_tokens: 0, cache_read_tokens: 0 });
+    expect(result[1]).toEqual({ iteration: 1, phase: 'review', input_tokens: 800, output_tokens: 300, cache_creation_tokens: 0, cache_read_tokens: 0 });
   });
 
   it('skips zero-token partial entries', () => {
@@ -502,6 +539,53 @@ describe('parsePhaseTokenSteps', () => {
     expect(result).toHaveLength(1);
     expect(result[0].input_tokens).toBe(500);
     expect(result[0].output_tokens).toBe(200);
+  });
+
+  it('parses cc and cr cache fields and sums them across API turns', () => {
+    const execOutput = [
+      '{"in":1000,"out":500,"cc":200,"cr":800,"iter":1,"phase":"execution"}',
+      '{"in":500,"out":200,"cc":100,"cr":300,"iter":1,"phase":"execution"}',
+    ].join('\n');
+    const result = parsePhaseTokenSteps(execOutput, '');
+    expect(result).toHaveLength(1);
+    expect(result[0].input_tokens).toBe(1500);
+    expect(result[0].output_tokens).toBe(700);
+    expect(result[0].cache_creation_tokens).toBe(300);
+    expect(result[0].cache_read_tokens).toBe(1100);
+  });
+
+  it('tracks latest partial cc/cr per key — same pattern as input/output', () => {
+    // Multiple partials: only the last matters; result then supersedes it
+    const execOutput = [
+      '{"in":500,"out":0,"cc":100,"cr":200,"iter":1,"phase":"execution","partial":true}',
+      '{"in":500,"out":200,"cc":150,"cr":300,"iter":1,"phase":"execution","partial":true}',
+      '{"in":500,"out":200,"cc":150,"cr":300,"iter":1,"phase":"execution"}',
+    ].join('\n');
+    const result = parsePhaseTokenSteps(execOutput, '');
+    expect(result).toHaveLength(1);
+    // Only the result entry counts — partial is reset when result arrives
+    expect(result[0].cache_creation_tokens).toBe(150);
+    expect(result[0].cache_read_tokens).toBe(300);
+  });
+
+  it('defaults cache fields to 0 when absent (legacy lines without cc/cr)', () => {
+    const execOutput = '{"in":1000,"out":500,"iter":1,"phase":"execution"}\n';
+    const result = parsePhaseTokenSteps(execOutput, '');
+    expect(result).toHaveLength(1);
+    expect(result[0].cache_creation_tokens).toBe(0);
+    expect(result[0].cache_read_tokens).toBe(0);
+  });
+
+  it('adds latest partial cache fields to completed totals for multi-turn phases', () => {
+    // Turn 1 complete with cache, Turn 2 in progress (partial) with cache
+    const execOutput = [
+      '{"in":500,"out":200,"cc":100,"cr":400,"iter":1,"phase":"execution"}',
+      '{"in":800,"out":0,"cc":200,"cr":600,"iter":1,"phase":"execution","partial":true}',
+    ].join('\n');
+    const result = parsePhaseTokenSteps(execOutput, '');
+    expect(result).toHaveLength(1);
+    expect(result[0].cache_creation_tokens).toBe(300);
+    expect(result[0].cache_read_tokens).toBe(1000);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements per-ticket cost/token attribution for the telemetry view (#466), which previously returned `ticketsShipped` and `costPerTicket` as hardcoded `null`.

Cache tokens are now captured end-to-end: `token-counter.sh` emits `cc`/`cr` (cache creation/read) fields from the Claude stream, the token parser and task-watcher carry them through, and the registry persists them per-task and as stack aggregates (schema v18). This enables an accurate per-ticket cache-hit rate.

A new `TicketRollupStore` (schema v19: `ticket_rollups` + `rollup_dirty_stacks`) caches per-ticket cost/token rollups in SQLite so per-ticket and per-model views stay fast and survive stack teardown. Attribution unions live `stacks` with archived `stack_history`, so a ticket's totals remain correct after its stack is torn down. A ticket counts as shipped when it's in the `merged` column or its (possibly archived) stack reached `pr_created`/`pushed`.

The cache auto-invalidates incrementally: archiving a stack, completing a task, or moving a ticket to `merged` marks the relevant stacks dirty via callbacks wired in `ipc.ts`, and the next read reconciles only the affected tickets (a `__board__` sentinel forces a full refresh when board columns change). Two new IPC handlers expose the data: `stats:telemetry:byTicket` and `stats:telemetry:refresh`; the existing summary handler now returns real `ticketsShipped` and `costPerTicket`.

## QA plan

1. Run a stack through a ticket to completion (execution + review) and confirm the task's token row now records non-zero `cache_read_tokens`/`cache_creation_tokens`.
2. Open the telemetry/stats view and confirm the summary shows a real `ticketsShipped` count and a `costPerTicket` value (not null) once at least one ticket has been merged or its stack reached pr_created/pushed.
3. Move a ticket to the `merged` column and confirm `ticketsShipped` increments after a refresh.
4. Inspect the per-ticket breakdown (`stats:telemetry:byTicket`) and verify each ticket shows cost, token totals, primary model, and a plausible cache-hit percentage; tasks with no ticket roll up under the orchestrator bucket.
5. Tear down a stack for a ticket and confirm that ticket's totals persist in the per-ticket view (sourced from stack history) rather than dropping to zero.
6. Trigger `stats:telemetry:refresh` and confirm totals are unchanged (idempotent) and that only dirtied tickets were recomputed.

Closes #466