### PR TITLE
[522] fix: telemetry range, model families, orchestrator spend

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
     refreshProjects,
     refreshMetrics,
     refreshSessionState,
+    fetchTelemetry,
     selectStack,
     setDockerConnected,
     sessionMonitorState,
@@ -174,6 +175,7 @@ export default function App() {
     refreshProjects();
     refreshStacks();
     refreshMetrics();
+    void fetchTelemetry();
 
     const pollInterval = dockerConnected
       ? STACK_POLL_INTERVAL
@@ -212,7 +214,7 @@ export default function App() {
       unsubNavigate();
       unsubStacksUpdated();
     };
-  }, [dockerConnected, refreshStacks, refreshProjects, refreshMetrics, selectStack]);
+  }, [dockerConnected, refreshStacks, refreshProjects, refreshMetrics, selectStack, fetchTelemetry]);
 
   return (
     <div className="h-screen flex flex-col bg-sandstorm-bg text-sandstorm-text">

--- a/src/renderer/components/TelemetryView.tsx
+++ b/src/renderer/components/TelemetryView.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useAppStore } from '../store';
 import type { KanbanColumn } from '../types/kanban';
-import type { ByTicketEntry, LifecycleCosts } from '@main/telemetry/types';
+import type { ByTicketEntry, ByModelEntry, LifecycleCosts } from '@main/telemetry/types';
 import { Sparkline } from './telemetry/Sparkline';
 import { Donut } from './telemetry/Donut';
 import { StackedBars } from './telemetry/StackedBars';
 import type { TokenClass } from './telemetry/StackedBars';
 import { TOKEN_COLORS, TOKEN_LABELS } from './telemetry/StackedBars';
-import { groupByPipeline } from './telemetry/utils';
+import { groupByPipeline, ORCHESTRATOR_TICKET_ID } from './telemetry/utils';
 import { StackedHBar } from './telemetry/StackedHBar';
 
 type RangeOption = '7d' | '30d' | '90d' | 'all';
