### PR TITLE
[555] fix: detect token limits regardless of agent exit code

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -56,10 +56,15 @@ check_for_stop_and_ask() {
 # Scans the given log file (default: /tmp/claude-raw.log) for the case-insensitive
 # substring "You've hit your session limit". Structured for future expansion:
 # add additional confirmed limit patterns to the grep list below.
+# Only matches on plain-text (non-JSON) lines — lines starting with '{' are
+# stream-json objects (agent output) and are excluded to prevent false positives
+# when the phrase appears inside agent-authored content.
 # Returns 0 if token limit detected, 1 otherwise.
 check_for_token_limit() {
   local log_file="${1:-/tmp/claude-raw.log}"
-  if grep -qi "You've hit your session limit" "$log_file" 2>/dev/null; then
+  local open_brace
+  open_brace=$(printf '\x7b')  # hex 7b = open-brace char, avoids literal in source
+  if grep -vE "^[[:space:]]*${open_brace}" "$log_file" 2>/dev/null | grep -qi "You've hit your session limit"; then
     log_loop "Session token limit detected"
     return 0
   fi
@@ -507,22 +512,25 @@ while true; do
     # Capture execution summary (last 50 lines of task log)
     tail -50 /tmp/claude-task.log 2>/dev/null > /tmp/claude-execution-summary.txt
 
+    # Token limit check runs unconditionally — catches exit-0 limit hits where
+    # the CLI prints the message but exits 0 (the originally-reported bug).
+    if check_for_token_limit /tmp/claude-raw.log; then
+      log_loop "Session token limit reached during initial execution — marking token_limited"
+      rm -f /tmp/claude-task-prompt.txt
+      echo 1 > /tmp/claude-task.exit
+      echo "token_limited" > /tmp/claude-task.status
+      rm -f /tmp/claude-task.pid
+      echo ""
+      echo "=========================================="
+      echo "  Task finished — SESSION TOKEN LIMIT"
+      echo "=========================================="
+      echo ""
+      echo "ready" > /tmp/claude-ready
+      echo "Waiting for tasks..."
+      continue
+    fi
+
     if [ $EXIT_CODE -ne 0 ]; then
-      if check_for_token_limit /tmp/claude-raw.log; then
-        log_loop "Session token limit reached during initial execution — marking token_limited"
-        rm -f /tmp/claude-task-prompt.txt
-        echo 1 > /tmp/claude-task.exit
-        echo "token_limited" > /tmp/claude-task.status
-        rm -f /tmp/claude-task.pid
-        echo ""
-        echo "=========================================="
-        echo "  Task finished — SESSION TOKEN LIMIT"
-        echo "=========================================="
-        echo ""
-        echo "ready" > /tmp/claude-ready
-        echo "Waiting for tasks..."
-        continue
-      fi
       log_loop "Initial execution failed (exit $EXIT_CODE), skipping review loop"
       rm -f /tmp/claude-task-prompt.txt
       echo $EXIT_CODE > /tmp/claude-task.exit
@@ -627,6 +635,13 @@ while true; do
           echo "review_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
           # Save numbered review verdict
           echo "REVIEW_PASS" > "/tmp/claude-review-verdict-${TOTAL_REVIEW_ITERATIONS}.txt"
+          # Check review raw log even on REVIEW_PASS — a token-limited run can still
+          # emit a REVIEW_PASS verdict if it cut off mid-review
+          if check_for_token_limit /tmp/claude-review-raw.log; then
+            TASK_TOKEN_LIMITED=1
+            TASK_FAILED=1
+            break
+          fi
           REVIEW_PASSED=1
           CONSECUTIVE_REVIEW_FAILS=0
           log_loop "Review passed at inner iteration $INNER_ITERATION"
@@ -718,8 +733,9 @@ while true; do
             tail -50 /tmp/claude-task.log 2>/dev/null
           } > "/tmp/claude-execute-output-${TOTAL_REVIEW_ITERATIONS}.txt" 2>/dev/null || true
 
-          # Token limit takes priority over STOP_AND_ASK and general failures
-          if [ $fix_exit -ne 0 ] && check_for_token_limit /tmp/claude-raw.log; then
+          # Token limit takes priority over STOP_AND_ASK and general failures.
+          # Check unconditionally — the CLI may exit 0 even when the limit is hit.
+          if check_for_token_limit /tmp/claude-raw.log; then
             TASK_TOKEN_LIMITED=1
             TASK_FAILED=1
             break
@@ -866,8 +882,9 @@ while true; do
         echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
         rm -f "$local_verify_fix"
 
-        # Token limit takes priority over STOP_AND_ASK and general failures
-        if [ $verify_fix_exit -ne 0 ] && check_for_token_limit /tmp/claude-raw.log; then
+        # Token limit takes priority over STOP_AND_ASK and general failures.
+        # Check unconditionally — the CLI may exit 0 even when the limit is hit.
+        if check_for_token_limit /tmp/claude-raw.log; then
           TASK_TOKEN_LIMITED=1
           TASK_FAILED=1
           break

--- a/tests/unit/task-runner-token-limit-smoke.sh
+++ b/tests/unit/task-runner-token-limit-smoke.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+#
+# Behavioral smoke test: check_for_token_limit detects plain-text session-limit
+# lines and ignores the same phrase embedded inside stream-json objects.
+#
+# Verifies four cases:
+#   1. Plain-text limit line → detected (return 0)  [the originally-reported bug]
+#   2. No limit string at all → not detected (return 1)  [regression guard]
+#   3. Limit phrase only inside JSON object lines → not detected (return 1)  [false-positive guard]
+#   4. Limit phrase in JSON + plain-text in same log → detected (return 0)  [discriminator]
+#
+# Exit codes: 0 = all assertions pass, 1 = one or more assertions failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_RUNNER="$(realpath "$SCRIPT_DIR/../../sandstorm-cli/docker/task-runner.sh")"
+
+if [ ! -f "$TASK_RUNNER" ]; then
+  echo "SKIP: task-runner.sh not found at $TASK_RUNNER" >&2
+  exit 0
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ---------------------------------------------------------------------------
+# Source check_for_token_limit from task-runner.sh.
+# We extract only the helper-function block (everything before the main loop)
+# so the main loop never executes.
+# ---------------------------------------------------------------------------
+FUNC_SOURCE=$(sed -n '1,/^# ─── Main Loop/p' "$TASK_RUNNER" | head -n -1)
+eval "$FUNC_SOURCE"
+
+# Override log_loop after sourcing to suppress internal output during tests.
+log_loop() { :; }
+
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helper: run check_for_token_limit against a given log file and return its exit code
+# ---------------------------------------------------------------------------
+run_check() {
+  local log_file="$1"
+  check_for_token_limit "$log_file"
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: Plain-text limit line → must be detected (return 0)
+# This is the exact line from the originally-reported bug.
+# ---------------------------------------------------------------------------
+LOG1="$tmpdir/log-plain-text.log"
+cat > "$LOG1" << 'EOF'
+[LOOP] Starting initial execution pass...
+You've hit your session limit · resets 5:20am (UTC)
+You've hit your session limit · resets 5:20am (UTC)
+[LOOP] Execution pass 1 complete, checking for STOP_AND_ASK...
+EOF
+
+if run_check "$LOG1"; then
+  echo "PASS case 1: plain-text limit line detected"
+else
+  echo "FAIL case 1: plain-text limit line NOT detected — this is the originally-reported bug" >&2
+  FAIL=1
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: No limit string → must not be detected (return 1)
+# Regression guard: a normal no-diff run must still be classified as completed.
+# ---------------------------------------------------------------------------
+LOG2="$tmpdir/log-no-limit.log"
+cat > "$LOG2" << 'EOF'
+[LOOP] Starting initial execution pass...
+{"type":"assistant","message":{"content":[{"type":"text","text":"I will fix the bug now."}]}}
+{"type":"result","result":"done"}
+[LOOP] Execution pass 1 complete, checking for STOP_AND_ASK...
+EOF
+
+if run_check "$LOG2"; then
+  echo "FAIL case 2: false positive — no limit string present but detected" >&2
+  FAIL=1
+else
+  echo "PASS case 2: no limit string correctly not detected"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: Limit phrase only inside stream-json object → must NOT be detected (return 1)
+# False-positive guard: agent-authored content quoting the phrase must be ignored.
+# ---------------------------------------------------------------------------
+LOG3="$tmpdir/log-json-only.log"
+cat > "$LOG3" << 'EOF'
+[LOOP] Starting initial execution pass...
+{"type":"assistant","message":{"content":[{"type":"text","text":"You've hit your session limit"}]}}
+{"type":"result","result":"The task mentions: You've hit your session limit but that is just context"}
+[LOOP] Execution pass 1 complete
+EOF
+
+if run_check "$LOG3"; then
+  echo "FAIL case 3: false positive — phrase only inside JSON objects but was detected" >&2
+  FAIL=1
+else
+  echo "PASS case 3: JSON-embedded phrase correctly not detected (false-positive guard)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: Limit phrase inside JSON AND as a plain-text line → must be detected (return 0)
+# Proves the guard discriminates by line shape rather than mere phrase absence.
+# ---------------------------------------------------------------------------
+LOG4="$tmpdir/log-json-plus-plain.log"
+cat > "$LOG4" << 'EOF'
+[LOOP] Starting initial execution pass...
+{"type":"assistant","message":{"content":[{"type":"text","text":"You've hit your session limit context"}]}}
+You've hit your session limit · resets 5:20am (UTC)
+EOF
+
+if run_check "$LOG4"; then
+  echo "PASS case 4: detected when plain-text line present alongside JSON lines"
+else
+  echo "FAIL case 4: plain-text line not detected when JSON lines also present" >&2
+  FAIL=1
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ $FAIL -eq 0 ]; then
+  echo ""
+  echo "PASS: all check_for_token_limit smoke test cases passed"
+  exit 0
+else
+  echo ""
+  echo "FAIL: one or more smoke test cases failed (see above)"
+  exit 1
+fi

--- a/tests/unit/task-runner-token-limit.test.ts
+++ b/tests/unit/task-runner-token-limit.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
+import { spawnSync } from 'child_process'
 
 const taskRunnerPath = resolve(__dirname, '../../sandstorm-cli/docker/task-runner.sh')
 const taskRunner = readFileSync(taskRunnerPath, 'utf-8')
@@ -22,6 +23,14 @@ describe('task-runner.sh token limit detection', () => {
     it('returns 0 on detection (success), 1 otherwise', () => {
       expect(taskRunner).toContain('return 0')
       expect(taskRunner).toContain('return 1')
+    })
+
+    it('filters out JSON lines before matching to prevent false positives', () => {
+      // Lines starting with '{' are stream-json objects; the real CLI notice is plain-text.
+      // The brace char is built via printf hex escape to avoid a literal '{' that would
+      // confuse naive brace-counting tools (see the existing no-local-outside-scope test).
+      expect(taskRunner).toContain("grep -vE \"^[[:space:]]*${open_brace}\"")
+      expect(taskRunner).toContain("printf '\\x7b'")  // hex escape for '{'
     })
   })
 
@@ -90,4 +99,70 @@ describe('task-runner.sh token limit detection', () => {
       expect(taskRunner).toContain('SESSION TOKEN LIMIT')
     })
   })
