### PR TITLE
[528] fix: tighten spec quality gate dependency and whole-contribution

### DIFF
--- a/src/main/spec-quality-gate.ts
+++ b/src/main/spec-quality-gate.ts
@@ -84,6 +84,15 @@ When the ticket references another ticket, module, or external system's output:
 - Read/write timing must be compatible — if the source writes at end-of-process and the consumer reads mid-process, that's a conflict.
 - How contract compatibility is verified must be specified.
 - If the data source doesn't exist yet, the ticket must include creating it or explicitly depend on a ticket that does.
+- The contract must resolve to an enforced artifact — a committed type/interface, a schema, or a contract test — not prose. A contract that exists only in an epic description, a code comment, or an unmerged sibling ticket's text is NOT a contract; FAIL the ticket until the owning ticket lands the artifact (or this ticket creates it). (Consuming existing committed code/types is fine — that IS an enforced artifact.)
+- Name the single owner of each shared surface the ticket touches; a consumer or extender must reference that owner and must not redefine the shape.
+
+### Contribution to the Whole
+If the ticket is part of a larger epic or multi-ticket effort:
+- It must name which epic-level acceptance behavior(s) it advances, so coverage is traceable and no envisioned element is orphaned.
+- If it cannot point to an acceptance behavior it serves, either the epic's acceptance definition is incomplete or the ticket is scope creep — resolve before dispatch.
+- This is the per-ticket coverage check only. It does NOT require end-to-end or visual verification, and it does NOT replace a whole-epic acceptance review (a green ticket is progress, not proof the whole behavior works assembled).
+- Skip this criterion for standalone tickets with no parent epic.
 
 ### All Verification Must Be Automatable
 Every verification item must be executable autonomously with no human involvement:

--- a/tests/unit/spec-quality-gate.test.ts
+++ b/tests/unit/spec-quality-gate.test.ts
@@ -37,6 +37,24 @@ describe('getDefaultSpecQualityGate', () => {
     expect(content).toContain('Read/write timing');
   });
 
+  it('includes enforced-artifact requirement in dependency contracts', () => {
+    const content = getDefaultSpecQualityGate();
+    expect(content).toContain('must resolve to an enforced artifact');
+    expect(content).toContain('not prose');
+  });
+
+  it('includes contribution-to-the-whole criterion', () => {
+    const content = getDefaultSpecQualityGate();
+    expect(content).toContain('### Contribution to the Whole');
+    expect(content).toContain('epic-level acceptance behavior');
+  });
+
+  it('new criteria do not reintroduce e2e/visual verification', () => {
+    const content = getDefaultSpecQualityGate();
+    expect(content).not.toContain('### End-to-End Data Flow Verification');
+    expect(content).not.toContain('### Automated Visual Verification');
+  });
+
   it('includes all-verification-automatable criterion', () => {
     const content = getDefaultSpecQualityGate();
     expect(content).toContain('### All Verification Must Be Automatable');


### PR DESCRIPTION
## Summary

Strengthens the spec quality gate so generated tickets resolve their dependencies to enforced, single-owner artifacts and stay accountable to the epic-level objective.

The `### Dependency Contracts` criterion now requires that every declared dependency resolve to an enforced artifact (not prose) and that each such artifact have a single owner, closing the gap where contracts could be satisfied by narrative description alone.

A new `### Contribution to the Whole` criterion is added between Dependency Contracts and All Verification Must Be Automatable, requiring each ticket to tie back to epic-level acceptance behavior so a plan of individually-green tickets still delivers the whole. The new criteria deliberately do not reintroduce e2e or visual verification, which remain locked out.

## QA plan

1. Trigger the spec quality gate against a draft ticket whose dependency is described only in prose and confirm it is flagged for not resolving to an enforced artifact.
2. Confirm a ticket whose dependency artifact has no single owner is flagged.
3. Confirm a ticket with no link to epic-level acceptance behavior is flagged by the new Contribution to the Whole criterion.
4. Confirm the gate still rejects specs that rely on e2e or visual verification.

Closes #528