### PR TITLE
[558] fix: allow repeated self-heal continuation on failed stacks

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -2035,8 +2035,10 @@ export class StackManager {
   }
 
   /**
-   * Grant the failed stack exactly one additional review round on the same branch.
-   * The guard is consumed on dispatch; a second call is rejected.
+   * Continue a failed stack on the same branch, repeatable.
+   * Uses --resume <session_id> when available (Case A) so the agent retains context;
+   * falls back to fresh dispatch (Case B) when session_id is null.
+   * The guard is used as a within-call race lock only — reset to 0 on success and on failure.
    */
   async selfHealContinue(stackId: string): Promise<void> {
     const stack = this.registry.getStack(stackId);
@@ -2044,17 +2046,11 @@ export class StackManager {
     if (stack.status !== 'failed') {
       throw new SandstormError(ErrorCode.INVALID_INPUT, `Stack "${stackId}" is not in failed state`);
     }
-    if (stack.selfheal_continue_used !== 0) {
-      throw new SandstormError(
-        ErrorCode.INVALID_INPUT,
-        `Stack "${stackId}" has already consumed its self-heal continuation`
-      );
-    }
 
     const task = this.registry.getMostRecentTask(stackId);
     if (!task) throw new SandstormError(ErrorCode.INTERNAL_ERROR, `No task found for stack "${stackId}"`);
 
-    // Consume the guard before dispatch to prevent double-use
+    // Set guard as within-call race lock before dispatch
     this.registry.setSelfhealContinueUsed(stackId, 1);
 
     this.registry.updateStackStatus(stackId, 'building');
@@ -2062,17 +2058,36 @@ export class StackManager {
     try {
       await this.ensureStackContainersRunning(stack, stackId);
     } catch (err) {
+      this.registry.setSelfhealContinueUsed(stackId, 0);
       this.registry.updateStackStatus(stackId, 'failed');
       this.notifyUpdate();
       throw err;
     }
 
     try {
-      await this.dispatchTask(stackId, task.prompt, task.model ?? undefined, {
-        gateApproved: true,
-        skipTicketFetch: true,
-      });
+      if (task.session_id) {
+        // Case A: resume with existing Claude session — reopen task, reset iterations, dispatch continuation
+        this.registry.reopenTaskForResume(task.id);
+        this.registry.setTaskIterations(task.id, 0, task.verify_retries);
+        const continuationPrompt =
+          'Continue the prior work on this task. The review loop count has been reset — you have fresh review iterations to work with. Resume from where you left off.';
+        await this.dispatchContinuation(stack, stackId, { ...task, status: 'running' }, continuationPrompt);
+      } else {
+        // Case B: no session_id — fresh dispatch of original task prompt
+        await this.dispatchTask(stackId, task.prompt, task.model ?? undefined, {
+          gateApproved: true,
+          skipTicketFetch: true,
+        });
+      }
+      // Reset guard on success so the stack remains continuable
+      this.registry.setSelfhealContinueUsed(stackId, 0);
     } catch (err) {
+      if (task.session_id) {
+        // Revert reopened task to terminal state so it doesn't strand in running
+        this.registry.completeTask(task.id, 1);
+      }
+      // Reset guard so the stack is not permanently blocked
+      this.registry.setSelfhealContinueUsed(stackId, 0);
       this.registry.updateStackStatus(stackId, 'failed');
       this.notifyUpdate();
       throw err;

--- a/src/main/control-plane/startup-reconciler.ts
+++ b/src/main/control-plane/startup-reconciler.ts
@@ -112,6 +112,14 @@ export async function runStartupReconciliation(
   registry.reconcilePrOpenStuckTickets();
   notifyUpdate();
 
+  // Reset selfheal_continue_used to 0 for every failed stack so previously-stuck
+  // stacks are continuable and the guard is never permanently set.
+  const failedStacks = registry.listStacks().filter((s) => s.status === 'failed');
+  for (const stack of failedStacks) {
+    registry.setSelfhealContinueUsed(stack.id, 0);
+  }
+  if (failedStacks.length > 0) notifyUpdate();
+
   const staleStacks = registry.listStacks().filter((s) => RECONCILE_STATUSES.has(s.status));
 
   for (const stack of staleStacks) {

--- a/src/renderer/components/ResolveFailureModal.tsx
+++ b/src/renderer/components/ResolveFailureModal.tsx
@@ -36,7 +36,7 @@ export function ResolveFailureModal({ stack, onClose, onResolved }: ResolveFailu
     return () => { cancelled = true; };
   }, [stack.id]);
 
-  const canSelfHeal = diagnosis?.eligibility.selfHeal === true && stack.selfheal_continue_used === 0;
+  const canSelfHeal = diagnosis?.eligibility.selfHeal === true;
   const canAnswerQuestions = diagnosis?.eligibility.answerQuestions === true && (diagnosis.questions?.length ?? 0) > 0;
   const canReincorporate = diagnosis?.eligibility.reincorporateSpec === true;
 
@@ -161,11 +161,9 @@ export function ResolveFailureModal({ stack, onClose, onResolved }: ResolveFailu
                     description="Re-dispatch the task on this same stack for one more review round."
                     enabled={canSelfHeal && !submitting}
                     disabledReason={
-                      stack.selfheal_continue_used !== 0
-                        ? 'Continuation already consumed'
-                        : !diagnosis.eligibility.selfHeal
-                          ? 'Diagnostic agent recommends against another attempt'
-                          : undefined
+                      !diagnosis.eligibility.selfHeal
+                        ? 'Diagnostic agent recommends against another attempt'
+                        : undefined
                     }
                     onAction={handleSelfHeal}
                     actionLabel="Continue"

--- a/src/renderer/components/StackCard.tsx
+++ b/src/renderer/components/StackCard.tsx
@@ -314,6 +314,22 @@ export function StackCard({ stack, showProject }: { stack: Stack; showProject?: 
         </div>
       )}
 
+      {/* Resolve Failure callout — persistent, always visible for failed stacks */}
+      {stack.status === 'failed' && (
+        <div className="mt-3 ml-5">
+          <button
+            onClick={(e) => { e.stopPropagation(); setShowResolveModal(true); }}
+            className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-red-500/10 text-red-400 border border-red-500/30 hover:bg-red-500/20 transition-colors active:scale-[0.98]"
+            data-testid={`card-resolve-failure-${stack.id}`}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+            </svg>
+            Resolve Failure
+          </button>
+        </div>
+      )}
+
       {/* Persistent primary-action callout — always visible, no hover gate (#315) */}
       {(stack.status === 'completed' || stack.status === 'pushed') && !stack.pr_url && (
         <div className="mt-3 ml-5">

--- a/tests/unit/components/ResolveFailureModal.test.tsx
+++ b/tests/unit/components/ResolveFailureModal.test.tsx
@@ -113,7 +113,7 @@ describe('ResolveFailureModal', () => {
     expect(btn.disabled).toBe(false);
   });
 
-  it('self-heal button is disabled when continuation already consumed', async () => {
+  it('self-heal button is enabled even when selfheal_continue_used is 1 (repeatable)', async () => {
     api.stacks.getFailureDiagnosis.mockResolvedValue(DIAGNOSIS_SELF_HEAL);
     render(
       <ResolveFailureModal stack={makeFailedStack({ selfheal_continue_used: 1 })} onClose={vi.fn()} onResolved={vi.fn()} />
@@ -121,7 +121,7 @@ describe('ResolveFailureModal', () => {
     await waitFor(() => expect(screen.queryByTestId('resolve-modal-loading')).toBeNull());
 
     const btn = screen.getByTestId('self-heal-btn') as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
+    expect(btn.disabled).toBe(false);
   });
 
   it('clicking self-heal calls selfHealContinue and triggers onResolved', async () => {

--- a/tests/unit/components/StackCard.test.tsx
+++ b/tests/unit/components/StackCard.test.tsx
@@ -228,6 +228,19 @@ describe('StackCard', () => {
     expect(resumeFn).toHaveBeenCalledWith('paused2', true);
   });
 
+  it('shows persistent Resolve Failure callout for failed stacks without hover', () => {
+    render(<StackCard stack={makeStack({ id: 'fail-callout', status: 'failed' })} />);
+    expect(screen.getByTestId('card-resolve-failure-fail-callout')).toBeDefined();
+  });
+
+  it('does not show persistent Resolve Failure callout for non-failed stacks', () => {
+    const { unmount } = render(<StackCard stack={makeStack({ id: 'up-callout', status: 'up' })} />);
+    expect(screen.queryByTestId('card-resolve-failure-up-callout')).toBeNull();
+    unmount();
+    render(<StackCard stack={makeStack({ id: 'running-callout', status: 'running' })} />);
+    expect(screen.queryByTestId('card-resolve-failure-running-callout')).toBeNull();
+  });
+
   it('shows Resolve Failure button only for failed stacks', () => {
     const { unmount } = render(
       <StackCard stack={makeStack({ id: 'resolve-failed', status: 'failed' })} />

--- a/tests/unit/self-heal-guard.test.ts
+++ b/tests/unit/self-heal-guard.test.ts
@@ -160,14 +160,11 @@ describe('resumeNeedsHumanStack status guard', () => {
 });
 
 describe('eligibility gating logic', () => {
-  it('selfHeal is true only when agent says true AND selfheal_continue_used === 0', () => {
-    const eligible = (agentSelfHeal: boolean, used: number) =>
-      agentSelfHeal === true && used === 0;
+  it('selfHeal is true when agent says true (selfheal_continue_used no longer gates UI eligibility)', () => {
+    const eligible = (agentSelfHeal: boolean) => agentSelfHeal === true;
 
-    expect(eligible(true, 0)).toBe(true);
-    expect(eligible(true, 1)).toBe(false);
-    expect(eligible(false, 0)).toBe(false);
-    expect(eligible(false, 1)).toBe(false);
+    expect(eligible(true)).toBe(true);
+    expect(eligible(false)).toBe(false);
   });
 
   it('answerQuestions requires questions to be non-empty', () => {
@@ -182,5 +179,133 @@ describe('eligibility gating logic', () => {
   it('reincorporateSpec follows agent verdict directly', () => {
     expect(true).toBe(true);  // gated only by diagnosis.eligibility.reincorporateSpec
     expect(false).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selfHealContinue — resume/repeat/guard behavior
+// ---------------------------------------------------------------------------
+
+describe('selfHealContinue', () => {
+  let registry: Registry;
+  let dbPath: string;
+  let manager: ReturnType<typeof makeStackManager>;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    manager = makeStackManager(registry);
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  function makeFailedStack(sessionId: string | null = null, reviewIterations = 3): { stackId: string; taskId: number } {
+    const stackId = `failed-${Math.random().toString(36).slice(2)}`;
+    registry.createStack({
+      id: stackId,
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: '123',
+      branch: 'feat/123-fix',
+      description: null,
+      status: 'up',
+      runtime: 'docker',
+    });
+    const task = registry.createTask(stackId, 'Fix the bug', 'sonnet');
+    if (sessionId) registry.setTaskSessionId(task.id, sessionId);
+    registry.setTaskIterations(task.id, reviewIterations, 0);
+    // Drive stack+task to failed state
+    registry.completeTask(task.id, 1);
+    return { stackId, taskId: task.id };
+  }
+
+  function mockDispatch() {
+    const ensureRunning = vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    const dispatchCont = vi.spyOn(manager as any, 'dispatchContinuation').mockResolvedValue(undefined);
+    const dispatchTask = vi.spyOn(manager, 'dispatchTask').mockResolvedValue({ id: 999, stack_id: 'x', status: 'running' } as any);
+    return { ensureRunning, dispatchCont, dispatchTask };
+  }
+
+  it('(a) dispatches via dispatchContinuation when session_id is present', async () => {
+    const { stackId } = makeFailedStack('session-abc');
+    const { dispatchCont, dispatchTask } = mockDispatch();
+
+    await manager.selfHealContinue(stackId);
+
+    expect(dispatchCont).toHaveBeenCalledOnce();
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it('(b) falls back to dispatchTask when session_id is null', async () => {
+    const { stackId } = makeFailedStack(null);
+    const { dispatchCont, dispatchTask } = mockDispatch();
+
+    await manager.selfHealContinue(stackId);
+
+    expect(dispatchTask).toHaveBeenCalledOnce();
+    expect(dispatchCont).not.toHaveBeenCalled();
+  });
+
+  it('(c) resets review_iterations to 0 on the resumed task (Case A)', async () => {
+    const { stackId, taskId } = makeFailedStack('session-xyz', 5);
+    mockDispatch();
+
+    await manager.selfHealContinue(stackId);
+
+    const task = registry.getMostRecentTask(stackId)!;
+    expect(task.id).toBe(taskId);
+    expect(task.review_iterations).toBe(0);
+  });
+
+  it('(d) is repeatable — second call does not throw after first succeeds', async () => {
+    const { stackId } = makeFailedStack('session-rep');
+    const { dispatchCont } = mockDispatch();
+
+    await manager.selfHealContinue(stackId);
+
+    // Reset stack to failed so second call is valid
+    registry.updateStackStatus(stackId, 'failed');
+
+    await expect(manager.selfHealContinue(stackId)).resolves.toBeUndefined();
+    expect(dispatchCont).toHaveBeenCalledTimes(2);
+  });
+
+  it('(e) resets selfheal_continue_used to 0 on dispatch failure (not stranded at 1)', async () => {
+    const { stackId } = makeFailedStack('session-fail');
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockResolvedValue(undefined);
+    vi.spyOn(manager as any, 'dispatchContinuation').mockRejectedValue(new Error('CLI failed'));
+
+    await expect(manager.selfHealContinue(stackId)).rejects.toThrow('CLI failed');
+
+    const stack = registry.getStack(stackId)!;
+    expect(stack.selfheal_continue_used).toBe(0);
+  });
+
+  it('(e) resets selfheal_continue_used to 0 when ensureStackContainersRunning fails', async () => {
+    const { stackId } = makeFailedStack('session-err');
+    vi.spyOn(manager as any, 'ensureStackContainersRunning').mockRejectedValue(new Error('Docker down'));
+
+    await expect(manager.selfHealContinue(stackId)).rejects.toThrow('Docker down');
+
+    const stack = registry.getStack(stackId)!;
+    expect(stack.selfheal_continue_used).toBe(0);
+  });
+
+  it('rejects non-failed stacks with INVALID_INPUT', async () => {
+    registry.createStack({
+      id: 'idle-sh',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: '123',
+      branch: 'feat/123-fix',
+      description: null,
+      status: 'idle',
+      runtime: 'docker',
+    });
+    await expect(manager.selfHealContinue('idle-sh')).rejects.toMatchObject({ code: 'INVALID_INPUT' });
   });
 });

--- a/tests/unit/startup-reconciler.test.ts
+++ b/tests/unit/startup-reconciler.test.ts
@@ -689,4 +689,74 @@ describe('runStartupReconciliation', () => {
 
     watcher.unwatchAll();
   });
+
+  // -------------------------------------------------------------------------
+  // (j) failed-stack guard reset — selfheal_continue_used reset to 0 on startup
+  // -------------------------------------------------------------------------
+  it('(j) resets selfheal_continue_used to 0 for every failed stack', async () => {
+    const stackId = `failed-guard-${Math.random().toString(36).slice(2)}`;
+    registry.createStack({
+      id: stackId,
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'failed',
+      runtime: 'docker',
+    });
+    registry.setSelfhealContinueUsed(stackId, 1);
+
+    const runtime = makeRuntime();
+    const sm = makeStackManagerMock();
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+
+    await runStartupReconciliation(
+      registry, sm as unknown as StackManager, watcher,
+      runtime, runtime, notifyUpdate,
+      { workspaceExistsFn: () => false }
+    );
+
+    const stack = registry.getStack(stackId)!;
+    expect(stack.selfheal_continue_used).toBe(0);
+
+    watcher.unwatchAll();
+  });
+
+  it('(j) idempotent — reset is safe to run twice', async () => {
+    const stackId = `failed-idempotent-${Math.random().toString(36).slice(2)}`;
+    registry.createStack({
+      id: stackId,
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'failed',
+      runtime: 'docker',
+    });
+    registry.setSelfhealContinueUsed(stackId, 1);
+
+    const runtime = makeRuntime();
+    const sm = makeStackManagerMock();
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+
+    await runStartupReconciliation(
+      registry, sm as unknown as StackManager, watcher,
+      runtime, runtime, notifyUpdate,
+      { workspaceExistsFn: () => false }
+    );
+
+    // Second run — should remain 0, not flip to 1
+    await runStartupReconciliation(
+      registry, sm as unknown as StackManager, watcher,
+      runtime, runtime, notifyUpdate,
+      { workspaceExistsFn: () => false }
+    );
+
+    const stack = registry.getStack(stackId)!;
+    expect(stack.selfheal_continue_used).toBe(0);
+
+    watcher.unwatchAll();
+  });
 });


### PR DESCRIPTION
## Summary

Failed stacks were permanently blocked from self-heal continuation after a single attempt, because `selfheal_continue_used` acted as a one-shot guard that was never reset. This change makes continuation repeatable and reliably reachable from the UI.

The "Resolve Failure" action is now a persistent callout on failed stack cards (always visible, no hover required), mirroring the existing session-paused Resume affordance. The continuation modal no longer disables itself once a continuation has been consumed.

On the control-plane side, `selfHealContinue` is rewritten to support repeated runs: when a session id is present it reopens the task, resets review iterations, and resumes the existing session; otherwise it falls back to a fresh dispatch. The `selfheal_continue_used` guard is reset on both success and failure so a stack can never get permanently stuck, and startup reconciliation clears the guard for all failed stacks so previously-blocked stacks recover after a restart.

## QA plan

1. Drive a stack to `failed` status.
2. Confirm the "Resolve Failure" callout is visible on the stack card without hovering.
3. Open the Resolve Failure modal and trigger a continuation; confirm it dispatches and the task resumes (same session id when one exists).
4. After it fails again, reopen the modal and confirm continuation is still available (not disabled with "Continuation already consumed").
5. With a failed stack present, restart the app and confirm the failed stack can immediately be continued again.

Closes #558