### PR TITLE
[473] feat: add backend settings storage and resolution

### DIFF
--- a/src/main/control-plane/backend-resolution.ts
+++ b/src/main/control-plane/backend-resolution.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure, electron-free, sqlite-free module for resolving the effective backend.
+ *
+ * Tests import this module directly without needing vi.mock('electron').
+ */
+
+export type BackendType = 'claude' | 'opencode';
+
+export interface GlobalBackendInput {
+  inner_backend: BackendType;
+  outer_backend: BackendType;
+  inner_provider: string | null;
+  inner_model: string | null;
+  outer_provider: string | null;
+  outer_model: string | null;
+}
+
+export interface ProjectBackendInput {
+  inner_backend: string;
+  outer_backend: string;
+  inner_provider: string | null;
+  inner_model: string | null;
+  outer_provider: string | null;
+  outer_model: string | null;
+}
+
+export interface EffectiveBackend {
+  backend: BackendType;
+  provider?: string;
+  model?: string;
+}
+
+/**
+ * Resolve the effective backend for a given surface.
+ * Resolution: project value > 'global' sentinel falls back to global > absent project row uses global.
+ */
+export function resolveEffectiveBackend(
+  global: GlobalBackendInput,
+  project: ProjectBackendInput | null,
+  surface: 'inner' | 'outer',
+): EffectiveBackend {
+  const globalBackend = surface === 'inner' ? global.inner_backend : global.outer_backend;
+  const globalProvider = surface === 'inner' ? global.inner_provider : global.outer_provider;
+  const globalModel = surface === 'inner' ? global.inner_model : global.outer_model;
+
+  if (!project) {
+    return {
+      backend: globalBackend,
+      ...(globalProvider ? { provider: globalProvider } : {}),
+      ...(globalModel ? { model: globalModel } : {}),
+    };
+  }
+
+  const backendRaw = surface === 'inner' ? project.inner_backend : project.outer_backend;
+  const backend: BackendType = backendRaw === 'global' ? globalBackend : (backendRaw as BackendType);
+
+  const providerRaw = surface === 'inner' ? project.inner_provider : project.outer_provider;
+  const provider = (providerRaw == null || providerRaw === 'global') ? globalProvider : providerRaw;
+
+  const modelRaw = surface === 'inner' ? project.inner_model : project.outer_model;
+  const model = (modelRaw == null || modelRaw === 'global') ? globalModel : modelRaw;
+
+  return {
+    backend,
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+  };
+}

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -3,6 +3,8 @@ import { app } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import { KANBAN_COLUMNS } from '../../shared/kanban';
+import { resolveEffectiveBackend } from './backend-resolution';
+import type { GlobalBackendInput, ProjectBackendInput, EffectiveBackend, BackendType } from './backend-resolution';
 
 export interface Stack {
   id: string;
@@ -140,6 +142,17 @@ export interface TokenValidationResult {
 export interface ModelSettings {
   inner_model: string;
   outer_model: string;
+}
+
+export type { BackendType, EffectiveBackend } from './backend-resolution';
+
+export interface BackendSettings {
+  inner_backend: string;
+  outer_backend: string;
+  inner_provider: string | null;
+  inner_model: string | null;
+  outer_provider: string | null;
+  outer_model: string | null;
 }
 
 export type TicketProvider = 'github' | 'jira';
@@ -600,6 +613,34 @@ export class Registry {
       this.db.exec('DROP TABLE IF EXISTS ticket_rollups');
       this.db.exec('DROP TABLE IF EXISTS rollup_dirty_stacks');
       this.setSchemaVersion(20);
+    }
+
+    if (currentVersion < 21) {
+      // Pluggable agent backend: persist per-surface backend choice and OpenCode credentials
+      try { this.db.exec("ALTER TABLE model_settings ADD COLUMN inner_backend TEXT NOT NULL DEFAULT 'claude'"); } catch { /* column already exists */ }
+      try { this.db.exec("ALTER TABLE model_settings ADD COLUMN outer_backend TEXT NOT NULL DEFAULT 'claude'"); } catch { /* column already exists */ }
+
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS opencode_settings (
+          key      TEXT NOT NULL,
+          surface  TEXT NOT NULL,
+          provider TEXT,
+          model    TEXT,
+          PRIMARY KEY (key, surface)
+        );
+      `);
+
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS backend_secrets (
+          key     TEXT NOT NULL,
+          surface TEXT NOT NULL,
+          name    TEXT,
+          value   TEXT,
+          PRIMARY KEY (key, surface)
+        );
+      `);
+
+      this.setSchemaVersion(21);
     }
 
   }
