### PR TITLE
[539] fix: show refinement error message on ticket card

### DIFF
--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -179,6 +179,12 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     (refinementSession.status === 'ready' && !!refinementSession.result?.error)
   )) || !!refineStartError;
 
+  const refineErrorMessage =
+    refinementSession?.error ??
+    refinementSession?.result?.error ??
+    refineStartError ??
+    'Refinement failed';
+
   return (
     <div
       className={`bg-sandstorm-surface border border-sandstorm-border rounded-lg p-3 flex flex-col gap-2 shadow-card ${ticket.column === 'merged' ? 'opacity-40' : ''}`}
@@ -234,10 +240,11 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
           {/* Error badge for clear visual indication of failure */}
           {showErrorState && (
             <span
-              className="text-xs text-red-400"
+              className="text-xs text-red-400 truncate block max-w-full"
               data-testid={`ticket-card-error-badge-${ticket.ticket_id}`}
+              title={refineErrorMessage}
             >
-              Refinement failed
+              {refineErrorMessage}
             </span>
           )}
           {/* No session, not in-flight, no error: offer to start refinement */}

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -1382,6 +1382,132 @@ describe('TicketCard', () => {
   });
 
   // =========================================================================
+  // #539 — Error message surfaced in refine-fail badge
+  // =========================================================================
+
+  it('refining: errored session — badge shows refinementSession.error text', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-err-msg',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        error: 'Claude API rate limit exceeded',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.textContent).toContain('Claude API rate limit exceeded');
+  });
+
+  it('refining: ready+result.error — badge shows refinementSession.result.error text', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-ready-err-msg',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+          error: 'spec gate validation failed',
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.textContent).toContain('spec gate validation failed');
+  });
+
+  it('refining: refineStartError only (no session) — badge shows gate-start error text', () => {
+    useAppStore.setState({
+      refineStartErrors: { [`42|${PROJECT_DIR}`]: 'IPC connection refused' },
+      refinementSessions: [],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.textContent).toContain('IPC connection refused');
+  });
+
+  it('refining: interrupted session with no error field — badge falls back to "Refinement failed"', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-int-noerr',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'interrupted',
+        phase: 'check',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.textContent).toBe('Refinement failed');
+  });
+
+  it('refining: error badge has title attribute equal to the full message', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-title',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        error: 'Detailed error message here',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.getAttribute('title')).toBe('Detailed error message here');
+  });
+
+  it('refining: error badge has truncation class applied', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-truncate',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        error: 'Some error',
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.classList.contains('truncate')).toBe(true);
+  });
+
+  it('refining: multiline error message renders in single badge element with full text in title', () => {
+    const multilineMsg = 'Line one\nLine two\nLine three';
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess-multiline',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'errored',
+        phase: 'check',
+        error: multilineMsg,
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    const badge = screen.getByTestId('ticket-card-error-badge-42');
+    expect(badge.textContent).toBe(multilineMsg);
+    expect(badge.getAttribute('title')).toBe(multilineMsg);
+    // Must be a single element, not multiple
+    expect(badge.tagName).toBeTruthy();
+  });
+
+  // =========================================================================
   // #510 — gap-question Answer path survives RefinementIndicator removal
   // =========================================================================
 


### PR DESCRIPTION
## Summary

The ticket card error badge previously rendered a hardcoded `"Refinement failed"` string, hiding the actual cause of a refinement failure. It now derives a real message from the available error sources and displays it.

The message is resolved with precedence: `refinementSession.error`, then `refinementSession.result.error` (ready state with a result error), then `refineStartError` (gate/start failure), falling back to `"Refinement failed"` when no source is set. The badge renders the resolved message, exposes the full text via a `title` attribute for hover, and truncates to a single line so long or multiline messages don't break the card layout.

## QA plan

1. Open a ticket whose refinement session errored and confirm the card shows the underlying error text rather than the generic "Refinement failed".
2. Hover the error badge and confirm the full message appears in the tooltip.
3. Trigger a refinement start/gate failure and confirm the start error text is shown.
4. Use a long or multiline error message and confirm the badge stays on a single truncated line without distorting the card; the full text is still visible on hover.
5. Confirm a failure with no message source available still falls back to "Refinement failed".

Closes #539