### PR TITLE
[557] fix: reconcile completed stacks and guard marker drift

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -11,6 +11,7 @@ import { SandstormError, ErrorCode } from '../errors';
 import { fetchRawBodyWithConfig, fetchTicketWithConfig, updateTicketWithConfig } from './ticket-config';
 import { referencesTicket } from './ticket-fetcher';
 import { workspacePathFor } from './pr-creator';
+import { parseTokenUsage } from './token-parser';
 
 const execFileAsync = promisify(execFile);
 
@@ -656,13 +657,21 @@ export class StackManager {
       throw err;
     }
 
-    const runningTask = this.registry.getRunningTask(stackId);
+    let runningTask = this.registry.getRunningTask(stackId);
 
     if (!runningTask) {
-      // Case C: no in-flight task — leave stack idle
-      this.registry.updateStackStatus(stackId, 'idle');
-      this.notifyUpdate();
-      return { outcome: 'idle' };
+      // Q-A fallback: try most-recent task + reopenTaskForResume before idling.
+      // Covers session_paused stacks whose task was already completed/closed
+      // (e.g. after recheckCompletedStack transitions a 'completed' stack here).
+      const mostRecentTask = this.registry.getMostRecentTask(stackId);
+      if (!mostRecentTask) {
+        // Case C: no task at all — leave stack idle
+        this.registry.updateStackStatus(stackId, 'idle');
+        this.notifyUpdate();
+        return { outcome: 'idle' };
+      }
+      this.registry.reopenTaskForResume(mostRecentTask.id);
+      runningTask = { ...mostRecentTask, status: 'running' as const };
     }
 
     if (runningTask.session_id) {
@@ -776,6 +785,105 @@ export class StackManager {
 
     this.taskWatcher.watch(stackId, claudeContainer.id);
     this.taskWatcher.streamOutput(stackId, claudeContainer.id, () => {}).catch(() => {});
+  }
+
+  /**
+   * Re-check a `completed` stack to determine if it was actually token-limited.
+   * Execs a two-stage grep against the container log (mirroring check_for_token_limit
+   * in task-runner.sh:63-72) and, on confirmation, drives the stack through the
+   * existing continuation machinery (Case A with session_id, Case B without).
+   *
+   * Returns `container_gone` when the claude container is absent or not running.
+   * Returns `not_token_limited` when the grep finds no marker.
+   * Returns `idle` when confirmed but no task record exists.
+   * Returns the resumeStackWithContinuation outcome otherwise.
+   */
+  async recheckCompletedStack(stackId: string): Promise<{
+    outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
+  }> {
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    // Idempotency guard — abort if status has already changed
+    if (stack.status !== 'completed') {
+      return { outcome: 'idle' };
+    }
+
+    const runtime = this.getRuntimeForStack(stack);
+    const composeProjectName = `sandstorm-${sanitizeComposeName(stack.project)}-${sanitizeComposeName(stack.id)}`;
+
+    let containers;
+    try {
+      containers = await runtime.listContainers({ name: `${composeProjectName}-claude` });
+    } catch (err) {
+      console.debug(`[StackManager] recheckCompletedStack: container list failed for ${stackId}:`, err);
+      return { outcome: 'container_gone' };
+    }
+
+    const container = containers[0] ?? null;
+    if (!container || container.status !== 'running') {
+      console.debug(`[StackManager] recheckCompletedStack: container absent or not running for ${stackId}`);
+      return { outcome: 'container_gone' };
+    }
+
+    // Two-stage grep mirrors check_for_token_limit() in task-runner.sh:63-72.
+    // The ^[[:space:]]*{ exclusion prevents JSON lines from producing false positives.
+    let grepResult;
+    try {
+      grepResult = await runtime.exec(container.id, [
+        'sh', '-c',
+        "grep -vE '^[[:space:]]*\\{' /tmp/claude-raw.log 2>/dev/null | grep -qi \"You've hit your session limit\"",
+      ]);
+    } catch {
+      return { outcome: 'not_token_limited' };
+    }
+
+    if (grepResult.exitCode !== 0) {
+      // Genuine completion — marker not found
+      return { outcome: 'not_token_limited' };
+    }
+
+    // Token limit confirmed. Get the most-recent task to update session_id.
+    const task = this.registry.getMostRecentTask(stackId);
+    if (!task) {
+      return { outcome: 'idle' };
+    }
+
+    // Best-effort: read session_id from log so resumeStackWithContinuation can use Case A.
+    try {
+      const rawResult = await runtime.exec(container.id, ['cat', '/tmp/claude-raw.log']);
+      if (rawResult.stdout) {
+        const usage = parseTokenUsage(rawResult.stdout);
+        if (usage.session_id) {
+          this.registry.setTaskSessionId(task.id, usage.session_id);
+        }
+      }
+    } catch {
+      // Non-fatal — resume falls back to Case B (fresh re-dispatch)
+    }
+
+    // Transition to session_paused so resumeStackWithContinuation can proceed.
+    // The task is still 'completed'; the Q-A fallback in resumeStackWithContinuation
+    // will call getMostRecentTask + reopenTaskForResume before Case A/B.
+    this.registry.updateStackStatus(stackId, 'session_paused');
+    this.notifyUpdate();
+
+    try {
+      const result = await this.resumeStackWithContinuation(stackId, () => false, true);
+      return result;
+    } catch (err) {
+      // Revert: close any reopened task and restore stack to completed.
+      // Include 'interrupted' because Case B calls interruptTask before dispatchTask;
+      // if dispatchTask throws, the task is 'interrupted', not 'running'.
+      const reopenedTask = this.registry.getMostRecentTask(stackId);
+      if (reopenedTask && (reopenedTask.status === 'running' || reopenedTask.status === 'interrupted')) {
+        this.registry.completeTask(reopenedTask.id, 0); // also sets stack to 'completed'
+      } else {
+        this.registry.updateStackStatus(stackId, 'completed');
+      }
+      this.notifyUpdate();
+      throw err;
+    }
   }
 
   /**

--- a/src/main/control-plane/startup-reconciler.ts
+++ b/src/main/control-plane/startup-reconciler.ts
@@ -133,6 +133,18 @@ export async function runStartupReconciliation(
     // Notify renderer after each stack so cards refresh live
     notifyUpdate();
   }
+
+  // Ongoing safeguard: re-check completed stacks for missed token-limit signals.
+  // recheckCompletedStack handles the container-absent case internally.
+  const completedStacks = registry.listStacks().filter((s) => s.status === 'completed');
+  for (const stack of completedStacks) {
+    try {
+      await stackManager.recheckCompletedStack(stack.id);
+    } catch (err) {
+      console.warn(`[StartupReconciler] Error rechecking completed stack ${stack.id}:`, err);
+    }
+    notifyUpdate();
+  }
 }
 
 async function reconcileStack(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1077,6 +1077,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     await stackManager.resumeNeedsHumanStack(stackId, answers);
   });
 
+  ipcMain.handle('stacks:recheckCompleted', async (_event, stackId: string) => {
+    return stackManager.recheckCompletedStack(stackId);
+  });
+
   ipcMain.handle('stacks:getFailureDiagnosis', async (_event, stackId: string) => {
     return getFailureDiagnosis(stackId, registry, agentBackend);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -77,6 +77,9 @@ export interface SandstormAPI {
     getFailureDiagnosis: (stackId: string) => Promise<unknown>;
     selfHealContinue: (stackId: string) => Promise<void>;
     restartWithFindings: (stackId: string, updatedTicketBody: string) => Promise<{ newStackId: string }>;
+    recheckCompleted: (stackId: string) => Promise<{
+      outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
+    }>;
   };
   tasks: {
     dispatch: (stackId: string, prompt: string, model?: string) => Promise<unknown>;
@@ -316,6 +319,8 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('stacks:selfHealContinue', stackId),
     restartWithFindings: (stackId: string, updatedTicketBody: string) =>
       ipcRenderer.invoke('stacks:restartWithFindings', stackId, updatedTicketBody),
+    recheckCompleted: (stackId: string) =>
+      ipcRenderer.invoke('stacks:recheckCompleted', stackId),
   },
   tasks: {
     dispatch: (stackId, prompt, model?) =>

--- a/src/renderer/components/StackCard.tsx
+++ b/src/renderer/components/StackCard.tsx
@@ -78,9 +78,10 @@ function formatMs(ms: number): string {
 }
 
 export function StackCard({ stack, showProject }: { stack: Stack; showProject?: boolean }) {
-  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation } = useAppStore();
+  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation, recheckCompletedStack } = useAppStore();
   const metrics: StackMetrics | undefined = stackMetrics[stack.id];
   const [showResolveModal, setShowResolveModal] = useState(false);
+  const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
 
   const runningCount = stack.services.filter(
     (s) => s.status === 'running'
@@ -125,6 +126,20 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
       await resumeStackWithContinuation(stack.id, true);
     } catch (err) {
       alert(`Failed to resume: ${err}`);
+    }
+  };
+
+  const handleRecheckCompleted = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRecheckMessage(null);
+    try {
+      const result = await recheckCompletedStack(stack.id);
+      if (result.outcome === 'container_gone') {
+        setRecheckMessage('Container not running — cannot verify log.');
+        setTimeout(() => setRecheckMessage(null), 4000);
+      }
+    } catch (err) {
+      alert(`Failed to re-check: ${err}`);
     }
   };
 
@@ -327,6 +342,23 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
             </svg>
             Make PR
           </button>
+        </div>
+      )}
+
+      {/* Re-check for missed token-limit on completed stacks */}
+      {stack.status === 'completed' && (
+        <div className="mt-2 ml-5">
+          <button
+            onClick={handleRecheckCompleted}
+            className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-md bg-orange-500/10 text-orange-400 border border-orange-500/20 hover:bg-orange-500/20 transition-colors active:scale-[0.98]"
+            data-testid={`card-recheck-${stack.id}`}
+            title="Check if this stack was token-limited and can be resumed"
+          >
+            Check for Resume
+          </button>
+          {recheckMessage && (
+            <span className="ml-2 text-xs text-sandstorm-muted">{recheckMessage}</span>
+          )}
         </div>
       )}
 

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -45,13 +45,14 @@ export function StackTableRow({
   showProject?: boolean;
   columnWidths?: Record<string, number>;
 }) {
-  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation } = useAppStore();
+  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation, recheckCompletedStack } = useAppStore();
   const metrics: StackMetrics | undefined = stackMetrics[stack.id];
   const [duration, setDuration] = useState(() =>
     getStackDuration(stack.created_at, stack.updated_at, stack.status),
   );
   const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
