### PR TITLE
[467] fix: attribute per-ticket usage from stack transcripts

### DIFF
--- a/sandstorm-cli/lib/init.sh
+++ b/sandstorm-cli/lib/init.sh
@@ -341,6 +341,7 @@ HEADER
     volumes:
       - \${SANDSTORM_WORKSPACE}:/app
       - \${SANDSTORM_CONTEXT}:/sandstorm-context:ro
+      - \${SANDSTORM_USAGE_DIR}/\${SANDSTORM_STACK_ID}:/home/claude/.claude/projects
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -215,9 +215,15 @@ run_compose() {
   local context_dir="$PROJECT_ROOT/.sandstorm/context"
   mkdir -p "$context_dir"
 
+  # Ensure per-stack usage dir exists so the transcript mount can bind
+  local usage_dir="$PROJECT_ROOT/.sandstorm/usage"
+  mkdir -p "$usage_dir/$STACK_ID"
+  chmod 777 "$usage_dir/$STACK_ID"
+
   SANDSTORM_DIR="$SANDSTORM_DIR" \
   SANDSTORM_WORKSPACE="$WORKSPACE" \
   SANDSTORM_CONTEXT="$context_dir" \
+  SANDSTORM_USAGE_DIR="$usage_dir" \
   SANDSTORM_PROJECT="$COMPOSE_PROJECT" \
   SANDSTORM_STACK_ID="$STACK_ID" \
   GIT_USER_NAME="$GIT_AUTHOR_NAME" \

--- a/src/main/compose-generator.ts
+++ b/src/main/compose-generator.ts
@@ -255,6 +255,7 @@ export function generateComposeYaml(analysis: ComposeAnalysis): string {
   lines.push('    volumes:');
   lines.push('      - ${SANDSTORM_WORKSPACE}:/app');
   lines.push('      - ${SANDSTORM_CONTEXT}:/sandstorm-context:ro');
+  lines.push('      - ${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects');
   lines.push('      - /var/run/docker.sock:/var/run/docker.sock');
   lines.push('    healthcheck:');
   lines.push('      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]');

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -358,12 +358,38 @@ export class StackManager {
       runtime: opts.runtime,
     });
 
+    // Write the stackId→ticket manifest before launching the build so telemetry
+    // readers can resolve ticket attribution as soon as transcripts appear.
+    this.writeStackManifest(opts.name, opts.ticket ?? null, projectName, opts.projectDir);
+
     // Launch the heavy work in the background
     this.buildStackInBackground(opts, projectName).catch(() => {
       // Error already stored in registry by buildStackInBackground
     });
 
     return stack;
+  }
+
+  private writeStackManifest(
+    stackId: string,
+    ticket: string | null,
+    project: string,
+    projectDir: string
+  ): void {
+    try {
+      const usageDir = path.join(projectDir, '.sandstorm', 'usage');
+      fs.mkdirSync(usageDir, { recursive: true });
+      const manifestPath = path.join(usageDir, `${stackId}.manifest.json`);
+      const manifest = {
+        stackId,
+        ticket,
+        project,
+        createdAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    } catch {
+      // Non-fatal — telemetry degrades to ticket=null for this stack
+    }
   }
 
   /**

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -391,6 +391,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
             '      - SANDSTORM_STACK_ID',
             '    volumes:',
             '      - ${SANDSTORM_WORKSPACE}:/app',
+            '      - ${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects',
             '      - /var/run/docker.sock:/var/run/docker.sock',
             '    healthcheck:',
             '      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]',
@@ -763,10 +764,6 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Telemetry (host orchestrator usage + per-ticket attribution) ---
 
-  const hostEngine = createUsageEngine(
-    os.homedir() + '/.claude/projects'
-  );
-
   const rollupStore = new TicketRollupStore(registry.getDb());
 
   // Wire auto-invalidation hooks so the rollup cache stays fresh
@@ -776,8 +773,29 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   };
   stackManager.setOnTaskCompleted((stackId) => rollupStore.markStackDirty(stackId));
 
+  /** Build the set of transcript roots on each request: host root + all stack usage dirs. */
+  function buildTelemetryRoots(): string[] {
+    const hostRoot = os.homedir() + '/.claude/projects';
+    const stackRoots: string[] = [];
+    for (const project of registry.listProjects()) {
+      const usageDir = path.join(project.directory, '.sandstorm', 'usage');
+      try {
+        const entries = fs.readdirSync(usageDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            stackRoots.push(path.join(usageDir, entry.name));
+          }
+        }
+      } catch {
+        // usage dir doesn't exist yet — skip
+      }
+    }
+    return [hostRoot, ...stackRoots];
+  }
+
   ipcMain.handle('stats:telemetry:summary', async (_event, range: DateRange) => {
-    const summary = hostEngine.getSummary(range);
+    const engine = createUsageEngine(buildTelemetryRoots());
+    const summary = engine.getSummary(range);
     const shipped = rollupStore.ticketsShipped();
     const totalCost = rollupStore.totalTicketCost();
     return {
@@ -788,19 +806,19 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle('stats:telemetry:daily', async (_event, range: DateRange) => {
-    return hostEngine.getDaily(range);
+    return createUsageEngine(buildTelemetryRoots()).getDaily(range);
   });
 
   ipcMain.handle('stats:telemetry:byModel', async (_event, range: DateRange) => {
-    return hostEngine.getByModel(range);
+    return createUsageEngine(buildTelemetryRoots()).getByModel(range);
   });
 
   ipcMain.handle('stats:telemetry:session', async (_event, range: DateRange) => {
-    return hostEngine.getSessions(range);
+    return createUsageEngine(buildTelemetryRoots()).getSessions(range);
   });
 
   ipcMain.handle('stats:telemetry:byTicket', async () => {
-    return rollupStore.getByTicket();
+    return createUsageEngine(buildTelemetryRoots()).getByTicket();
   });
 
   ipcMain.handle('stats:telemetry:refresh', async () => {

--- a/src/main/telemetry/aggregator.ts
+++ b/src/main/telemetry/aggregator.ts
@@ -3,9 +3,11 @@
  * Accepts parsed RawUsageEntry arrays and produces the shapes consumed by IPC handlers.
  */
 
+import fs from 'fs';
+import path from 'path';
 import { computeCost } from './pricing';
 import type { RawUsageEntry } from './parser';
-import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry } from './types';
+import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, TranscriptByTicketEntry } from './types';
 
 function dateOf(isoTimestamp: string): string {
   return isoTimestamp.slice(0, 10); // YYYY-MM-DD
@@ -218,3 +220,80 @@ export function aggregateSessions(entries: RawUsageEntry[], range: DateRange): S
     })
     .sort((a, b) => b.start.localeCompare(a.start));
 }
+
+interface StackManifest {
+  stackId: string;
+  ticket: string | null;
+  project: string;
+  createdAt: string;
+}
+
+function readManifest(manifestPath: string): StackManifest | null {
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    if (typeof parsed.stackId !== 'string') return null;
+    return parsed as StackManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Aggregate entries by ticket, reading stack manifests to resolve stackId → ticket.
+ * stackRoots are the stack-specific dirs (e.g. <project>/.sandstorm/usage/<stackId>).
+ * The paired manifest is at stackRoot + '.manifest.json'.
+ * Entries with no mapped ticket (host-root entries or missing manifest) fall into ticket=null.
+ */
+export function aggregateByTicket(
+  entries: RawUsageEntry[],
+  stackRoots: string[]
+): TranscriptByTicketEntry[] {
+  // Build stackId → ticket map from manifests
+  const stackToTicket = new Map<string, string | null>();
+  for (const root of stackRoots) {
+    const manifestPath = root + '.manifest.json';
+    const manifest = readManifest(manifestPath);
+    if (manifest) {
+      stackToTicket.set(manifest.stackId, manifest.ticket ?? null);
+    }
+  }
+
+  // Group entries by (ticket, stackId)
+  const byKey = new Map<string, {
+    ticket: string | null;
+    stackId: string | null;
+    tokens: TokenCounts;
+    sessions: Set<string>;
+    cost: number;
+  }>();
+
+  for (const entry of entries) {
+    const ticket = entry.stackId != null ? (stackToTicket.get(entry.stackId) ?? null) : null;
+    const key = `${ticket ?? '__null__'}::${entry.stackId ?? '__null__'}`;
+
+    if (!byKey.has(key)) {
+      byKey.set(key, { ticket, stackId: entry.stackId, tokens: zeroTokens(), sessions: new Set(), cost: 0 });
+    }
+    const bucket = byKey.get(key)!;
+    addTokens(bucket.tokens, entry);
+    bucket.sessions.add(entry.sessionId);
+    const { cost } = computeCost(entry.model, {
+      input: entry.input,
+      output: entry.output,
+      cacheCreate: entry.cacheCreate,
+      cacheRead: entry.cacheRead,
+    });
+    bucket.cost += cost;
+  }
+
+  return [...byKey.values()].map((data) => ({
+    ticket: data.ticket,
+    stackId: data.stackId,
+    tokens: data.tokens,
+    cost: data.cost,
+    sessions: data.sessions.size,
+  }));
+}
+

--- a/src/main/telemetry/parser.ts
+++ b/src/main/telemetry/parser.ts
@@ -14,6 +14,7 @@ export interface RawUsageEntry {
   output: number;
   cacheCreate: number;
   cacheRead: number;
+  stackId: string | null; // basename of stack root dir; null for host-root entries
 }
 
 export interface ParseResult {
@@ -22,7 +23,7 @@ export interface ParseResult {
 }
 
 /** Extract usage entry from a parsed JSON object, returning null if not a usage record. */
-function extractUsage(obj: Record<string, unknown>): RawUsageEntry | null {
+function extractUsage(obj: Record<string, unknown>, stackId: string | null): RawUsageEntry | null {
   const sessionId = obj.sessionId;
   const timestamp = obj.timestamp;
   if (typeof sessionId !== 'string' || typeof timestamp !== 'string') return null;
@@ -39,6 +40,7 @@ function extractUsage(obj: Record<string, unknown>): RawUsageEntry | null {
         output: typeof u.output_tokens === 'number' ? u.output_tokens : 0,
         cacheCreate: typeof u.cache_creation_input_tokens === 'number' ? u.cache_creation_input_tokens : 0,
         cacheRead: typeof u.cache_read_input_tokens === 'number' ? u.cache_read_input_tokens : 0,
+        stackId,
       };
     }
   }
@@ -57,6 +59,7 @@ function extractUsage(obj: Record<string, unknown>): RawUsageEntry | null {
           output: typeof u.output_tokens === 'number' ? u.output_tokens : 0,
           cacheCreate: typeof u.cache_creation_input_tokens === 'number' ? u.cache_creation_input_tokens : 0,
           cacheRead: typeof u.cache_read_input_tokens === 'number' ? u.cache_read_input_tokens : 0,
+          stackId,
         };
       }
     }
@@ -66,7 +69,7 @@ function extractUsage(obj: Record<string, unknown>): RawUsageEntry | null {
 }
 
 /** Parse a single JSONL file, returning entries and a count of malformed lines. */
-export function parseJSONLFile(filePath: string): ParseResult {
+export function parseJSONLFile(filePath: string, stackId: string | null = null): ParseResult {
   let content: string;
   try {
     content = fs.readFileSync(filePath, 'utf-8');
@@ -94,7 +97,7 @@ export function parseJSONLFile(filePath: string): ParseResult {
       continue;
     }
 
-    const entry = extractUsage(obj as Record<string, unknown>);
+    const entry = extractUsage(obj as Record<string, unknown>, stackId);
     if (entry) entries.push(entry);
     // non-usage lines (user messages, tool results, etc.) are silently ignored
   }
@@ -122,15 +125,45 @@ export function findJSONLFiles(dir: string): string[] {
 }
 
 /** Parse all JSONL files under a root directory. */
-export function parseTranscriptRoot(rootDir: string): ParseResult {
+export function parseTranscriptRoot(rootDir: string, stackId: string | null = null): ParseResult {
   const files = findJSONLFiles(rootDir);
   const allEntries: RawUsageEntry[] = [];
   let totalSkipped = 0;
 
   for (const file of files) {
-    const { entries, skippedLines } = parseJSONLFile(file);
+    const { entries, skippedLines } = parseJSONLFile(file, stackId);
     allEntries.push(...entries);
     totalSkipped += skippedLines;
+  }
+
+  return { entries: allEntries, skippedLines: totalSkipped };
+}
+
+/**
+ * Parse JSONL files from multiple roots with file-path-level deduplication.
+ * Roots ending with `/.claude/projects` are treated as the host root (stackId=null).
+ * All other roots get stackId=path.basename(root).
+ *
+ * Dedup is at file-path level: a file reachable under two roots is parsed once.
+ * Entry-level dedup is NOT performed — sessionId spans many entries.
+ */
+export function parseTranscriptRoots(roots: string[]): ParseResult {
+  const seenFiles = new Set<string>();
+  const allEntries: RawUsageEntry[] = [];
+  let totalSkipped = 0;
+
+  for (const root of roots) {
+    const stackId = root.endsWith('/.claude/projects') ? null : path.basename(root);
+    const files = findJSONLFiles(root);
+
+    for (const file of files) {
+      if (seenFiles.has(file)) continue;
+      seenFiles.add(file);
+
+      const { entries, skippedLines } = parseJSONLFile(file, stackId);
+      allEntries.push(...entries);
+      totalSkipped += skippedLines;
+    }
   }
 
   return { entries: allEntries, skippedLines: totalSkipped };

--- a/src/main/telemetry/types.ts
+++ b/src/main/telemetry/types.ts
@@ -47,6 +47,15 @@ export interface ByTicketEntry {
   unpriced: boolean;      // true when any task used a model with no known price
 }
 
+/** Per-ticket cost and token attribution derived from transcript files + stack manifests. */
+export interface TranscriptByTicketEntry {
+  ticket: string | null;  // ticket ID resolved from manifest; null for host-root and unmapped stacks
+  stackId: string | null; // originating stack ID; null for host-root entries
+  tokens: TokenCounts;
+  cost: number;
+  sessions: number;
+}
+
 export interface DailyEntry {
   date: string; // YYYY-MM-DD
   cost: number;

--- a/src/main/telemetry/usage-engine.ts
+++ b/src/main/telemetry/usage-engine.ts
@@ -12,28 +12,33 @@
  * Cost figures are "estimated (list price)" — not actual billed amounts.
  */
 
-import { parseTranscriptRoot } from './parser';
-import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions } from './aggregator';
-import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry } from './types';
+import { parseTranscriptRoots } from './parser';
+import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions, aggregateByTicket } from './aggregator';
+import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, TranscriptByTicketEntry } from './types';
 
-export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry };
+export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, TranscriptByTicketEntry };
 
 export interface UsageEngine {
   getSummary(range: DateRange): TelemetrySummary;
   getDaily(range: DateRange): DailyEntry[];
   getByModel(range: DateRange): ByModelEntry[];
   getSessions(range: DateRange): SessionEntry[];
+  getByTicket(): TranscriptByTicketEntry[];
 }
 
 /**
- * Create a usage engine that reads transcripts from the given root directory.
- * Typically called with `os.homedir() + '/.claude/projects'` for host telemetry.
+ * Create a usage engine that reads transcripts from the given root directories.
+ * Pass `[os.homedir() + '/.claude/projects', ...stackRoots]` for host + stack telemetry.
+ * Roots ending with `/.claude/projects` are the host root (stackId=null).
+ * All other roots are stack roots (stackId=basename of root dir).
  *
  * Returns zeroed shapes when no transcripts exist — never throws.
  */