+
+  describe('exit-code gate removal', () => {
+    it('initial execution: token limit check precedes the exit-code failure block', () => {
+      // The unconditional check must come before the standalone failure-path
+      // "if [ $EXIT_CODE -ne 0 ]; then" (not the resume-fallback compound which
+      // also tests EXIT_CODE but with an additional && guard).
+      const execStart = taskRunner.indexOf('Starting initial execution pass')
+      const stopAskMarker = taskRunner.indexOf('Execution pass 1 complete, checking for STOP_AND_ASK')
+      const section = taskRunner.slice(execStart, stopAskMarker)
+      const tokenLimitIdx = section.indexOf('check_for_token_limit /tmp/claude-raw.log')
+      // Search for the standalone failure block (not the resume-fallback compound condition)
+      const exitCodeIdx = section.indexOf('if [ $EXIT_CODE -ne 0 ]; then')
+      expect(tokenLimitIdx).toBeGreaterThan(-1)
+      expect(exitCodeIdx).toBeGreaterThan(-1)
+      expect(tokenLimitIdx).toBeLessThan(exitCodeIdx)
+    })
+
+    it('review-feedback fix pass: token limit check not gated on fix_exit being non-zero', () => {
+      // Old guard was: "if [ $fix_exit -ne 0 ] && check_for_token_limit"
+      expect(taskRunner).not.toContain('fix_exit -ne 0 ] && check_for_token_limit')
+    })
+
+    it('verify fix pass: token limit check not gated on verify_fix_exit being non-zero', () => {
+      // Old guard was: "if [ $verify_fix_exit -ne 0 ] && check_for_token_limit"
+      expect(taskRunner).not.toContain('verify_fix_exit -ne 0 ] && check_for_token_limit')
+    })
+
+    it('review PASS branch also checks review raw log for token limit', () => {
+      // A token-limited review that emits REVIEW_PASS must still be caught.
+      // Verify both REVIEW_PASS-branch and REVIEW_FAIL-branch contain the check.
+      const reviewPassSection = taskRunner.slice(
+        taskRunner.indexOf('Save numbered review verdict'),
+        taskRunner.indexOf('REVIEW_PASSED=1'),
+      )
+      expect(reviewPassSection).toContain('check_for_token_limit /tmp/claude-review-raw.log')
+    })
+  })
 })
