### PR TITLE
[524] fix: add move-to-backlog action to refining tickets

### DIFF
--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -47,6 +47,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
 
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
   const [showEarlyDiscardDialog, setShowEarlyDiscardDialog] = useState(false);
+  const [showMoveToBacklogDialog, setShowMoveToBacklogDialog] = useState(false);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
@@ -123,6 +124,15 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
       removeRefinementSession(refinementSession.id);
     }
     void discardStack(ticket.ticket_id, ticket.project_dir, 'close');
+  };
+
+  const handleMoveToBacklog = async () => {
+    setShowMoveToBacklogDialog(false);
+    if (refinementSession) {
+      await window.sandstorm.tickets.cancelRefinement(refinementSession.id).catch(() => {});
+      removeRefinementSession(refinementSession.id);
+    }
+    void moveTicketColumn(ticket.ticket_id, ticket.project_dir, 'backlog');
   };
 
   const isEarlyColumn = ticket.column === 'backlog' || ticket.column === 'refining' || ticket.column === 'spec_ready';
@@ -270,6 +280,13 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               Answer
             </button>
           )}
+          <button
+            onClick={() => setShowMoveToBacklogDialog(true)}
+            className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-surface-hover text-sandstorm-muted border border-sandstorm-border hover:border-sandstorm-accent/30 hover:text-sandstorm-text transition-colors font-medium"
+            data-testid={`ticket-card-move-to-backlog-${ticket.ticket_id}`}
+          >
+            Move to backlog
+          </button>
           {discardErrorBlock}
         </div>
       )}
@@ -424,6 +441,17 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
           confirmLabel="Discard ticket"
           onConfirm={() => void handleEarlyDiscardConfirm()}
           onCancel={() => setShowEarlyDiscardDialog(false)}
+        />
+      )}
+
+      {showMoveToBacklogDialog && (
+        <ConfirmDialog
+          title="Move ticket back to backlog?"
+          body="This discards the current refinement session and moves the ticket back to the backlog. Answers you already submitted and any title/body edits are kept on the ticket — only the in-progress refinement session is lost."
+          confirmLabel="Move to backlog"
+          onConfirm={() => void handleMoveToBacklog()}
+          onCancel={() => setShowMoveToBacklogDialog(false)}
+          data-testid={`move-to-backlog-dialog-${ticket.ticket_id}`}
         />
       )}
 

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -1410,6 +1410,99 @@ describe('TicketCard', () => {
     expect(api.tickets.cancelRefinement).not.toHaveBeenCalled();
   });
 
+  // =========================================================================
+  // #524 — Move to backlog from refining
+  // =========================================================================
+
+  it('refining: shows Move to backlog button distinct from Discard button', () => {
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByTestId('ticket-card-move-to-backlog-42')).toBeDefined();
+    expect(screen.getByTestId('ticket-card-discard-42')).toBeDefined();
+  });
+
+  it('refining: clicking Move to backlog opens dialog without calling cancelRefinement or moveTicketColumn', async () => {
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-move-to-backlog-42'));
+    expect(screen.getByTestId('move-to-backlog-dialog-42')).toBeDefined();
+    await act(async () => {});
+    expect(api.tickets.cancelRefinement).not.toHaveBeenCalled();
+    expect(api.ticketBoard.setColumn).not.toHaveBeenCalled();
+  });
+
+  it('refining: confirming Move to backlog with running session calls cancelRefinement, removeRefinementSession, then moveTicketColumn(backlog) in order', async () => {
+    const callOrder: string[] = [];
+    const removeSpy = vi.fn().mockImplementation(() => { callOrder.push('remove'); });
+    api.tickets.cancelRefinement.mockImplementation(async () => { callOrder.push('cancel'); });
+    api.ticketBoard.setColumn.mockImplementation(async () => { callOrder.push('setColumn'); });
+
+    useAppStore.setState({
+      removeRefinementSession: removeSpy,
+      boardTickets: [makeTicket('refining') as any],
+      refinementSessions: [{
+        id: 'sess-move',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'running',
+        phase: 'check',
+        startedAt: 0,
+      }],
+    } as any);
+
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-move-to-backlog-42'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'backlog'));
+    expect(api.tickets.cancelRefinement).toHaveBeenCalledWith('sess-move');
+    expect(removeSpy).toHaveBeenCalledWith('sess-move');
+    expect(callOrder).toEqual(['cancel', 'remove', 'setColumn']);
+    expect(api.tickets.close).not.toHaveBeenCalled();
+    expect(api.ticketBoard.delete).not.toHaveBeenCalled();
+  });
+
+  it('refining: confirming Move to backlog with no session skips cancelRefinement and calls moveTicketColumn(backlog)', async () => {
+    useAppStore.setState({
+      boardTickets: [makeTicket('refining') as any],
+      refinementSessions: [],
+    } as any);
+
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-move-to-backlog-42'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(api.ticketBoard.setColumn).toHaveBeenCalledWith('42', PROJECT_DIR, 'backlog'));
+    expect(api.tickets.cancelRefinement).not.toHaveBeenCalled();
+  });
+
+  it('refining: cancelling Move to backlog dialog calls neither cancelRefinement nor moveTicketColumn', async () => {
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-move-to-backlog-42'));
+    expect(screen.getByTestId('move-to-backlog-dialog-42')).toBeDefined();
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+    expect(screen.queryByTestId('move-to-backlog-dialog-42')).toBeNull();
+    await act(async () => {});
+    expect(api.tickets.cancelRefinement).not.toHaveBeenCalled();
+    expect(api.ticketBoard.setColumn).not.toHaveBeenCalled();
+  });
+
+  it('refining: Discard button still opens close-ticket dialog after adding Move to backlog (regression)', async () => {
+    const discardSpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ discardStack: discardSpy, refinementSessions: [] } as any);
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-discard-42'));
+    expect(screen.queryByTestId('move-to-backlog-dialog-42')).toBeNull();
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+    await waitFor(() => expect(discardSpy).toHaveBeenCalledWith('42', PROJECT_DIR, 'close'));
+  });
+
   it('refining: running session — no session-destructive IPC call is made (#510)', () => {
     useAppStore.setState({
       refinementSessions: [{


### PR DESCRIPTION
## Summary

Adds a "Move to backlog" action to tickets in the refining column, giving users a non-destructive way to step back from an in-progress refinement without discarding the ticket.

The new button sits alongside the existing Discard control and opens its own confirmation dialog. Confirming cancels any active refinement session (best-effort), removes the local session, and moves the ticket back to the backlog column. Already-submitted answers and any title/body edits stay on the ticket — only the in-progress refinement session is lost. When no session is running, the cancel step is skipped and the ticket is simply moved.

## QA plan

1. Open a ticket and start refinement so it lands in the refining column.
2. Confirm a "Move to backlog" button appears next to Discard on the card.
3. Click "Move to backlog" and verify the confirmation dialog explains that the refinement session is discarded but answers and edits are kept.
4. Cancel the dialog and confirm nothing changes — the ticket stays in refining.
5. Reopen the dialog, confirm, and verify the ticket returns to the backlog column with its answers and title/body edits intact.
6. Verify the existing Discard control still opens the close-ticket dialog and behaves as before.

Closes #524