+  const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
   const rowRef = useRef<HTMLTableRowElement>(null);
   const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -126,6 +127,20 @@ export function StackTableRow({
       await resumeStackWithContinuation(stack.id, true);
     } catch (err) {
       alert(`Failed to resume: ${err}`);
+    }
+  };
+
+  const handleRecheckCompleted = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRecheckMessage(null);
+    try {
+      const result = await recheckCompletedStack(stack.id);
+      if (result.outcome === 'container_gone') {
+        setRecheckMessage('Container not running');
+        setTimeout(() => setRecheckMessage(null), 4000);
+      }
+    } catch (err) {
+      alert(`Failed to re-check: ${err}`);
     }
   };
 
@@ -233,6 +248,21 @@ export function StackTableRow({
               >
                 ▶ Resume
               </button>
+            )}
+            {stack.status === 'completed' && (
+              <>
+                <button
+                  onClick={handleRecheckCompleted}
+                  className="text-[10px] font-medium px-2 py-0.5 rounded bg-orange-500/10 text-orange-400 border border-orange-500/20 hover:bg-orange-500/20 transition-colors"
+                  data-testid={`row-recheck-${stack.id}`}
+                  title="Check if this stack was token-limited and can be resumed"
+                >
+                  Check Resume
+                </button>
+                {recheckMessage && (
+                  <span className="text-[10px] text-sandstorm-muted">{recheckMessage}</span>
+                )}
+              </>
             )}
             {stack.status === 'needs_human' && (
               <button

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -25,6 +25,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     refinementSessions,
     retryRefinementForTicket,
     resumeStackWithContinuation,
+    recheckCompletedStack,
     startStackForTicket,
     stackCreateErrors,
     stackCreateInFlight,
@@ -49,6 +50,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const [showEarlyDiscardDialog, setShowEarlyDiscardDialog] = useState(false);
   const [showMoveToBacklogDialog, setShowMoveToBacklogDialog] = useState(false);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
+  const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
   const stackKey = `${ticket.ticket_id}|${ticket.project_dir}`;
@@ -95,6 +97,20 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const handleResume = () => {
     if (stack) {
       void resumeStackWithContinuation(stack.id, true);
+    }
+  };
+
+  const handleRecheckCompleted = async () => {
+    if (!stack) return;
+    setRecheckMessage(null);
+    try {
+      const result = await recheckCompletedStack(stack.id);
+      if (result.outcome === 'container_gone') {
+        setRecheckMessage('Container not running — cannot verify log.');
+        setTimeout(() => setRecheckMessage(null), 4000);
+      }
+    } catch (err) {
+      alert(`Failed to re-check: ${err}`);
     }
   };
 
@@ -350,6 +366,20 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
             >
               Resume
             </button>
+          )}
+          {stack && stack.status === 'completed' && (
+            <div>
+              <button
+                onClick={handleRecheckCompleted}
+                className="w-full text-xs py-1 px-3 rounded-md bg-orange-500/10 text-orange-400 border border-orange-500/20 hover:bg-orange-500/20 transition-colors font-medium"
+                data-testid={`ticket-card-recheck-${ticket.ticket_id}`}
+              >
+                Check for Resume
+              </button>
+              {recheckMessage && (
+                <p className="mt-1 text-xs text-sandstorm-muted">{recheckMessage}</p>
+              )}
+            </div>
           )}
           {stack && stack.status === 'needs_human' && (
             <button

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -494,6 +494,9 @@ interface AppState {
   sessionHaltAll: () => Promise<string[]>;
   sessionResumeAll: () => Promise<string[]>;
   resumeStackWithContinuation: (stackId: string, manual?: boolean) => Promise<void>;
+  recheckCompletedStack: (stackId: string) => Promise<{
+    outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
+  }>;
 
   // Kanban board
   boardTickets: TicketBoardEntry[];
@@ -695,6 +698,9 @@ declare global {
         getFailureDiagnosis: (stackId: string) => Promise<FailureDiagnosis>;
         selfHealContinue: (stackId: string) => Promise<void>;
         restartWithFindings: (stackId: string, updatedTicketBody: string) => Promise<{ newStackId: string }>;
+        recheckCompleted: (stackId: string) => Promise<{
+          outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
+        }>;
       };
       tasks: {
         dispatch: (stackId: string, prompt: string, model?: string) => Promise<Task>;
@@ -1145,6 +1151,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       return;
     }
     await get().refreshStacks();
+  },
+
+  recheckCompletedStack: async (stackId: string) => {
+    const result = await window.sandstorm.stacks.recheckCompleted(stackId);
+    await get().refreshStacks();
+    return result;
   },
 
   // Kanban board

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -2339,6 +2339,7 @@ describe('IPC Handlers', () => {
       'stacks:getFailureDiagnosis',
       'stacks:selfHealContinue',
       'stacks:restartWithFindings',
+      'stacks:recheckCompleted',
       'stats:telemetry:summary',
       'stats:telemetry:daily',
       'stats:telemetry:byModel',

--- a/tests/unit/main/control-plane/marker-drift-guard.test.ts
+++ b/tests/unit/main/control-plane/marker-drift-guard.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Drift-guard test (ticket #557, Dependency Contracts).
+ *
+ * The token-limit marker and {-filter appear in two places:
+ *   1. sandstorm-cli/docker/task-runner.sh — check_for_token_limit()
+ *   2. StackManager.recheckCompletedStack — the inline exec command
+ *
+ * This test reads task-runner.sh and asserts the desktop re-check command
+ * uses the identical marker string and {-line exclusion, so a change to
+ * one side without the other is caught in CI.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const TASK_RUNNER_PATH = path.resolve(
+  __dirname,
+  '../../../../sandstorm-cli/docker/task-runner.sh',
+);
+
+const STACK_MANAGER_PATH = path.resolve(
+  __dirname,
+  '../../../../src/main/control-plane/stack-manager.ts',
+);
+
+describe('token-limit marker drift guard', () => {
+  it('task-runner.sh check_for_token_limit contains the expected marker', () => {
+    const source = fs.readFileSync(TASK_RUNNER_PATH, 'utf8');
+    // The function should exist
+    expect(source).toContain('check_for_token_limit');
+    // The marker string (case-insensitive grep)
+    expect(source).toContain("You've hit your session limit");
+    // The {-filter
+    expect(source).toMatch(/\^\[\[:space:\]\]\*.*\{/);
+  });
+
+  it('stack-manager.ts recheckCompletedStack uses the same marker as task-runner.sh', () => {
+    const shellSource = fs.readFileSync(TASK_RUNNER_PATH, 'utf8');
+    const tsSource = fs.readFileSync(STACK_MANAGER_PATH, 'utf8');
+
+    // Extract the marker from task-runner.sh
+    // The line looks like: grep -qi "You've hit your session limit"
+    const markerMatch = shellSource.match(/grep -qi\s+"([^"]+)"/);
+    expect(markerMatch).not.toBeNull();
+    const marker = markerMatch![1];
+
+    // The desktop re-check command must contain the same marker
+    expect(tsSource).toContain(marker);
+  });
+
+  it('stack-manager.ts recheckCompletedStack uses the {-line exclusion', () => {
+    const tsSource = fs.readFileSync(STACK_MANAGER_PATH, 'utf8');
+
+    // The exec command must include the {-filter (grep -vE '^[[:space:]]*\{')
+    // Allow for JS string escaping (\\{ or \{)
+    expect(tsSource).toMatch(/\^\[\[:space:\]\]\*\\*\{/);
+  });
+
+  it('stack-manager.ts recheckCompletedStack targets /tmp/claude-raw.log', () => {
+    const tsSource = fs.readFileSync(STACK_MANAGER_PATH, 'utf8');
+    expect(tsSource).toContain('/tmp/claude-raw.log');
+  });
+});

--- a/tests/unit/main/control-plane/stack-manager-recheck-completed.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-recheck-completed.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for StackManager.recheckCompletedStack (ticket #557)
+ * and the Q-A extension to resumeStackWithContinuation.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { StackManager } from '../../../../src/main/control-plane/stack-manager';
+import { Registry } from '../../../../src/main/control-plane/registry';
+import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
+import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
+import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `sm-recheck-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function createMockRuntime(): ContainerRuntime {
+  return {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn().mockResolvedValue({}),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
+    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+const RUNNING_CONTAINER = { id: 'cid-abc', name: 'sandstorm-proj-s1-claude-1', status: 'running' };
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe('StackManager.recheckCompletedStack', () => {
+  let registry: Registry;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+  let resumeSpy: ReturnType<typeof vi.spyOn>;
+  let dispatchTaskSpy: ReturnType<typeof vi.spyOn>;
+  let dispatchContinuationSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    const portAllocator = new PortAllocator(registry, [40100, 40199]);
+    const taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+
+    registry.createStack({
+      id: 's1',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'completed',
+      runtime: 'docker',
+    });
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  // Helpers
+  function setupRunningContainer() {
+    vi.mocked(runtime.listContainers).mockResolvedValue([RUNNING_CONTAINER]);
+  }
+
+  function setupTokenLimitedGrep() {
+    // exit 0 = token limit found
+    vi.mocked(runtime.exec).mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+  }
+
+  function setupNoTokenLimitGrep() {
+    // exit 1 = not found
+    vi.mocked(runtime.exec).mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+  }
+
+  function createCompletedTask(sessionId: string | null = null): number {
+    const task = registry.createTask('s1', 'do the work', null);
+    // Close it as completed (exit 0)
+    registry.completeTask(task.id, 0);
+    if (sessionId) {
+      registry.setTaskSessionId(task.id, sessionId);
+    }
+    return task.id;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Container absent / not running
+  // ---------------------------------------------------------------------------
+  it('returns container_gone when no container is found', async () => {
+    vi.mocked(runtime.listContainers).mockResolvedValue([]);
+    createCompletedTask();
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('container_gone');
+    // Stack unchanged
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  it('returns container_gone when container is not running', async () => {
+    vi.mocked(runtime.listContainers).mockResolvedValue([
+      { ...RUNNING_CONTAINER, status: 'exited' },
+    ]);
+    createCompletedTask();
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('container_gone');
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  it('returns container_gone when listContainers throws', async () => {
+    vi.mocked(runtime.listContainers).mockRejectedValue(new Error('Docker not available'));
+    createCompletedTask();
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('container_gone');
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Not token-limited
+  // ---------------------------------------------------------------------------
+  it('returns not_token_limited when grep exits non-zero', async () => {
+    setupRunningContainer();
+    setupNoTokenLimitGrep();
+    createCompletedTask();
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('not_token_limited');
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  it('returns not_token_limited when exec throws', async () => {
+    setupRunningContainer();
+    vi.mocked(runtime.exec).mockRejectedValue(new Error('exec failure'));
+    createCompletedTask();
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('not_token_limited');
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Token limit confirmed — Case A (session_id present)
+  // ---------------------------------------------------------------------------
+  it('resumes via Case A when token-limited and session_id is present', async () => {
+    setupRunningContainer();
+    createCompletedTask('sess-123');
+
+    // Sequence: exec 1 = grep (exit 0), exec 2 = cat raw log (returns session json)
+    vi.mocked(runtime.exec)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // grep
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '{"type":"result","session_id":"sess-123"}', stderr: '' }); // cat log
+
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    dispatchContinuationSpy = vi.spyOn(manager as any, 'dispatchContinuation').mockResolvedValue(undefined);
+
+    const result = await manager.recheckCompletedStack('s1');
+
+    expect(result.outcome).toBe('resuming_with_session');
+    expect(dispatchContinuationSpy).toHaveBeenCalledOnce();
+    // Task was reopened then used for Case A
+    const task = registry.getMostRecentTask('s1');
+    expect(task?.status).toBe('running');
+    expect(task?.session_id).toBe('sess-123');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Token limit confirmed — Case B (no session_id)
+  // ---------------------------------------------------------------------------
+  it('resumes via Case B when token-limited and no session_id', async () => {
+    setupRunningContainer();
+    createCompletedTask(null); // no session_id
+
+    vi.mocked(runtime.exec)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // grep
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // cat log — no session_id
+
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    dispatchTaskSpy = vi.spyOn(manager, 'dispatchTask').mockResolvedValue({
+      id: 99, stack_id: 's1', status: 'running',
+    });
+
+    const result = await manager.recheckCompletedStack('s1');
+
+    expect(result.outcome).toBe('resumed_fresh');
+    expect(dispatchTaskSpy).toHaveBeenCalledOnce();
+    // prompt should be original task prompt
+    expect(dispatchTaskSpy).toHaveBeenCalledWith(
+      's1',
+      'do the work',
+      undefined,
+      expect.objectContaining({ skipTicketFetch: true }),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency
+  // ---------------------------------------------------------------------------
+  it('aborts with idle when stack is no longer completed (idempotency guard)', async () => {
+    // Make it session_paused so it's no longer 'completed'
+    registry.updateStackStatus('s1', 'session_paused');
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('idle');
+    // listContainers should not have been called
+    expect(runtime.listContainers).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Resume dispatch failure → revert to completed
+  // ---------------------------------------------------------------------------
+  it('reverts to completed when dispatch fails', async () => {
+    setupRunningContainer();
+    createCompletedTask('sess-456');
+
+    vi.mocked(runtime.exec)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // grep
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '{"type":"result","session_id":"sess-456"}', stderr: '' }); // cat
+
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    dispatchContinuationSpy = vi.spyOn(manager as any, 'dispatchContinuation')
+      .mockRejectedValue(new Error('dispatch failed'));
+
+    await expect(manager.recheckCompletedStack('s1')).rejects.toThrow('dispatch failed');
+
+    // Stack must be reverted to completed — not left in session_paused or building
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Resume dispatch failure — Case B (no session_id) → revert to completed
+  // ---------------------------------------------------------------------------
+  it('reverts to completed and task not stranded in interrupted when Case B dispatch fails', async () => {
+    setupRunningContainer();
+    createCompletedTask(null); // no session_id → Case B path
+
+    vi.mocked(runtime.exec)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // grep
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // cat log — no session_id
+
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    vi.spyOn(manager, 'dispatchTask').mockRejectedValue(new Error('dispatch failed'));
+
+    await expect(manager.recheckCompletedStack('s1')).rejects.toThrow('dispatch failed');
+
+    // Stack must revert to completed
+    expect(registry.getStack('s1')?.status).toBe('completed');
+    // Task must NOT remain in 'interrupted' — it should be completed (terminal state restored)
+    const task = registry.getMostRecentTask('s1');
+    expect(task?.status).not.toBe('interrupted');
+    expect(task?.status).toBe('completed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // No task record at all
+  // ---------------------------------------------------------------------------
+  it('returns idle when no task exists for the stack', async () => {
+    setupRunningContainer();
+    setupTokenLimitedGrep();
+    // Do not create any task — getMostRecentTask returns undefined
+
+    const result = await manager.recheckCompletedStack('s1');
+    expect(result.outcome).toBe('idle');
+    // Stack status unchanged (no transition attempted)
+    expect(registry.getStack('s1')?.status).toBe('completed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Inline grep correctness
+  // ---------------------------------------------------------------------------
+  it('execs the two-stage grep targeting /tmp/claude-raw.log with the {-line exclusion', async () => {
+    setupRunningContainer();
+    setupNoTokenLimitGrep();
+    createCompletedTask();
+
+    await manager.recheckCompletedStack('s1');
+
+    // Find the exec call that ran the grep
+    const execCalls = vi.mocked(runtime.exec).mock.calls;
+    const grepCall = execCalls.find((args) => {
+      const cmd = args[1] as string[];
+      return cmd[0] === 'sh' && cmd[1] === '-c';
+    });
+    expect(grepCall).toBeDefined();
+    const shellCmd = (grepCall![1] as string[])[2];
+
+    // Must target the log file
+    expect(shellCmd).toContain('/tmp/claude-raw.log');
+    // Must include the {-line exclusion
+    expect(shellCmd).toMatch(/\^\[/);
+    expect(shellCmd).toContain('{');
+    // Must include the marker
+    expect(shellCmd).toContain("You've hit your session limit");
+  });
+
+  it('treats JSON-only log lines as non-matching (filter correctness)', () => {
+    // Simulate the two-stage grep via the shell command:
+    // The exclusion must filter out lines that begin with optional whitespace + {
+    const shellCmd =
+      "grep -vE '^[[:space:]]*\\{' /tmp/claude-raw.log 2>/dev/null | grep -qi \"You've hit your session limit\"";
+
+    // Lines that begin with '{' (JSON) should be filtered by the first grep
+    const jsonLine = '{"type":"result","result":"You\'ve hit your session limit"}';
+    const plainLine = "You've hit your session limit";
+
+    // Verify the exclusion regex matches json-prefixed lines
+    const exclusionRe = /^[[:space:]]*\{/;
+    // Use JS equivalent
+    const jsExclusionRe = /^[\s]*\{/;
+    expect(jsExclusionRe.test(jsonLine)).toBe(true);
+    expect(jsExclusionRe.test(plainLine)).toBe(false);
+
+    // The shell command references the correct log file and marker
+    expect(shellCmd).toContain('/tmp/claude-raw.log');
+    expect(shellCmd).toContain("You've hit your session limit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Q-A extension: resumeStackWithContinuation Case C fallback
+// ---------------------------------------------------------------------------
+describe('resumeStackWithContinuation Q-A fallback (Case C → getMostRecentTask)', () => {
+  let registry: Registry;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    const portAllocator = new PortAllocator(registry, [40200, 40299]);
+    const taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+
+    registry.createStack({
+      id: 's2',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'session_paused',
+      runtime: 'docker',
+    });
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to getMostRecentTask when getRunningTask returns nothing', async () => {
+    // Create and complete a task (no running task)
+    const task = registry.createTask('s2', 'original prompt', null);
+    registry.setTaskSessionId(task.id, 'sess-789');
+    registry.completeTask(task.id, 0); // task is now 'completed', no running task
+    // completeTask also sets stack to 'completed'; restore to session_paused
+    registry.updateStackStatus('s2', 'session_paused');
+
+    const dispatchContinuationSpy = vi.spyOn(manager as any, 'dispatchContinuation')
+      .mockResolvedValue(undefined);
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    vi.spyOn(manager as any, 'findClaudeContainer').mockResolvedValue({ id: 'cid', status: 'running' });
+
+    const result = await manager.resumeStackWithContinuation('s2', () => false, true);
+
+    expect(result.outcome).toBe('resuming_with_session');
+    expect(dispatchContinuationSpy).toHaveBeenCalledOnce();
+    // Task should have been reopened
+    const reopened = registry.getMostRecentTask('s2');
+    expect(reopened?.status).toBe('running');
+  });
+
+  it('returns idle when neither running task nor most-recent task exists', async () => {
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+
+    const result = await manager.resumeStackWithContinuation('s2', () => false, true);
+    expect(result.outcome).toBe('idle');
+  });
+
+  it('does NOT trigger Q-A fallback when a running task already exists (regression)', async () => {
+    // Create a running task — normal Case A path.
+    // createTask also sets stack status to 'running'; restore to session_paused.
+    const task = registry.createTask('s2', 'running work', null);
+    registry.setTaskSessionId(task.id, 'sess-run-1');
+    registry.updateStackStatus('s2', 'session_paused');
+
+    const dispatchContinuationSpy = vi.spyOn(manager as any, 'dispatchContinuation')
+      .mockResolvedValue(undefined);
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    vi.spyOn(manager as any, 'findClaudeContainer').mockResolvedValue({ id: 'cid', status: 'running' });
+
+    const result = await manager.resumeStackWithContinuation('s2', () => false, true);
+
+    // Case A is reached directly — no fallback triggered
+    expect(result.outcome).toBe('resuming_with_session');
+    expect(dispatchContinuationSpy).toHaveBeenCalledOnce();
+    // The task was already running, not reopened
+    const t = registry.getRunningTask('s2');
+    expect(t?.id).toBe(task.id);
+  });
+});

--- a/tests/unit/main/control-plane/startup-reconciler-completed.test.ts
+++ b/tests/unit/main/control-plane/startup-reconciler-completed.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the completed-stacks pass in runStartupReconciliation (ticket #557).
+ * Verifies that recheckCompletedStack is called for each completed stack on startup.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { runStartupReconciliation } from '../../../../src/main/control-plane/startup-reconciler';
+import { Registry } from '../../../../src/main/control-plane/registry';
+import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
+import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
+import { StackManager } from '../../../../src/main/control-plane/stack-manager';
+import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `sr-completed-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function createMockRuntime(): ContainerRuntime {
+  return {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn().mockResolvedValue({}),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
+    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+describe('runStartupReconciliation — completed stacks pass', () => {
+  let registry: Registry;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let taskWatcher: TaskWatcher;
+  let dbPath: string;
+  let notifyUpdate: ReturnType<typeof vi.fn>;
+  let recheckSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    const portAllocator = new PortAllocator(registry, [40300, 40399]);
+    taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+    notifyUpdate = vi.fn();
+
+    // Stub recheckCompletedStack so it doesn't need real Docker
+    recheckSpy = vi.spyOn(manager, 'recheckCompletedStack').mockResolvedValue({ outcome: 'not_token_limited' });
+  });
+
+  afterEach(() => {
+    taskWatcher.unwatchAll();
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  it('calls recheckCompletedStack for each completed stack', async () => {
+    registry.createStack({
+      id: 'c1', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'completed', runtime: 'docker',
+    });
+    registry.createStack({
+      id: 'c2', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'completed', runtime: 'docker',
+    });
+
+    await runStartupReconciliation(
+      registry, manager, taskWatcher, runtime, runtime, notifyUpdate,
+    );
+
+    expect(recheckSpy).toHaveBeenCalledTimes(2);
+    expect(recheckSpy).toHaveBeenCalledWith('c1');
+    expect(recheckSpy).toHaveBeenCalledWith('c2');
+  });
+
+  it('does not call recheckCompletedStack for non-completed stacks', async () => {
+    registry.createStack({
+      id: 'r1', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'running', runtime: 'docker',
+    });
+    registry.createStack({
+      id: 'f1', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'failed', runtime: 'docker',
+    });
+
+    await runStartupReconciliation(
+      registry, manager, taskWatcher, runtime, runtime, notifyUpdate,
+    );
+
+    expect(recheckSpy).not.toHaveBeenCalled();
+  });
+
+  it('continues past a completed stack that throws during recheck', async () => {
+    recheckSpy
+      .mockRejectedValueOnce(new Error('transient error'))
+      .mockResolvedValueOnce({ outcome: 'not_token_limited' });
+
+    registry.createStack({
+      id: 'e1', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'completed', runtime: 'docker',
+    });
+    registry.createStack({
+      id: 'e2', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'completed', runtime: 'docker',
+    });
+
+    // Should not throw even though first recheck fails
+    await expect(
+      runStartupReconciliation(registry, manager, taskWatcher, runtime, runtime, notifyUpdate),
+    ).resolves.not.toThrow();
+
+    expect(recheckSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns container_gone for completed stacks with no running container', async () => {
+    recheckSpy.mockResolvedValue({ outcome: 'container_gone' });
+
+    registry.createStack({
+      id: 'cg', project: 'p', project_dir: '/p', ticket: null,
+      branch: null, description: null, status: 'completed', runtime: 'docker',
+    });
+
+    await runStartupReconciliation(
+      registry, manager, taskWatcher, runtime, runtime, notifyUpdate,
+    );
+
+    expect(recheckSpy).toHaveBeenCalledWith('cg');
+    // Stack status unchanged
+    expect(registry.getStack('cg')?.status).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Summary

Makes completed stacks reconcile correctly on recheck and startup, and adds a guard against marker drift so a stack's persisted state stays consistent with its actual task state.

When a completed stack is rechecked and reopened, dispatching new work could fail partway through. Previously the revert path only handled tasks left in the `running` state, so a task that had already been moved to `interrupted` before dispatch threw would be stranded in that non-terminal state while the stack reverted to `completed`. The revert condition now also covers `interrupted`, so the task is properly closed and restored to its terminal state, keeping stack and task status in agreement.

The startup reconciler and IPC/preload surface are updated to handle the completed-stack path, and the renderer (StackCard, StackTableRow, TicketCard, store) reflects the reconciled state to the user.

New tests cover the marker drift guard, recheck of completed stacks (including the Case B dispatch-failure path where a task must not be stranded in `interrupted`), and startup reconciliation of completed stacks.

## QA plan

1. Start a stack and let its task run to completion so the stack shows `completed`.
2. Trigger a recheck of the completed stack and confirm it reopens, dispatches work, and the UI (card, table row, ticket card) reflects the running state.
3. Simulate a dispatch failure during recheck (e.g. a stack with no session id): confirm the stack reverts to `completed` and the task returns to its terminal state rather than being stuck in `interrupted`.
4. Restart the app with a completed stack present and confirm the startup reconciler leaves it in a consistent completed state with no marker drift.

Closes #557