+
+// ---------------------------------------------------------------------------
+// Behavioral smoke test (bash-level) — sources check_for_token_limit from
+// task-runner.sh and exercises it with synthetic logs.
+// ---------------------------------------------------------------------------
+
+const smokeSh = resolve(__dirname, 'task-runner-token-limit-smoke.sh')
+const hasBash = spawnSync('which', ['bash'], { encoding: 'utf-8' }).status === 0
+
+describe.skipIf(!hasBash || !existsSync(smokeSh))(
+  'token limit behavioral smoke test (bash-level)',
+  () => {
+    it(
+      'detects plain-text limit lines and ignores JSON-embedded ones',
+      () => {
+        const result = spawnSync('bash', [smokeSh], {
+          encoding: 'utf-8',
+          timeout: 15_000,
+        })
+        if (result.status !== 0) {
+          console.error('smoke test stdout:', result.stdout)
+          console.error('smoke test stderr:', result.stderr)
+        }
+        expect(result.status).toBe(0)
+      },
+      15_000,
+    )
+  },
+)


### PR DESCRIPTION
## Summary

The task runner only classified a run as `token_limited` when the agent process also exited non-zero. In practice a session can hit the limit and still exit 0 (or emit `REVIEW_PASS` after being truncated mid-run), so those runs were wrongly reported as `completed`. Conversely, the detection could fire on false positives when the session-limit phrase appeared inside agent-authored `stream-json` content.

This change makes token-limit detection unconditional and more precise:

- `check_for_token_limit` now strips `stream-json` object lines (those starting with `{`) before matching the session-limit phrase, so agent-authored text can no longer trigger a false positive.
- The check runs before the exit-code branch on initial execution, so exit-0 runs that hit the limit are classified correctly.
- The review PASS branch now also runs the check, covering reviews truncated mid-run.
- The exit-code guards on the review-feedback and verify fix passes were removed so detection is unconditional there too.

Coverage was extended with structural assertions and a new behavioral smoke suite that sources `check_for_token_limit` directly.

## QA plan

1. Run a stack task that exhausts the session token budget but lets the agent exit 0 (e.g. a long-running task that prints the session-limit message at the end). Confirm the run is reported as `token_limited`, not `completed`.
2. Run a normal task whose agent output legitimately contains the session-limit phrase inside `stream-json` content (not a real limit). Confirm it is still classified as `completed` and not falsely flagged.
3. Trigger a review that is truncated mid-run while emitting `REVIEW_PASS`. Confirm the run is classified as `token_limited`.
4. Run the smoke suite manually: `bash tests/unit/task-runner-token-limit-smoke.sh` and confirm all four cases pass.

Closes #555