@@ -1186,8 +1227,9 @@ export class Registry {
 
   setGlobalModelSettings(settings: Partial<ModelSettings>): void {
     const current = this.getGlobalModelSettings();
+    // Use UPDATE to avoid resetting the new inner_backend/outer_backend columns
     this.db.prepare(
-      "INSERT OR REPLACE INTO model_settings (key, inner_model, outer_model) VALUES ('global', ?, ?)"
+      "UPDATE model_settings SET inner_model = ?, outer_model = ? WHERE key = 'global'"
     ).run(
       settings.inner_model ?? current.inner_model,
       settings.outer_model ?? current.outer_model,
@@ -1207,9 +1249,13 @@ export class Registry {
     const existing = this.getProjectModelSettings(projectDir);
     const inner = settings.inner_model ?? existing?.inner_model ?? 'global';
     const outer = settings.outer_model ?? existing?.outer_model ?? 'global';
+    // INSERT OR IGNORE ensures row exists with backend defaults; UPDATE sets only model columns
     this.db.prepare(
-      'INSERT OR REPLACE INTO model_settings (key, inner_model, outer_model) VALUES (?, ?, ?)'
-    ).run(key, inner, outer);
+      "INSERT OR IGNORE INTO model_settings (key, inner_model, outer_model, inner_backend, outer_backend) VALUES (?, 'global', 'global', 'global', 'global')"
+    ).run(key);
+    this.db.prepare(
+      'UPDATE model_settings SET inner_model = ?, outer_model = ? WHERE key = ?'
+    ).run(inner, outer, key);
   }
 
   removeProjectModelSettings(projectDir: string): void {
@@ -1398,6 +1444,161 @@ export class Registry {
       inner_model: project.inner_model === 'global' ? global.inner_model : project.inner_model,
       outer_model: project.outer_model === 'global' ? global.outer_model : project.outer_model,
     };
+  }
+
+  // --- Backend Settings ---
+
+  getGlobalBackendSettings(): BackendSettings {
+    const modelRow = this.db.prepare(
+      "SELECT inner_backend, outer_backend FROM model_settings WHERE key = 'global'"
+    ).get() as { inner_backend: string; outer_backend: string } | undefined;
+
+    const innerOC = this.db.prepare(
+      "SELECT provider, model FROM opencode_settings WHERE key = 'global' AND surface = 'inner'"
+    ).get() as { provider: string | null; model: string | null } | undefined;
+
+    const outerOC = this.db.prepare(
+      "SELECT provider, model FROM opencode_settings WHERE key = 'global' AND surface = 'outer'"
+    ).get() as { provider: string | null; model: string | null } | undefined;
+
+    return {
+      inner_backend: modelRow?.inner_backend ?? 'claude',
+      outer_backend: modelRow?.outer_backend ?? 'claude',
+      inner_provider: innerOC?.provider ?? null,
+      inner_model: innerOC?.model ?? null,
+      outer_provider: outerOC?.provider ?? null,
+      outer_model: outerOC?.model ?? null,
+    };
+  }
+
+  setGlobalBackendSettings(settings: Partial<BackendSettings>): void {
+    const current = this.getGlobalBackendSettings();
+
+    this.db.prepare(
+      "UPDATE model_settings SET inner_backend = ?, outer_backend = ? WHERE key = 'global'"
+    ).run(
+      settings.inner_backend ?? current.inner_backend,
+      settings.outer_backend ?? current.outer_backend,
+    );
+
+    this.db.prepare(
+      "INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'inner', ?, ?)"
+    ).run(
+      settings.inner_provider !== undefined ? settings.inner_provider : current.inner_provider,
+      settings.inner_model !== undefined ? settings.inner_model : current.inner_model,
+    );
+
+    this.db.prepare(
+      "INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'outer', ?, ?)"
+    ).run(
+      settings.outer_provider !== undefined ? settings.outer_provider : current.outer_provider,
+      settings.outer_model !== undefined ? settings.outer_model : current.outer_model,
+    );
+  }
+
+  getProjectBackendSettings(projectDir: string): BackendSettings | null {
+    const key = `project:${path.resolve(projectDir)}`;
+
+    const modelRow = this.db.prepare(
+      'SELECT inner_backend, outer_backend FROM model_settings WHERE key = ?'
+    ).get(key) as { inner_backend: string; outer_backend: string } | undefined;
+
+    if (!modelRow) return null;
+
+    const innerOC = this.db.prepare(
+      "SELECT provider, model FROM opencode_settings WHERE key = ? AND surface = 'inner'"
+    ).get(key) as { provider: string | null; model: string | null } | undefined;
+
+    const outerOC = this.db.prepare(
+      "SELECT provider, model FROM opencode_settings WHERE key = ? AND surface = 'outer'"
+    ).get(key) as { provider: string | null; model: string | null } | undefined;
+
+    return {
+      inner_backend: modelRow.inner_backend,
+      outer_backend: modelRow.outer_backend,
+      inner_provider: innerOC?.provider ?? null,
+      inner_model: innerOC?.model ?? null,
+      outer_provider: outerOC?.provider ?? null,
+      outer_model: outerOC?.model ?? null,
+    };
+  }
+
+  setProjectBackendSettings(projectDir: string, settings: Partial<BackendSettings>): void {
+    const key = `project:${path.resolve(projectDir)}`;
+    const existing = this.getProjectBackendSettings(projectDir);
+
+    const inner_backend = settings.inner_backend ?? existing?.inner_backend ?? 'global';
+    const outer_backend = settings.outer_backend ?? existing?.outer_backend ?? 'global';
+
+    // Ensure row exists with safe defaults; then update only backend columns
+    this.db.prepare(
+      "INSERT OR IGNORE INTO model_settings (key, inner_model, outer_model, inner_backend, outer_backend) VALUES (?, 'global', 'global', 'global', 'global')"
+    ).run(key);
+    this.db.prepare(
+      'UPDATE model_settings SET inner_backend = ?, outer_backend = ? WHERE key = ?'
+    ).run(inner_backend, outer_backend, key);
+
+    const inner_provider = settings.inner_provider !== undefined ? settings.inner_provider : (existing?.inner_provider ?? null);
+    const inner_model = settings.inner_model !== undefined ? settings.inner_model : (existing?.inner_model ?? null);
+    const outer_provider = settings.outer_provider !== undefined ? settings.outer_provider : (existing?.outer_provider ?? null);
+    const outer_model = settings.outer_model !== undefined ? settings.outer_model : (existing?.outer_model ?? null);
+
+    this.db.prepare(
+      "INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES (?, 'inner', ?, ?)"
+    ).run(key, inner_provider, inner_model);
+
+    this.db.prepare(
+      "INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES (?, 'outer', ?, ?)"
+    ).run(key, outer_provider, outer_model);
+  }
+
+  getEffectiveBackend(projectDir: string, surface: 'inner' | 'outer'): EffectiveBackend {
+    const globalSettings = this.getGlobalBackendSettings();
+    const projectSettings = this.getProjectBackendSettings(projectDir);
+
+    const globalInput: GlobalBackendInput = {
+      inner_backend: globalSettings.inner_backend as BackendType,
+      outer_backend: globalSettings.outer_backend as BackendType,
+      inner_provider: globalSettings.inner_provider,
+      inner_model: globalSettings.inner_model,
+      outer_provider: globalSettings.outer_provider,
+      outer_model: globalSettings.outer_model,
+    };
+
+    const projectInput: ProjectBackendInput | null = projectSettings
+      ? {
+          inner_backend: projectSettings.inner_backend,
+          outer_backend: projectSettings.outer_backend,
+          inner_provider: projectSettings.inner_provider,
+          inner_model: projectSettings.inner_model,
+          outer_provider: projectSettings.outer_provider,
+          outer_model: projectSettings.outer_model,
+        }
+      : null;
+
+    return resolveEffectiveBackend(globalInput, projectInput, surface);
+  }
+
+  // --- Backend Secrets ---
+
+  setBackendSecret(key: string, surface: 'inner' | 'outer', name: string, value: string): void {
+    this.db.prepare(
+      'INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES (?, ?, ?, ?)'
+    ).run(key, surface, name, value);
+  }
+
+  hasBackendSecret(key: string, surface: 'inner' | 'outer'): boolean {
+    const row = this.db.prepare(
+      'SELECT 1 FROM backend_secrets WHERE key = ? AND surface = ?'
+    ).get(key, surface);
+    return row != null;
+  }
+
+  getBackendSecret(key: string, surface: 'inner' | 'outer'): string | null {
+    const row = this.db.prepare(
+      'SELECT value FROM backend_secrets WHERE key = ? AND surface = ?'
+    ).get(key, surface) as { value: string } | undefined;
+    return row?.value ?? null;
   }
 
   // --- Session Monitor Settings ---

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -940,6 +940,36 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return registry.getEffectiveModels(projectDir);
   });
 
