### PR TITLE
[515] fix: add Answer button for needs_human stacks on ticket cards

### DIFF
--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -4,6 +4,7 @@ import { makePrEligible } from '../utils/duration';
 import { suggestStackName } from '../lib/stack-name';
 import { DiscardStackDialog } from './DiscardStackDialog';
 import { ConfirmDialog } from './ConfirmDialog';
+import { AnswerQuestionsModal } from './AnswerQuestionsModal';
 
 interface TicketCardProps {
   ticket: TicketBoardEntry;
@@ -41,10 +42,12 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     autoResolveInFlight,
     autoResolveErrors,
     mergeConflicts,
+    refreshStacks,
   } = useAppStore();
 
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
   const [showEarlyDiscardDialog, setShowEarlyDiscardDialog] = useState(false);
+  const [showAnswerModal, setShowAnswerModal] = useState(false);
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
   const stackKey = `${ticket.ticket_id}|${ticket.project_dir}`;
@@ -92,6 +95,15 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     if (stack) {
       void resumeStackWithContinuation(stack.id, true);
     }
+  };
+
+  const handleAnswer = () => {
+    setShowAnswerModal(true);
+  };
+
+  const handleAnswerResumed = () => {
+    setShowAnswerModal(false);
+    void refreshStacks();
   };
 
   const handleDiscardBackToBacklog = () => {
@@ -312,6 +324,15 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               Resume
             </button>
           )}
+          {stack && stack.status === 'needs_human' && (
+            <button
+              onClick={handleAnswer}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-amber-500/10 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20 transition-colors font-medium"
+              data-testid={`ticket-card-in-stack-answer-${ticket.ticket_id}`}
+            >
+              Answer
+            </button>
+          )}
           {stack && (makePrEligible(stack) || prInFlight) && (
             <button
               onClick={handleCreatePR}
@@ -409,6 +430,14 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
           onCloseTicket={handleDiscardCloseTicket}
           onCancel={() => setShowDiscardDialog(false)}
           data-testid={`discard-stack-dialog-${ticket.ticket_id}`}
+        />
+      )}
+
+      {showAnswerModal && stack && (
+        <AnswerQuestionsModal
+          stackId={stack.id}
+          onClose={() => setShowAnswerModal(false)}
+          onResumed={handleAnswerResumed}
         />
       )}
     </div>

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -8,6 +8,16 @@ import { TicketCard } from '../../../src/renderer/components/TicketCard';
 import { useAppStore } from '../../../src/renderer/store';
 import { mockSandstormApi } from './setup';
 
+// Mock AnswerQuestionsModal to avoid IPC calls in tests
+vi.mock('../../../src/renderer/components/AnswerQuestionsModal', () => ({
+  AnswerQuestionsModal: ({ onClose, onResumed }: { stackId: string; onClose: () => void; onResumed: () => void }) => (
+    <div data-testid="answer-questions-modal">
+      <button data-testid="answer-modal-close" onClick={onClose}>Close</button>
+      <button data-testid="answer-modal-resumed" onClick={onResumed}>Resumed</button>
+    </div>
+  ),
+}));
+
 // Mock DiscardStackDialog to avoid full dialog rendering in all tests
 vi.mock('../../../src/renderer/components/DiscardStackDialog', () => ({
   DiscardStackDialog: ({ onBackToBacklog, onCloseTicket, onCancel, 'data-testid': testId }: {
@@ -622,6 +632,69 @@ describe('TicketCard', () => {
     render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
     expect(screen.getByTestId('ticket-card-resume-42')).toBeDefined();
     expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
+  });
+
+  it('in_stack: shows Answer button when stack.status === needs_human', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-in-stack-answer-42')).toBeDefined();
+  });
+
+  it('in_stack: does not show Answer button when no linked stack', () => {
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-in-stack-answer-42')).toBeNull();
+  });
+
+  it('in_stack: does not show Answer button for non-needs_human statuses', () => {
+    const nonAnswerStatuses = ['running', 'building', 'completed', 'failed', 'session_paused'];
+    nonAnswerStatuses.forEach((status) => {
+      const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status, pr_url: null, pr_number: null } as any;
+      const { unmount } = render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+      expect(screen.queryByTestId('ticket-card-in-stack-answer-42')).toBeNull();
+      unmount();
+    });
+  });
+
+  it('in_stack: needs_human does not show Create PR button (regression: was missing Answer affordance)', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-in-stack-answer-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
+  });
+
+  it('in_stack: clicking Answer button mounts AnswerQuestionsModal', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('answer-questions-modal')).toBeNull();
+    fireEvent.click(screen.getByTestId('ticket-card-in-stack-answer-42'));
+    expect(screen.getByTestId('answer-questions-modal')).toBeDefined();
+  });
+
+  it('in_stack: closing AnswerQuestionsModal hides it', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-in-stack-answer-42'));
+    expect(screen.getByTestId('answer-questions-modal')).toBeDefined();
+    fireEvent.click(screen.getByTestId('answer-modal-close'));
+    expect(screen.queryByTestId('answer-questions-modal')).toBeNull();
+  });
+
+  it('in_stack: onResumed closes modal and calls refreshStacks', async () => {
+    const refreshSpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ refreshStacks: refreshSpy } as any);
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-in-stack-answer-42'));
+    fireEvent.click(screen.getByTestId('answer-modal-resumed'));
+    await waitFor(() => expect(refreshSpy).toHaveBeenCalled());
+    expect(screen.queryByTestId('answer-questions-modal')).toBeNull();
+  });
+
+  it('in_stack: session_paused still shows Resume button (regression guard)', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'session_paused', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-resume-42')).toBeDefined();
+    expect(screen.queryByTestId('ticket-card-in-stack-answer-42')).toBeNull();
   });
 
   it('pr_open: shows Merge button when stack has pr_number set', () => {


### PR DESCRIPTION
## Summary

Tickets whose stack is waiting on human input (`stack.status === 'needs_human'`) previously had no way to respond from the ticket card. This adds an **Answer** action to the `in_stack` view that opens the existing `AnswerQuestionsModal`, letting the user reply to the agent's questions and resume the stack without leaving the board.

When the modal reports the session resumed, it closes and refreshes the stacks so the card reflects the new status. The action is gated on `needs_human` only, so other statuses (e.g. `session_paused` still showing Resume) are unaffected.

## QA plan

1. Open a ticket whose stack is in the `needs_human` state.
2. Confirm an **Answer** button appears in the in-stack section (and that Create PR is not shown).
3. Click **Answer** and verify the answer-questions modal opens.
4. Close the modal without answering and confirm it dismisses and the button remains.
5. Submit answers and confirm the modal closes, the stack list refreshes, and the card reflects the resumed status.
6. Verify a ticket with a `session_paused` stack still shows the Resume action and no Answer button.

Closes #515