### PR TITLE
[468] fix: split per-ticket telemetry cost across lifecycle stages

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -421,6 +421,10 @@ export class ClaudeBackend implements AgentBackend {
 
   // --- Ephemeral agent (one-shot Claude process) ---
 
+  getEphemeralTimingPath(): string {
+    return this.ephemeralTimingPath;
+  }
+
   /**
    * Spawn a one-shot Claude process that evaluates a prompt and returns the text result.
    * Uses -p (pipe/print) mode — no session persistence, no MCP tools.
@@ -431,6 +435,7 @@ export class ClaudeBackend implements AgentBackend {
     projectDir: string,
     timeoutMs = 300_000,
     onChunk?: (event: EphemeralStreamEvent) => void,
+    attribution?: { ticketId?: string; stage?: string },
   ): { promise: Promise<string>; cancel: () => void } {
     const claudeBin = getClaudeBin();
     const args = [
@@ -488,6 +493,8 @@ export class ClaudeBackend implements AgentBackend {
         turnCount,
         cancelled: isCancelled,
         ...(errorMessage != null ? { errorMessage } : {}),
+        ...(attribution?.ticketId != null ? { ticketId: attribution.ticketId } : {}),
+        ...(attribution?.stage != null ? { stage: attribution.stage } : {}),
       };
       appendEphemeralTiming(this.ephemeralTimingPath, record);
     };
@@ -585,8 +592,13 @@ export class ClaudeBackend implements AgentBackend {
     return { promise, cancel };
   }
 
-  runEphemeralAgent(prompt: string, projectDir: string, timeoutMs = 300_000): Promise<string> {
-    return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs).promise;
+  runEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs = 300_000,
+    attribution?: { ticketId?: string; stage?: string },
+  ): Promise<string> {
+    return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs, undefined, attribution).promise;
   }
 
   /**

--- a/src/main/agent/ephemeral-timing.ts
+++ b/src/main/agent/ephemeral-timing.ts
@@ -20,7 +20,7 @@
  *   }
  */
 
-import { appendFileSync } from 'fs';
+import { appendFileSync, readFileSync } from 'fs';
 
 export interface EphemeralTimingRecord {
   ts: string;
@@ -33,6 +33,8 @@ export interface EphemeralTimingRecord {
   turnCount: number;
   cancelled: boolean;
   errorMessage?: string;
+  ticketId?: string;  // optional attribution for lifecycle tracking
+  stage?: string;     // optional stage label: 'refine' | 'spec' | 'pr'
 }
 
 export function appendEphemeralTiming(filePath: string, record: EphemeralTimingRecord): void {
@@ -40,5 +42,24 @@ export function appendEphemeralTiming(filePath: string, record: EphemeralTimingR
     appendFileSync(filePath, JSON.stringify(record) + '\n');
   } catch {
     // Best effort — swallow write failures
+  }
+}
+
+/** Read all timing records from the JSONL store. Returns [] on missing/malformed file. */
+export function readEphemeralTimingRecords(filePath: string): EphemeralTimingRecord[] {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const records: EphemeralTimingRecord[] = [];
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        records.push(JSON.parse(line) as EphemeralTimingRecord);
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return records;
+  } catch {
+    return [];
   }
 }

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -112,8 +112,16 @@ export interface AgentBackend {
 
   // --- Ephemeral agents ---
 
+  /** Path to the JSON Lines file where ephemeral timing records are written */
+  getEphemeralTimingPath(): string;
+
   /** Spawn a one-shot agent process that evaluates a prompt and returns the text result */
-  runEphemeralAgent(prompt: string, projectDir: string, timeoutMs?: number): Promise<string>;
+  runEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    attribution?: { ticketId?: string; stage?: string },
+  ): Promise<string>;
 
   /** Spawn a cancellable one-shot agent process; returns a promise and a cancel function */
   spawnEphemeralAgent(
@@ -121,6 +129,7 @@ export interface AgentBackend {
     projectDir: string,
     timeoutMs?: number,
     onChunk?: (event: EphemeralStreamEvent) => void,
+    attribution?: { ticketId?: string; stage?: string },
   ): { promise: Promise<string>; cancel: () => void };
 
   /**

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -326,7 +326,7 @@ async function handleSpecCheck(
   const { ctx } = res;
 
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS);
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' });
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -524,13 +524,13 @@ async function handleSpecRefine(
 
   if (!userAnswers) {
     const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody);
-    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS);
+    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' });
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   }
 
   const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS);
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' });
   return applySpecRefineResult(ticketId, projectDir, result, true);
 }
 
@@ -556,7 +556,7 @@ export function spawnSpecCheck(
     if (cancelled) throw new Error('Cancelled');
 
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk);
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' });
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 
@@ -651,7 +651,7 @@ export function spawnSpecRefine(
       // No pooled session (timed out, app restarted, etc.) — fall back to a
       // cold ephemeral so the user's answers still produce a result.
       const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(
-        answerPrompt, projectDir, 0, onChunk,
+        answerPrompt, projectDir, 0, onChunk, { ticketId, stage: 'refine' },
       );
       activeDispose = epCancel;
       if (cancelled) { epCancel(); throw new Error('Cancelled'); }

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -922,6 +922,22 @@ export class Registry {
   }
 
   /**
+   * Return per-ticket, per-phase token weight totals for lifecycle cost splitting.
+   * Joins task_token_steps → tasks → stacks to resolve the ticket for each step.
+   * Only rows where stacks.ticket IS NOT NULL are included (excludes ad-hoc stacks).
+   */
+  getStepWeightsByTicket(): { ticket: string; phase: string; totalTokens: number }[] {
+    return this.db.prepare(`
+      SELECT s.ticket, tts.phase, SUM(tts.input_tokens + tts.output_tokens) AS totalTokens
+      FROM task_token_steps tts
+      JOIN tasks t ON t.id = tts.task_id
+      JOIN stacks s ON s.id = t.stack_id
+      WHERE s.ticket IS NOT NULL
+      GROUP BY s.ticket, tts.phase
+    `).all() as { ticket: string; phase: string; totalTokens: number }[];
+  }
+
+  /**
    * Validate that per-step token sums match phase totals and grand total.
    * Returns validation result with computed sums.
    */

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -90,6 +90,7 @@ import { KANBAN_COLUMNS } from '../shared/kanban';
 import os from 'os';
 import { createUsageEngine, clearUsageCache } from './telemetry/usage-engine';
 import type { DateRange, ByTicketEntry } from './telemetry/usage-engine';
+import { readEphemeralTimingRecords } from './agent/ephemeral-timing';
 import { ORCHESTRATOR_TICKET_ID } from './telemetry/types';
 import { TicketRollupStore } from './telemetry/rollup-store';
 
@@ -823,7 +824,12 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle('stats:telemetry:byTicket', async (): Promise<ByTicketEntry[]> => {
-    return createUsageEngine(buildTelemetryRoots()).getByTicket();
+    const stepWeights = registry.getStepWeightsByTicket();
+    const allEphemeral = readEphemeralTimingRecords(agentBackend.getEphemeralTimingPath());
+    const ephemeralRecords = allEphemeral
+      .filter((r) => r.ticketId != null && r.stage != null)
+      .map((r) => ({ ticketId: r.ticketId!, stage: r.stage!, turnCount: r.turnCount }));
+    return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords).getByTicket();
   });
 
   ipcMain.handle('stats:telemetry:refresh', async () => {
@@ -1443,7 +1449,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       },
       {
         runEphemeral: (prompt, projectDir, timeoutMs) =>
-          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs),
+          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }),
         fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
       },
     );