+  // --- Backend Settings ---
+
+  ipcMain.handle('backendSettings:getGlobal', () => {
+    return registry.getGlobalBackendSettings();
+  });
+
+  ipcMain.handle('backendSettings:setGlobal', (_event, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => {
+    registry.setGlobalBackendSettings(settings);
+  });
+
+  ipcMain.handle('backendSettings:getProject', (_event, projectDir: string) => {
+    return registry.getProjectBackendSettings(projectDir);
+  });
+
+  ipcMain.handle('backendSettings:setProject', (_event, projectDir: string, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => {
+    registry.setProjectBackendSettings(projectDir, settings);
+  });
+
+  ipcMain.handle('backendSettings:getEffective', (_event, projectDir: string, surface: 'inner' | 'outer') => {
+    return registry.getEffectiveBackend(projectDir, surface);
+  });
+
+  ipcMain.handle('backendSettings:setSecret', (_event, key: string, surface: 'inner' | 'outer', name: string, value: string) => {
+    registry.setBackendSecret(key, surface, name, value);
+  });
+
+  ipcMain.handle('backendSettings:secretStatus', (_event, key: string, surface: 'inner' | 'outer') => {
+    return { set: registry.hasBackendSecret(key, surface) };
+  });
+
   // --- Session Monitor ---
 
   ipcMain.handle('session:getState', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -141,6 +141,15 @@ export interface SandstormAPI {
     removeProject: (projectDir: string) => Promise<void>;
     getEffective: (projectDir: string) => Promise<{ inner_model: string; outer_model: string }>;
   };
+  backendSettings: {
+    getGlobal: () => Promise<{ inner_backend: string; outer_backend: string; inner_provider: string | null; inner_model: string | null; outer_provider: string | null; outer_model: string | null }>;
+    setGlobal: (settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => Promise<void>;
+    getProject: (projectDir: string) => Promise<{ inner_backend: string; outer_backend: string; inner_provider: string | null; inner_model: string | null; outer_provider: string | null; outer_model: string | null } | null>;
+    setProject: (projectDir: string, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => Promise<void>;
+    getEffective: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
+    setSecret: (key: string, surface: 'inner' | 'outer', name: string, value: string) => Promise<void>;
+    secretStatus: (key: string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
+  };
   projectTicketConfig: {
     get: (projectDir: string) => Promise<{
       provider: 'github' | 'jira';
@@ -363,6 +372,15 @@ const api: SandstormAPI = {
     setProject: (projectDir, settings) => ipcRenderer.invoke('modelSettings:setProject', projectDir, settings),
     removeProject: (projectDir) => ipcRenderer.invoke('modelSettings:removeProject', projectDir),
     getEffective: (projectDir) => ipcRenderer.invoke('modelSettings:getEffective', projectDir),
+  },
+  backendSettings: {
+    getGlobal: () => ipcRenderer.invoke('backendSettings:getGlobal'),
+    setGlobal: (settings) => ipcRenderer.invoke('backendSettings:setGlobal', settings),
+    getProject: (projectDir) => ipcRenderer.invoke('backendSettings:getProject', projectDir),
+    setProject: (projectDir, settings) => ipcRenderer.invoke('backendSettings:setProject', projectDir, settings),
+    getEffective: (projectDir, surface) => ipcRenderer.invoke('backendSettings:getEffective', projectDir, surface),
+    setSecret: (key, surface, name, value) => ipcRenderer.invoke('backendSettings:setSecret', key, surface, name, value),
+    secretStatus: (key, surface) => ipcRenderer.invoke('backendSettings:secretStatus', key, surface),
   },
   projectTicketConfig: {
     get: (projectDir) => ipcRenderer.invoke('projectTicketConfig:get', projectDir),

--- a/tests/unit/backend-resolution.test.ts
+++ b/tests/unit/backend-resolution.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEffectiveBackend } from '../../src/main/control-plane/backend-resolution';
+import type { GlobalBackendInput, ProjectBackendInput } from '../../src/main/control-plane/backend-resolution';
+
+const baseGlobal: GlobalBackendInput = {
+  inner_backend: 'claude',
+  outer_backend: 'claude',
+  inner_provider: null,
+  inner_model: null,
+  outer_provider: null,
+  outer_model: null,
+};
+
+describe('resolveEffectiveBackend', () => {
+  describe('null project — falls back to global', () => {
+    it('returns global inner backend when project is null', () => {
+      const result = resolveEffectiveBackend(baseGlobal, null, 'inner');
+      expect(result.backend).toBe('claude');
+    });
+
+    it('returns global outer backend when project is null', () => {
+      const result = resolveEffectiveBackend(baseGlobal, null, 'outer');
+      expect(result.backend).toBe('claude');
+    });
+
+    it('includes global provider and model when set', () => {
+      const global: GlobalBackendInput = {
+        ...baseGlobal,
+        inner_backend: 'opencode',
+        inner_provider: 'anthropic',
+        inner_model: 'claude-3-5-sonnet',
+      };
+      const result = resolveEffectiveBackend(global, null, 'inner');
+      expect(result.backend).toBe('opencode');
+      expect(result.provider).toBe('anthropic');
+      expect(result.model).toBe('claude-3-5-sonnet');
+    });
+
+    it('omits provider/model from result when global has nulls', () => {
+      const result = resolveEffectiveBackend(baseGlobal, null, 'inner');
+      expect(result).not.toHaveProperty('provider');
+      expect(result).not.toHaveProperty('model');
+    });
+  });
+
+  describe('project override', () => {
+    it('uses project backend when set to opencode', () => {
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'global',
+        inner_provider: 'openai',
+        inner_model: 'gpt-4o',
+        outer_provider: null,
+        outer_model: null,
+      };
+      const result = resolveEffectiveBackend(baseGlobal, project, 'inner');
+      expect(result.backend).toBe('opencode');
+      expect(result.provider).toBe('openai');
+      expect(result.model).toBe('gpt-4o');
+    });
+
+    it('outer surface reads outer fields', () => {
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'claude',
+        inner_provider: 'openai',
+        inner_model: 'gpt-4o',
+        outer_provider: null,
+        outer_model: null,
+      };
+      const result = resolveEffectiveBackend(baseGlobal, project, 'outer');
+      expect(result.backend).toBe('claude');
+      expect(result).not.toHaveProperty('provider');
+      expect(result).not.toHaveProperty('model');
+    });
+  });
+
+  describe('"global" sentinel inheritance', () => {
+    it('backend: project "global" inherits global backend', () => {
+      const global: GlobalBackendInput = { ...baseGlobal, inner_backend: 'opencode' };
+      const project: ProjectBackendInput = {
+        inner_backend: 'global',
+        outer_backend: 'global',
+        inner_provider: null,
+        inner_model: null,
+        outer_provider: null,
+        outer_model: null,
+      };
+      expect(resolveEffectiveBackend(global, project, 'inner').backend).toBe('opencode');
+    });
+
+    it('provider: project null inherits global provider', () => {
+      const global: GlobalBackendInput = { ...baseGlobal, inner_provider: 'anthropic' };
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'global',
+        inner_provider: null,
+        inner_model: null,
+        outer_provider: null,
+        outer_model: null,
+      };
+      const result = resolveEffectiveBackend(global, project, 'inner');
+      expect(result.provider).toBe('anthropic');
+    });
+
+    it('provider: project "global" sentinel inherits global provider', () => {
+      const global: GlobalBackendInput = { ...baseGlobal, inner_provider: 'anthropic' };
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'global',
+        inner_provider: 'global',
+        inner_model: null,
+        outer_provider: null,
+        outer_model: null,
+      };
+      const result = resolveEffectiveBackend(global, project, 'inner');
+      expect(result.provider).toBe('anthropic');
+    });
+
+    it('model: project null inherits global model', () => {
+      const global: GlobalBackendInput = { ...baseGlobal, inner_model: 'claude-3-5-sonnet' };
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'global',
+        inner_provider: null,
+        inner_model: null,
+        outer_provider: null,
+        outer_model: null,
+      };
+      const result = resolveEffectiveBackend(global, project, 'inner');
+      expect(result.model).toBe('claude-3-5-sonnet');
+    });
+
+    it('model: project "global" sentinel inherits global model', () => {
+      const global: GlobalBackendInput = { ...baseGlobal, outer_model: 'opus' };
+      const project: ProjectBackendInput = {
+        inner_backend: 'global',
+        outer_backend: 'global',
+        inner_provider: null,
+        inner_model: null,
+        outer_provider: null,
+        outer_model: 'global',
+      };
+      const result = resolveEffectiveBackend(global, project, 'outer');
+      expect(result.model).toBe('opus');
+    });
+
+    it('project overrides global when all fields are concrete', () => {
+      const global: GlobalBackendInput = {
+        inner_backend: 'claude',
+        outer_backend: 'claude',
+        inner_provider: 'anthropic',
+        inner_model: 'sonnet',
+        outer_provider: 'anthropic',
+        outer_model: 'opus',
+      };
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'opencode',
+        inner_provider: 'openai',
+        inner_model: 'gpt-4o',
+        outer_provider: 'openai',
+        outer_model: 'gpt-4-turbo',
+      };
+      const inner = resolveEffectiveBackend(global, project, 'inner');
+      expect(inner.backend).toBe('opencode');
+      expect(inner.provider).toBe('openai');
+      expect(inner.model).toBe('gpt-4o');
+
+      const outer = resolveEffectiveBackend(global, project, 'outer');
+      expect(outer.backend).toBe('opencode');
+      expect(outer.provider).toBe('openai');
+      expect(outer.model).toBe('gpt-4-turbo');
+    });
+
+    it('mixes project and global: one field overridden, other inherits', () => {
+      const global: GlobalBackendInput = {
+        inner_backend: 'claude',
+        outer_backend: 'claude',
+        inner_provider: 'anthropic',
+        inner_model: 'opus',
+        outer_provider: null,
+        outer_model: null,
+      };
+      const project: ProjectBackendInput = {
+        inner_backend: 'opencode',
+        outer_backend: 'global',
+        inner_provider: 'global',  // inherit global provider
+        inner_model: 'gpt-4o',     // concrete override
+        outer_provider: null,
+        outer_model: null,
+      };
+      const result = resolveEffectiveBackend(global, project, 'inner');
+      expect(result.backend).toBe('opencode');
+      expect(result.provider).toBe('anthropic');  // inherited
+      expect(result.model).toBe('gpt-4o');         // overridden
+    });
+  });
+});

--- a/tests/unit/backend-settings.test.ts
+++ b/tests/unit/backend-settings.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Registry } from '../../src/main/control-plane/registry';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+function makeTempDb(): string {
+  return path.join(os.tmpdir(), `sandstorm-backend-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+describe('Backend Settings', () => {
+  let registry: Registry;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  describe('v21 migration', () => {
+    it('inner_backend and outer_backend columns exist on model_settings with default "claude"', () => {
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_backend).toBe('claude');
+      expect(settings.outer_backend).toBe('claude');
+    });
+
+    it('opencode_settings table exists and is initially empty', () => {
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_provider).toBeNull();
+      expect(settings.inner_model).toBeNull();
+      expect(settings.outer_provider).toBeNull();
+      expect(settings.outer_model).toBeNull();
+    });
+
+    it('backend_secrets table exists and hasBackendSecret returns false initially', () => {
+      expect(registry.hasBackendSecret('global', 'inner')).toBe(false);
+      expect(registry.hasBackendSecret('global', 'outer')).toBe(false);
+    });
+  });
+
+  describe('global backend settings', () => {
+    it('returns defaults on fresh database', () => {
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_backend).toBe('claude');
+      expect(settings.outer_backend).toBe('claude');
+      expect(settings.inner_provider).toBeNull();
+      expect(settings.inner_model).toBeNull();
+      expect(settings.outer_provider).toBeNull();
+      expect(settings.outer_model).toBeNull();
+    });
+
+    it('updates inner backend', () => {
+      registry.setGlobalBackendSettings({ inner_backend: 'opencode' });
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_backend).toBe('opencode');
+      expect(settings.outer_backend).toBe('claude');
+    });
+
+    it('updates outer backend', () => {
+      registry.setGlobalBackendSettings({ outer_backend: 'opencode' });
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_backend).toBe('claude');
+      expect(settings.outer_backend).toBe('opencode');
+    });
+
+    it('sets provider and model for inner surface', () => {
+      registry.setGlobalBackendSettings({
+        inner_backend: 'opencode',
+        inner_provider: 'anthropic',
+        inner_model: 'claude-3-5-sonnet',
+      });
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_provider).toBe('anthropic');
+      expect(settings.inner_model).toBe('claude-3-5-sonnet');
+      expect(settings.outer_provider).toBeNull();
+    });
+
+    it('partial update preserves other fields', () => {
+      registry.setGlobalBackendSettings({
+        inner_backend: 'opencode',
+        inner_provider: 'anthropic',
+        inner_model: 'claude-3-5-sonnet',
+        outer_backend: 'opencode',
+        outer_provider: 'openai',
+        outer_model: 'gpt-4o',
+      });
+      registry.setGlobalBackendSettings({ inner_backend: 'claude' });
+      const settings = registry.getGlobalBackendSettings();
+      expect(settings.inner_backend).toBe('claude');
+      expect(settings.outer_backend).toBe('opencode');
+      expect(settings.outer_provider).toBe('openai');
+      expect(settings.outer_model).toBe('gpt-4o');
+    });
+
+    it('does not disturb existing model settings (inner_model/outer_model)', () => {
+      registry.setGlobalModelSettings({ inner_model: 'opus', outer_model: 'sonnet' });
+      registry.setGlobalBackendSettings({ inner_backend: 'opencode' });
+      const models = registry.getGlobalModelSettings();
+      expect(models.inner_model).toBe('opus');
+      expect(models.outer_model).toBe('sonnet');
+    });
+  });
+
+  describe('project backend settings', () => {
+    it('returns null when no project override is set', () => {
+      expect(registry.getProjectBackendSettings('/proj/a')).toBeNull();
+    });
+
+    it('sets and retrieves project-specific backend', () => {
+      registry.setProjectBackendSettings('/proj/a', { inner_backend: 'opencode', outer_backend: 'claude' });
+      const settings = registry.getProjectBackendSettings('/proj/a');
+      expect(settings).not.toBeNull();
+      expect(settings!.inner_backend).toBe('opencode');
+      expect(settings!.outer_backend).toBe('claude');
+    });
+
+    it('uses "global" as default when partially setting project backends', () => {
+      registry.setProjectBackendSettings('/proj/b', { inner_backend: 'opencode' });
+      const settings = registry.getProjectBackendSettings('/proj/b');
+      expect(settings!.inner_backend).toBe('opencode');
+      expect(settings!.outer_backend).toBe('global');
+    });
+
+    it('sets and retrieves provider/model for project', () => {
+      registry.setProjectBackendSettings('/proj/a', {
+        inner_backend: 'opencode',
+        inner_provider: 'openai',
+        inner_model: 'gpt-4o',
+      });
+      const settings = registry.getProjectBackendSettings('/proj/a');
+      expect(settings!.inner_provider).toBe('openai');
+      expect(settings!.inner_model).toBe('gpt-4o');
+    });
+
+    it('different projects have independent settings', () => {
+      registry.setProjectBackendSettings('/proj/a', { inner_backend: 'opencode' });
+      registry.setProjectBackendSettings('/proj/b', { outer_backend: 'opencode' });
+      expect(registry.getProjectBackendSettings('/proj/a')!.inner_backend).toBe('opencode');
+      expect(registry.getProjectBackendSettings('/proj/b')!.outer_backend).toBe('opencode');
+    });
+
+    it('does not clobber model settings when setting backend settings', () => {
+      registry.setProjectModelSettings('/proj/a', { inner_model: 'opus', outer_model: 'sonnet' });
+      registry.setProjectBackendSettings('/proj/a', { inner_backend: 'opencode' });
+      const models = registry.getProjectModelSettings('/proj/a');
+      expect(models!.inner_model).toBe('opus');
+      expect(models!.outer_model).toBe('sonnet');
+    });
+
+    it('does not clobber backend settings when setting model settings', () => {
+      registry.setProjectBackendSettings('/proj/a', { inner_backend: 'opencode' });
+      registry.setProjectModelSettings('/proj/a', { inner_model: 'opus' });
+      const backend = registry.getProjectBackendSettings('/proj/a');
+      expect(backend!.inner_backend).toBe('opencode');
+    });
+  });
+
+  describe('getEffectiveBackend inheritance', () => {
+    it('falls back to global when no project override', () => {
+      registry.setGlobalBackendSettings({ inner_backend: 'opencode', inner_provider: 'anthropic', inner_model: 'claude-3-5-sonnet' });
+      const effective = registry.getEffectiveBackend('/proj/a', 'inner');
+      expect(effective.backend).toBe('opencode');
+      expect(effective.provider).toBe('anthropic');
+      expect(effective.model).toBe('claude-3-5-sonnet');
+    });
+
+    it('uses project override when set to concrete backend', () => {
+      registry.setGlobalBackendSettings({ inner_backend: 'claude' });
+      registry.setProjectBackendSettings('/proj/a', { inner_backend: 'opencode' });
+      const effective = registry.getEffectiveBackend('/proj/a', 'inner');
+      expect(effective.backend).toBe('opencode');
+    });
+
+    it('resolves "global" backend sentinel to global value', () => {
+      registry.setGlobalBackendSettings({ outer_backend: 'opencode' });
+      registry.setProjectBackendSettings('/proj/a', { outer_backend: 'global' });
+      const effective = registry.getEffectiveBackend('/proj/a', 'outer');
+      expect(effective.backend).toBe('opencode');
+    });
+
+    it('resolves null project provider to global provider', () => {
+      registry.setGlobalBackendSettings({ inner_provider: 'anthropic', inner_model: 'sonnet' });
+      registry.setProjectBackendSettings('/proj/a', { inner_backend: 'opencode' });
+      const effective = registry.getEffectiveBackend('/proj/a', 'inner');
+      expect(effective.provider).toBe('anthropic');
+      expect(effective.model).toBe('sonnet');
+    });
+
+    it('returns correct surface (outer vs inner are independent)', () => {
+      registry.setGlobalBackendSettings({ inner_backend: 'opencode', outer_backend: 'claude' });
+      expect(registry.getEffectiveBackend('/proj/a', 'inner').backend).toBe('opencode');
+      expect(registry.getEffectiveBackend('/proj/a', 'outer').backend).toBe('claude');
+    });
+  });
+
+  describe('backend secrets', () => {
+    it('hasBackendSecret returns false before any secret is set', () => {
+      expect(registry.hasBackendSecret('global', 'inner')).toBe(false);
+    });
+
+    it('round-trip: set secret, hasBackendSecret returns true, getBackendSecret returns value', () => {
+      registry.setBackendSecret('global', 'inner', 'api_key', 'sk-test-123');
+      expect(registry.hasBackendSecret('global', 'inner')).toBe(true);
+      expect(registry.getBackendSecret('global', 'inner')).toBe('sk-test-123');
+    });
+
+    it('different key/surface pairs are independent', () => {
+      registry.setBackendSecret('global', 'inner', 'api_key', 'inner-secret');
+      expect(registry.hasBackendSecret('global', 'outer')).toBe(false);
+      expect(registry.getBackendSecret('global', 'outer')).toBeNull();
+    });
+
+    it('overwrites existing secret', () => {
+      registry.setBackendSecret('global', 'inner', 'api_key', 'old-key');
+      registry.setBackendSecret('global', 'inner', 'api_key', 'new-key');
+      expect(registry.getBackendSecret('global', 'inner')).toBe('new-key');
+    });
+
+    it('getBackendSecret returns null when secret does not exist', () => {
+      expect(registry.getBackendSecret('global', 'inner')).toBeNull();
+    });
+
+    it('project key secrets are independent of global', () => {
+      const projectKey = `project:${path.resolve('/proj/a')}`;
+      registry.setBackendSecret(projectKey, 'inner', 'api_key', 'proj-secret');
+      expect(registry.hasBackendSecret('global', 'inner')).toBe(false);
+      expect(registry.getBackendSecret(projectKey, 'inner')).toBe('proj-secret');
+    });
+  });
+});

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -61,6 +61,13 @@ const {
     setDarkFactoryEnabled: vi.fn(),
     getDb: vi.fn().mockReturnValue({}),
     getStepWeightsByTicket: vi.fn().mockReturnValue([]),
+    getGlobalBackendSettings: vi.fn().mockReturnValue({ inner_backend: 'claude', outer_backend: 'claude', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null }),
+    setGlobalBackendSettings: vi.fn(),
+    getProjectBackendSettings: vi.fn().mockReturnValue(null),
+    setProjectBackendSettings: vi.fn(),
+    getEffectiveBackend: vi.fn().mockReturnValue({ backend: 'claude' }),
+    setBackendSecret: vi.fn(),
+    hasBackendSecret: vi.fn().mockReturnValue(false),
   };
 
   const mockStackManager = {
@@ -2178,6 +2185,13 @@ describe('IPC Handlers', () => {
       'modelSettings:setProject',
       'modelSettings:removeProject',
       'modelSettings:getEffective',
+      'backendSettings:getGlobal',
+      'backendSettings:setGlobal',
+      'backendSettings:getProject',
+      'backendSettings:setProject',
+      'backendSettings:getEffective',
+      'backendSettings:setSecret',
+      'backendSettings:secretStatus',
       'runtime:available',
       'session:getState',
       'session:getSettings',
@@ -2348,6 +2362,97 @@ describe('IPC Handlers', () => {
       await expect(
         invokeHandler('ticket-board:delete', { ticketId: '', projectDir: '/proj' })
       ).rejects.toThrow(/ticketId is required/);
+    });
+  });
+
+  // =========================================================================
+  // Backend Settings IPC handlers
+  // =========================================================================
+  describe('backendSettings:getGlobal', () => {
+    it('returns registry.getGlobalBackendSettings()', async () => {
+      const expected = { inner_backend: 'opencode', outer_backend: 'claude', inner_provider: 'anthropic', inner_model: 'claude-3-5-sonnet', outer_provider: null, outer_model: null };
+      mockRegistry.getGlobalBackendSettings.mockReturnValueOnce(expected);
+      const result = await invokeHandler('backendSettings:getGlobal');
+      expect(mockRegistry.getGlobalBackendSettings).toHaveBeenCalled();
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('backendSettings:setGlobal', () => {
+    it('calls registry.setGlobalBackendSettings with the provided settings', async () => {
+      const settings = { inner_backend: 'opencode', outer_backend: 'claude' };
+      await invokeHandler('backendSettings:setGlobal', settings);
+      expect(mockRegistry.setGlobalBackendSettings).toHaveBeenCalledWith(settings);
+    });
+  });
+
+  describe('backendSettings:getProject', () => {
+    it('returns null when no project override exists', async () => {
+      mockRegistry.getProjectBackendSettings.mockReturnValueOnce(null);
+      const result = await invokeHandler('backendSettings:getProject', '/proj');
+      expect(mockRegistry.getProjectBackendSettings).toHaveBeenCalledWith('/proj');
+      expect(result).toBeNull();
+    });
+
+    it('returns project settings when present', async () => {
+      const expected = { inner_backend: 'opencode', outer_backend: 'global', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null };
+      mockRegistry.getProjectBackendSettings.mockReturnValueOnce(expected);
+      const result = await invokeHandler('backendSettings:getProject', '/proj');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('backendSettings:setProject', () => {
+    it('calls registry.setProjectBackendSettings with projectDir and settings', async () => {
+      const settings = { inner_backend: 'opencode' };
+      await invokeHandler('backendSettings:setProject', '/proj', settings);
+      expect(mockRegistry.setProjectBackendSettings).toHaveBeenCalledWith('/proj', settings);
+    });
+  });
+
+  describe('backendSettings:getEffective', () => {
+    it('returns effective backend for inner surface', async () => {
+      mockRegistry.getEffectiveBackend.mockReturnValueOnce({ backend: 'opencode', provider: 'anthropic', model: 'claude-3-5-sonnet' });
+      const result = await invokeHandler('backendSettings:getEffective', '/proj', 'inner');
+      expect(mockRegistry.getEffectiveBackend).toHaveBeenCalledWith('/proj', 'inner');
+      expect(result).toEqual({ backend: 'opencode', provider: 'anthropic', model: 'claude-3-5-sonnet' });
+    });
+
+    it('returns effective backend for outer surface', async () => {
+      mockRegistry.getEffectiveBackend.mockReturnValueOnce({ backend: 'claude' });
+      const result = await invokeHandler('backendSettings:getEffective', '/proj', 'outer');
+      expect(mockRegistry.getEffectiveBackend).toHaveBeenCalledWith('/proj', 'outer');
+      expect(result).toEqual({ backend: 'claude' });
+    });
+  });
+
+  describe('backendSettings:setSecret', () => {
+    it('calls registry.setBackendSecret and returns undefined (write-only)', async () => {
+      const result = await invokeHandler('backendSettings:setSecret', 'global', 'inner', 'api_key', 'sk-test');
+      expect(mockRegistry.setBackendSecret).toHaveBeenCalledWith('global', 'inner', 'api_key', 'sk-test');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('backendSettings:secretStatus', () => {
+    it('returns { set: false } when no secret stored', async () => {
+      mockRegistry.hasBackendSecret.mockReturnValueOnce(false);
+      const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner');
+      expect(mockRegistry.hasBackendSecret).toHaveBeenCalledWith('global', 'inner');
+      expect(result).toEqual({ set: false });
+    });
+
+    it('returns { set: true } when secret exists', async () => {
+      mockRegistry.hasBackendSecret.mockReturnValueOnce(true);
+      const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner');
+      expect(result).toEqual({ set: true });
+    });
+
+    it('does not expose the secret value — only returns { set: boolean }', async () => {
+      mockRegistry.hasBackendSecret.mockReturnValueOnce(true);
+      const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner') as Record<string, unknown>;
+      expect(Object.keys(result)).toEqual(['set']);
+      expect(result['set']).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds per-surface backend selection (inner/outer) with global defaults, project-level overrides, and secret storage, plus a pure resolver that computes the effective backend for a given surface.

The data layer gains a v21 migration that adds `inner_backend`/`outer_backend` columns to `model_settings` (defaulting to `claude`) and introduces `opencode_settings` and `backend_secrets` tables. The global/project model-settings writers were switched to non-clobbering update patterns so the new backend columns survive existing writes. Resolution logic lives in a new electron-free module (`backend-resolution.ts`) so it can be unit-tested in isolation and reused.

The settings are exposed to the renderer through seven `backendSettings:*` IPC handlers and a typed `backendSettings` bridge on `SandstormAPI`. Reading raw secrets is intentionally not exposed over IPC — only a presence check (`hasBackendSecret`) is surfaced, keeping secret values in the main process.

## QA plan

1. Launch the app against an existing database (pre-v21) and confirm it starts cleanly and migrates without error; verify existing model settings are preserved.
2. Set a global backend for the inner and outer surfaces, then confirm the effective backend reflects those defaults.
3. Set a project-level backend override and confirm `getEffectiveBackend` returns the override for that project while other projects fall back to the global default.
4. Save a backend secret, then verify the secret-status check reports it as present and that no IPC channel returns the raw secret value.
5. Restart the app and confirm global settings, project overrides, and secret presence all persist.

Closes #473