-export function createUsageEngine(transcriptRoot: string): UsageEngine {
+export function createUsageEngine(roots: string[]): UsageEngine {
+  const stackRoots = roots.filter((r) => !r.endsWith('/.claude/projects'));
+
   function load() {
-    return parseTranscriptRoot(transcriptRoot);
+    return parseTranscriptRoots(roots);
   }
 
   return {
@@ -56,5 +61,11 @@ export function createUsageEngine(transcriptRoot: string): UsageEngine {
       const { entries } = load();
       return aggregateSessions(entries, range);
     },
+
+    getByTicket(): TranscriptByTicketEntry[] {
+      const { entries } = load();
+      return aggregateByTicket(entries, stackRoots);
+    },
   };
 }
+

--- a/tests/unit/compose-generator.test.ts
+++ b/tests/unit/compose-generator.test.ts
@@ -259,6 +259,11 @@ describe('compose-generator', () => {
       expect(yaml).toContain('  claude:');
       expect(yaml).toContain('    image: sandstorm-test-project-claude');
       expect(yaml).toContain('      - ${SANDSTORM_WORKSPACE}:/app');
+      // Usage transcript mount
+      expect(yaml).toContain('      - ${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects');
+      // Must NOT mount the entire .claude dir — only the projects subpath
+      expect(yaml).not.toContain(':/home/claude/.claude\n');
+      expect(yaml).not.toContain(':/home/claude/.claude ');
     });
 
     it('includes network overrides when named networks exist', () => {

--- a/tests/unit/context-mount.test.ts
+++ b/tests/unit/context-mount.test.ts
@@ -45,12 +45,18 @@ describe('context mount in generated docker-compose.yml', () => {
       }
     }
 
-    // Should have 3 volume entries: workspace, context, docker socket
+    // Should have 4 volume entries: workspace, context, usage dir, docker socket
     const volumeEntries = volumeLines.filter((l) => l.startsWith('- '));
-    expect(volumeEntries).toHaveLength(3);
+    expect(volumeEntries).toHaveLength(4);
     expect(volumeEntries[0]).toContain('SANDSTORM_WORKSPACE');
     expect(volumeEntries[1]).toContain('SANDSTORM_CONTEXT');
-    expect(volumeEntries[2]).toContain('docker.sock');
+    expect(volumeEntries[2]).toContain('SANDSTORM_USAGE_DIR');
+    expect(volumeEntries[3]).toContain('docker.sock');
+
+    // Full path assertion: usage dir mounts only into /home/claude/.claude/projects
+    expect(initScript).toContain('\\${SANDSTORM_USAGE_DIR}/\\${SANDSTORM_STACK_ID}:/home/claude/.claude/projects');
+    // Negative assertion: no volume mounts over the bare .claude directory
+    expect(initScript).not.toMatch(/\/home\/claude\/\.claude(?!\/projects)/);
   });
 });
 

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -44,7 +44,7 @@ const {
   const mockLoadRefinements = vi.fn().mockReturnValue([]);
 
   const mockRegistry = {
-    listProjects: vi.fn(),
+    listProjects: vi.fn().mockReturnValue([]),
     addProject: vi.fn(),
     removeProject: vi.fn(),
     getProject: vi.fn(),
@@ -148,6 +148,7 @@ const {
     getDaily: vi.fn(),
     getByModel: vi.fn(),
     getSessions: vi.fn(),
+    getByTicket: vi.fn().mockReturnValue([]),
   };
 
   const mockRollupStoreInstance = {
@@ -674,25 +675,21 @@ describe('IPC Handlers', () => {
       expect(mockUsageEngine.getSessions).toHaveBeenCalledWith(range);
     });
 
-    it('stats:telemetry:byTicket delegates to rollupStore.getByTicket and returns the array', async () => {
+    it('stats:telemetry:byTicket delegates to usageEngine.getByTicket and returns the array', async () => {
       const entries = [
         {
-          ticketId: 'T-42',
-          title: 'Fix the bug',
-          column: 'merged',
-          model: 'claude-opus-4-5',
+          ticket: 'T-42',
+          stackId: 'stack-abc',
+          tokens: { input: 500, output: 200, cacheCreate: 0, cacheRead: 100, total: 800 },
           cost: 2.5,
-          tokens: { input: 500, output: 200, cacheRead: 100, cacheCreation: 50 },
-          cacheHit: 16.7,
-          lifecycle: null,
-          unpriced: false,
+          sessions: 1,
         },
       ];
-      mockRollupStoreInstance.getByTicket.mockReturnValueOnce(entries);
+      mockUsageEngine.getByTicket.mockReturnValueOnce(entries);
 
       const result = await invokeHandler('stats:telemetry:byTicket');
 
-      expect(mockRollupStoreInstance.getByTicket).toHaveBeenCalledOnce();
+      expect(mockUsageEngine.getByTicket).toHaveBeenCalledOnce();
       expect(result).toEqual(entries);
     });
 
@@ -983,6 +980,18 @@ describe('IPC Handlers', () => {
           expect(fs.existsSync(composePath)).toBe(true);
           const skipped = (result as { skippedFiles?: string[] }).skippedFiles ?? [];
           expect(skipped).not.toContain('docker-compose.yml');
+        });
+
+        it('no-service compose includes usage mount and does not mount over /home/claude/.claude', async () => {
+          const composePath = path.join(tmpDir, '.sandstorm', 'docker-compose.yml');
+
+          await runFallback(tmpDir);
+
+          expect(fs.existsSync(composePath)).toBe(true);
+          const content = fs.readFileSync(composePath, 'utf-8');
+          expect(content).toContain('${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects');
+          // Must mount only the projects/ subpath, not the parent .claude dir
+          expect(content).not.toMatch(/\/home\/claude\/\.claude(?!\/projects)/);
         });
       });
     });

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -302,6 +302,68 @@ describe('StackManager', () => {
         expect(updateCallback).toHaveBeenCalled();
       }, { timeout: 5000 });
     });