@@ -1530,7 +1536,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         { stackId, workspace, ticket: stack.ticket },
         {
           runEphemeral: (prompt, projectDir, timeoutMs) =>
-            agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs),
+            agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }),
           fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
         },
       );

--- a/src/main/telemetry/aggregator.ts
+++ b/src/main/telemetry/aggregator.ts
@@ -9,6 +9,22 @@ import { computeCost } from './pricing';
 import type { RawUsageEntry } from './parser';
 import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
 import { ORCHESTRATOR_TICKET_ID } from './types';
+import { computeLifecycleSplit } from './lifecycle-split';
+import type { LifecycleWeights } from './lifecycle-split';
+
+/** Per-ticket step weights read from task_token_steps (injected, electron-free). */
+export interface StepWeightRow {
+  ticket: string;
+  phase: string;  // 'execution' | 'review' are the only values written
+  totalTokens: number;
+}
+
+/** Per-run ephemeral weight record (from ephemeral-timing store, injected). */
+export interface EphemeralWeightRecord {
+  ticketId: string;
+  stage: string;  // 'refine' | 'spec' | 'pr'
+  turnCount: number;
+}
 
 function dateOf(isoTimestamp: string): string {
   return isoTimestamp.slice(0, 10); // YYYY-MM-DD
@@ -247,10 +263,15 @@ function readManifest(manifestPath: string): StackManifest | null {
  * The paired manifest is at stackRoot + '.manifest.json'.
  * Entries with no mapped ticket (host-root entries or missing manifest) roll up under
  * ORCHESTRATOR_TICKET_ID. A ticket worked across multiple stacks produces one row.
+ *
+ * stepWeights and ephemeralRecords are injected (read on the Electron side) so this
+ * function stays electron-free and unit-testable with plain arrays.
  */
 export function aggregateByTicket(
   entries: RawUsageEntry[],
-  stackRoots: string[]
+  stackRoots: string[],
+  stepWeights: StepWeightRow[] = [],
+  ephemeralRecords: EphemeralWeightRecord[] = [],
 ): ByTicketEntry[] {
   // Build stackId → ticket map from manifests
   const stackToTicket = new Map<string, string | null>();
@@ -289,6 +310,30 @@ export function aggregateByTicket(
     if (unpriced) bucket.unpriced = true;
   }
 
+  // Build per-ticket lifecycle weights from injected step + ephemeral data
+  const ticketWeights = new Map<string, LifecycleWeights>();
+
+  const getWeights = (ticketId: string): LifecycleWeights => {
+    let w = ticketWeights.get(ticketId);
+    if (!w) { w = {}; ticketWeights.set(ticketId, w); }
+    return w;
+  };
+
+  for (const row of stepWeights) {
+    if (row.phase !== 'execution' && row.phase !== 'review') continue;
+    const w = getWeights(row.ticket);
+    const stage = row.phase as 'execution' | 'review';
+    w[stage] = (w[stage] ?? 0) + row.totalTokens;
+  }
+
+  for (const rec of ephemeralRecords) {
+    if (!rec.ticketId || !rec.stage) continue;
+    if (rec.stage !== 'refine' && rec.stage !== 'spec' && rec.stage !== 'pr') continue;
+    const w = getWeights(rec.ticketId);
+    const stage = rec.stage as 'refine' | 'spec' | 'pr';
+    w[stage] = (w[stage] ?? 0) + rec.turnCount;
+  }
+
   return [...byTicket.entries()].map(([ticketId, data]) => {
     const { input, cacheRead } = data.tokens;
     const denom = input + cacheRead;
@@ -301,13 +346,15 @@ export function aggregateByTicket(
       if (output > maxOutput) { maxOutput = output; primaryModel = model; }
     }
 
+    const lifecycle = computeLifecycleSplit(data.cost, ticketWeights.get(ticketId) ?? {});
+
     return {
       ticketId,
       model: primaryModel,
       cost: data.cost,
       tokens: data.tokens,
       cacheHit,
-      lifecycle: null,
+      lifecycle,
       unpriced: data.unpriced,
     } satisfies ByTicketEntry;
   });

--- a/src/main/telemetry/lifecycle-split.ts
+++ b/src/main/telemetry/lifecycle-split.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure, electron-free lifecycle cost split.
+ *
+ * Takes the authoritative ticket cost (from transcripts) and per-stage weights,
+ * returns the six-stage USD breakdown whose sum equals cost exactly.
+ *
+ * verify weight is always forced to 0 — verify runs .sandstorm/verify.sh
+ * (tests/build), not run_claude, so it has no LLM spend.
+ */
+
+import type { LifecycleCosts } from './types';
+
+export type LifecycleStage = 'refine' | 'spec' | 'execution' | 'review' | 'verify' | 'pr';
+
+export const LIFECYCLE_STAGES: readonly LifecycleStage[] = [
+  'refine', 'spec', 'execution', 'review', 'verify', 'pr',
+];
+
+export type LifecycleWeights = Partial<Record<LifecycleStage, number>>;
+
+/**
+ * Split `cost` across the six lifecycle stages proportionally by `weights`.
+ *
+ * Rules:
+ * - verify is always 0 (no LLM spend) regardless of the weights input
+ * - All six keys are always present in the result
+ * - When cost === 0, returns all-zero object
+ * - When all effective weights are 0 and cost > 0, returns null (no signal)
+ * - Residual from floating-point rounding is assigned to the largest-weight
+ *   stage so sum(result) === cost exactly (within 1e-10 tolerance)
+ */
+export function computeLifecycleSplit(
+  cost: number,
+  weights: LifecycleWeights,
+): LifecycleCosts | null {
+  const effective: Record<LifecycleStage, number> = {
+    refine: weights.refine ?? 0,
+    spec: weights.spec ?? 0,
+    execution: weights.execution ?? 0,
+    review: weights.review ?? 0,
+    verify: 0,  // always zero — no LLM spend
+    pr: weights.pr ?? 0,
+  };
+
+  if (cost === 0) {
+    return { refine: 0, spec: 0, execution: 0, review: 0, verify: 0, pr: 0 };
+  }
+
+  const totalWeight = LIFECYCLE_STAGES.reduce((s, stage) => s + effective[stage], 0);
+  if (totalWeight === 0) return null;
+
+  const splits: Record<LifecycleStage, number> = {} as Record<LifecycleStage, number>;
+  for (const stage of LIFECYCLE_STAGES) {
+    splits[stage] = cost * (effective[stage] / totalWeight);
+  }
+
+  // Assign floating-point residual to the largest-weight stage
+  const sumSplits = LIFECYCLE_STAGES.reduce((s, stage) => s + splits[stage], 0);
+  const residual = cost - sumSplits;
+
+  let largestStage: LifecycleStage = LIFECYCLE_STAGES[0];
+  let largestWeight = -1;
+  for (const stage of LIFECYCLE_STAGES) {
+    if (effective[stage] > largestWeight) {
+      largestWeight = effective[stage];
+      largestStage = stage;
+    }
+  }
+  splits[largestStage] += residual;
+
+  return splits;
+}

--- a/src/main/telemetry/types.ts
+++ b/src/main/telemetry/types.ts
@@ -31,15 +31,25 @@ export interface TelemetrySummary {
   skippedLines: number;           // malformed JSONL lines skipped across all files
 }
 
+/** Per-stage cost breakdown for a ticket (USD, estimated at list price). */
+export interface LifecycleCosts {
+  refine: number;
+  spec: number;
+  execution: number;
+  review: number;
+  verify: number;  // always 0 — verify runs tests/build, not LLM
+  pr: number;
+}
+
 /** Canonical per-ticket cost attribution derived from transcript files. */
 export interface ByTicketEntry {
-  ticketId: string;        // real ID, or '__orchestrator__' for unattributed/host spend
-  model: string | null;    // primary model (highest output tokens)
-  cost: number;            // estimated USD, from transcripts (authoritative)
-  tokens: TokenCounts;     // {input, output, cacheCreate, cacheRead, total}
-  cacheHit: number;        // cacheRead / (input + cacheRead) × 100; 0 when all-zero
-  lifecycle: null;         // pending sub-issue #468
-  unpriced: boolean;       // true when any entry used a model with no known price
+  ticketId: string;                  // real ID, or '__orchestrator__' for unattributed/host spend
+  model: string | null;              // primary model (highest output tokens)
+  cost: number;                      // estimated USD, from transcripts (authoritative)
+  tokens: TokenCounts;               // {input, output, cacheCreate, cacheRead, total}
+  cacheHit: number;                  // cacheRead / (input + cacheRead) × 100; 0 when all-zero
+  lifecycle: LifecycleCosts | null;  // null when no stage signal exists; sum equals cost
+  unpriced: boolean;                 // true when any entry used a model with no known price
 }
 
 export interface DailyEntry {

--- a/src/main/telemetry/usage-engine.ts
+++ b/src/main/telemetry/usage-engine.ts
@@ -15,7 +15,10 @@
 import fs from 'fs';
 import { parseTranscriptRoots, findJSONLFiles, type ParseResult } from './parser';
 import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions, aggregateByTicket } from './aggregator';
+import type { StepWeightRow, EphemeralWeightRecord } from './aggregator';
 import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
+
+export type { StepWeightRow, EphemeralWeightRecord };
 
 export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry };
 
@@ -84,9 +87,16 @@ function loadCached(roots: string[]): ParseResult {
  * Roots ending with `/.claude/projects` are the host root (stackId=null).
  * All other roots are stack roots (stackId=basename of root dir).
  *
+ * stepWeights and ephemeralRecords are injected from the Electron side (SQLite + file-store)
+ * so the pure aggregation logic stays electron-free. Pass undefined to omit lifecycle data.
+ *
  * Returns zeroed shapes when no transcripts exist — never throws.
  */
-export function createUsageEngine(roots: string[]): UsageEngine {
+export function createUsageEngine(
+  roots: string[],
+  stepWeights?: StepWeightRow[],
+  ephemeralRecords?: EphemeralWeightRecord[],
+): UsageEngine {
   const stackRoots = roots.filter((r) => !r.endsWith('/.claude/projects'));
 
   return {
@@ -112,7 +122,7 @@ export function createUsageEngine(roots: string[]): UsageEngine {
 
     getByTicket(): ByTicketEntry[] {
       const { entries } = loadCached(roots);
-      return aggregateByTicket(entries, stackRoots);
+      return aggregateByTicket(entries, stackRoots, stepWeights, ephemeralRecords);
     },
   };
 }

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -59,6 +59,7 @@ const {
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
     setDarkFactoryEnabled: vi.fn(),
     getDb: vi.fn().mockReturnValue({}),
+    getStepWeightsByTicket: vi.fn().mockReturnValue([]),
   };
 
   const mockStackManager = {
@@ -107,6 +108,7 @@ const {
     getAuthStatus: vi.fn(),
     login: vi.fn(),
     syncCredentials: vi.fn(),
+    getEphemeralTimingPath: vi.fn().mockReturnValue('/tmp/mock-ephemeral-timing.jsonl'),
   };
 
   const mockDockerConnectionManager = {
@@ -235,6 +237,11 @@ vi.mock('os', async (importOriginal) => {
 vi.mock('../../src/main/telemetry/usage-engine', () => ({
   createUsageEngine: vi.fn(() => mockUsageEngine),
   clearUsageCache: vi.fn(),
+}));
+
+vi.mock('../../src/main/agent/ephemeral-timing', () => ({
+  appendEphemeralTiming: vi.fn(),
+  readEphemeralTimingRecords: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock('../../src/main/telemetry/rollup-store', () => ({

--- a/tests/unit/telemetry/lifecycle-split.test.ts
+++ b/tests/unit/telemetry/lifecycle-split.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import { computeLifecycleSplit, LIFECYCLE_STAGES } from '../../../src/main/telemetry/lifecycle-split';
+
+const STAGES = LIFECYCLE_STAGES;
+
+describe('computeLifecycleSplit', () => {
+  // --- Sum invariant ---
+
+  it('sum invariant: all stage values sum to cost exactly', () => {
+    const result = computeLifecycleSplit(10.5, { execution: 3, review: 1 });
+    expect(result).not.toBeNull();
+    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    expect(Math.abs(sum - 10.5)).toBeLessThan(1e-10);
+  });
+
+  it('sum invariant: holds for small fractional cost with varied weights', () => {
+    const cost = 0.001234;
+    const result = computeLifecycleSplit(cost, { refine: 2, spec: 3, execution: 7, review: 5, pr: 1 });
+    expect(result).not.toBeNull();
+    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    expect(Math.abs(sum - cost)).toBeLessThan(1e-10);
+  });
+
+  it('sum invariant: holds when a single stage has all weight', () => {
+    const cost = 7.77;
+    const result = computeLifecycleSplit(cost, { execution: 100 });
+    expect(result).not.toBeNull();
+    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    expect(Math.abs(sum - cost)).toBeLessThan(1e-10);
+  });
+
+  // --- Six keys always present ---
+
+  it('six keys always present: only execution+review weights given', () => {
+    const result = computeLifecycleSplit(5.0, { execution: 3, review: 1 });
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!).sort()).toEqual(STAGES.slice().sort());
+    expect(result!.refine).toBe(0);
+    expect(result!.spec).toBe(0);
+    expect(result!.verify).toBe(0);
+    expect(result!.pr).toBe(0);
+  });
+
+  it('six keys always present: all stages have weights', () => {
+    const result = computeLifecycleSplit(1.0, { refine: 1, spec: 1, execution: 1, review: 1, pr: 1 });
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!).sort()).toEqual(STAGES.slice().sort());
+  });
+
+  // --- Skipped stage → 0 ---
+
+  it('skipped stage: missing refine weight → lifecycle.refine === 0', () => {
+    const result = computeLifecycleSplit(10.0, { execution: 5, review: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.refine).toBe(0);
+  });
+
+  it('skipped stage: all of refine/spec/pr absent → those are 0', () => {
+    const result = computeLifecycleSplit(4.0, { execution: 3, review: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.refine).toBe(0);
+    expect(result!.spec).toBe(0);
+    expect(result!.pr).toBe(0);
+  });
+
+  // --- verify always 0 ---
+
+  it('verify is always 0 regardless of weight input', () => {
+    const result = computeLifecycleSplit(8.0, { execution: 4, review: 4, verify: 999 });
+    expect(result).not.toBeNull();
+    expect(result!.verify).toBe(0);
+  });
+
+  it('verify is 0 even when it is the only weight given', () => {
+    const result = computeLifecycleSplit(5.0, { verify: 100 });
+    // verify is forced to 0, total effective weight is 0, cost > 0 → null
+    expect(result).toBeNull();
+  });
+
+  // --- Zero-cost ticket ---
+
+  it('zero cost returns all-zero object', () => {
+    const result = computeLifecycleSplit(0, { execution: 10, review: 5 });
+    expect(result).not.toBeNull();
+    for (const stage of STAGES) {
+      expect(result![stage]).toBe(0);
+    }
+  });
+
+  it('zero cost with no weights returns all-zero object', () => {
+    const result = computeLifecycleSplit(0, {});
+    expect(result).not.toBeNull();
+    for (const stage of STAGES) {
+      expect(result![stage]).toBe(0);
+    }
+  });
+
+  // --- No-signal ticket → null ---
+
+  it('nonzero cost with all weights absent returns null', () => {
+    expect(computeLifecycleSplit(5.0, {})).toBeNull();
+  });
+
+  it('nonzero cost with all weights zero returns null', () => {
+    expect(computeLifecycleSplit(5.0, { execution: 0, review: 0 })).toBeNull();
+  });
+
+  it('nonzero cost with only verify weight (forced to 0) returns null', () => {
+    expect(computeLifecycleSplit(3.0, { verify: 50 })).toBeNull();
+  });
+
+  // --- Proportionality ---
+
+  it('execution 3× review: lifecycle.execution === 3 × lifecycle.review', () => {
+    const cost = 8.0;
+    const result = computeLifecycleSplit(cost, { execution: 9, review: 3 });
+    expect(result).not.toBeNull();
+    expect(result!.execution).toBeCloseTo(result!.review * 3, 10);
+  });
+
+  it('proportionality with multiple stages', () => {
+    const cost = 12.0;
+    const result = computeLifecycleSplit(cost, { refine: 1, spec: 2, execution: 6, review: 3 });
+    expect(result).not.toBeNull();
+    const total = 1 + 2 + 6 + 3;
+    expect(result!.refine).toBeCloseTo(cost * (1 / total), 8);
+    expect(result!.spec).toBeCloseTo(cost * (2 / total), 8);
+    expect(result!.execution).toBeCloseTo(cost * (6 / total), 8);
+    expect(result!.review).toBeCloseTo(cost * (3 / total), 8);
+  });
+
+  // --- Residual rule ---
+
+  it('residual is assigned to the largest-weight stage', () => {
+    // With floating point, sum may drift; largest stage should absorb the residual
+    const cost = 1.0 / 3.0; // 0.333...
+    const result = computeLifecycleSplit(cost, { execution: 1 });
+    expect(result).not.toBeNull();
+    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    expect(Math.abs(sum - cost)).toBeLessThan(1e-10);
+    expect(result!.execution).toBeCloseTo(cost, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateByTicket — lifecycle plumbing integration
+// ---------------------------------------------------------------------------
+
+import { describe as d2, it as it2, expect as expect2, beforeEach as be2, afterEach as ae2 } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { aggregateByTicket } from '../../../src/main/telemetry/aggregator';
+import type { StepWeightRow, EphemeralWeightRecord } from '../../../src/main/telemetry/aggregator';
+
+d2('aggregateByTicket lifecycle plumbing', () => {
+  let tmpDir: string;
+
+  be2(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lc-agg-')); });
+  ae2(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  const makeEntry = (sid: string, stackId: string | null, model = 'claude-sonnet-4-5', input = 1000, output = 500) => ({
+    sessionId: sid,
+    stackId,
+    model,
+    input,
+    output,
+    cacheCreate: 0,
+    cacheRead: 0,
+    timestamp: '2024-03-01T10:00:00.000Z',
+  });
+
+  const makeManifest = (dir: string, stackId: string, ticket: string) => {
+    fs.writeFileSync(dir + '.manifest.json', JSON.stringify({ stackId, ticket, project: 'p', createdAt: '2024-01-01T00:00:00.000Z' }));
+  };
+
+  it2('no weights → lifecycle null for nonzero-cost ticket', () => {
+    const stackDir = path.join(tmpDir, 'stack-nw');
+    fs.mkdirSync(stackDir);
+    makeManifest(stackDir, 'stack-nw', 'T-1');
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-nw')], [stackDir]);
+    const row = result.find((r) => r.ticketId === 'T-1');
+    expect(row).toBeDefined();
+    expect2(row!.lifecycle).toBeNull();
+  });
+
+  it2('step weights → lifecycle populated, verify always 0', () => {
+    const stackDir = path.join(tmpDir, 'stack-sw');
+    fs.mkdirSync(stackDir);
+    makeManifest(stackDir, 'stack-sw', 'T-2');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-2', phase: 'execution', totalTokens: 300 },
+      { ticket: 'T-2', phase: 'review', totalTokens: 100 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-sw')], [stackDir], stepWeights);
+    const row = result.find((r) => r.ticketId === 'T-2');
+    expect(row).toBeDefined();
+    expect2(row!.lifecycle).not.toBeNull();
+    expect2(row!.lifecycle!.verify).toBe(0);
+
+    // Sum must equal cost
+    const lc = row!.lifecycle!;
+    const sum = lc.refine + lc.spec + lc.execution + lc.review + lc.verify + lc.pr;
+    expect2(Math.abs(sum - row!.cost)).toBeLessThan(1e-10);
+  });
+
+  it2('ephemeral record feeds spec weight into lifecycle', () => {
+    const stackDir = path.join(tmpDir, 'stack-ep');
+    fs.mkdirSync(stackDir);
+    makeManifest(stackDir, 'stack-ep', 'T-3');
+
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'T-3', stage: 'spec', turnCount: 5 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-ep')], [stackDir], [], ephemeralRecords);
+    const row = result.find((r) => r.ticketId === 'T-3');
+    expect(row).toBeDefined();
+    expect2(row!.lifecycle).not.toBeNull();
+    expect2(row!.lifecycle!.spec).toBeGreaterThan(0);
+    expect2(row!.lifecycle!.verify).toBe(0);
+  });
+
+  it2('multi-stack ticket: step weights sum across stacks', () => {
+    const stackDir1 = path.join(tmpDir, 'stack-ms1');
+    const stackDir2 = path.join(tmpDir, 'stack-ms2');
+    fs.mkdirSync(stackDir1);
+    fs.mkdirSync(stackDir2);
+    makeManifest(stackDir1, 'stack-ms1', 'T-4');
+    makeManifest(stackDir2, 'stack-ms2', 'T-4');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-4', phase: 'execution', totalTokens: 200 },
+      { ticket: 'T-4', phase: 'execution', totalTokens: 400 }, // second stack
+      { ticket: 'T-4', phase: 'review', totalTokens: 100 },
+    ];
+
+    const entries = [
+      makeEntry('s1', 'stack-ms1'),
+      makeEntry('s2', 'stack-ms2'),
+    ];
+    const result = aggregateByTicket(entries, [stackDir1, stackDir2], stepWeights);
+    const row = result.find((r) => r.ticketId === 'T-4');
+    expect(row).toBeDefined();
+    expect2(row!.lifecycle).not.toBeNull();
+    const lc = row!.lifecycle!;
+    const sum = lc.refine + lc.spec + lc.execution + lc.review + lc.verify + lc.pr;
+    expect2(Math.abs(sum - row!.cost)).toBeLessThan(1e-10);
+    // execution weight 600 vs review 100 → execution should be ~6× review
+    expect2(lc.execution).toBeCloseTo(lc.review * 6, 6);
+  });
+
+  it2('orchestrator bucket always has lifecycle null', () => {
+    const result = aggregateByTicket([makeEntry('s1', null)], []);
+    const row = result.find((r) => r.ticketId === '__orchestrator__');
+    expect(row).toBeDefined();
+    // Orchestrator has no step or ephemeral weights → lifecycle null
+    expect2(row!.lifecycle).toBeNull();
+  });
+});

--- a/tests/unit/telemetry/usage-engine.test.ts
+++ b/tests/unit/telemetry/usage-engine.test.ts
@@ -12,7 +12,7 @@ import {
   aggregateSessions,
   aggregateByTicket,
 } from '../../../src/main/telemetry/aggregator';
-import { createUsageEngine, clearUsageCache } from '../../../src/main/telemetry/usage-engine';
+import { createUsageEngine, clearUsageCache, type StepWeightRow, type EphemeralWeightRecord } from '../../../src/main/telemetry/usage-engine';
 import { ORCHESTRATOR_TICKET_ID } from '../../../src/main/telemetry/types';
 
 const FIXTURES = path.resolve(__dirname, 'fixtures');
@@ -1006,5 +1006,110 @@ describe('summary costPerTicket source', () => {
     expect(orchEntry).toBeDefined();
     expect(orchEntry!.cost).toBeGreaterThan(0);
     expect(nonOrchCost).toBeLessThan(nonOrchCost + orchEntry!.cost);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Q2 plumbing — injected stepWeights / ephemeralRecords reach aggregateByTicket
+// ---------------------------------------------------------------------------
+
+describe('createUsageEngine — injected weights produce non-null lifecycle (Q2 plumbing)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-q2-'));
+    clearUsageCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    clearUsageCache();
+  });
+
+  function writeManifest(stackRoot: string, stackId: string, ticket: string) {
+    fs.writeFileSync(stackRoot + '.manifest.json', JSON.stringify({
+      stackId, ticket, project: 'p', createdAt: '2024-01-01T00:00:00.000Z',
+    }));
+  }
+
+  function writeTranscript(stackRoot: string, sessionId: string) {
+    const entry = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', model: 'claude-sonnet-4-5', usage: { input_tokens: 100, output_tokens: 50 } },
+      timestamp: '2024-03-01T10:00:00.000Z',
+      sessionId,
+    });
+    fs.writeFileSync(path.join(stackRoot, 'usage.jsonl'), entry + '\n');
+  }
+
+  it('injected stepWeights produce non-null lifecycle for matching ticket', () => {
+    const stackRoot = path.join(tmpDir, 'stack-q2');
+    fs.mkdirSync(stackRoot);
+    writeManifest(stackRoot, 'stack-q2', 'TICKET-Q2');
+    writeTranscript(stackRoot, 'sess-q2');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'TICKET-Q2', phase: 'execution', totalTokens: 3000 },
+      { ticket: 'TICKET-Q2', phase: 'review', totalTokens: 1000 },
+    ];
+
+    const engine = createUsageEngine([stackRoot], stepWeights, []);
+    const rows = engine.getByTicket();
+
+    const row = rows.find((r) => r.ticketId === 'TICKET-Q2');
+    expect(row).toBeDefined();
+    expect(row!.lifecycle).not.toBeNull();
+    expect(row!.lifecycle!.execution).toBeGreaterThan(0);
+    expect(row!.lifecycle!.review).toBeGreaterThan(0);
+    expect(row!.lifecycle!.verify).toBe(0);
+  });
+
+  it('injected ephemeralRecords produce non-null lifecycle for matching ticket', () => {
+    const stackRoot = path.join(tmpDir, 'stack-eph');
+    fs.mkdirSync(stackRoot);
+    writeManifest(stackRoot, 'stack-eph', 'TICKET-EPH');
+    writeTranscript(stackRoot, 'sess-eph');
+
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'TICKET-EPH', stage: 'spec', turnCount: 5 },
+      { ticketId: 'TICKET-EPH', stage: 'pr', turnCount: 2 },
+    ];
+
+    const engine = createUsageEngine([stackRoot], [], ephemeralRecords);
+    const rows = engine.getByTicket();
+
+    const row = rows.find((r) => r.ticketId === 'TICKET-EPH');
+    expect(row).toBeDefined();
+    expect(row!.lifecycle).not.toBeNull();
+    expect(row!.lifecycle!.spec).toBeGreaterThan(0);
+    expect(row!.lifecycle!.pr).toBeGreaterThan(0);
+  });
+
+  it('injected step + ephemeral weights both reach aggregateByTicket and sum to cost', () => {
+    const stackRoot = path.join(tmpDir, 'stack-both');
+    fs.mkdirSync(stackRoot);
+    writeManifest(stackRoot, 'stack-both', 'TICKET-BOTH');
+    writeTranscript(stackRoot, 'sess-both');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'TICKET-BOTH', phase: 'execution', totalTokens: 6000 },
+      { ticket: 'TICKET-BOTH', phase: 'review', totalTokens: 2000 },
+    ];
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'TICKET-BOTH', stage: 'refine', turnCount: 3 },
+      { ticketId: 'TICKET-BOTH', stage: 'spec', turnCount: 4 },
+      { ticketId: 'TICKET-BOTH', stage: 'pr', turnCount: 2 },
+    ];
+
+    const engine = createUsageEngine([stackRoot], stepWeights, ephemeralRecords);
+    const rows = engine.getByTicket();
+
+    const row = rows.find((r) => r.ticketId === 'TICKET-BOTH');
+    expect(row).toBeDefined();
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    const lifecycleSum = lc.refine + lc.spec + lc.execution + lc.review + lc.verify + lc.pr;
+    expect(Math.abs(lifecycleSum - row!.cost)).toBeLessThan(1e-6);
   });
 });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -188,7 +188,8 @@ describe('MCP tools', () => {
       expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
         expect.stringContaining('Fix bug'),
         '/proj',
-        1_800_000
+        1_800_000,
+        { ticketId: '42', stage: 'spec' }
       );
       expect(result.passed).toBe(true);
       expect(result.report).toContain('PASS');
@@ -560,7 +561,8 @@ describe('MCP tools', () => {
       expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
         expect.stringContaining('auth tokens expire silently'),
         '/proj',
-        1_800_000
+        1_800_000,
+        { ticketId: '42', stage: 'refine' }
       );
       expect(result.passed).toBe(true);
       expect(result.updatedBody).toContain('Better spec');


### PR DESCRIPTION
## Summary

Replaces the `lifecycle: null` placeholder on per-ticket telemetry with a real six-stage USD breakdown (refine, spec, execution, review, verify, pr). The authoritative per-ticket cost from transcripts is split proportionally across stages by token weight, so the six stage costs always sum back to the ticket total.

Weights come from two sources, both injected into the pure aggregator so it stays electron-free and unit-testable:

- **Execution and review** weights come from `task_token_steps`, joined through tasks and stacks to resolve each step's ticket (new `Registry.getStepWeightsByTicket`).
- **Refine, spec, and pr** weights come from the ephemeral-timing JSONL store. Ephemeral agent runs now carry optional `{ ticketId, stage }` attribution, threaded through `runEphemeralAgent`/`spawnEphemeralAgent` and tagged at each call site in `tools.ts` (spec-check, spec-refine) and `ipc.ts` (pr).

The split logic (`lifecycle-split.ts`) forces `verify` to 0 (it runs tests/build, not an LLM), returns all-zero when cost is 0, returns `null` when no stage signal exists, and assigns the floating-point residual to the largest-weight stage so the sum equals cost exactly. The `stats:telemetry:byTicket` IPC handler reads both weight sources and passes them into the usage engine.

## QA plan

1. Run a ticket through a stack so it accrues execution/review token steps and at least one ephemeral spec-refine and PR run.
2. Open the telemetry/usage view and inspect the per-ticket row's lifecycle breakdown.
3. Confirm the six stage values are populated, `verify` shows 0, and the stages sum to the ticket's total cost.
4. Confirm a ticket with no stage signal still shows a total cost with a null/empty lifecycle rather than erroring.

Closes #468