### PR TITLE
[566] fix: gate retry cancel broadcast and cover board move fanout

### DIFF
--- a/src/main/control-plane/refinement-store.ts
+++ b/src/main/control-plane/refinement-store.ts
@@ -64,3 +64,27 @@ export function persistRefinement(session: RefinementSession): void {
 export function deleteRefinement(id: string): void {
   writeAll(readAll().filter((s) => s.id !== id));
 }
+
+const LIVE_REFINEMENT_COLUMNS = new Set(['refining', 'spec_ready']);
+
+/**
+ * Pure helper: partition sessions into those that should be kept vs pruned.
+ * A session is kept only when its ticket's board column is 'refining' or 'spec_ready'.
+ * Sessions whose ticket row is absent (getColumn returns null) are pruned.
+ */
+export function filterSessionsByBoardState(
+  sessions: RefinementSession[],
+  getColumn: (ticketId: string, projectDir: string) => string | null,
+): { keep: RefinementSession[]; prune: RefinementSession[] } {
+  const keep: RefinementSession[] = [];
+  const prune: RefinementSession[] = [];
+  for (const session of sessions) {
+    const col = getColumn(session.ticketId, session.projectDir);
+    if (col !== null && LIVE_REFINEMENT_COLUMNS.has(col)) {
+      keep.push(session);
+    } else {
+      prune.push(session);
+    }
+  }
+  return { keep, prune };
+}

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -884,8 +884,12 @@ export class Registry {
 
   /** Optional callback invoked after archiveStack — used by rollup store for cache invalidation. */
   onStackArchived?: (stackId: string) => void;
-  /** Optional callback invoked after setBoardTicketColumn — used by rollup store for cache invalidation. */
-  onBoardTicketMoved?: (ticketId: string, column: string) => void;
+  /** Listeners invoked after setBoardTicketColumn. Signature includes projectDir so subscribers can key by (ticketId, projectDir). */
+  private _boardTicketMovedListeners: Array<(ticketId: string, projectDir: string, column: string) => void> = [];
+
+  onBoardTicketMoved(listener: (ticketId: string, projectDir: string, column: string) => void): void {
+    this._boardTicketMovedListeners.push(listener);
+  }
 
   /** Exposes the underlying Database instance for modules that need direct SQL access (e.g. rollup store). */
   getDb(): Database.Database {
@@ -1531,7 +1535,9 @@ export class Registry {
        VALUES (?, ?, ?, '')
        ON CONFLICT(ticket_id, project_dir) DO UPDATE SET column = excluded.column, updated_at = datetime('now')`
     ).run(ticketId, normalizedDir, column);
-    this.onBoardTicketMoved?.(ticketId, column);
+    for (const listener of this._boardTicketMovedListeners) {
+      listener(ticketId, normalizedDir, column);
+    }
   }
 
   /**

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -70,6 +70,7 @@ import {
   loadRefinements,
   persistRefinement,
   deleteRefinement,
+  filterSessionsByBoardState,
   type RefinementSession,
 } from './control-plane/refinement-store';
 import { randomUUID } from 'crypto';
@@ -1215,13 +1216,58 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     mainWindow?.webContents.send('refinement:update', session);
   }
 
+  /** Cancel a refinement session: abort in-flight agent, remove from map, delete from disk, broadcast cancelled. */
+  function cancelRefinementSession(id: string, broadcast = true): void {
+    const entry = activeRefinements.get(id);
+    if (entry) {
+      entry.cancel?.();
+      activeRefinements.delete(id);
+      deleteRefinement(id);
+      if (broadcast) {
+        mainWindow?.webContents.send('refinement:update', { id, status: 'cancelled' });
+      }
+    }
+  }
+
   // On startup, load any persisted sessions (running → interrupted) and
-  // broadcast them to the renderer once the window is ready.
+  // prune sessions whose tickets are no longer in an active refinement column.
   const persistedSessions = loadRefinements();
-  for (const s of persistedSessions) {
+
+  // Build a per-project column cache to avoid redundant queries.
+  const _startupColumnCache = new Map<string, Map<string, string>>();
+  const { keep: sessionsToKeep, prune: sessionsToPrune } = filterSessionsByBoardState(
+    persistedSessions,
+    (ticketId, projectDir) => {
+      if (!_startupColumnCache.has(projectDir)) {
+        const rows = registry.listBoardTickets(projectDir);
+        _startupColumnCache.set(projectDir, new Map(rows.map((r) => [r.ticket_id, r.column])));
+      }
+      return _startupColumnCache.get(projectDir)!.get(ticketId) ?? null;
+    },
+  );
+
+  for (const s of sessionsToPrune) {
+    deleteRefinement(s.id);
+  }
+
+  for (const s of sessionsToKeep) {
     activeRefinements.set(s.id, { session: s, cancel: null });
     persistRefinement(s);
   }
+
+  // Subscribe to board column changes: cancel any refinement session when a ticket
+  // leaves the refinement lifecycle (moves to backlog, in_stack, or merged).
+  const REFINEMENT_CLEANUP_COLUMNS = new Set(['backlog', 'in_stack', 'merged']);
+  registry.onBoardTicketMoved((ticketId, projectDir, column) => {
+    if (!REFINEMENT_CLEANUP_COLUMNS.has(column)) return;
+    for (const [id, entry] of activeRefinements) {
+      if (entry.session.ticketId === ticketId && entry.session.projectDir === projectDir) {
+        cancelRefinementSession(id);
+        break;
+      }
+    }
+  });
+
   // Delay the broadcast slightly so the renderer has time to mount.
   setTimeout(() => {
     for (const { session } of activeRefinements.values()) {
@@ -1340,13 +1386,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle('tickets:cancelRefinement', (_event, id: string) => {
-    const entry = activeRefinements.get(id);
-    if (entry) {
-      entry.cancel?.();
-      activeRefinements.delete(id);
-      deleteRefinement(id);
-      mainWindow?.webContents.send('refinement:update', { id, status: 'cancelled' });
-    }
+    cancelRefinementSession(id);
   });
 
   ipcMain.handle('tickets:listRefinements', () => {
@@ -1363,9 +1403,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       // Cancel the existing session internally (without sending a cancelled event
       // to the renderer, since we are immediately replacing it).
       if (existingEntry) {
-        existingEntry.cancel?.();
-        activeRefinements.delete(sessionId);
-        deleteRefinement(sessionId);
+        cancelRefinementSession(sessionId, false);
       }
 
       // Determine whether to resume from refine phase or restart from check.

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1246,11 +1246,21 @@ export const useAppStore = create<AppState>((set, get) => ({
     const key = `${ticketId}|${projectDir}`;
     // Guard: prevent duplicate gate start during async latency window
     if (get().refineInFlight[key]) return;
-    // Guard: don't start a second gate if a session already exists
+
     const existingSession = get().refinementSessions.find(
       (s) => s.ticketId === ticketId && s.projectDir === projectDir
     );
-    if (existingSession) return;
+
+    if (existingSession) {
+      if (existingSession.status === 'running') {
+        // An in-flight gate is already running — surface its dialog instead of starting a new one.
+        get().openRefinementSession(existingSession.id);
+        return;
+      }
+      // Stale session (ready, errored, interrupted) — discard it and start fresh.
+      void window.sandstorm.tickets.cancelRefinement(existingSession.id).catch(() => {});
+      get().removeRefinementSession(existingSession.id);
+    }
 
     set((state) => {
       const { [key]: _, ...restErrors } = state.refineStartErrors;

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -33,6 +33,7 @@ const {
   mockDeleteRefinement,
   mockPersistRefinement,
   mockLoadRefinements,
+  mockFilterSessionsByBoardState,
   mockUsageEngine,
   mockRollupStoreInstance,
 } = vi.hoisted(() => {
@@ -43,6 +44,19 @@ const {
   const mockDeleteRefinement = vi.fn();
   const mockPersistRefinement = vi.fn();
   const mockLoadRefinements = vi.fn().mockReturnValue([]);
+  const mockFilterSessionsByBoardState = vi.fn().mockImplementation(
+    (sessions: Array<{ ticketId: string; projectDir: string; id: string }>, getColumn: (t: string, p: string) => string | null) => {
+      const LIVE = new Set(['refining', 'spec_ready']);
+      const keep: typeof sessions = [];
+      const prune: typeof sessions = [];
+      for (const s of sessions) {
+        const col = getColumn(s.ticketId, s.projectDir);
+        if (col !== null && LIVE.has(col)) keep.push(s);
+        else prune.push(s);
+      }
+      return { keep, prune };
+    },
+  );
 
   const mockRegistry = {
     listProjects: vi.fn().mockReturnValue([]),
@@ -75,6 +89,7 @@ const {
     getGlobalRouting: vi.fn().mockReturnValue({ assignments: {}, preset: null }),
     setGlobalRouting: vi.fn(),
     applyPreset: vi.fn(),
+    onBoardTicketMoved: vi.fn(),
   };
 
   const mockStackManager = {
@@ -202,6 +217,7 @@ const {
     mockDeleteRefinement,
     mockPersistRefinement,
     mockLoadRefinements,
+    mockFilterSessionsByBoardState,
     mockUsageEngine,
     mockRollupStoreInstance,
   };
@@ -325,6 +341,7 @@ vi.mock('../../src/main/control-plane/refinement-store', () => ({
   persistRefinement: (...args: unknown[]) => mockPersistRefinement(...args),
   deleteRefinement: (...args: unknown[]) => mockDeleteRefinement(...args),
   loadRefinements: () => mockLoadRefinements(),
+  filterSessionsByBoardState: (...args: unknown[]) => mockFilterSessionsByBoardState(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -2125,6 +2142,204 @@ describe('IPC Handlers', () => {
       // surface is the fix. This assertion replaces the old registration check
       // that expected it to be present.
       expect(registeredHandlers['tickets:discardRefinement']).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Lifecycle cleanup — cancelRefinementSession on board column changes (#566)
+  // =========================================================================
+  describe('refinement lifecycle cleanup on board moves (#566)', () => {
+    function getBoardMovedListener(): (ticketId: string, projectDir: string, column: string) => void {
+      const calls = mockRegistry.onBoardTicketMoved.mock.calls;
+      if (calls.length === 0) throw new Error('onBoardTicketMoved was not called during registerIpcHandlers');
+      return calls[0][0] as (ticketId: string, projectDir: string, column: string) => void;
+    }
+
+    it('subscribes a listener to registry.onBoardTicketMoved during setup', () => {
+      expect(mockRegistry.onBoardTicketMoved).toHaveBeenCalledOnce();
+      expect(typeof getBoardMovedListener()).toBe('function');
+    });
+
+    it('cancels active session when ticket moves to backlog', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'T-1', '/proj') as { sessionId: string };
+
+      const listener = getBoardMovedListener();
+      listener('T-1', '/proj', 'backlog');
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith(sessionId);
+      expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('refinement:update', { id: sessionId, status: 'cancelled' });
+    });
+
+    it('cancels active session when ticket moves to in_stack', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'T-2', '/proj') as { sessionId: string };
+
+      const listener = getBoardMovedListener();
+      listener('T-2', '/proj', 'in_stack');
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith(sessionId);
+      expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('refinement:update', { id: sessionId, status: 'cancelled' });
+    });
+
+    it('cancels active session when ticket moves to merged', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'T-3', '/proj') as { sessionId: string };
+
+      const listener = getBoardMovedListener();
+      listener('T-3', '/proj', 'merged');
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith(sessionId);
+    });
+
+    it('does NOT cancel session when ticket moves to spec_ready', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'T-4', '/proj') as { sessionId: string };
+      mockDeleteRefinement.mockClear();
+
+      const listener = getBoardMovedListener();
+      listener('T-4', '/proj', 'spec_ready');
+
+      expect(mockDeleteRefinement).not.toHaveBeenCalledWith(sessionId);
+    });
+
+    it('does NOT cancel session when ticket moves to refining', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'T-5', '/proj') as { sessionId: string };
+      mockDeleteRefinement.mockClear();
+
+      const listener = getBoardMovedListener();
+      listener('T-5', '/proj', 'refining');
+
+      expect(mockDeleteRefinement).not.toHaveBeenCalledWith(sessionId);
+    });
+
+    it('calls entry.cancel() to abort in-flight agent on cleanup', async () => {
+      const cancelFn = vi.fn();
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: cancelFn });
+      await invokeHandler('tickets:specCheckAsync', 'T-6', '/proj');
+
+      const listener = getBoardMovedListener();
+      listener('T-6', '/proj', 'backlog');
+
+      expect(cancelFn).toHaveBeenCalled();
+    });
+
+    it('does not cancel a session for a different ticket', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      await invokeHandler('tickets:specCheckAsync', 'T-7', '/proj');
+      mockDeleteRefinement.mockClear();
+
+      const listener = getBoardMovedListener();
+      listener('T-OTHER', '/proj', 'backlog');
+
+      expect(mockDeleteRefinement).not.toHaveBeenCalled();
+    });
+
+    it('does not cancel a session for a different projectDir', async () => {
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: vi.fn() });
+      await invokeHandler('tickets:specCheckAsync', 'T-8', '/proj-a');
+      mockDeleteRefinement.mockClear();
+
+      const listener = getBoardMovedListener();
+      listener('T-8', '/proj-b', 'backlog');
+
+      expect(mockDeleteRefinement).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Startup prune — stale sessions deleted before broadcast (#566)
+  // =========================================================================
+  describe('startup prune (#566)', () => {
+    function reRegister() {
+      for (const key of Object.keys(registeredHandlers)) {
+        delete registeredHandlers[key];
+      }
+      const win = { webContents: { send: vi.fn() } };
+      registerIpcHandlers(win as unknown as import('electron').BrowserWindow);
+    }
+
+    it('deletes sessions for tickets in non-live columns before broadcast', () => {
+      const stale = { id: 'stale-1', ticketId: 'T1', projectDir: '/proj1', status: 'ready' as const, phase: 'check' as const, startedAt: 0 };
+      const live = { id: 'live-1', ticketId: 'T2', projectDir: '/proj2', status: 'interrupted' as const, phase: 'check' as const, startedAt: 0 };
+
+      mockLoadRefinements.mockReturnValueOnce([stale, live]);
+      mockRegistry.listBoardTickets.mockImplementation((projectDir: string) => {
+        if (projectDir === '/proj1') return [{ ticket_id: 'T1', project_dir: '/proj1', column: 'backlog', title: '', created_at: '', updated_at: '' }];
+        if (projectDir === '/proj2') return [{ ticket_id: 'T2', project_dir: '/proj2', column: 'refining', title: '', created_at: '', updated_at: '' }];
+        return [];
+      });
+
+      mockDeleteRefinement.mockClear();
+      reRegister();
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith('stale-1');
+      expect(mockDeleteRefinement).not.toHaveBeenCalledWith('live-1');
+    });
+
+    it('deletes sessions whose ticket board row does not exist', () => {
+      const orphan = { id: 'orphan-1', ticketId: 'T9', projectDir: '/gone', status: 'ready' as const, phase: 'check' as const, startedAt: 0 };
+
+      mockLoadRefinements.mockReturnValueOnce([orphan]);
+      mockRegistry.listBoardTickets.mockReturnValue([]);
+
+      mockDeleteRefinement.mockClear();
+      reRegister();
+
+      expect(mockDeleteRefinement).toHaveBeenCalledWith('orphan-1');
+    });
+
+    it('keeps sessions for tickets in spec_ready', () => {
+      const live = { id: 'live-sr', ticketId: 'TS', projectDir: '/proj', status: 'ready' as const, phase: 'check' as const, startedAt: 0 };
+
+      mockLoadRefinements.mockReturnValueOnce([live]);
+      mockRegistry.listBoardTickets.mockReturnValue([
+        { ticket_id: 'TS', project_dir: '/proj', column: 'spec_ready', title: '', created_at: '', updated_at: '' },
+      ]);
+
+      mockDeleteRefinement.mockClear();
+      reRegister();
+
+      expect(mockDeleteRefinement).not.toHaveBeenCalledWith('live-sr');
+    });
+
+    it('persists kept sessions back to disk', () => {
+      const live = { id: 'live-p', ticketId: 'TL', projectDir: '/p', status: 'interrupted' as const, phase: 'check' as const, startedAt: 0 };
+
+      mockLoadRefinements.mockReturnValueOnce([live]);
+      mockRegistry.listBoardTickets.mockReturnValue([
+        { ticket_id: 'TL', project_dir: '/p', column: 'refining', title: '', created_at: '', updated_at: '' },
+      ]);
+
+      mockPersistRefinement.mockClear();
+      reRegister();
+
+      expect(mockPersistRefinement).toHaveBeenCalledWith(expect.objectContaining({ id: 'live-p' }));
+    });
+  });
+
+  // =========================================================================
+  // cancelRefinementSession helper — used by cancelRefinement and cleanup (#566)
+  // =========================================================================
+  describe('tickets:cancelRefinement uses shared cancel helper', () => {
+    it('aborts in-flight agent, removes from map, deletes from disk, broadcasts cancelled', async () => {
+      const cancelFn = vi.fn();
+      mockSpawnSpecCheck.mockReturnValue({ promise: new Promise(() => {}), cancel: cancelFn });
+      const { sessionId } = await invokeHandler('tickets:specCheckAsync', 'T-C', '/proj') as { sessionId: string };
+      mockDeleteRefinement.mockClear();
+      mockMainWindow.webContents.send.mockClear();
+
+      await invokeHandler('tickets:cancelRefinement', sessionId);
+
+      expect(cancelFn).toHaveBeenCalled();
+      expect(mockDeleteRefinement).toHaveBeenCalledWith(sessionId);
+      expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('refinement:update', { id: sessionId, status: 'cancelled' });
+    });
+
+    it('is a no-op for unknown session id', async () => {
+      await expect(invokeHandler('tickets:cancelRefinement', 'no-such-id')).resolves.not.toThrow();
+      expect(mockDeleteRefinement).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/main/refinement-store.test.ts
+++ b/tests/unit/main/refinement-store.test.ts
@@ -26,6 +26,7 @@ import {
   loadRefinements,
   persistRefinement,
   deleteRefinement,
+  filterSessionsByBoardState,
   type RefinementSession,
 } from '../../../src/main/control-plane/refinement-store';
 
@@ -116,5 +117,88 @@ describe('refinement-store', () => {
   it('handles corrupted store file gracefully', () => {
     fs.writeFileSync(storePath, 'not valid json{{');
     expect(loadRefinements()).toEqual([]);
+  });
+});
+
+describe('filterSessionsByBoardState', () => {
+  function makeSession(overrides: Partial<RefinementSession> = {}): RefinementSession {
+    return {
+      id: 'test-id',
+      ticketId: '123',
+      projectDir: '/proj',
+      status: 'ready',
+      phase: 'check',
+      startedAt: 0,
+      ...overrides,
+    };
+  }
+
+  it('keeps sessions whose ticket column is refining', () => {
+    const s = makeSession({ ticketId: 'T1', projectDir: '/p' });
+    const { keep, prune } = filterSessionsByBoardState([s], () => 'refining');
+    expect(keep).toHaveLength(1);
+    expect(prune).toHaveLength(0);
+  });
+
+  it('keeps sessions whose ticket column is spec_ready', () => {
+    const s = makeSession({ ticketId: 'T1', projectDir: '/p' });
+    const { keep, prune } = filterSessionsByBoardState([s], () => 'spec_ready');
+    expect(keep).toHaveLength(1);
+    expect(prune).toHaveLength(0);
+  });
+
+  it('prunes sessions in backlog', () => {
+    const s = makeSession({ ticketId: 'T1', projectDir: '/p' });
+    const { keep, prune } = filterSessionsByBoardState([s], () => 'backlog');
+    expect(keep).toHaveLength(0);
+    expect(prune).toHaveLength(1);
+  });
+
+  it('prunes sessions in in_stack', () => {
+    const s = makeSession({ ticketId: 'T1', projectDir: '/p' });
+    const { keep, prune } = filterSessionsByBoardState([s], () => 'in_stack');
+    expect(keep).toHaveLength(0);
+    expect(prune).toHaveLength(1);
+  });
+
+  it('prunes sessions in merged', () => {
+    const s = makeSession();
+    const { keep, prune } = filterSessionsByBoardState([s], () => 'merged');
+    expect(keep).toHaveLength(0);
+    expect(prune).toHaveLength(1);
+  });
+
+  it('prunes sessions whose ticket row is absent (getColumn returns null)', () => {
+    const s = makeSession();
+    const { keep, prune } = filterSessionsByBoardState([s], () => null);
+    expect(keep).toHaveLength(0);
+    expect(prune).toHaveLength(1);
+  });
+
+  it('partitions a mixed list correctly', () => {
+    const keep1 = makeSession({ id: 'k1', ticketId: 'T1', projectDir: '/p1' });
+    const keep2 = makeSession({ id: 'k2', ticketId: 'T2', projectDir: '/p2' });
+    const prune1 = makeSession({ id: 'p1', ticketId: 'T3', projectDir: '/p3' });
+    const prune2 = makeSession({ id: 'p2', ticketId: 'T4', projectDir: '/p4' });
+
+    const columns: Record<string, string | null> = {
+      'T1': 'refining',
+      'T2': 'spec_ready',
+      'T3': 'in_stack',
+      'T4': null,
+    };
+
+    const result = filterSessionsByBoardState(
+      [keep1, keep2, prune1, prune2],
+      (ticketId) => columns[ticketId] ?? null,
+    );
+    expect(result.keep.map((s) => s.id)).toEqual(['k1', 'k2']);
+    expect(result.prune.map((s) => s.id)).toEqual(['p1', 'p2']);
+  });
+
+  it('returns empty keep and prune for empty input', () => {
+    const { keep, prune } = filterSessionsByBoardState([], () => null);
+    expect(keep).toHaveLength(0);
+    expect(prune).toHaveLength(0);
   });
 });

--- a/tests/unit/refinement-streaming.test.ts
+++ b/tests/unit/refinement-streaming.test.ts
@@ -62,6 +62,8 @@ vi.mock('../../src/main/index', () => ({
     getProject: vi.fn(),
     getPorts: vi.fn(),
     getDb: vi.fn().mockReturnValue({}),
+    listBoardTickets: vi.fn().mockReturnValue([]),
+    onBoardTicketMoved: vi.fn(),
   },
   stackManager: {
     setOnStackUpdate: vi.fn(),

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1385,6 +1385,32 @@ describe('Registry', () => {
   // ==========================================================================
   // Model Routing CRUD
   // ==========================================================================
+  describe('onBoardTicketMoved', () => {
+    it('dispatches to multiple subscribers with (ticketId, projectDir, column)', () => {
+      const calls1: [string, string, string][] = [];
+      const calls2: [string, string, string][] = [];
+      registry.onBoardTicketMoved((tid, dir, col) => calls1.push([tid, dir, col]));
+      registry.onBoardTicketMoved((tid, dir, col) => calls2.push([tid, dir, col]));
+
+      registry.setBoardTicketColumn('ticket-1', '/my/project', 'in_stack');
+
+      expect(calls1).toHaveLength(1);
+      expect(calls1[0]).toEqual(['ticket-1', path.resolve('/my/project'), 'in_stack']);
+      expect(calls2).toHaveLength(1);
+      expect(calls2[0]).toEqual(['ticket-1', path.resolve('/my/project'), 'in_stack']);
+    });
+
+    it('fires on every setBoardTicketColumn call across multiple moves', () => {
+      const calls: string[] = [];
+      registry.onBoardTicketMoved((tid, _dir, col) => calls.push(`${tid}:${col}`));
+
+      registry.setBoardTicketColumn('t1', '/p', 'backlog');
+      registry.setBoardTicketColumn('t2', '/p', 'in_stack');
+
+      expect(calls).toEqual(['t1:backlog', 't2:in_stack']);
+    });
+  });
+
   describe('model routing CRUD', () => {
     it('getGlobalRouting returns empty config on fresh database', () => {
       const config = registry.getGlobalRouting();

--- a/tests/unit/store.openRefineDialogFromCard.test.ts
+++ b/tests/unit/store.openRefineDialogFromCard.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for openRefineDialogFromCard — covers the bug where stale refinement
+ * sessions caused a silent no-op, and the running-session path.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from '../../src/renderer/store';
+import type { RefinementSession } from '../../src/main/control-plane/refinement-store';
+
+const TICKET_ID = 'T-42';
+const PROJECT_DIR = '/proj';
+
+function makeSession(overrides: Partial<RefinementSession> = {}): RefinementSession {
+  return {
+    id: 'sess-1',
+    ticketId: TICKET_ID,
+    projectDir: PROJECT_DIR,
+    status: 'ready',
+    phase: 'check',
+    startedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeSandstormApi(overrides: Record<string, unknown> = {}) {
+  const specCheckAsync = vi.fn().mockResolvedValue({ sessionId: 'new-sess' });
+  const cancelRefinement = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    ticketBoard: {
+      setColumn: vi.fn().mockResolvedValue(undefined),
+    },
+    tickets: {
+      specCheckAsync,
+      cancelRefinement,
+      listRefinements: vi.fn().mockResolvedValue([]),
+    },
+    stacks: { list: vi.fn().mockResolvedValue([]) },
+    projects: { list: vi.fn().mockResolvedValue([]) },
+    ...overrides,
+  } as unknown as typeof window.sandstorm;
+
+  Object.defineProperty(window, 'sandstorm', {
+    value: api,
+    writable: true,
+    configurable: true,
+  });
+
+  return { specCheckAsync, cancelRefinement, setColumn: (api.ticketBoard as { setColumn: ReturnType<typeof vi.fn> }).setColumn };
+}
+
+describe('openRefineDialogFromCard', () => {
+  let mocks: ReturnType<typeof makeSandstormApi>;
+
+  beforeEach(() => {
+    mocks = makeSandstormApi();
+    useAppStore.setState({
+      refinementSessions: [],
+      boardTickets: [],
+      refineInFlight: {},
+      refineStartErrors: {},
+      projects: [{ id: 1, name: 'proj', directory: PROJECT_DIR, added_at: '' }],
+      activeProjectId: 1,
+    } as Parameters<typeof useAppStore.setState>[0]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // The regression: stale session must not cause a silent no-op
+  // ---------------------------------------------------------------------------
+
+  it('regression: stale ready session is cancelled and fresh gate starts', async () => {
+    const stale = makeSession({ status: 'ready' });
+    useAppStore.setState({ refinementSessions: [stale] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+
+    await Promise.resolve();
+
+    expect(mocks.cancelRefinement).toHaveBeenCalledWith('sess-1');
+    expect(mocks.specCheckAsync).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+  });
+
+  it('stale errored session is cancelled and fresh gate starts', async () => {
+    const stale = makeSession({ status: 'errored' });
+    useAppStore.setState({ refinementSessions: [stale] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+
+    await Promise.resolve();
+
+    expect(mocks.cancelRefinement).toHaveBeenCalledWith('sess-1');
+    expect(mocks.specCheckAsync).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+  });
+
+  it('stale interrupted session is cancelled and fresh gate starts', async () => {
+    const stale = makeSession({ status: 'interrupted' });
+    useAppStore.setState({ refinementSessions: [stale] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+
+    await Promise.resolve();
+
+    expect(mocks.cancelRefinement).toHaveBeenCalledWith('sess-1');
+    expect(mocks.specCheckAsync).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+  });
+
+  it('stale session is removed from store state before starting fresh gate', async () => {
+    const stale = makeSession({ status: 'ready' });
+    useAppStore.setState({ refinementSessions: [stale] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+    await Promise.resolve();
+
+    const sessions = useAppStore.getState().refinementSessions;
+    const stillStale = sessions.find((s) => s.id === 'sess-1');
+    expect(stillStale).toBeUndefined();
+  });
+
+  it('card moves to refining after stale session is discarded', async () => {
+    const stale = makeSession({ status: 'ready' });
+    useAppStore.setState({ refinementSessions: [stale] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+    await Promise.resolve();
+
+    expect(mocks.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'refining');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Running session: open the dialog, do NOT start a new gate
+  // ---------------------------------------------------------------------------
+
+  it('running session: opens existing session dialog and does not cancel or start new gate', async () => {
+    const running = makeSession({ status: 'running' });
+    useAppStore.setState({ refinementSessions: [running] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+    await Promise.resolve();
+
+    expect(mocks.cancelRefinement).not.toHaveBeenCalled();
+    expect(mocks.specCheckAsync).not.toHaveBeenCalled();
+    expect(useAppStore.getState().currentRefinementSessionId).toBe('sess-1');
+    expect(useAppStore.getState().showRefineTicketDialog).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // No existing session: normal fresh-gate flow
+  // ---------------------------------------------------------------------------
+
+  it('no existing session: starts gate and moves to refining', async () => {
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+    await Promise.resolve();
+
+    expect(mocks.cancelRefinement).not.toHaveBeenCalled();
+    expect(mocks.specCheckAsync).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+    expect(mocks.setColumn).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR, 'refining');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Double-click guard
+  // ---------------------------------------------------------------------------
+
+  it('refineInFlight guard prevents a second call from starting another gate', async () => {
+    useAppStore.setState({
+      refineInFlight: { [`${TICKET_ID}|${PROJECT_DIR}`]: true },
+    } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+    await Promise.resolve();
+
+    expect(mocks.specCheckAsync).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cancel IPC failure is swallowed (best-effort)
+  // ---------------------------------------------------------------------------
+
+  it('cancelRefinement failure is swallowed and gate still starts', async () => {
+    mocks.cancelRefinement.mockRejectedValueOnce(new Error('IPC fail'));
+    const stale = makeSession({ status: 'ready' });
+    useAppStore.setState({ refinementSessions: [stale] } as Parameters<typeof useAppStore.setState>[0]);
+
+    useAppStore.getState().openRefineDialogFromCard(TICKET_ID, PROJECT_DIR, 'backlog');
+    // Give the async cancelRefinement time to reject
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mocks.specCheckAsync).toHaveBeenCalledWith(TICKET_ID, PROJECT_DIR);
+  });
+});


### PR DESCRIPTION
## Summary

The retry refinement path was duplicating the session-cancel logic inline rather than reusing `cancelRefinementSession`, which risked drift and meant the no-broadcast intent of retry was not expressed through the shared code path. `cancelRefinementSession` now takes an optional `broadcast` flag (defaulting to `true`), and `tickets:retryRefinementAsync` calls `cancelRefinementSession(sessionId, false)` so the retry cancel stays silent while all other callers keep broadcasting.

This branch also adds regression coverage for the registry's `onBoardTicketMoved` dispatch: prior tests only verified a single subscriber, leaving multi-subscriber fanout untested. New tests register two subscribers and assert both fire when `setBoardTicketColumn` runs, exercising the real Registry dispatch loop.

## QA plan

1. Start a refinement session on a ticket and trigger a retry. Confirm the retry cancels the prior session cleanly and that no stray cancellation event is broadcast to the renderer (the in-progress UI should transition straight into the new run, not flash a cancelled state).
2. Cancel a refinement session through the normal cancel action and confirm the cancellation still broadcasts and the UI updates as before.
3. Move a ticket between board columns and confirm any views/subscribers depending on board moves all update together.

Closes #566