### PR TITLE
[499] fix: unify per-ticket cost on transcript data with parse cache

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -88,8 +88,9 @@ import { listTicketComments, postComment } from './control-plane/ticket-comments
 import { getLatestUserAnswers, ANSWER_COMMENT_MARKER } from './scheduler/refine-to-comments';
 import { KANBAN_COLUMNS } from '../shared/kanban';
 import os from 'os';
-import { createUsageEngine } from './telemetry/usage-engine';
-import type { DateRange } from './telemetry/usage-engine';
+import { createUsageEngine, clearUsageCache } from './telemetry/usage-engine';
+import type { DateRange, ByTicketEntry } from './telemetry/usage-engine';
+import { ORCHESTRATOR_TICKET_ID } from './telemetry/types';
 import { TicketRollupStore } from './telemetry/rollup-store';
 
 // Set __sandstorm at module-load time so app.evaluate() works immediately
@@ -797,7 +798,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     const engine = createUsageEngine(buildTelemetryRoots());
     const summary = engine.getSummary(range);
     const shipped = rollupStore.ticketsShipped();
-    const totalCost = rollupStore.totalTicketCost();
+    // Numerator: lifetime sum of per-ticket transcript cost excluding orchestrator bucket
+    const allByTicket = engine.getByTicket();
+    const totalCost = allByTicket
+      .filter((e) => e.ticketId !== ORCHESTRATOR_TICKET_ID)
+      .reduce((sum, e) => sum + e.cost, 0);
     return {
       ...summary,
       ticketsShipped: shipped,
@@ -817,11 +822,12 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return createUsageEngine(buildTelemetryRoots()).getSessions(range);
   });
 
