### PR TITLE
[523] fix: add axis labels to telemetry chart, extract token formatter

### DIFF
--- a/src/renderer/components/TelemetryView.tsx
+++ b/src/renderer/components/TelemetryView.tsx
@@ -8,6 +8,7 @@ import { StackedBars } from './telemetry/StackedBars';
 import type { TokenClass } from './telemetry/StackedBars';
 import { TOKEN_COLORS, TOKEN_LABELS } from './telemetry/StackedBars';
 import { groupByPipeline, ORCHESTRATOR_TICKET_ID } from './telemetry/utils';
+import { formatTokensCompact } from '../utils/format';
 import { StackedHBar } from './telemetry/StackedHBar';
 
 type RangeOption = '7d' | '30d' | '90d' | 'all';
@@ -98,11 +99,6 @@ function fmt$(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
-  return String(n);
-}
 
 function fmtDelta(curr: number, prev: number): string {
   if (prev === 0) return '—';
@@ -307,11 +303,11 @@ export function TelemetryView() {
           <div className="bg-sandstorm-surface rounded-xl border border-sandstorm-border p-4 flex flex-col gap-2">
             <span className="text-[11px] text-sandstorm-muted uppercase tracking-wider">Tokens</span>
             <span className="text-2xl font-mono font-bold text-sandstorm-text" data-testid="kpi-tokens-total">
-              {telemetrySummary ? fmtTokens(telemetrySummary.tokens.total) : '—'}
+              {telemetrySummary ? formatTokensCompact(telemetrySummary.tokens.total) : '—'}
             </span>
             <span className="text-xs font-mono text-sandstorm-muted" data-testid="kpi-tokens-inout">
               {telemetrySummary
-                ? `in ${fmtTokens(telemetrySummary.tokens.input)} / out ${fmtTokens(telemetrySummary.tokens.output)}`
+                ? `in ${formatTokensCompact(telemetrySummary.tokens.input)} / out ${formatTokensCompact(telemetrySummary.tokens.output)}`
                 : '—'}
             </span>
           </div>

--- a/src/renderer/components/telemetry/StackedBars.tsx
+++ b/src/renderer/components/telemetry/StackedBars.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { DailyEntry } from '@main/telemetry/types';
+import { formatTokensCompact } from '../../utils/format';
 
 export type TokenClass = 'input' | 'output' | 'cacheCreate' | 'cacheRead';
 
@@ -18,6 +19,18 @@ export const TOKEN_LABELS: Record<TokenClass, string> = {
 };
 
 const CLASS_ORDER: TokenClass[] = ['cacheRead', 'cacheCreate', 'output', 'input'];
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function formatDate(dateStr: string): string {
+  const parts = dateStr.split('-');
+  const month = MONTHS[parseInt(parts[1], 10) - 1];
+  const day = parseInt(parts[2], 10);
+  return `${month} ${day}`;
+}
+
+const Y_AXIS_W = 38;
+const X_AXIS_H = 16;
 
 interface StackedBarsProps {
   data: DailyEntry[];
@@ -59,23 +72,31 @@ export function StackedBars({ data, activeClasses, width = 400, height = 120 }: 
       return Math.max(max, sum);
     }, 0) || 1;
 
+  const plotW = width - Y_AXIS_W;
+  const plotH = height - X_AXIS_H;
+
   const barCount = data.length;
-  const barWidth = Math.max(Math.floor((width / barCount) * 0.7), 2);
-  const barGap = Math.max((width - barWidth * barCount) / (barCount + 1), 1);
+  const barWidth = Math.max(Math.floor((plotW / barCount) * 0.7), 2);
+  const barGap = Math.max((plotW - barWidth * barCount) / (barCount + 1), 1);
+
+  const step = data.length > 12 ? Math.ceil(data.length / 12) : 1;
 
   const rects: React.ReactElement[] = [];
+  const xLabels: React.ReactElement[] = [];
+
   data.forEach((day, i) => {
-    const x = barGap + i * (barWidth + barGap);
-    let y = height;
+    const barX = Y_AXIS_W + barGap + i * (barWidth + barGap);
+    let y = plotH;
+
     CLASS_ORDER.filter((c) => activeClasses.has(c)).forEach((cls) => {
       const val = day.tokens[cls] ?? 0;
-      const barH = Math.max((val / yMax) * height, 0);
+      const barH = Math.max((val / yMax) * plotH, 0);
       y -= barH;
       if (barH > 0) {
         rects.push(
           <rect
             key={`${i}-${cls}`}
-            x={x}
+            x={barX}
             y={y}
             width={barWidth}
             height={barH}
@@ -84,6 +105,21 @@ export function StackedBars({ data, activeClasses, width = 400, height = 120 }: 
         );
       }
     });
+
+    if (i % step === 0) {
+      xLabels.push(
+        <text
+          key={`label-${i}`}
+          x={barX + barWidth / 2}
+          y={plotH + X_AXIS_H - 3}
+          textAnchor="middle"
+          fontSize={9}
+          className="fill-current text-sandstorm-muted"
+        >
+          {formatDate(day.date)}
+        </text>,
+      );
+    }
   });
 
   return (
@@ -93,7 +129,26 @@ export function StackedBars({ data, activeClasses, width = 400, height = 120 }: 
       data-testid="stacked-bars"
       data-ymax={yMax}
     >
+      <text
+        x={Y_AXIS_W - 4}
+        y={10}
+        textAnchor="end"
+        fontSize={10}
+        className="fill-current text-sandstorm-muted"
+      >
+        {formatTokensCompact(yMax)}
+      </text>
+      <text
+        x={Y_AXIS_W - 4}
+        y={plotH}
+        textAnchor="end"
+        fontSize={10}
+        className="fill-current text-sandstorm-muted"
+      >
+        0
+      </text>
       {rects}
+      {xLabels}
     </svg>
   );
 }

--- a/src/renderer/utils/format.ts
+++ b/src/renderer/utils/format.ts
@@ -11,6 +11,13 @@ export function formatTokenCount(tokens: number): string {
   return `${(tokens / 1000000).toFixed(2)}M`;
 }
 
+export function formatTokensCompact(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
   if (bytes < 1024) return `${bytes} B`;

--- a/tests/unit/components/telemetry/StackedBars.test.tsx
+++ b/tests/unit/components/telemetry/StackedBars.test.tsx
@@ -70,4 +70,44 @@ describe('StackedBars', () => {
     const svg = container.querySelector('[data-testid="stacked-bars"]');
     expect(svg?.getAttribute('data-ymax')).toBe('20000');
   });
+
+  it('renders a date label for each entry when N <= 12', () => {
+    render(
+      <StackedBars
+        data={daily}
+        activeClasses={new Set<TokenClass>(['input', 'output', 'cacheCreate', 'cacheRead'])}
+      />,
+    );
+    expect(screen.getByText('Jun 1')).toBeDefined();
+    expect(screen.getByText('Jun 2')).toBeDefined();
+  });
+
+  it('renders at most 12 date labels for 30 entries and always includes the first', () => {
+    const thirtyDays: DailyEntry[] = Array.from({ length: 30 }, (_, i) => ({
+      date: `2026-06-${String(i + 1).padStart(2, '0')}`,
+      cost: 1.0,
+      tokens: { input: 1000, output: 500, cacheCreate: 100, cacheRead: 200 },
+      byModel: {},
+    }));
+    const { container } = render(
+      <StackedBars data={thirtyDays} activeClasses={new Set<TokenClass>(['input'])} />,
+    );
+    const svg = container.querySelector('[data-testid="stacked-bars"]')!;
+    const allTexts = Array.from(svg.querySelectorAll('text'));
+    const dateTexts = allTexts.filter((t) => /^[A-Z][a-z]+ \d+$/.test(t.textContent ?? ''));
+    expect(dateTexts.length).toBeLessThanOrEqual(12);
+    expect(dateTexts.some((t) => t.textContent === 'Jun 1')).toBe(true);
+  });
+
+  it('renders y-axis compact top tick and baseline 0 tick', () => {
+    // yMax for daily fixture (all classes): day 2 sum = 20000+8000+1000+4000 = 33000 => "33K"
+    render(
+      <StackedBars
+        data={daily}
+        activeClasses={new Set<TokenClass>(['input', 'output', 'cacheCreate', 'cacheRead'])}
+      />,
+    );
+    expect(screen.getByText('33K')).toBeDefined();
+    expect(screen.getByText('0')).toBeDefined();
+  });
 });

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTokenTooltip, formatTokenCount, formatBytes } from '../../src/renderer/utils/format';
+import { buildTokenTooltip, formatTokenCount, formatBytes, formatTokensCompact } from '../../src/renderer/utils/format';
 import type { Stack } from '../../src/renderer/store';
 
 function makeStack(overrides: Partial<Stack> = {}): Stack {
@@ -38,6 +38,28 @@ describe('formatTokenCount', () => {
 
   it('formats millions with M suffix', () => {
     expect(formatTokenCount(1500000)).toBe('1.50M');
+  });
+});
+
+describe('formatTokensCompact', () => {
+  it('returns raw integer for values under 1000', () => {
+    expect(formatTokensCompact(999)).toBe('999');
+  });
+
+  it('formats thousands with uppercase K and no decimal', () => {
+    expect(formatTokensCompact(20000)).toBe('20K');
+    expect(formatTokensCompact(850000)).toBe('850K');
+    expect(formatTokensCompact(1000)).toBe('1K');
+    expect(formatTokensCompact(999_999)).toBe('1000K');
+  });
+
+  it('formats millions with 1 decimal place', () => {
+    expect(formatTokensCompact(1_000_000)).toBe('1.0M');
+    expect(formatTokensCompact(1_200_000)).toBe('1.2M');
+  });
+
+  it('formats billions with 2 decimal places', () => {
+    expect(formatTokensCompact(1_000_000_000)).toBe('1.00B');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds x- and y-axis labels to the telemetry stacked-bar chart so usage over time is readable at a glance. The x-axis shows thinned date labels (`Jun 4` format, at most 12 labels with deterministic stepping that always includes the first day), and the y-axis shows a top tick (formatted peak token count) and a `0` baseline. The plot area is inset to make room for the axes.

Token formatting is now centralized: a new `formatTokensCompact` helper in `format.ts` renders counts as `XK` / `X.XM` / `X.XXB`. The private `fmtTokens` in `TelemetryView` was removed and replaced with this shared helper (behavior-identical over its existing range), and the chart's y-axis uses it too.

## QA plan

1. Open the Telemetry view with at least a few days of usage data.
2. Confirm the chart now shows date labels along the bottom and token labels on the left.
3. With many days (>12), confirm date labels are thinned evenly and the first day is always labeled.
4. Confirm the top-left y-axis label matches the tallest bar's token total, formatted compactly (e.g. `33K`, `1.2M`, `2.50B`), with a `0` at the baseline.
5. Confirm existing token totals elsewhere in the Telemetry view are unchanged.

Closes #523