@@ -34,6 +34,64 @@ const LIFECYCLE_COLORS: Record<LifecycleStage, string> = {
 
 const MODEL_PALETTE = ['#d4a854', '#7b5ea7', '#4a7fb5', '#4a8c6e', '#c9a227', '#e87b5a'];
 
+const MODEL_FAMILIES: Array<{ key: string; displayLabel: string; color: string }> = [
+  { key: 'opus', displayLabel: 'Opus', color: MODEL_PALETTE[0] },
+  { key: 'sonnet', displayLabel: 'Sonnet', color: MODEL_PALETTE[1] },
+  { key: 'haiku', displayLabel: 'Haiku', color: MODEL_PALETTE[2] },
+];
+
+interface ModelRow {
+  key: string;
+  label: string;
+  color: string;
+  cost: number;
+  unpriced: boolean;
+}
+
+function getModelFamily(model: string): string | null {
+  const lc = model.toLowerCase();
+  for (const { key } of MODEL_FAMILIES) {
+    if (lc.includes(key)) return key;
+  }
+  return null;
+}
+
+function buildModelRows(byModel: ByModelEntry[]): ModelRow[] {
+  const familyCosts: Record<string, { cost: number; unpriced: boolean }> = {};
+  const extras: ByModelEntry[] = [];
+
+  for (const entry of byModel) {
+    const family = getModelFamily(entry.model);
+    if (family) {
+      if (!familyCosts[family]) familyCosts[family] = { cost: 0, unpriced: false };
+      familyCosts[family].cost += entry.cost;
+      familyCosts[family].unpriced = familyCosts[family].unpriced || entry.unpriced;
+    } else {
+      extras.push(entry);
+    }
+  }
+
+  const rows: ModelRow[] = MODEL_FAMILIES.map(({ key, displayLabel, color }) => ({
+    key,
+    label: displayLabel,
+    color,
+    cost: familyCosts[key]?.cost ?? 0,
+    unpriced: familyCosts[key]?.unpriced ?? false,
+  }));
+
+  extras.forEach((entry, i) => {
+    rows.push({
+      key: entry.model,
+      label: entry.model,
+      color: MODEL_PALETTE[(MODEL_FAMILIES.length + i) % MODEL_PALETTE.length],
+      cost: entry.cost,
+      unpriced: entry.unpriced,
+    });
+  });
+
+  return rows;
+}
+
 function fmt$(n: number): string {
   if (n === 0) return '$0.00';
   if (n < 0.01) return '<$0.01';
@@ -51,6 +109,14 @@ function fmtDelta(curr: number, prev: number): string {
   const pct = ((curr - prev) / prev) * 100;
   const sign = pct >= 0 ? '▲' : '▼';
   return `${sign}${Math.abs(pct).toFixed(1)}%`;
+}
+
+function fmtDeltaWithDir(curr: number, prev: number): string {
+  if (prev === 0) return '—';
+  const pct = ((curr - prev) / prev) * 100;
+  const sign = pct >= 0 ? '▲' : '▼';
+  const dir = pct >= 0 ? 'higher' : 'lower';
+  return `${sign}${Math.abs(pct).toFixed(1)}% ${dir}`;
 }
 
 const ALL_TOKEN_CLASSES: TokenClass[] = ['input', 'output', 'cacheCreate', 'cacheRead'];
@@ -103,11 +169,13 @@ export function TelemetryView() {
 
   // Derived: per-ticket rows (join with boardTickets for title/column)
   const ticketRows = telemetryByTicket.map((entry) => {
-    const board = boardTickets.find((t) => t.ticket_id === entry.ticketId);
+    const isOrchestrator = entry.ticketId === ORCHESTRATOR_TICKET_ID;
+    const board = isOrchestrator ? undefined : boardTickets.find((t) => t.ticket_id === entry.ticketId);
     return {
       ...entry,
-      title: board?.title ?? `#${entry.ticketId}`,
-      column: board?.column as KanbanColumn | undefined,
+      title: isOrchestrator ? 'Orchestrator · ad-hoc' : (board?.title ?? `#${entry.ticketId}`),
+      column: isOrchestrator ? undefined : (board?.column as KanbanColumn | undefined),
+      displayId: isOrchestrator ? '—' : `#${entry.ticketId}`,
     };
   });
 
@@ -120,26 +188,26 @@ export function TelemetryView() {
     return b.cost - a.cost; // stable tie-break
   });
 
-  // Max ticket cost for bar scaling
-  const maxTicketCost = sortedTickets.reduce((m, t) => Math.max(m, t.cost), 0) || 1;
+  // Max ticket cost for bar scaling (zero-cost tickets get affordance, not bars)
+  const maxTicketCost = sortedTickets.reduce((m, t) => Math.max(m, t.cost), 0);
 
   // Pipeline groups
   const pipelineGroups = groupByPipeline(telemetryByTicket, boardTickets);
   const pipelineTotal = pipelineGroups.reduce((s, g) => s + g.totalCost, 0);
 
-  // Month-vs-last bar heights
+  // Month-vs-last bar scaling
   const monthMax = Math.max(
     telemetrySummary?.monthCost ?? 0,
     telemetrySummary?.prevMonthCost ?? 0,
     0.0001,
   );
 
-  // Model donut segments
-  const modelSegments = telemetryByModel.map((m, i) => ({
-    value: m.cost,
-    color: MODEL_PALETTE[i % MODEL_PALETTE.length],
-    label: m.model,
-  }));
+  // Model rows with fixed scaffold + extras
+  const modelRows = buildModelRows(telemetryByModel);
+  const modelTotal = modelRows.reduce((s, r) => s + r.cost, 0);
+  const modelSegments = modelRows
+    .filter((r) => r.cost > 0)
+    .map((r) => ({ value: r.cost, color: r.color, label: r.label }));
 
   const hasLifecycle = telemetryByTicket.some((e) => e.lifecycle !== null);
 
@@ -310,34 +378,30 @@ export function TelemetryView() {
           {/* Panel 3: Cost by model */}
           <div className="bg-sandstorm-surface rounded-xl border border-sandstorm-border p-4" data-testid="panel-by-model">
             <div className="text-sm font-medium text-sandstorm-text mb-3">Cost by Model</div>
-            {telemetryByModel.length === 0 ? (
-              <div className="text-sandstorm-muted text-xs py-4 text-center">No data</div>
-            ) : (
-              <div className="flex items-center gap-4">
-                <Donut
-                  segments={modelSegments}
-                  size={100}
-                  centerLabel={telemetrySummary ? fmt$(telemetrySummary.monthCost) : undefined}
-                />
-                <div className="flex flex-col gap-1.5 flex-1 min-w-0">
-                  {telemetryByModel.map((m, i) => (
-                    <div key={m.model} className="flex items-center justify-between gap-2" data-testid={`model-row-${i}`}>
-                      <div className="flex items-center gap-1.5 min-w-0">
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{ backgroundColor: MODEL_PALETTE[i % MODEL_PALETTE.length] }}
-                        />
-                        <span className="text-xs text-sandstorm-text-secondary truncate">{m.model}</span>
-                        {m.unpriced && (
-                          <span className="text-[10px] text-amber-400 shrink-0" title="No price data for this model">unpriced</span>
-                        )}
-                      </div>
-                      <span className="text-xs font-mono text-sandstorm-text shrink-0">{fmt$(m.cost)}</span>
+            <div className="flex items-center gap-4">
+              <Donut
+                segments={modelSegments}
+                size={100}
+                centerLabel={fmt$(modelTotal)}
+              />
+              <div className="flex flex-col gap-1.5 flex-1 min-w-0">
+                {modelRows.map((row) => (
+                  <div key={row.key} className="flex items-center justify-between gap-2" data-testid={`model-row-${row.key}`}>
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span
+                        className="w-2 h-2 rounded-full shrink-0"
+                        style={{ backgroundColor: row.color }}
+                      />
+                      <span className="text-xs text-sandstorm-text-secondary truncate">{row.label}</span>
+                      {row.unpriced && (
+                        <span className="text-[10px] text-amber-400 shrink-0" title="No price data for this model">unpriced</span>
+                      )}
                     </div>
-                  ))}
-                </div>
+                    <span className="text-xs font-mono text-sandstorm-text shrink-0">{fmt$(row.cost)}</span>
+                  </div>
+                ))}
               </div>
-            )}
+            </div>
           </div>
 
           {/* Panel 6: This month vs last */}
@@ -345,37 +409,37 @@ export function TelemetryView() {
             <div className="text-sm font-medium text-sandstorm-text mb-3">This Month vs Last</div>
             {telemetrySummary ? (
               <div className="flex flex-col gap-3">
-                {/* Bars */}
-                <div className="flex items-end gap-4" data-testid="month-vs-bars">
+                {/* Horizontal bars */}
+                <div className="flex flex-col gap-2" data-testid="month-vs-bars">
                   {[
                     { label: 'This month', cost: telemetrySummary.monthCost, testId: 'bar-this-month' },
                     { label: 'Last month', cost: telemetrySummary.prevMonthCost, testId: 'bar-last-month' },
                   ].map(({ label, cost, testId }) => (
-                    <div key={label} className="flex flex-col items-center gap-1">
-                      <span className="text-xs font-mono text-sandstorm-text">{fmt$(cost)}</span>
-                      <div
-                        className="w-12 bg-sandstorm-accent rounded-t"
-                        style={{ height: `${Math.max((cost / monthMax) * 80, cost > 0 ? 4 : 0)}px` }}
-                        data-testid={testId}
-                        data-cost={cost}
-                        data-height-pct={(cost / monthMax) * 100}
-                      />
-                      <span className="text-[10px] text-sandstorm-muted">{label}</span>
+                    <div key={label} className="flex items-center gap-2">
+                      <span className="text-xs text-sandstorm-muted w-[72px] shrink-0">{label}</span>
+                      <div className="flex-1 bg-sandstorm-border/30 rounded overflow-hidden h-4">
+                        <div
+                          className="h-full rounded bg-sandstorm-accent"
+                          style={{ width: `${Math.max((cost / monthMax) * 100, cost > 0 ? 1 : 0)}%` }}
+                          data-testid={testId}
+                          data-cost={cost}
+                          data-width-pct={(cost / monthMax) * 100}
+                        />
+                      </div>
+                      <span className="text-xs font-mono text-sandstorm-text w-12 text-right shrink-0">{fmt$(cost)}</span>
                     </div>
                   ))}
-                  <div className="ml-2 self-center">
-                    <span
-                      className={`text-sm font-mono font-bold ${
-                        telemetrySummary.monthCost >= telemetrySummary.prevMonthCost
-                          ? 'text-red-400'
-                          : 'text-emerald-400'
-                      }`}
-                      data-testid="month-delta"
-                    >
-                      {fmtDelta(telemetrySummary.monthCost, telemetrySummary.prevMonthCost)}
-                    </span>
-                  </div>
                 </div>
+                <span
+                  className={`text-sm font-mono font-bold ${
+                    telemetrySummary.monthCost >= telemetrySummary.prevMonthCost
+                      ? 'text-red-400'
+                      : 'text-emerald-400'
+                  }`}
+                  data-testid="month-delta"
+                >
+                  {fmtDeltaWithDir(telemetrySummary.monthCost, telemetrySummary.prevMonthCost)}
+                </span>
                 <Sparkline data={dailyCosts} width={220} height={40} />
               </div>
             ) : (
@@ -438,7 +502,7 @@ export function TelemetryView() {
           ) : (
             <div className="flex flex-col gap-2" data-testid="ticket-rows">
               {sortedTickets.map((entry) => {
-                const barWidthPct = (entry.cost / maxTicketCost) * 100;
+                const barWidthPct = maxTicketCost > 0 ? (entry.cost / maxTicketCost) * 100 : 0;
                 const rightValue =
                   sortKey === 'total' || !entry.lifecycle
                     ? fmt$(entry.cost)
@@ -447,13 +511,17 @@ export function TelemetryView() {
                 return (
                   <div key={entry.ticketId} className="flex items-center gap-3" data-testid={`ticket-row-${entry.ticketId}`}>
                     <span className="text-xs font-mono text-sandstorm-muted shrink-0 w-14 truncate">
-                      #{entry.ticketId}
+                      {entry.displayId}
                     </span>
                     <span className="text-xs text-sandstorm-text-secondary shrink-0 w-32 truncate" title={entry.title}>
                       {entry.title}
                     </span>
                     <div className="flex-1 relative h-4 bg-sandstorm-border/30 rounded overflow-hidden">
-                      {entry.lifecycle ? (
+                      {entry.cost === 0 ? (
+                        <span className="text-xs text-sandstorm-muted italic pl-1" data-testid={`ticket-no-spend-${entry.ticketId}`}>
+                          no spend recorded yet
+                        </span>
+                      ) : entry.lifecycle ? (
                         <div style={{ width: `${barWidthPct}%`, height: '100%' }}>
                           <StackedHBar
                             segments={LIFECYCLE_STAGES.map((stage) => ({
@@ -487,38 +555,42 @@ export function TelemetryView() {
         {/* Panel 5: Spend by pipeline stage */}
         <div className="bg-sandstorm-surface rounded-xl border border-sandstorm-border p-4" data-testid="panel-pipeline">
           <div className="text-sm font-medium text-sandstorm-text mb-3">Spend by Pipeline Stage</div>
+          {/* Single 100% stacked bar */}
+          <div className="mb-3" data-testid="pipeline-bar">
+            <StackedHBar
+              segments={pipelineGroups
+                .filter((g) => g.totalCost > 0)
+                .map((g) => ({
+                  value: g.totalCost,
+                  color: g.color,
+                  label: `${g.displayName}: ${fmt$(g.totalCost)} (${pipelineTotal > 0 ? g.pct.toFixed(1) : '0'}%)`,
+                }))}
+              height={16}
+            />
+          </div>
+          {/* Per-column figure rows */}
           <div className="flex flex-col gap-2">
             {pipelineGroups.map((group) => (
               <div key={group.column} className="flex items-center gap-3" data-testid={`pipeline-row-${group.column}`}>
+                <span
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: group.color }}
+                />
                 <span className="text-xs text-sandstorm-text-secondary shrink-0 w-24">{group.displayName}</span>
-                <div className="flex-1">
-                  {group.totalCost > 0 ? (
-                    <div
-                      className="h-4 rounded"
-                      style={{
-                        width: `${group.pct}%`,
-                        backgroundColor: group.color,
-                        minWidth: '2px',
-                      }}
-                    />
-                  ) : (
-                    <span className="text-xs text-sandstorm-muted" data-testid={`pipeline-empty-${group.column}`}>
-                      $0 — not yet started
+                {group.totalCost > 0 ? (
+                  <>
+                    <span className="text-xs font-mono text-sandstorm-text" data-testid={`pipeline-cost-${group.column}`}>
+                      {fmt$(group.totalCost)}
                     </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  {group.totalCost > 0 && (
-                    <>
-                      <span className="text-xs font-mono text-sandstorm-text" data-testid={`pipeline-cost-${group.column}`}>
-                        {fmt$(group.totalCost)}
-                      </span>
-                      <span className="text-xs font-mono text-sandstorm-muted" data-testid={`pipeline-pct-${group.column}`}>
-                        {pipelineTotal > 0 ? `${group.pct.toFixed(1)}%` : '0%'}
-                      </span>
-                    </>
-                  )}
-                </div>
+                    <span className="text-xs font-mono text-sandstorm-muted" data-testid={`pipeline-pct-${group.column}`}>
+                      {pipelineTotal > 0 ? `${group.pct.toFixed(1)}%` : '0%'}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-xs text-sandstorm-muted" data-testid={`pipeline-empty-${group.column}`}>
+                    $0 — not yet started
+                  </span>
+                )}
               </div>
             ))}
           </div>
@@ -528,4 +600,3 @@ export function TelemetryView() {
     </div>
   );
 }
-

--- a/src/renderer/components/telemetry/utils.ts
+++ b/src/renderer/components/telemetry/utils.ts
@@ -1,4 +1,6 @@
+import { ORCHESTRATOR_TICKET_ID } from '../../../shared/constants';
 import type { ByTicketEntry } from '@main/telemetry/types';
+export { ORCHESTRATOR_TICKET_ID };
 import type { TicketBoardEntry } from '../../store';
 import { KANBAN_COLUMNS } from '../../types/kanban';
 import type { KanbanColumn } from '../../types/kanban';
@@ -36,6 +38,7 @@ export function groupByPipeline(
   const costByColumn: Record<string, number> = {};
 
   for (const entry of byTicket) {
+    if (entry.ticketId === ORCHESTRATOR_TICKET_ID) continue;
     const board = boardTickets.find((t) => t.ticket_id === entry.ticketId);
     const col = board?.column ?? 'unattributed';
     costByColumn[col] = (costByColumn[col] ?? 0) + entry.cost;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1884,7 +1884,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         window.sandstorm.telemetry.summary(range),
         window.sandstorm.telemetry.daily(range),
         window.sandstorm.telemetry.byModel(range),
-        window.sandstorm.telemetry.byTicket(),
+        window.sandstorm.telemetry.byTicket(range),
       ]);
       if (seq !== _telemetryFetchSeq) return;
       set({

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,1 @@
+export const ORCHESTRATOR_TICKET_ID = '__orchestrator__';

--- a/tests/unit/components/TelemetryView.test.tsx
+++ b/tests/unit/components/TelemetryView.test.tsx
@@ -250,15 +250,15 @@ describe('TelemetryView', () => {
       expect(screen.getByTestId('bar-last-month')).toBeDefined();
     });
 
-    it('bars are scaled to max(monthCost, prevMonthCost)', () => {
+    it('renders horizontal bars (data-width-pct attribute)', () => {
       render(<TelemetryView />);
       const thisBar = screen.getByTestId('bar-this-month');
       const lastBar = screen.getByTestId('bar-last-month');
-      const thisH = parseFloat(thisBar.getAttribute('data-height-pct') ?? '0');
-      const lastH = parseFloat(lastBar.getAttribute('data-height-pct') ?? '0');
+      const thisW = parseFloat(thisBar.getAttribute('data-width-pct') ?? '0');
+      const lastW = parseFloat(lastBar.getAttribute('data-width-pct') ?? '0');
       // this month ($10.50) > last month ($8.00) → this bar has 100%, last bar ~76%
-      expect(thisH).toBeCloseTo(100, 0);
-      expect(lastH).toBeCloseTo(76.2, 0);
+      expect(thisW).toBeCloseTo(100, 0);
+      expect(lastW).toBeCloseTo(76.2, 0);
     });
 
     it('shows delta sign correctly', () => {
@@ -271,6 +271,23 @@ describe('TelemetryView', () => {
       render(<TelemetryView />);
       expect(screen.getByTestId('month-delta').textContent).toContain('▼');
     });
+
+    it('delta includes "higher" when this month > last', () => {
+      render(<TelemetryView />);
+      expect(screen.getByTestId('month-delta').textContent).toContain('higher');
+    });
+
+    it('delta includes "lower" when this month < last', () => {
+      setupStore({ summary: { monthCost: 3.0, prevMonthCost: 8.0 } });
+      render(<TelemetryView />);
+      expect(screen.getByTestId('month-delta').textContent).toContain('lower');
+    });
+
+    it('shows — for delta when prevMonthCost is 0 (no higher/lower)', () => {
+      setupStore({ summary: { monthCost: 5.0, prevMonthCost: 0 } });
+      render(<TelemetryView />);
+      expect(screen.getByTestId('month-delta').textContent).toBe('—');
+    });
   });
 
   describe('Pipeline panel', () => {
@@ -280,6 +297,12 @@ describe('TelemetryView', () => {
       expect(screen.getByTestId('pipeline-row-backlog')).toBeDefined();
       expect(screen.getByTestId('pipeline-row-merged')).toBeDefined();
       expect(screen.getByTestId('pipeline-row-unattributed')).toBeDefined();
+    });
+
+    it('renders a single stacked bar in the pipeline panel', () => {
+      render(<TelemetryView />);
+      const pipelineBar = screen.getByTestId('pipeline-bar');
+      expect(pipelineBar.querySelector('[data-testid="stacked-hbar"]')).toBeTruthy();
     });
 
     it('shows $0 hint for empty columns', () => {
@@ -294,7 +317,7 @@ describe('TelemetryView', () => {
       expect(screen.getByTestId('pipeline-cost-merged').textContent).toBe('$4.50');
     });
 
-    it('unmatched ticketId (orchestrator) goes to Unattributed', () => {
+    it('orchestrator entry is excluded from pipeline grouping (not counted in Unattributed)', () => {
       setupStore({
         byTicket: [
           { ticketId: '__orchestrator__', model: null, cost: 2.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
@@ -302,7 +325,119 @@ describe('TelemetryView', () => {
       });
       render(<TelemetryView />);
       const unattribRow = screen.getByTestId('pipeline-row-unattributed');
-      expect(unattribRow.textContent).toContain('$2.00');
+      // orchestrator is excluded — unattributed row should show empty state
+      expect(unattribRow.textContent).not.toContain('$2.00');
+      expect(unattribRow.textContent).toContain('$0 — not yet started');
+    });
+  });
+
+  describe('Orchestrator row', () => {
+    it('renders orchestrator as "Orchestrator · ad-hoc" title, not #__orchestrator__', () => {
+      setupStore({
+        byTicket: [
+          { ticketId: '__orchestrator__', model: null, cost: 2.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
+        ],
+      });
+      render(<TelemetryView />);
+      const row = screen.getByTestId('ticket-row-__orchestrator__');
+      expect(row.textContent).toContain('Orchestrator · ad-hoc');
+      expect(row.textContent).not.toContain('#__orchestrator__');
+    });
+
+    it('orchestrator row shows — as displayId', () => {
+      setupStore({
+        byTicket: [
+          { ticketId: '__orchestrator__', model: null, cost: 2.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
+        ],
+      });
+      render(<TelemetryView />);
+      const row = screen.getByTestId('ticket-row-__orchestrator__');
+      expect(row.textContent).toContain('—');
+    });
+  });
+
+  describe('Zero-cost tickets', () => {
+    it('shows "no spend recorded yet" affordance for zero-cost tickets', () => {
+      setupStore({
+        byTicket: [
+          { ticketId: '99', model: null, cost: 0, tokens: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, total: 0 }, cacheHit: 0, lifecycle: null, unpriced: false },
+        ],
+      });
+      render(<TelemetryView />);
+      expect(screen.getByTestId('ticket-no-spend-99')).toBeDefined();
+      expect(screen.getByTestId('ticket-no-spend-99').textContent).toContain('no spend recorded yet');
+    });
+
+    it('does not show no-spend affordance for tickets with cost > 0', () => {
+      render(<TelemetryView />);
+      expect(screen.queryByTestId('ticket-no-spend-42')).toBeNull();
+    });
+  });
+
+  describe('Model legend scaffold', () => {
+    it('renders Opus, Sonnet, and Haiku rows even when absent in byModel', () => {
+      setupStore({ byModel: [] });
+      render(<TelemetryView />);
+      expect(screen.getByTestId('model-row-opus')).toBeDefined();
+      expect(screen.getByTestId('model-row-sonnet')).toBeDefined();
+      expect(screen.getByTestId('model-row-haiku')).toBeDefined();
+    });
+
+    it('absent scaffold model shows $0.00', () => {
+      setupStore({
+        byModel: [
+          { model: 'claude-sonnet-4-6', cost: 5.0, tokens: { input: 50000, output: 20000, cacheCreate: 1000, cacheRead: 4000, total: 75000 }, sessions: 3, unpriced: false },
+        ],
+      });
+      render(<TelemetryView />);
+      // opus and haiku are absent
+      expect(screen.getByTestId('model-row-opus').textContent).toContain('$0.00');
+      expect(screen.getByTestId('model-row-haiku').textContent).toContain('$0.00');
+    });
+
+    it('donut center matches byModel sum (range total), not monthCost', () => {
+      // monthCost = 10.50, but byModel sums to 10.50 (8.0+2.5)
+      render(<TelemetryView />);
+      const centerLabel = screen.getByTestId('donut-center-label');
+      // byModel total = 8.0 + 2.5 = 10.5
+      expect(centerLabel.textContent).toBe('$10.50');
+    });
+
+    it('donut center shows $0.00 when byModel is empty', () => {
+      setupStore({ byModel: [] });
+      render(<TelemetryView />);
+      const centerLabel = screen.getByTestId('donut-center-label');
+      expect(centerLabel.textContent).toBe('$0.00');
+    });
+
+    it('extra model not in scaffold is still rendered', () => {
+      setupStore({
+        byModel: [
+          { model: 'claude-gemma-3', cost: 1.0, tokens: { input: 5000, output: 2000, cacheCreate: 0, cacheRead: 0, total: 7000 }, sessions: 1, unpriced: false },
+        ],
+      });
+      render(<TelemetryView />);
+      expect(screen.getByTestId('model-row-claude-gemma-3')).toBeDefined();
+    });
+  });
+
+  describe('Eager telemetry fetch', () => {
+    it('fetchTelemetry populates telemetrySummary independently of TelemetryView mounting', async () => {
+      const api = mockSandstormApi();
+      api.telemetry.summary.mockResolvedValue({
+        monthCost: 7.5,
+        prevMonthCost: 3.0,
+        tokens: { input: 10000, output: 5000, cacheCreate: 500, cacheRead: 2000, total: 17500 },
+        cacheHitPct: 16.7,
+        sessions: 2,
+        ticketsShipped: null,
+        costPerTicket: null,
+        unpricedModels: [],
+        skippedLines: 0,
+      });
+      // Call directly — simulates App.tsx eager fetch without TelemetryView mounted
+      await useAppStore.getState().fetchTelemetry();
+      expect(useAppStore.getState().telemetrySummary?.monthCost).toBe(7.5);
     });
   });
 

--- a/tests/unit/components/telemetry/utils.test.ts
+++ b/tests/unit/components/telemetry/utils.test.ts
@@ -53,12 +53,15 @@ describe('groupByPipeline', () => {
     expect(unattr.displayName).toBe('Unattributed');
   });
 
-  it('__orchestrator__ goes to Unattributed', () => {
+  it('__orchestrator__ is excluded from pipeline grouping entirely', () => {
     const byTicket = [makeEntry('__orchestrator__', 2.5)];
     const boardTickets: TicketBoardEntry[] = [];
     const groups = groupByPipeline(byTicket, boardTickets);
     const unattr = groups.find((g) => g.column === 'unattributed')!;
-    expect(unattr.totalCost).toBe(2.5);
+    // orchestrator excluded — does not count toward any column, including unattributed
+    expect(unattr.totalCost).toBe(0);
+    const grandTotal = groups.reduce((s, g) => s + g.totalCost, 0);
+    expect(grandTotal).toBe(0);
   });
 
   it('percentages sum to 100', () => {

--- a/tests/unit/store/telemetry-slice.test.ts
+++ b/tests/unit/store/telemetry-slice.test.ts
@@ -150,10 +150,12 @@ describe('telemetry store slice', () => {
       expect(callArg.since).toBe('1970-01-01');
     });
 
-    it('byTicket is called without a range argument', async () => {
+    it('byTicket is called with the same DateRange as summary', async () => {
       const api = mockSandstormApi();
+      useAppStore.setState({ telemetryRange: '30d' });
       await useAppStore.getState().fetchTelemetry();
-      expect(api.telemetry.byTicket).toHaveBeenCalledWith();
+      const summaryArg = api.telemetry.summary.mock.calls[0][0] as { since: string; until: string };
+      expect(api.telemetry.byTicket).toHaveBeenCalledWith(summaryArg);
     });
   });
 });


### PR DESCRIPTION
## Summary

Reworks the telemetry view so the per-ticket data honors the selected date range and the panels read clearly when spend is sparse or comes from ad-hoc work.

- The per-ticket telemetry call now passes the active range, so the ticket list, pipeline grouping, and totals all reflect the chosen window (7d/30d/90d/all) instead of always returning the full history.
- Telemetry is now fetched on app mount, so the view has data on first open rather than only after the first poll.
- Orchestrator (ad-hoc) spend, identified by a shared `ORCHESTRATOR_TICKET_ID` constant, is excluded from pipeline-stage grouping and surfaced as its own labeled row instead of masquerading as a board ticket.
- Cost-by-model now groups raw model strings into Opus/Sonnet/Haiku families with a fixed scaffold (so the three always render, even at zero), and lists any unrecognized models as extras. The donut center shows the model total.
- "This month vs last" switched from vertical bars to horizontal bars with a directional, labeled delta (higher/lower).
- Zero-cost tickets render a "no spend recorded yet" affordance instead of an empty/degenerate bar, and bar scaling no longer divides by a forced minimum.

## QA plan

1. Open the Telemetry view and confirm all panels populate immediately on app launch.
2. Switch the range selector between 7d / 30d / 90d / all and verify the per-ticket list, totals, and pipeline-stage breakdown change to match the selected window.
3. Confirm the Cost by Model panel always shows Opus, Sonnet, and Haiku rows (zero cost included), lists any other models below them, and the donut center equals the sum of the rows.
4. Confirm orchestrator/ad-hoc spend appears as an "Orchestrator · ad-hoc" row with a "—" id and does not appear in any pipeline column.
5. Find a ticket with no recorded spend and confirm it shows "no spend recorded yet" rather than an empty bar.
6. Check "This Month vs Last" renders horizontal bars with a delta that reads as a percentage plus higher/lower direction.

Closes #522