-  ipcMain.handle('stats:telemetry:byTicket', async () => {
+  ipcMain.handle('stats:telemetry:byTicket', async (): Promise<ByTicketEntry[]> => {
     return createUsageEngine(buildTelemetryRoots()).getByTicket();
   });
 
   ipcMain.handle('stats:telemetry:refresh', async () => {
+    clearUsageCache();
     rollupStore.refresh();
     return { ok: true };
   });

--- a/src/main/telemetry/aggregator.ts
+++ b/src/main/telemetry/aggregator.ts
@@ -7,7 +7,8 @@ import fs from 'fs';
 import path from 'path';
 import { computeCost } from './pricing';
 import type { RawUsageEntry } from './parser';
-import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, TranscriptByTicketEntry } from './types';
+import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
+import { ORCHESTRATOR_TICKET_ID } from './types';
 
 function dateOf(isoTimestamp: string): string {
   return isoTimestamp.slice(0, 10); // YYYY-MM-DD
@@ -244,56 +245,71 @@ function readManifest(manifestPath: string): StackManifest | null {
  * Aggregate entries by ticket, reading stack manifests to resolve stackId → ticket.
  * stackRoots are the stack-specific dirs (e.g. <project>/.sandstorm/usage/<stackId>).
  * The paired manifest is at stackRoot + '.manifest.json'.
- * Entries with no mapped ticket (host-root entries or missing manifest) fall into ticket=null.
+ * Entries with no mapped ticket (host-root entries or missing manifest) roll up under
+ * ORCHESTRATOR_TICKET_ID. A ticket worked across multiple stacks produces one row.
  */
 export function aggregateByTicket(
   entries: RawUsageEntry[],
   stackRoots: string[]
-): TranscriptByTicketEntry[] {
+): ByTicketEntry[] {
   // Build stackId → ticket map from manifests
   const stackToTicket = new Map<string, string | null>();
   for (const root of stackRoots) {
-    const manifestPath = root + '.manifest.json';
-    const manifest = readManifest(manifestPath);
+    const manifest = readManifest(root + '.manifest.json');
     if (manifest) {
       stackToTicket.set(manifest.stackId, manifest.ticket ?? null);
     }
   }
 
-  // Group entries by (ticket, stackId)
-  const byKey = new Map<string, {
-    ticket: string | null;
-    stackId: string | null;
+  // Group entries by ticket alone (multi-stack tickets aggregate into one row)
+  const byTicket = new Map<string, {
     tokens: TokenCounts;
-    sessions: Set<string>;
+    modelOutputs: Map<string, number>;
     cost: number;
+    unpriced: boolean;
   }>();
 
   for (const entry of entries) {
-    const ticket = entry.stackId != null ? (stackToTicket.get(entry.stackId) ?? null) : null;
-    const key = `${ticket ?? '__null__'}::${entry.stackId ?? '__null__'}`;
+    const rawTicket = entry.stackId != null ? (stackToTicket.get(entry.stackId) ?? null) : null;
+    const ticketId = rawTicket ?? ORCHESTRATOR_TICKET_ID;
 
-    if (!byKey.has(key)) {
-      byKey.set(key, { ticket, stackId: entry.stackId, tokens: zeroTokens(), sessions: new Set(), cost: 0 });
+    if (!byTicket.has(ticketId)) {
+      byTicket.set(ticketId, { tokens: zeroTokens(), modelOutputs: new Map(), cost: 0, unpriced: false });
     }
-    const bucket = byKey.get(key)!;
+    const bucket = byTicket.get(ticketId)!;
     addTokens(bucket.tokens, entry);
-    bucket.sessions.add(entry.sessionId);
-    const { cost } = computeCost(entry.model, {
+    bucket.modelOutputs.set(entry.model, (bucket.modelOutputs.get(entry.model) ?? 0) + entry.output);
+    const { cost, unpriced } = computeCost(entry.model, {
       input: entry.input,
       output: entry.output,
       cacheCreate: entry.cacheCreate,
       cacheRead: entry.cacheRead,
     });
     bucket.cost += cost;
+    if (unpriced) bucket.unpriced = true;
   }
 
-  return [...byKey.values()].map((data) => ({
-    ticket: data.ticket,
-    stackId: data.stackId,
-    tokens: data.tokens,
-    cost: data.cost,
-    sessions: data.sessions.size,
-  }));
+  return [...byTicket.entries()].map(([ticketId, data]) => {
+    const { input, cacheRead } = data.tokens;
+    const denom = input + cacheRead;
+    const cacheHit = denom > 0 ? (cacheRead / denom) * 100 : 0;
+
+    // Primary model = highest summed output tokens (first encountered on ties)
+    let primaryModel: string | null = null;
+    let maxOutput = -1;
+    for (const [model, output] of data.modelOutputs) {
+      if (output > maxOutput) { maxOutput = output; primaryModel = model; }
+    }
+
+    return {
+      ticketId,
+      model: primaryModel,
+      cost: data.cost,
+      tokens: data.tokens,
+      cacheHit,
+      lifecycle: null,
+      unpriced: data.unpriced,
+    } satisfies ByTicketEntry;
+  });
 }
 

--- a/src/main/telemetry/attribution.ts
+++ b/src/main/telemetry/attribution.ts
@@ -1,8 +1,9 @@
 import Database from 'better-sqlite3';
 import { computeCost } from './pricing';
 import type { ByTicketEntry } from './types';
+import { ORCHESTRATOR_TICKET_ID } from './types';
 
-export const ORCHESTRATOR_TICKET_ID = '__orchestrator__';
+export { ORCHESTRATOR_TICKET_ID };
 
 interface TaskCostRow {
   ticket: string | null;
@@ -157,15 +158,14 @@ export function computeTicketRollups(db: Database.Database): ByTicketEntry[] {
 
     result.push({
       ticketId,
-      title: bucket.title,
-      column: bucket.column,
       model: primaryModel,
       cost: bucket.cost,
       tokens: {
         input: bucket.input,
         output: bucket.output,
+        cacheCreate: bucket.cacheCreation,
         cacheRead: bucket.cacheRead,
-        cacheCreation: bucket.cacheCreation,
+        total: bucket.input + bucket.output + bucket.cacheCreation + bucket.cacheRead,
       },
       cacheHit,
       lifecycle: null,

--- a/src/main/telemetry/rollup-store.ts
+++ b/src/main/telemetry/rollup-store.ts
@@ -58,15 +58,14 @@ export class TicketRollupStore {
       const cacheHit = denom > 0 ? (row.total_cache_read / denom) * 100 : 0;
       return {
         ticketId: row.ticket_id,
-        title: row.title,
-        column: row.column,
         model: row.primary_model,
         cost: row.total_cost,
         tokens: {
           input: row.total_input_tokens,
           output: row.total_output_tokens,
+          cacheCreate: row.total_cache_creation,
           cacheRead: row.total_cache_read,
-          cacheCreation: row.total_cache_creation,
+          total: row.total_input_tokens + row.total_output_tokens + row.total_cache_creation + row.total_cache_read,
         },
         cacheHit,
         lifecycle: null,
@@ -93,13 +92,13 @@ export class TicketRollupStore {
       for (const entry of entries) {
         upsert.run(
           entry.ticketId,
-          entry.title,
-          entry.column,
+          entry.ticketId, // title: no longer in ByTicketEntry; use ticketId as fallback
+          null,           // column: no longer in ByTicketEntry
           entry.cost,
           entry.tokens.input,
           entry.tokens.output,
           entry.tokens.cacheRead,
-          entry.tokens.cacheCreation,
+          entry.tokens.cacheCreate,
           entry.model,
           entry.unpriced ? 1 : 0
         );
@@ -183,9 +182,9 @@ export class TicketRollupStore {
     this.db.transaction(() => {
       for (const entry of affected) {
         upsert.run(
-          entry.ticketId, entry.title, entry.column, entry.cost,
+          entry.ticketId, entry.ticketId, null, entry.cost,
           entry.tokens.input, entry.tokens.output,
-          entry.tokens.cacheRead, entry.tokens.cacheCreation,
+          entry.tokens.cacheRead, entry.tokens.cacheCreate,
           entry.model, entry.unpriced ? 1 : 0
         );
       }

--- a/src/main/telemetry/types.ts
+++ b/src/main/telemetry/types.ts
@@ -1,5 +1,7 @@
 /** All costs are estimated at list price (not actual billed amount). */
 
+export const ORCHESTRATOR_TICKET_ID = '__orchestrator__';
+
 export interface DateRange {
   since: string; // YYYY-MM-DD, inclusive
   until: string; // YYYY-MM-DD, inclusive
@@ -29,31 +31,15 @@ export interface TelemetrySummary {
   skippedLines: number;           // malformed JSONL lines skipped across all files
 }
 
-/** Per-ticket cost and token attribution derived from tasks/stacks token columns. */
+/** Canonical per-ticket cost attribution derived from transcript files. */
 export interface ByTicketEntry {
-  ticketId: string;       // ticket ID, or '__orchestrator__' for tasks with no ticket
-  title: string;          // ticket title from ticket_board, or ticketId as fallback
-  column: string | null;  // current kanban column; null for orchestrator bucket
-  model: string | null;   // primary model (highest output tokens across all tasks)
-  cost: number;           // estimated USD cost across all tasks for this ticket
-  tokens: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheCreation: number;
-  };
-  cacheHit: number;       // cache_read / (input + cache_read) × 100; 0 when all-zero
-  lifecycle: null;        // pending sub-issue 4
-  unpriced: boolean;      // true when any task used a model with no known price
-}
-
-/** Per-ticket cost and token attribution derived from transcript files + stack manifests. */
-export interface TranscriptByTicketEntry {
-  ticket: string | null;  // ticket ID resolved from manifest; null for host-root and unmapped stacks
-  stackId: string | null; // originating stack ID; null for host-root entries
-  tokens: TokenCounts;
-  cost: number;
-  sessions: number;
+  ticketId: string;        // real ID, or '__orchestrator__' for unattributed/host spend
+  model: string | null;    // primary model (highest output tokens)
+  cost: number;            // estimated USD, from transcripts (authoritative)
+  tokens: TokenCounts;     // {input, output, cacheCreate, cacheRead, total}
+  cacheHit: number;        // cacheRead / (input + cacheRead) × 100; 0 when all-zero
+  lifecycle: null;         // pending sub-issue #468
+  unpriced: boolean;       // true when any entry used a model with no known price
 }
 
 export interface DailyEntry {

--- a/src/main/telemetry/usage-engine.ts
+++ b/src/main/telemetry/usage-engine.ts
@@ -12,19 +12,71 @@
  * Cost figures are "estimated (list price)" — not actual billed amounts.
  */
 
-import { parseTranscriptRoots } from './parser';
+import fs from 'fs';
+import { parseTranscriptRoots, findJSONLFiles, type ParseResult } from './parser';
 import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions, aggregateByTicket } from './aggregator';
-import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, TranscriptByTicketEntry } from './types';
+import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
 
-export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, TranscriptByTicketEntry };
+export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry };
 
 export interface UsageEngine {
   getSummary(range: DateRange): TelemetrySummary;
   getDaily(range: DateRange): DailyEntry[];
   getByModel(range: DateRange): ByModelEntry[];
   getSessions(range: DateRange): SessionEntry[];
-  getByTicket(): TranscriptByTicketEntry[];
+  getByTicket(): ByTicketEntry[];
 }
+
+// ---------------------------------------------------------------------------
+// Module-scoped parse cache
+//
+// Shared across all engine instances so multiple IPC calls in the same page
+// load hit the cache rather than re-parsing all JSONL files.
+// Cache key = sorted root list + per-file (mtime, size) for each .jsonl file.
+// A file addition, removal, or modification triggers a miss and full re-parse.
+// ---------------------------------------------------------------------------
+
+interface ParseCache {
+  key: string;
+  result: ParseResult;
+}
+
+let _parseCache: ParseCache | null = null;
+
+export function clearUsageCache(): void {
+  _parseCache = null;
+}
+
+function buildCacheKey(roots: string[]): string {
+  const sortedRoots = [...roots].sort();
+  const parts: string[] = [...sortedRoots];
+  for (const root of sortedRoots) {
+    const files = findJSONLFiles(root).sort();
+    for (const file of files) {
+      try {
+        const stat = fs.statSync(file);
+        parts.push(`${file}:${stat.mtimeMs}:${stat.size}`);
+      } catch {
+        parts.push(`${file}:missing`);
+      }
+    }
+  }
+  return parts.join('\0');
+}
+
+function loadCached(roots: string[]): ParseResult {
+  const key = buildCacheKey(roots);
+  if (_parseCache !== null && _parseCache.key === key) {
+    return _parseCache.result;
+  }
+  const result = parseTranscriptRoots(roots);
+  _parseCache = { key, result };
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Engine factory
+// ---------------------------------------------------------------------------
 
 /**
  * Create a usage engine that reads transcripts from the given root directories.
@@ -37,35 +89,30 @@ export interface UsageEngine {
 export function createUsageEngine(roots: string[]): UsageEngine {
   const stackRoots = roots.filter((r) => !r.endsWith('/.claude/projects'));
 
-  function load() {
-    return parseTranscriptRoots(roots);
-  }
-
   return {
     getSummary(range: DateRange): TelemetrySummary {
-      const { entries, skippedLines } = load();
+      const { entries, skippedLines } = loadCached(roots);
       return aggregateSummary(entries, range, skippedLines);
     },
 
     getDaily(range: DateRange): DailyEntry[] {
-      const { entries } = load();
+      const { entries } = loadCached(roots);
       return aggregateDaily(entries, range);
     },
 
     getByModel(range: DateRange): ByModelEntry[] {
-      const { entries } = load();
+      const { entries } = loadCached(roots);
       return aggregateByModel(entries, range);
     },
 
     getSessions(range: DateRange): SessionEntry[] {
-      const { entries } = load();
+      const { entries } = loadCached(roots);
       return aggregateSessions(entries, range);
     },
 
-    getByTicket(): TranscriptByTicketEntry[] {
-      const { entries } = load();
+    getByTicket(): ByTicketEntry[] {
+      const { entries } = loadCached(roots);
       return aggregateByTicket(entries, stackRoots);
     },
   };
 }
-

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -234,6 +234,7 @@ vi.mock('os', async (importOriginal) => {
 
 vi.mock('../../src/main/telemetry/usage-engine', () => ({
   createUsageEngine: vi.fn(() => mockUsageEngine),
+  clearUsageCache: vi.fn(),
 }));
 
 vi.mock('../../src/main/telemetry/rollup-store', () => ({
@@ -301,6 +302,7 @@ vi.mock('../../src/main/control-plane/refinement-store', () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 import { registerIpcHandlers } from '../../src/main/ipc';
+import { clearUsageCache } from '../../src/main/telemetry/usage-engine';
 import { dialog, BrowserWindow } from 'electron';
 import { execFile } from 'child_process';
 
@@ -678,11 +680,13 @@ describe('IPC Handlers', () => {
     it('stats:telemetry:byTicket delegates to usageEngine.getByTicket and returns the array', async () => {
       const entries = [
         {
-          ticket: 'T-42',
-          stackId: 'stack-abc',
-          tokens: { input: 500, output: 200, cacheCreate: 0, cacheRead: 100, total: 800 },
+          ticketId: 'T-42',
+          model: 'claude-sonnet-4-5',
           cost: 2.5,
-          sessions: 1,
+          tokens: { input: 500, output: 200, cacheCreate: 0, cacheRead: 100, total: 800 },
+          cacheHit: 16.666666666666668,
+          lifecycle: null,
+          unpriced: false,
         },
       ];
       mockUsageEngine.getByTicket.mockReturnValueOnce(entries);
@@ -697,6 +701,7 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('stats:telemetry:refresh');
 
       expect(mockRollupStoreInstance.refresh).toHaveBeenCalledOnce();
+      expect(vi.mocked(clearUsageCache)).toHaveBeenCalledOnce();
       expect(result).toEqual({ ok: true });
     });
   });

--- a/tests/unit/telemetry/attribution.test.ts
+++ b/tests/unit/telemetry/attribution.test.ts
@@ -66,8 +66,7 @@ describe('computeTicketRollups', () => {
     const rollups = computeTicketRollups(db);
     expect(rollups).toHaveLength(1);
     expect(rollups[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
-    expect(rollups[0].title).toBe('Orchestrator / ad-hoc');
-    expect(rollups[0].column).toBeNull();
+    // title/column removed from canonical ByTicketEntry in ticket #499 (renderer-joined)
   });
 
   it('attributes post-teardown tasks from stack_history.task_history', () => {
@@ -135,13 +134,15 @@ describe('computeTicketRollups', () => {
     expect(rollups[0].model).toBe('claude-sonnet-4-5');
   });
 
-  it('enriches title and column from ticket_board', () => {
+  it('returns correct rollup when ticket_board row exists for ticket', () => {
+    // title/column removed from canonical ByTicketEntry in ticket #499 (renderer-joined)
     db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-7')`);
     db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-sonnet-4-5')`);
     db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('TICKET-7', '/proj', 'pr_open', 'My Feature')`);
     const rollups = computeTicketRollups(db);
-    expect(rollups[0].title).toBe('My Feature');
-    expect(rollups[0].column).toBe('pr_open');
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].ticketId).toBe('TICKET-7');
+    expect(rollups[0].cost).toBeGreaterThan(0);
   });
 
   it('places orchestrator bucket last in sorted output', () => {

--- a/tests/unit/telemetry/rollup-store.test.ts
+++ b/tests/unit/telemetry/rollup-store.test.ts
@@ -145,6 +145,7 @@ describe('TicketRollupStore', () => {
   });
 
   it('markDirty() (for board moves) triggers refresh on next getByTicket', () => {
+    // column removed from canonical ByTicketEntry in ticket #499 (renderer-joined)
     db.exec(`INSERT INTO stacks (id, ticket) VALUES ('s1', 'TICKET-B')`);
     db.exec(`INSERT INTO tasks (stack_id, input_tokens, output_tokens, resolved_model) VALUES ('s1', 100, 50, 'claude-sonnet-4-5')`);
     db.exec(`INSERT INTO ticket_board (ticket_id, project_dir, column, title) VALUES ('TICKET-B', '/proj', 'pr_open', 'Board Ticket')`);
@@ -155,7 +156,10 @@ describe('TicketRollupStore', () => {
     store.markDirty();
 
     const rollups = store.getByTicket();
-    expect(rollups[0].column).toBe('merged');
+    // Verify the refresh ran and the rollup is correct
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].ticketId).toBe('TICKET-B');
+    expect(rollups[0].cost).toBeGreaterThan(0);
   });
 
   it('cacheHit is 0 for all-zero-token ticket (division-by-zero guard)', () => {

--- a/tests/unit/telemetry/usage-engine.test.ts
+++ b/tests/unit/telemetry/usage-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -12,7 +12,8 @@ import {
   aggregateSessions,
   aggregateByTicket,
 } from '../../../src/main/telemetry/aggregator';
-import { createUsageEngine } from '../../../src/main/telemetry/usage-engine';
+import { createUsageEngine, clearUsageCache } from '../../../src/main/telemetry/usage-engine';
+import { ORCHESTRATOR_TICKET_ID } from '../../../src/main/telemetry/types';
 
 const FIXTURES = path.resolve(__dirname, 'fixtures');
 
@@ -583,21 +584,18 @@ describe('aggregateByTicket', () => {
     const result = aggregateByTicket(entries, [stackRoot]);
 
     expect(result).toHaveLength(1);
-    expect(result[0].ticket).toBe('PROJ-42');
-    expect(result[0].stackId).toBe('stack-1');
-    expect(result[0].sessions).toBe(1);
+    expect(result[0].ticketId).toBe('PROJ-42');
   });
 
-  it('host-root entries (stackId=null) fall into ticket=null bucket', () => {
+  it('host-root entries (stackId=null) roll up under orchestrator sentinel', () => {
     const entries = [makeEntry('sess-host', null)];
     const result = aggregateByTicket(entries, []);
 
     expect(result).toHaveLength(1);
-    expect(result[0].ticket).toBeNull();
-    expect(result[0].stackId).toBeNull();
+    expect(result[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
   });
 
-  it('unmapped stack (no manifest) falls into ticket=null bucket', () => {
+  it('unmapped stack (no manifest) rolls up under orchestrator sentinel', () => {
     const stackRoot = path.join(tmpDir, 'no-manifest-stack');
     fs.mkdirSync(stackRoot);
     // No manifest file written
@@ -606,10 +604,10 @@ describe('aggregateByTicket', () => {
     const result = aggregateByTicket(entries, [stackRoot]);
 
     expect(result).toHaveLength(1);
-    expect(result[0].ticket).toBeNull();
+    expect(result[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
   });
 
-  it('malformed manifest degrades to ticket=null without throwing', () => {
+  it('malformed manifest degrades to orchestrator bucket without throwing', () => {
     const stackRoot = path.join(tmpDir, 'bad-manifest-stack');
     fs.mkdirSync(stackRoot);
     fs.writeFileSync(stackRoot + '.manifest.json', 'not valid json {{{');
@@ -617,10 +615,10 @@ describe('aggregateByTicket', () => {
     const entries = [makeEntry('sess-y', 'bad-manifest-stack')];
     expect(() => aggregateByTicket(entries, [stackRoot])).not.toThrow();
     const result = aggregateByTicket(entries, [stackRoot]);
-    expect(result[0].ticket).toBeNull();
+    expect(result[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
   });
 
-  it('manifest with ticket=null maps to null bucket', () => {
+  it('manifest with ticket=null rolls up under orchestrator sentinel', () => {
     const stackRoot = path.join(tmpDir, 'no-ticket-stack');
     fs.mkdirSync(stackRoot);
     fs.writeFileSync(stackRoot + '.manifest.json', JSON.stringify({
@@ -629,7 +627,7 @@ describe('aggregateByTicket', () => {
 
     const entries = [makeEntry('sess-z', 'no-ticket-stack')];
     const result = aggregateByTicket(entries, [stackRoot]);
-    expect(result[0].ticket).toBeNull();
+    expect(result[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
   });
 
   it('accumulates tokens and cost per bucket', () => {
@@ -645,9 +643,368 @@ describe('aggregateByTicket', () => {
     ];
     const result = aggregateByTicket(entries, [stackRoot]);
     expect(result).toHaveLength(1);
+    expect(result[0].ticketId).toBe('T-1');
     expect(result[0].tokens.input).toBe(300);
     expect(result[0].tokens.output).toBe(150);
-    expect(result[0].sessions).toBe(2);
     expect(result[0].cost).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateByTicket — new canonical shape (ticket 499)
+// ---------------------------------------------------------------------------
+
+describe('aggregateByTicket — canonical shape', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-canonical-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeEntry(sessionId: string, stackId: string | null, model = 'claude-sonnet-4-5', input = 100, output = 50, cacheRead = 0) {
+    return { sessionId, model, timestamp: '2024-03-01T10:00:00.000Z', input, output, cacheCreate: 0, cacheRead, stackId };
+  }
+
+  function makeManifest(dir: string, stackId: string, ticket: string | null) {
+    fs.writeFileSync(dir + '.manifest.json', JSON.stringify({
+      stackId, ticket, project: 'p', createdAt: '2024-01-01T00:00:00.000Z',
+    }));
+  }
+
+  it('multi-stack-per-ticket → one row with summed tokens and cost', () => {
+    const stackA = path.join(tmpDir, 'stack-a');
+    const stackB = path.join(tmpDir, 'stack-b');
+    fs.mkdirSync(stackA);
+    fs.mkdirSync(stackB);
+    makeManifest(stackA, 'stack-a', 'TICKET-1');
+    makeManifest(stackB, 'stack-b', 'TICKET-1');
+
+    const entries = [
+      makeEntry('s1', 'stack-a', 'claude-sonnet-4-5', 100, 50),
+      makeEntry('s2', 'stack-b', 'claude-sonnet-4-5', 200, 80),
+    ];
+    const result = aggregateByTicket(entries, [stackA, stackB]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ticketId).toBe('TICKET-1');
+    expect(result[0].tokens.input).toBe(300);
+    expect(result[0].tokens.output).toBe(130);
+    expect(result[0].cost).toBeGreaterThan(0);
+  });
+
+  it('emits the model with highest output tokens as primary model', () => {
+    const stackRoot = path.join(tmpDir, 'stack-model');
+    fs.mkdirSync(stackRoot);
+    makeManifest(stackRoot, 'stack-model', 'TICKET-2');
+
+    const entries = [
+      makeEntry('s1', 'stack-model', 'claude-sonnet-4-5', 100, 30),   // 30 output
+      makeEntry('s2', 'stack-model', 'claude-opus-4-5', 100, 200),     // 200 output — winner
+    ];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].model).toBe('claude-opus-4-5');
+  });
+
+  it('cacheHit = cacheRead / (input + cacheRead) × 100', () => {
+    const stackRoot = path.join(tmpDir, 'stack-cache');
+    fs.mkdirSync(stackRoot);
+    makeManifest(stackRoot, 'stack-cache', 'TICKET-3');
+
+    // input=100, cacheRead=400 → cacheHit = 400/500 × 100 = 80%
+    const entries = [{ sessionId: 's1', model: 'claude-sonnet-4-5', timestamp: '2024-03-01T10:00:00.000Z', input: 100, output: 50, cacheCreate: 0, cacheRead: 400, stackId: 'stack-cache' }];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].cacheHit).toBeCloseTo(80, 3);
+  });
+
+  it('cacheHit = 0 when input and cacheRead are both zero', () => {
+    const stackRoot = path.join(tmpDir, 'stack-nocache');
+    fs.mkdirSync(stackRoot);
+    makeManifest(stackRoot, 'stack-nocache', 'TICKET-4');
+
+    const entries = [makeEntry('s1', 'stack-nocache', 'claude-sonnet-4-5', 0, 50, 0)];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].cacheHit).toBe(0);
+  });
+
+  it('unpriced=true when any entry uses an unknown model', () => {
+    const stackRoot = path.join(tmpDir, 'stack-unpriced');
+    fs.mkdirSync(stackRoot);
+    makeManifest(stackRoot, 'stack-unpriced', 'TICKET-5');
+
+    const entries = [
+      makeEntry('s1', 'stack-unpriced', 'claude-sonnet-4-5', 100, 50),
+      makeEntry('s2', 'stack-unpriced', 'unknown-future-model-xyz', 100, 50),
+    ];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].unpriced).toBe(true);
+  });
+
+  it('unpriced=false when all entries use priced models', () => {
+    const stackRoot = path.join(tmpDir, 'stack-priced');
+    fs.mkdirSync(stackRoot);
+    makeManifest(stackRoot, 'stack-priced', 'TICKET-6');
+
+    const entries = [makeEntry('s1', 'stack-priced', 'claude-sonnet-4-5', 100, 50)];
+    const result = aggregateByTicket(entries, [stackRoot]);
+    expect(result[0].unpriced).toBe(false);
+  });
+
+  it('orchestrator bucket: host-root entries roll up under __orchestrator__', () => {
+    // stackId=null → no manifest lookup → orchestrator
+    const entries = [makeEntry('s1', null)];
+    const result = aggregateByTicket(entries, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].ticketId).toBe(ORCHESTRATOR_TICKET_ID);
+  });
+
+  it('contract: emitted row has exactly the canonical field set', () => {
+    const stackRoot = path.join(tmpDir, 'stack-contract');
+    fs.mkdirSync(stackRoot);
+    makeManifest(stackRoot, 'stack-contract', 'CONTRACT-1');
+
+    const entries = [makeEntry('s1', 'stack-contract')];
+    const result = aggregateByTicket(entries, [stackRoot]);
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(Object.keys(row).sort()).toEqual(
+      ['cacheHit', 'cost', 'lifecycle', 'model', 'ticketId', 'tokens', 'unpriced'].sort()
+    );
+    expect(Object.keys(row.tokens).sort()).toEqual(
+      ['cacheCreate', 'cacheRead', 'input', 'output', 'total'].sort()
+    );
+    expect(row.lifecycle).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getByTicket — contract test via UsageEngine (implementation-independent)
+// ---------------------------------------------------------------------------
+
+describe('UsageEngine.getByTicket contract', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-contract-'));
+    clearUsageCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    clearUsageCache();
+  });
+
+  it('getByTicket rows satisfy the canonical field contract', () => {
+    const stackRoot = path.join(tmpDir, 'stack-1');
+    fs.mkdirSync(stackRoot);
+    fs.writeFileSync(stackRoot + '.manifest.json', JSON.stringify({
+      stackId: 'stack-1', ticket: 'T-99', project: 'p', createdAt: '2024-01-01T00:00:00.000Z',
+    }));
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', model: 'claude-sonnet-4-5', usage: { input_tokens: 100, output_tokens: 50 } },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: 'sess-contract',
+    });
+    fs.writeFileSync(path.join(stackRoot, 'usage.jsonl'), entry + '\n');
+
+    const engine = createUsageEngine([stackRoot]);
+    const rows = engine.getByTicket();
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(Object.keys(row).sort()).toEqual(
+        ['cacheHit', 'cost', 'lifecycle', 'model', 'ticketId', 'tokens', 'unpriced'].sort()
+      );
+      expect(Object.keys(row.tokens).sort()).toEqual(
+        ['cacheCreate', 'cacheRead', 'input', 'output', 'total'].sort()
+      );
+      expect(typeof row.ticketId).toBe('string');
+      expect(row.lifecycle).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parse cache
+// ---------------------------------------------------------------------------
+
+describe('parse cache', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-cache-'));
+    clearUsageCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    clearUsageCache();
+    vi.restoreAllMocks();
+  });
+
+  function writeJsonl(dir: string, filename: string, sessionId: string): string {
+    const filePath = path.join(dir, filename);
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', model: 'claude-sonnet-4-5', usage: { input_tokens: 10, output_tokens: 5 } },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId,
+    });
+    fs.writeFileSync(filePath, entry + '\n');
+    return filePath;
+  }
+
+  it('second call with same files does not re-read JSONL files', () => {
+    const stackDir = path.join(tmpDir, 'stack-c');
+    fs.mkdirSync(stackDir);
+    writeJsonl(stackDir, 'usage.jsonl', 'sess-c1');
+
+    const engine = createUsageEngine([stackDir]);
+    engine.getByTicket(); // first call — parses
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    engine.getByTicket(); // second call — cache hit
+
+    const jsonlReads = readSpy.mock.calls.filter((c) => String(c[0]).endsWith('.jsonl'));
+    expect(jsonlReads).toHaveLength(0);
+  });
+
+  it('re-parses when a file mtime changes', () => {
+    const stackDir = path.join(tmpDir, 'stack-m');
+    fs.mkdirSync(stackDir);
+    const filePath = writeJsonl(stackDir, 'usage.jsonl', 'sess-m1');
+
+    const engine = createUsageEngine([stackDir]);
+    engine.getByTicket(); // prime cache
+
+    const futureTime = new Date(Date.now() + 10_000);
+    fs.utimesSync(filePath, futureTime, futureTime);
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    engine.getByTicket(); // mtime changed — cache miss
+
+    const jsonlReads = readSpy.mock.calls.filter((c) => String(c[0]).endsWith('.jsonl'));
+    expect(jsonlReads.length).toBeGreaterThan(0);
+  });
+
+  it('re-parses when a new JSONL file is added', () => {
+    const stackDir = path.join(tmpDir, 'stack-n');
+    fs.mkdirSync(stackDir);
+    writeJsonl(stackDir, 'usage.jsonl', 'sess-n1');
+
+    const engine = createUsageEngine([stackDir]);
+    engine.getByTicket(); // prime cache
+
+    // Add a new file — cache key changes
+    writeJsonl(stackDir, 'usage2.jsonl', 'sess-n2');
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    engine.getByTicket();
+
+    const jsonlReads = readSpy.mock.calls.filter((c) => String(c[0]).endsWith('.jsonl'));
+    expect(jsonlReads.length).toBeGreaterThan(0);
+  });
+
+  it('clearUsageCache forces re-parse on next call', () => {
+    const stackDir = path.join(tmpDir, 'stack-cl');
+    fs.mkdirSync(stackDir);
+    writeJsonl(stackDir, 'usage.jsonl', 'sess-cl1');
+
+    const engine = createUsageEngine([stackDir]);
+    engine.getByTicket(); // prime cache
+
+    clearUsageCache();
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    engine.getByTicket(); // cache cleared — must re-parse
+
+    const jsonlReads = readSpy.mock.calls.filter((c) => String(c[0]).endsWith('.jsonl'));
+    expect(jsonlReads.length).toBeGreaterThan(0);
+  });
+
+  it('multiple engine instances share the cache', () => {
+    const stackDir = path.join(tmpDir, 'stack-shared');
+    fs.mkdirSync(stackDir);
+    writeJsonl(stackDir, 'usage.jsonl', 'sess-sh1');
+
+    const engine1 = createUsageEngine([stackDir]);
+    engine1.getByTicket(); // prime cache with engine1
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    const engine2 = createUsageEngine([stackDir]);
+    engine2.getByTicket(); // engine2 should hit the shared cache
+
+    const jsonlReads = readSpy.mock.calls.filter((c) => String(c[0]).endsWith('.jsonl'));
+    expect(jsonlReads).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summary costPerTicket — transcript-authoritative source
+// ---------------------------------------------------------------------------
+
+describe('summary costPerTicket source', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-summary-'));
+    clearUsageCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    clearUsageCache();
+  });
+
+  it('non-orchestrator cost sum from getByTicket matches expected independent computation', () => {
+    const stackA = path.join(tmpDir, 'stack-a');
+    const stackB = path.join(tmpDir, 'stack-b');
+    const orchestratorDir = path.join(tmpDir, '.claude', 'projects');
+    fs.mkdirSync(stackA);
+    fs.mkdirSync(stackB);
+    fs.mkdirSync(orchestratorDir, { recursive: true });
+
+    const writeManifest = (dir: string, stackId: string, ticket: string) => {
+      fs.writeFileSync(dir + '.manifest.json', JSON.stringify({ stackId, ticket, project: 'p', createdAt: '2024-01-01T00:00:00.000Z' }));
+    };
+    writeManifest(stackA, 'stack-a', 'T-1');
+    writeManifest(stackB, 'stack-b', 'T-2');
+
+    const makeEntry = (model: string, input: number, output: number) => JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', model, usage: { input_tokens: input, output_tokens: output } },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId: `sess-${Math.random()}`,
+    });
+
+    // stack-a: ticket T-1
+    fs.writeFileSync(path.join(stackA, 'a.jsonl'), makeEntry('claude-sonnet-4-5', 1_000_000, 500_000) + '\n');
+    // stack-b: ticket T-2
+    fs.writeFileSync(path.join(stackB, 'b.jsonl'), makeEntry('claude-sonnet-4-5', 500_000, 250_000) + '\n');
+    // orchestrator (host-root)
+    fs.writeFileSync(path.join(orchestratorDir, 'host.jsonl'), makeEntry('claude-sonnet-4-5', 100_000, 50_000) + '\n');
+
+    const engine = createUsageEngine([orchestratorDir, stackA, stackB]);
+    const byTicket = engine.getByTicket();
+
+    const nonOrchCost = byTicket
+      .filter((e) => e.ticketId !== ORCHESTRATOR_TICKET_ID)
+      .reduce((sum, e) => sum + e.cost, 0);
+
+    // Independently compute expected: sonnet pricing = $3/M input, $15/M output
+    const expectedT1 = (1_000_000 * 3 + 500_000 * 15) / 1_000_000; // $10.5
+    const expectedT2 = (500_000 * 3 + 250_000 * 15) / 1_000_000;   // $5.25
+    expect(nonOrchCost).toBeCloseTo(expectedT1 + expectedT2, 2);
+
+    // Orchestrator cost must NOT be included
+    const orchEntry = byTicket.find((e) => e.ticketId === ORCHESTRATOR_TICKET_ID);
+    expect(orchEntry).toBeDefined();
+    expect(orchEntry!.cost).toBeGreaterThan(0);
+    expect(nonOrchCost).toBeLessThan(nonOrchCost + orchEntry!.cost);
   });
 });


### PR DESCRIPTION
## Summary

The telemetry layer carried two divergent per-ticket shapes — `ByTicketEntry` (from the SQLite task/stack rollup) and `TranscriptByTicketEntry` (from transcript files) — and the summary card's total cost was sourced from the rollup store while the by-ticket table was sourced from transcripts, so the two views could disagree.

This change makes transcript-derived data the single authoritative source for per-ticket cost:

- Collapses the two types into one canonical `ByTicketEntry`, dropping the stale `title`/`column` fields (deferred to sub-issue #468) and removing `TranscriptByTicketEntry`.
- `aggregateByTicket` now rolls up by ticket alone, so a ticket worked across multiple stacks produces a single row. Host-root and unmapped spend collapse under `ORCHESTRATOR_TICKET_ID`, which is promoted to `types.ts` as the shared constant. Each row computes its primary model (highest summed output tokens), cache-hit rate, and an `unpriced` flag.
- `stats:telemetry:summary` derives total cost by summing per-ticket transcript cost excluding the orchestrator bucket, replacing `rollupStore.totalTicketCost()` so the headline figure matches the by-ticket table.
- Normalizes `TokenCounts` to `cacheCreate` plus a precomputed `total`, updating the rollup store's read/upsert paths accordingly.
- Adds a module-scoped parse cache to the usage engine keyed on the sorted root list plus each JSONL file's mtime and size, so the several IPC calls fired during one stats page load reuse a single parse instead of re-reading every transcript. `clearUsageCache()` is called on `stats:telemetry:refresh` to force a re-parse.

## QA plan

1. Open the stats/telemetry view and confirm it loads without errors.
2. Verify the summary card's total cost equals the sum of the per-ticket table rows (orchestrator row excluded).
3. Confirm a ticket that ran across more than one stack shows as a single row with combined cost and tokens.
4. Confirm host/unattributed spend appears under the orchestrator bucket and is excluded from the headline total.
5. Click refresh and confirm figures update to reflect newly written transcripts (cache invalidation), rather than serving stale numbers.
6. Spot-check that primary model and cache-hit percentage per ticket look reasonable.

Closes #499