+
+    it('writes manifest sibling file with correct fields on createStack', () => {
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      manager.createStack({
+        name: 'manifest-test',
+        projectDir: tmpDir,
+        ticket: 'PROJ-99',
+        runtime: 'docker',
+        gateApproved: true,
+      });
+
+      const manifestPath = path.join(tmpDir, '.sandstorm', 'usage', 'manifest-test.manifest.json');
+      expect(fs.existsSync(manifestPath)).toBe(true);
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      expect(manifest.stackId).toBe('manifest-test');
+      expect(manifest.ticket).toBe('PROJ-99');
+      expect(manifest.project).toBe(path.basename(tmpDir));
+      expect(typeof manifest.createdAt).toBe('string');
+      // createdAt should be a valid ISO 8601 timestamp
+      expect(new Date(manifest.createdAt).getTime()).toBeGreaterThan(0);
+    });
+
+    it('writes manifest with ticket=null for stacks without a ticket', () => {
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      manager.createStack({
+        name: 'no-ticket-stack',
+        projectDir: tmpDir,
+        runtime: 'docker',
+      });
+
+      const manifestPath = path.join(tmpDir, '.sandstorm', 'usage', 'no-ticket-stack.manifest.json');
+      expect(fs.existsSync(manifestPath)).toBe(true);
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      expect(manifest.ticket).toBeNull();
+    });
+
+    it('manifest is a sibling of usage/<stackId>/, not inside it', () => {
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+      manager.createStack({
+        name: 'sibling-test',
+        projectDir: tmpDir,
+        runtime: 'docker',
+      });
+
+      const usageDir = path.join(tmpDir, '.sandstorm', 'usage');
+      const manifestPath = path.join(usageDir, 'sibling-test.manifest.json');
+      const transcriptDir = path.join(usageDir, 'sibling-test');
+
+      expect(fs.existsSync(manifestPath)).toBe(true);
+      // Manifest must be AT usage/sibling-test.manifest.json, not inside usage/sibling-test/
+      const manifestInsideDir = path.join(transcriptDir, 'sibling-test.manifest.json');
+      // transcriptDir may not exist yet (created by shell at compose up time), but if it did
+      // the manifest should not be there
+      if (fs.existsSync(transcriptDir)) {
+        expect(fs.existsSync(manifestInsideDir)).toBe(false);
+      }
+    });
   });
 
   describe('dispatchTask', () => {

--- a/tests/unit/telemetry/usage-engine.test.ts
+++ b/tests/unit/telemetry/usage-engine.test.ts
@@ -3,13 +3,14 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import { parseJSONLFile, findJSONLFiles, parseTranscriptRoot } from '../../../src/main/telemetry/parser';
+import { parseJSONLFile, findJSONLFiles, parseTranscriptRoot, parseTranscriptRoots } from '../../../src/main/telemetry/parser';
 import { computeCost } from '../../../src/main/telemetry/pricing';
 import {
   aggregateSummary,
   aggregateDaily,
   aggregateByModel,
   aggregateSessions,
+  aggregateByTicket,
 } from '../../../src/main/telemetry/aggregator';
 import { createUsageEngine } from '../../../src/main/telemetry/usage-engine';
 
@@ -363,7 +364,7 @@ describe('aggregateSessions', () => {
 
 describe('createUsageEngine', () => {
   it('returns zeroed summary when root directory does not exist', () => {
-    const engine = createUsageEngine('/nonexistent/path');
+    const engine = createUsageEngine(['/nonexistent/path']);
     const summary = engine.getSummary({ since: '2024-01-01', until: '2024-12-31' });
     expect(summary.tokens.total).toBe(0);
     expect(summary.sessions).toBe(0);
@@ -372,7 +373,7 @@ describe('createUsageEngine', () => {
   });
 
   it('returns empty arrays for daily/byModel/session when root does not exist', () => {
-    const engine = createUsageEngine('/nonexistent/path');
+    const engine = createUsageEngine(['/nonexistent/path']);
     const range = { since: '2024-01-01', until: '2024-12-31' };
     expect(engine.getDaily(range)).toHaveLength(0);
     expect(engine.getByModel(range)).toHaveLength(0);
@@ -380,10 +381,273 @@ describe('createUsageEngine', () => {
   });
 
   it('reads from fixture directory end-to-end', () => {
-    const engine = createUsageEngine(FIXTURES);
+    const engine = createUsageEngine([FIXTURES]);
     const range = { since: '2024-01-01', until: '2024-12-31' };
     const summary = engine.getSummary(range);
     expect(summary.sessions).toBeGreaterThan(0);
     expect(summary.tokens.input).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTranscriptRoots — multi-root union + dedup
+// ---------------------------------------------------------------------------
+
+describe('parseTranscriptRoots', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-roots-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('merges entries from two disjoint roots', () => {
+    const rootA = path.join(tmpDir, 'rootA');
+    const rootB = path.join(tmpDir, 'rootB');
+    fs.mkdirSync(rootA);
+    fs.mkdirSync(rootB);
+
+    const entryA = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: 'sess-ra',
+    });
+    const entryB = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 20, output_tokens: 8 },
+      },
+      timestamp: '2024-03-01T11:00:00.000Z',
+      sessionId: 'sess-rb',
+    });
+    fs.writeFileSync(path.join(rootA, 'a.jsonl'), entryA + '\n');
+    fs.writeFileSync(path.join(rootB, 'b.jsonl'), entryB + '\n');
+
+    const { entries } = parseTranscriptRoots([rootA, rootB]);
+    const sids = entries.map((e) => e.sessionId);
+    expect(sids).toContain('sess-ra');
+    expect(sids).toContain('sess-rb');
+    expect(entries).toHaveLength(2);
+  });
+
+  it('deduplicates at file-path level — a file under two roots is parsed once', () => {
+    const rootA = path.join(tmpDir, 'rootA');
+    fs.mkdirSync(rootA);
+
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: 'sess-dup',
+    });
+    fs.writeFileSync(path.join(rootA, 'dup.jsonl'), entry + '\n');
+
+    // Pass the same root twice — should not parse the file twice
+    const { entries } = parseTranscriptRoots([rootA, rootA]);
+    const dupEntries = entries.filter((e) => e.sessionId === 'sess-dup');
+    expect(dupEntries).toHaveLength(1);
+  });
+
+  it('does NOT collapse entries sharing a sessionId across roots', () => {
+    const rootA = path.join(tmpDir, 'rootA');
+    const rootB = path.join(tmpDir, 'rootB');
+    fs.mkdirSync(rootA);
+    fs.mkdirSync(rootB);
+
+    const makeEntry = (ts: string) => JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      timestamp: ts,
+      sessionId: 'shared-session',
+    });
+    fs.writeFileSync(path.join(rootA, 'fa.jsonl'), makeEntry('2024-03-01T10:00:00.000Z') + '\n');
+    fs.writeFileSync(path.join(rootB, 'fb.jsonl'), makeEntry('2024-03-01T11:00:00.000Z') + '\n');
+
+    const { entries } = parseTranscriptRoots([rootA, rootB]);
+    const shared = entries.filter((e) => e.sessionId === 'shared-session');
+    // Both entries should be present — dedup is at file-path level, not sessionId level
+    expect(shared).toHaveLength(2);
+  });
+
+  it('sets stackId=null for host root (path ending with /.claude/projects)', () => {
+    const hostRoot = path.join(tmpDir, '.claude', 'projects');
+    fs.mkdirSync(hostRoot, { recursive: true });
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: 'sess-host',
+    });
+    fs.writeFileSync(path.join(hostRoot, 'host.jsonl'), entry + '\n');
+
+    const { entries } = parseTranscriptRoots([hostRoot]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].stackId).toBeNull();
+  });
+
+  it('sets stackId=basename for non-host roots', () => {
+    const stackRoot = path.join(tmpDir, 'my-stack-123');
+    fs.mkdirSync(stackRoot);
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: 'sess-stack',
+    });
+    fs.writeFileSync(path.join(stackRoot, 'stack.jsonl'), entry + '\n');
+
+    const { entries } = parseTranscriptRoots([stackRoot]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].stackId).toBe('my-stack-123');
+  });
+
+  it('directory-only filter: manifest JSON files next to stack dirs are not treated as roots', () => {
+    // Simulate usage/ dir containing: <stackId>/ dir + <stackId>.manifest.json file
+    const usageDir = path.join(tmpDir, 'usage');
+    const stackDir = path.join(usageDir, 'stack-abc');
+    fs.mkdirSync(stackDir, { recursive: true });
+    fs.writeFileSync(path.join(usageDir, 'stack-abc.manifest.json'), JSON.stringify({ stackId: 'stack-abc' }));
+
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant', model: 'claude-sonnet-4-5',
+        usage: { input_tokens: 5, output_tokens: 2 },
+      },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: 'sess-abc',
+    });
+    fs.writeFileSync(path.join(stackDir, 'abc.jsonl'), entry + '\n');
+
+    // Filter directories only from usageDir — manifest file must be excluded
+    const stackRoots = fs.readdirSync(usageDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => path.join(usageDir, e.name));
+
+    expect(stackRoots).toHaveLength(1);
+    expect(stackRoots[0]).toBe(stackDir);
+
+    const { entries } = parseTranscriptRoots(stackRoots);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].stackId).toBe('stack-abc'); // basename = stackId, not 'stack-abc.manifest.json'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateByTicket — manifest contract
+// ---------------------------------------------------------------------------
+
+describe('aggregateByTicket', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-byticket-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeEntry(sessionId: string, stackId: string | null, input = 100, output = 50) {
+    return { sessionId, model: 'claude-sonnet-4-5', timestamp: '2024-03-01T10:00:00.000Z', input, output, cacheCreate: 0, cacheRead: 0, stackId };
+  }
+
+  it('resolves stackId to ticket via manifest', () => {
+    const stackRoot = path.join(tmpDir, 'stack-1');
+    fs.mkdirSync(stackRoot);
+    fs.writeFileSync(stackRoot + '.manifest.json', JSON.stringify({
+      stackId: 'stack-1', ticket: 'PROJ-42', project: 'myproj', createdAt: '2024-03-01T00:00:00.000Z',
+    }));
+
+    const entries = [makeEntry('sess-a', 'stack-1')];
+    const result = aggregateByTicket(entries, [stackRoot]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ticket).toBe('PROJ-42');
+    expect(result[0].stackId).toBe('stack-1');
+    expect(result[0].sessions).toBe(1);
+  });
+
+  it('host-root entries (stackId=null) fall into ticket=null bucket', () => {
+    const entries = [makeEntry('sess-host', null)];
+    const result = aggregateByTicket(entries, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ticket).toBeNull();
+    expect(result[0].stackId).toBeNull();
+  });
+
+  it('unmapped stack (no manifest) falls into ticket=null bucket', () => {
+    const stackRoot = path.join(tmpDir, 'no-manifest-stack');
+    fs.mkdirSync(stackRoot);
+    // No manifest file written
+
+    const entries = [makeEntry('sess-x', 'no-manifest-stack')];
+    const result = aggregateByTicket(entries, [stackRoot]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ticket).toBeNull();
+  });
+
+  it('malformed manifest degrades to ticket=null without throwing', () => {
+    const stackRoot = path.join(tmpDir, 'bad-manifest-stack');
+    fs.mkdirSync(stackRoot);
+    fs.writeFileSync(stackRoot + '.manifest.json', 'not valid json {{{');
+
+    const entries = [makeEntry('sess-y', 'bad-manifest-stack')];
+    expect(() => aggregateByTicket(entries, [stackRoot])).not.toThrow();
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].ticket).toBeNull();
+  });
+
+  it('manifest with ticket=null maps to null bucket', () => {
+    const stackRoot = path.join(tmpDir, 'no-ticket-stack');
+    fs.mkdirSync(stackRoot);
+    fs.writeFileSync(stackRoot + '.manifest.json', JSON.stringify({
+      stackId: 'no-ticket-stack', ticket: null, project: 'myproj', createdAt: '2024-03-01T00:00:00.000Z',
+    }));
+
+    const entries = [makeEntry('sess-z', 'no-ticket-stack')];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].ticket).toBeNull();
+  });
+
+  it('accumulates tokens and cost per bucket', () => {
+    const stackRoot = path.join(tmpDir, 'cost-stack');
+    fs.mkdirSync(stackRoot);
+    fs.writeFileSync(stackRoot + '.manifest.json', JSON.stringify({
+      stackId: 'cost-stack', ticket: 'T-1', project: 'p', createdAt: '2024-01-01T00:00:00.000Z',
+    }));
+
+    const entries = [
+      makeEntry('s1', 'cost-stack', 100, 50),
+      makeEntry('s2', 'cost-stack', 200, 100),
+    ];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result).toHaveLength(1);
+    expect(result[0].tokens.input).toBe(300);
+    expect(result[0].tokens.output).toBe(150);
+    expect(result[0].sessions).toBe(2);
+    expect(result[0].cost).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Per-ticket cost and token attribution previously relied on the rollup store, which did not capture the inner Claude agent's real transcript usage. This wires actual transcript data from each stack into the telemetry engine so tickets are attributed from the source records.

- Each stack now bind-mounts its inner agent transcripts (`/home/claude/.claude/projects`) to a per-stack host usage dir (`<project>/.sandstorm/usage/<stackId>`). The mount is added to the CLI `init.sh` heredoc, the `compose-generator`, and the IPC compose template; `stack.sh` creates and chmods the dir before compose runs.
- `StackManager` writes a `<stackId>.manifest.json` alongside the usage dir at create time, recording the `stackId -> ticket` mapping so telemetry can resolve attribution as soon as transcripts appear.
- The telemetry parser tags every entry with its originating `stackId` and gains `parseTranscriptRoots`, which parses multiple roots with file-path-level dedup (host root -> `stackId=null`, others -> basename).
- `aggregateByTicket` reads the manifests to map `stackId -> ticket` and groups usage by `(ticket, stackId)`; the usage engine now takes an array of roots and exposes `getByTicket()`.
- IPC telemetry handlers build the root set per request (host root plus every project's stack usage dirs) and construct the engine on demand, replacing the single host-only engine. `stats:telemetry:byTicket` now serves transcript-derived attribution.

Unmapped or host-root entries degrade gracefully to `ticket=null`; manifest write failures are non-fatal.

## QA plan

1. Create a stack for a ticket and confirm `<project>/.sandstorm/usage/<stackId>/` and `<stackId>.manifest.json` are created, with the manifest holding the correct `stackId` and `ticket`.
2. Dispatch a task to the inner agent, let it run, and confirm transcript JSONL files appear under the per-stack usage dir.
3. Open the stats/telemetry view and verify the per-ticket breakdown shows non-zero cost, tokens, and session counts for that ticket.
4. Create a second stack for a different ticket and confirm usage is attributed to each ticket separately, not merged.
5. Confirm host-orchestrator usage and stacks with no manifest surface under `ticket=null` rather than erroring.

Closes #467