### PR TITLE
[570] fix: add clear button to ticket search input

### DIFF
--- a/src/renderer/components/TopNav.tsx
+++ b/src/renderer/components/TopNav.tsx
@@ -66,6 +66,14 @@ function SearchIcon() {
   );
 }
 
+function ClearIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M18 6L6 18M6 6l12 12"/>
+    </svg>
+  );
+}
+
 
 export function TopNav() {
   const {
@@ -90,6 +98,7 @@ export function TopNav() {
 
   const workspaceRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const project = activeProject();
 
@@ -256,13 +265,27 @@ export function TopNav() {
               <SearchIcon />
             </span>
             <input
+              ref={searchInputRef}
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search tickets…"
-              className="w-full pl-8 pr-3 py-1.5 text-sm bg-sandstorm-surface border border-sandstorm-border rounded-lg text-sandstorm-text placeholder-sandstorm-muted/60 focus:outline-none focus:border-sandstorm-accent"
+              className="w-full pl-8 pr-8 py-1.5 text-sm bg-sandstorm-surface border border-sandstorm-border rounded-lg text-sandstorm-text placeholder-sandstorm-muted/60 focus:outline-none focus:border-sandstorm-accent"
               data-testid="search-input"
             />
+            {searchQuery.length > 0 && (
+              <button
+                type="button"
+                data-testid="search-clear-btn"
+                onClick={() => {
+                  setSearchQuery('');
+                  searchInputRef.current?.focus();
+                }}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-sandstorm-muted/60 hover:text-sandstorm-text transition-colors"
+              >
+                <ClearIcon />
+              </button>
+            )}
           </div>
         </div>
 

--- a/tests/unit/components/TopNav.test.tsx
+++ b/tests/unit/components/TopNav.test.tsx
@@ -306,6 +306,32 @@ describe('TopNav', () => {
     expect(useAppStore.getState().searchQuery).toBe('fix bug');
   });
 
+  it('clear button is not rendered when searchQuery is empty', () => {
+    useAppStore.setState({ searchQuery: '' } as any);
+    render(<TopNav />);
+    expect(screen.queryByTestId('search-clear-btn')).toBeNull();
+  });
+
+  it('clear button is rendered when searchQuery is non-empty', () => {
+    useAppStore.setState({ searchQuery: 'abc' } as any);
+    render(<TopNav />);
+    expect(screen.getByTestId('search-clear-btn')).toBeDefined();
+  });
+
+  it('clicking clear button sets searchQuery to empty string', () => {
+    useAppStore.setState({ searchQuery: 'abc' } as any);
+    render(<TopNav />);
+    fireEvent.click(screen.getByTestId('search-clear-btn'));
+    expect(useAppStore.getState().searchQuery).toBe('');
+  });
+
+  it('clicking clear button returns focus to search input', () => {
+    useAppStore.setState({ searchQuery: 'abc' } as any);
+    render(<TopNav />);
+    fireEvent.click(screen.getByTestId('search-clear-btn'));
+    expect(document.activeElement).toBe(screen.getByTestId('search-input'));
+  });
+
   // ── Identity ──────────────────────────────────────────────────────────────
 
   it('shows Login button when not logged in', async () => {


### PR DESCRIPTION
## Summary

The ticket search field in the top nav had no way to quickly reset the query other than manually selecting and deleting the text. This adds a clear (×) button that appears inside the search input whenever a query is present.

- The button only renders when the search query is non-empty.
- Clicking it clears the query and returns focus to the input so the user can keep typing.
- Input right padding was widened so entered text no longer overlaps the button.

## QA plan

1. Open the app and locate the ticket search field in the top nav.
2. Confirm no clear button is shown while the field is empty.
3. Type a query and confirm a × button appears on the right side of the input without overlapping the text.
4. Click the clear button and confirm the query is removed and the field shows all tickets again.
5. Confirm focus returns to the input after clearing (you can keep typing immediately).

Closes #570