### PR TITLE
[569] feat: surface spec-gate FAIL report and gaps in refine

### DIFF
--- a/src/main/control-plane/ticket-spec.ts
+++ b/src/main/control-plane/ticket-spec.ts
@@ -15,6 +15,8 @@ export interface RefineQuestion {
   id: string;
   question: string;
   options: RefineQuestionOption[];
+  /** 'gap' = self-resolvable spec correction (read-only in UI, not fed to spec_refine) */
+  kind?: 'gap';
 }
 
 /**
@@ -31,6 +33,15 @@ export interface SpecGateResult {
   cached: boolean;
   /** Set when the ticket can't be evaluated (unconfigured provider, etc.). */
   error?: string;
+  /** Full evaluator report text, capped at 64KB. Present on FAIL; null/absent on PASS or error. */
+  reportText?: string | null;
+}
+
+const MAX_REPORT_TEXT_LEN = 64 * 1024;
+
+export function capReportText(text: string): string {
+  if (text.length <= MAX_REPORT_TEXT_LEN) return text;
+  return text.slice(0, MAX_REPORT_TEXT_LEN) + '\n\n[Report truncated at 64KB]';
 }
 
 /** Raw spec-gate report payload coming back from the ephemeral agent. */
@@ -58,22 +69,36 @@ export function extractGateSummary(report: string): string {
  * fence under a `### Questions` or `### Gaps` heading and parses it as
  * RefineQuestion[]. Falls back to the legacy numbered-list parser (coercing
  * each line to a RefineQuestion with no options) when no valid JSON block is found.
+ * Also parses checkbox items (`- [ ] …`) under `### Gaps` and marks them `kind:'gap'`.
  */
 export function extractQuestions(report: string): RefineQuestion[] {
   if (!report) return [];
 
-  // Try JSON block parser first.
+  // Try JSON block parser first for interactive questions.
   const jsonResult = tryParseJsonBlock(report);
-  if (jsonResult !== null) return jsonResult;
+  // Also extract checkbox gaps regardless (they appear alongside JSON questions).
+  const checkboxGaps = extractCheckboxGaps(report);
 
-  // Fallback: legacy numbered-item parser.
+  if (jsonResult !== null) {
+    // Gaps render above interactive questions in the UI.
+    return [...checkboxGaps, ...jsonResult];
+  }
+
+  // Fallback: numbered-item + checkbox-gap parser.
   const lines = report.split('\n');
   let capture = false;
+  let captureKind: 'question' | 'gap' = 'question';
   const out: RefineQuestion[] = [];
   let idx = 0;
   for (const line of lines) {
-    if (/^### (Questions|Gaps)/i.test(line)) {
+    if (/^### Questions/i.test(line)) {
       capture = true;
+      captureKind = 'question';
+      continue;
+    }
+    if (/^### Gaps/i.test(line)) {
+      capture = true;
+      captureKind = 'gap';
       continue;
     }
     if (/^## /.test(line)) {
@@ -81,9 +106,49 @@ export function extractQuestions(report: string): RefineQuestion[] {
       continue;
     }
     if (!capture) continue;
-    const m = line.match(/^[0-9]+\.\s*(.*)$/);
+    // Numbered items work for both sections.
+    const numbered = line.match(/^[0-9]+\.\s*(.*)$/);
+    if (numbered && numbered[1].trim()) {
+      const item: RefineQuestion = { id: `q${idx + 1}`, question: numbered[1].trim(), options: [] };
+      if (captureKind === 'gap') item.kind = 'gap';
+      out.push(item);
+      idx++;
+      continue;
+    }
+    // Checkbox items (mandated format for Gaps section by buildSpecCheckPrompt).
+    if (captureKind === 'gap') {
+      const checkbox = line.match(/^-\s+\[[ x?]\]\s+(.*)$/);
+      if (checkbox && checkbox[1].trim()) {
+        out.push({ id: `g${idx + 1}`, question: checkbox[1].trim(), options: [], kind: 'gap' });
+        idx++;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract checkbox items (`- [ ] …`) from the `### Gaps` section only.
+ * Used when a JSON block is present so gaps are combined with JSON questions.
+ */
+function extractCheckboxGaps(report: string): RefineQuestion[] {
+  const lines = report.split('\n');
+  let capture = false;
+  const out: RefineQuestion[] = [];
+  let idx = 0;
+  for (const line of lines) {
+    if (/^### Gaps/i.test(line)) {
+      capture = true;
+      continue;
+    }
+    // Stop at any other section heading (## or ###).
+    if (capture && (/^## /.test(line) || /^### /.test(line))) {
+      break;
+    }
+    if (!capture) continue;
+    const m = line.match(/^-\s+\[[ x?]\]\s+(.*)$/);
     if (m && m[1].trim()) {
-      out.push({ id: `q${idx + 1}`, question: m[1].trim(), options: [] });
+      out.push({ id: `g${idx + 1}`, question: m[1].trim(), options: [], kind: 'gap' });
       idx++;
     }
   }
@@ -328,6 +393,7 @@ export async function runSpecCheck(
     gateSummary: extractGateSummary(reportText),
     ticketUrl: url || null,
     cached: false,
+    reportText: passed ? null : capReportText(reportText),
   };
 }
 
@@ -393,6 +459,7 @@ export async function runSpecRefine(
     gateSummary: extractGateSummary(reportText),
     ticketUrl: url || null,
     cached: false,
+    reportText: passed ? null : capReportText(reportText),
   };
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -63,6 +63,7 @@ import {
   extractQuestions,
   extractGateSummary,
   shortBodyHash,
+  capReportText,
   type SpecGateReport,
   type SpecGateResult,
 } from './control-plane/ticket-spec';
@@ -90,7 +91,7 @@ import type { EphemeralStreamEvent } from './agent/types';
 import { handleToolCall, spawnSpecCheck, spawnSpecRefine } from './claude/tools';
 import { listTicketsWithConfig } from './control-plane/ticket-lister';
 import { listTicketComments, postComment } from './control-plane/ticket-comments';
-import { getLatestUserAnswers, ANSWER_COMMENT_MARKER } from './scheduler/refine-to-comments';
+import { getLatestUserAnswers, ANSWER_COMMENT_MARKER, GATE_FAIL_REPORT_MARKER } from './scheduler/refine-to-comments';
 import { KANBAN_COLUMNS } from '../shared/kanban';
 import os from 'os';
 import { createUsageEngine, clearUsageCache } from './telemetry/usage-engine';
@@ -1324,6 +1325,8 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
           if (body) await specDeps.markSpecReady(ticketId, shortBodyHash(body));
         }
 
+        const cappedReport = capReportText(reportText);
+
         const result: SpecGateResult = rawError
           ? { passed: false, questions: [], gateSummary: '', ticketUrl: url || null, cached: false, error: rawError }
           : {
@@ -1332,12 +1335,18 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
               gateSummary: extractGateSummary(reportText),
               ticketUrl: url || null,
               cached: false,
+              reportText: passed ? null : (cappedReport || null),
             };
 
         const done: RefinementSession = { ...session, status: 'ready', result };
         activeRefinements.set(id, { session: done, cancel: null });
         persistRefinement(done);
         emitRefinementUpdate(done);
+
+        // Best-effort: post FAIL report as a ticket comment so it's visible on GitHub.
+        if (!passed && !rawError && cappedReport) {
+          postComment(ticketId, projectDir, `${GATE_FAIL_REPORT_MARKER}\n\n${cappedReport}`).catch(() => {});
+        }
       })
       .catch((err: unknown) => {
         const entry = activeRefinements.get(id);

--- a/src/main/scheduler/refine-to-comments.ts
+++ b/src/main/scheduler/refine-to-comments.ts
@@ -47,6 +47,21 @@ export const BOT_COMMENT_MARKER = '<!-- sandstorm:bot-question -->';
 /** Marker that identifies answer comments posted by the interactive dialog. */
 export const ANSWER_COMMENT_MARKER = '<!-- sandstorm:user-answers -->';
 
+/** Marker that identifies FAIL gate-report comments posted by the interactive dialog. */
+export const GATE_FAIL_REPORT_MARKER = '<!-- sandstorm:gate-fail-report -->';
+
+/**
+ * Returns the body text of the most-recent GATE_FAIL_REPORT_MARKER comment,
+ * or null if none exists. Mirrors the append-plus-read-latest pattern used by
+ * getLatestUserAnswers for ANSWER_COMMENT_MARKER.
+ */
+export function getLatestGateFailReport(comments: TicketComment[]): string | null {
+  const candidates = comments.filter((c) => c.body.includes(GATE_FAIL_REPORT_MARKER));
+  if (candidates.length === 0) return null;
+  const latest = candidates[candidates.length - 1];
+  return latest.body.replace(GATE_FAIL_REPORT_MARKER, '').trim();
+}
+
 export interface RefineToCommentsDeps {
   listTickets: (label: string, projectDir: string) => Promise<TicketEntry[]>;
   listComments: (ticketId: string, projectDir: string) => Promise<TicketComment[]>;

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -79,13 +79,13 @@ export function RefineTicketDialog() {
   const sessionError = session?.error ?? null;
 
   // Initialise answers when gate questions change, restoring from draft if available.
-  // normalizeQuestion handles legacy string[] items (old persisted sessions).
+  // Only interactive questions (kind !== 'gap') get answer slots.
   useEffect(() => {
-    if (gate && !gate.passed && gate.questions.length > 0) {
-      const normalized = gate.questions.map((q, i) => normalizeQuestion(q, i));
+    if (gate && !gate.passed) {
+      const interactive = gate.questions.filter((q) => q.kind !== 'gap');
+      if (interactive.length === 0) return;
+      const normalized = interactive.map((q, i) => normalizeQuestion(q, i));
       // Read draft imperatively to avoid adding refineAnswerDrafts as a reactive dep.
-      // Questions are not re-fetched on reopen (same gate.questions), so position is stable;
-      // draft[i] corresponds to normalized[i] (id-first match degenerates to positional here).
       const sessionId = useAppStore.getState().currentRefinementSessionId;
       const draft = sessionId ? (useAppStore.getState().refineAnswerDrafts[sessionId] ?? null) : null;
       const defaults = defaultAnswers(normalized);
@@ -188,7 +188,7 @@ export function RefineTicketDialog() {
 
   const handleSubmitAnswers = useCallback(async () => {
     if (!session || !projectDir) return;
-    const rawQuestions = gate?.questions ?? [];
+    const rawQuestions = (gate?.questions ?? []).filter((q) => q.kind !== 'gap');
     const questions = rawQuestions.map((q, i) => normalizeQuestion(q, i));
     const combined = combineAnswers(questions, answers);
     setLocalError(null);
@@ -454,28 +454,52 @@ export function RefineTicketDialog() {
               </div>
             )}
 
-            {showFailState && gate && (
-              <div className="space-y-3" data-testid="refine-fail">
-                <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
-                  Spec gate failed. {gate.gateSummary}
-                </div>
-                {gate.questions.length === 0 ? (
-                  <div className="text-xs text-sandstorm-muted">
-                    No structured questions parsed. The full report was committed to the ticket — open it on GitHub to read it.
+            {showFailState && gate && (() => {
+              const gapItems = gate.questions.filter((q) => q.kind === 'gap');
+              const interactiveQuestions = gate.questions.filter((q) => q.kind !== 'gap');
+              return (
+                <div className="space-y-3" data-testid="refine-fail">
+                  <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
+                    Spec gate failed. {gate.gateSummary}
                   </div>
-                ) : (
-                  <QuestionList
-                    questions={gate.questions.map((q, i) => normalizeQuestion(q, i))}
-                    answers={answers}
-                    onAnswersChange={(next) => {
-                      setAnswers(next);
-                      if (session) setRefineAnswerDraft(session.id, next);
-                    }}
-                    testIdPrefix="refine"
-                  />
-                )}
-              </div>
-            )}
+                  {gapItems.length > 0 && (
+                    <div data-testid="refine-gap-items">
+                      <div className="text-xs font-medium text-sandstorm-text-secondary mb-1.5">Spec Gaps</div>
+                      <ul className="space-y-1">
+                        {gapItems.map((gap) => (
+                          <li key={gap.id} className="text-xs text-sandstorm-muted flex gap-2" data-testid="refine-gap-item">
+                            <span className="mt-0.5 text-amber-400 shrink-0">•</span>
+                            <span>{gap.question}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {interactiveQuestions.length > 0 ? (
+                    <QuestionList
+                      questions={interactiveQuestions.map((q, i) => normalizeQuestion(q, i))}
+                      answers={answers}
+                      onAnswersChange={(next) => {
+                        setAnswers(next);
+                        if (session) setRefineAnswerDraft(session.id, next);
+                      }}
+                      testIdPrefix="refine"
+                    />
+                  ) : gate.reportText ? (
+                    <pre
+                      className="text-xs font-mono text-sandstorm-text bg-sandstorm-bg border border-sandstorm-border rounded-lg p-3 max-h-48 overflow-y-auto whitespace-pre-wrap break-words"
+                      data-testid="refine-report-text"
+                    >
+                      {gate.reportText}
+                    </pre>
+                  ) : (
+                    <div className="text-xs text-sandstorm-muted" data-testid="refine-no-report">
+                      No structured questions parsed. Use Retry to re-run the gate.
+                    </div>
+                  )}
+                </div>
+              );
+            })()}
 
             {(showErrorState) && !confirmingCancel && (
               <div className="text-xs text-sandstorm-muted" data-testid="refine-error-state">
@@ -531,7 +555,7 @@ export function RefineTicketDialog() {
                   </button>
                 )}
 
-                {showFailState && gate && gate.questions.length > 0 && (
+                {showFailState && gate && gate.questions.filter((q) => q.kind !== 'gap').length > 0 && (
                   <button
                     onClick={handleSubmitAnswers}
                     disabled={isSubmitDisabled(answers)}
@@ -542,7 +566,7 @@ export function RefineTicketDialog() {
                   </button>
                 )}
 
-                {showFailState && gate && gate.questions.length === 0 && (
+                {showFailState && gate && gate.questions.filter((q) => q.kind !== 'gap').length === 0 && (
                   <button
                     onClick={handleRetry}
                     className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg transition-all active:scale-[0.98] shadow-glow"

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -872,6 +872,8 @@ export interface RefineQuestion {
   id: string;
   question: string;
   options: RefineQuestionOption[];
+  /** 'gap' = self-resolvable spec correction (read-only in UI, not fed to spec_refine) */
+  kind?: 'gap';
 }
 
 /** Renderer-side mirror of `SpecGateResult` from main/control-plane/ticket-spec.ts. */
@@ -882,6 +884,8 @@ export interface SpecGateResult {
   ticketUrl: string | null;
   cached: boolean;
   error?: string;
+  /** Full evaluator report text, capped at 64KB. Present on FAIL; null/absent on PASS or error. */
+  reportText?: string | null;
 }
 
 export type RefinementStatus = 'running' | 'ready' | 'errored' | 'interrupted';

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -1695,4 +1695,133 @@ describe('RefineTicketDialog', () => {
       expect(s.streamingOutput).toBeUndefined();
     });
   });
+
+  // =========================================================================
+  // FAIL report text + gap items — #569
+  // =========================================================================
+  describe('FAIL report text rendering (#569)', () => {
+    it('renders report text when FAIL has 0 questions and reportText is present', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: [],
+            gateSummary: 'Gate=FAIL, questions=0',
+            ticketUrl: null,
+            cached: false,
+            reportText: '## Spec Quality Gate: FAIL\n\nCitations are stale.',
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByTestId('refine-fail')).toBeDefined();
+      expect(screen.getByTestId('refine-report-text')).toBeDefined();
+      expect(screen.getByTestId('refine-report-text').textContent).toContain('Citations are stale.');
+      // Must NOT contain the old false copy
+      expect(screen.queryByText(/committed to the ticket/i)).toBeNull();
+    });
+
+    it('renders accurate fallback copy (no false claim) when reportText is absent (legacy session)', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: [],
+            gateSummary: 'Gate=FAIL, questions=0',
+            ticketUrl: null,
+            cached: false,
+            // No reportText field (legacy session)
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByTestId('refine-no-report')).toBeDefined();
+      // Must NOT contain the false "committed" copy
+      expect(screen.queryByText(/committed to the ticket/i)).toBeNull();
+    });
+
+    it('renders gap items as read-only list when questions contain only gaps', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: [
+              { id: 'g1', question: 'Citation stale — update to line 42', options: [], kind: 'gap' },
+              { id: 'g2', question: 'Wrong version check', options: [], kind: 'gap' },
+            ],
+            gateSummary: 'Gate=FAIL, questions=2',
+            ticketUrl: null,
+            cached: false,
+            reportText: 'Full report here',
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByTestId('refine-gap-items')).toBeDefined();
+      const gapItems = screen.getAllByTestId('refine-gap-item');
+      expect(gapItems).toHaveLength(2);
+      expect(gapItems[0].textContent).toContain('Citation stale');
+      // No interactive question inputs
+      expect(screen.queryByTestId('refine-answer-0')).toBeNull();
+      // Submit not shown — only Retry
+      expect(screen.queryByTestId('refine-submit-answers')).toBeNull();
+      expect(screen.getByTestId('refine-run-gate')).toBeDefined();
+    });
+
+    it('renders gap items read-only alongside QuestionList for interactive questions', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: [
+              { id: 'g1', question: 'Fix the citation', options: [], kind: 'gap' },
+              ...MULTI_OPT_QUESTIONS,
+            ],
+            gateSummary: 'Gate=FAIL, questions=3',
+            ticketUrl: null,
+            cached: false,
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      // Gap items rendered read-only
+      expect(screen.getByTestId('refine-gap-items')).toBeDefined();
+      // Interactive questions rendered in QuestionList
+      expect(screen.getByTestId('refine-answer-0')).toBeDefined();
+      // Submit button shows (interactive questions present)
+      expect(screen.getByTestId('refine-submit-answers')).toBeDefined();
+    });
+
+    it('Retry button shown when questions are all gaps (no interactive questions)', () => {
+      useAppStore.setState({
+        refinementSessions: [{
+          id: 'session-1', ticketId: '310', projectDir: '/proj',
+          status: 'ready', phase: 'check', startedAt: Date.now(),
+          result: {
+            passed: false,
+            questions: [{ id: 'g1', question: 'Fix it', options: [], kind: 'gap' }],
+            gateSummary: 'Gate=FAIL, questions=1',
+            ticketUrl: null,
+            cached: false,
+          },
+        }],
+        currentRefinementSessionId: 'session-1',
+      });
+      render(<RefineTicketDialog />);
+      expect(screen.getByTestId('refine-run-gate')).toBeDefined();
+      expect(screen.queryByTestId('refine-submit-answers')).toBeNull();
+    });
+  });
 });

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -29,6 +29,7 @@ const {
   mockSessionMonitor,
   mockSpawnSpecCheck,
   mockSpawnSpecRefine,
+  mockPostComment,
   mockListTicketComments,
   mockDeleteRefinement,
   mockPersistRefinement,
@@ -40,6 +41,7 @@ const {
   const registeredHandlers: Record<string, (...args: unknown[]) => unknown> = {};
   const mockSpawnSpecCheck = vi.fn();
   const mockSpawnSpecRefine = vi.fn();
+  const mockPostComment = vi.fn().mockResolvedValue(undefined);
   const mockListTicketComments = vi.fn().mockResolvedValue([]);
   const mockDeleteRefinement = vi.fn();
   const mockPersistRefinement = vi.fn();
@@ -213,6 +215,7 @@ const {
     mockSessionMonitor,
     mockSpawnSpecCheck,
     mockSpawnSpecRefine,
+    mockPostComment,
     mockListTicketComments,
     mockDeleteRefinement,
     mockPersistRefinement,
@@ -334,7 +337,7 @@ vi.mock('../../src/main/claude/tools', () => ({
 
 vi.mock('../../src/main/control-plane/ticket-comments', () => ({
   listTicketComments: (...args: unknown[]) => mockListTicketComments(...args),
-  postComment: vi.fn().mockResolvedValue(undefined),
+  postComment: (...args: unknown[]) => mockPostComment(...args),
 }));
 
 vi.mock('../../src/main/control-plane/refinement-store', () => ({
@@ -2143,6 +2146,106 @@ describe('IPC Handlers', () => {
       // that expected it to be present.
       expect(registeredHandlers['tickets:discardRefinement']).toBeUndefined();
     });
+  });
+
+  // =========================================================================
+  // FAIL report posting — #569
+  // =========================================================================
+  describe('tickets:specCheckAsync — FAIL report comment posting (#569)', () => {
+    async function runSpecCheckAsyncWithReport(
+      report: string,
+      passed: boolean,
+    ): Promise<void> {
+      let resolveFn!: (v: Record<string, unknown>) => void;
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>((r) => { resolveFn = r; }),
+        cancel: vi.fn(),
+      });
+      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+      mockExecFile.mockImplementation(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(new Error('exec-fail'), '', '');
+        },
+      );
+
+      await invokeHandler('tickets:specCheckAsync', 'T-569', '/tmp/proj') as { sessionId: string };
+      mockPostComment.mockClear();
+      mockPersistRefinement.mockClear();
+
+      resolveFn({ passed, report });
+      // Flush multiple ticks: the PASS path has extra awaits (readTicketUrl + fetchTicket).
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    }
+
+    it('posts a GATE_FAIL_REPORT_MARKER comment on FAIL with non-empty report', async () => {
+      await runSpecCheckAsyncWithReport('## Spec Quality Gate: FAIL\n\nSome report', false);
+      expect(mockPostComment).toHaveBeenCalledOnce();
+      const [, , body] = mockPostComment.mock.calls[0] as [string, string, string];
+      expect(body).toContain('<!-- sandstorm:gate-fail-report -->');
+      expect(body).toContain('## Spec Quality Gate: FAIL');
+    });
+
+    it('does NOT post a comment on PASS', async () => {
+      await runSpecCheckAsyncWithReport('## Spec Quality Gate: PASS\n\nAll good', true);
+      expect(mockPostComment).not.toHaveBeenCalled();
+    });
+
+    it('does NOT post a comment when report is empty', async () => {
+      await runSpecCheckAsyncWithReport('', false);
+      expect(mockPostComment).not.toHaveBeenCalled();
+    });
+
+    it('gate flow completes successfully even if postComment rejects', async () => {
+      mockPostComment.mockRejectedValueOnce(new Error('network failure'));
+      let resolveFn!: (v: Record<string, unknown>) => void;
+      mockSpawnSpecCheck.mockReturnValue({
+        promise: new Promise<Record<string, unknown>>((r) => { resolveFn = r; }),
+        cancel: vi.fn(),
+      });
+      const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+      mockExecFile.mockImplementation(
+        (_cmd: unknown, _args: unknown, _opts: unknown, callback: (...a: unknown[]) => void) => {
+          callback(new Error('exec-fail'), '', '');
+        },
+      );
+
+      await invokeHandler('tickets:specCheckAsync', 'T-569-err', '/tmp/proj');
+      resolveFn({ passed: false, report: '## Spec Quality Gate: FAIL\n\nFailed' });
+      // Flush: the .catch() on postComment should absorb the error without
+      // propagating it or crashing the completion handler.
+      await new Promise((r) => setTimeout(r, 0));
+      // persistRefinement(ready) should still have been called
+      const readyCall = mockPersistRefinement.mock.calls.find(
+        (call) => (call[0] as { status: string }).status === 'ready',
+      );
+      expect(readyCall).toBeDefined();
+    });
+
+    it('includes reportText in the persisted result on FAIL', async () => {
+      await runSpecCheckAsyncWithReport('## Spec Quality Gate: FAIL\n\nSome details', false);
+      const readyCall = mockPersistRefinement.mock.calls.find(
+        (call) => (call[0] as { status: string }).status === 'ready',
+      );
+      expect(readyCall).toBeDefined();
+      const session = readyCall![0] as { result?: { reportText?: string } };
+      expect(session.result?.reportText).toContain('## Spec Quality Gate: FAIL');
+    });
+
+    it('truncates reportText to 64KB and appends truncation notice on FAIL', async () => {
+      const hugeReport = 'x'.repeat(64 * 1024 + 100);
+      await runSpecCheckAsyncWithReport(hugeReport, false);
+      const readyCall = mockPersistRefinement.mock.calls.find(
+        (call) => (call[0] as { status: string }).status === 'ready',
+      );
+      expect(readyCall).toBeDefined();
+      const session = readyCall![0] as { result?: { reportText?: string } };
+      const stored = session.result?.reportText ?? '';
+      expect(stored.length).toBeLessThan(hugeReport.length);
+      expect(stored).toContain('[Report truncated at 64KB]');
+    });
+
   });
 
   // =========================================================================

--- a/tests/unit/main/scheduler/refine-to-comments.test.ts
+++ b/tests/unit/main/scheduler/refine-to-comments.test.ts
@@ -7,8 +7,10 @@ import {
   getLastBotComment,
   getUserAnswersAfterBot,
   getLatestUserAnswers,
+  getLatestGateFailReport,
   BOT_COMMENT_MARKER,
   ANSWER_COMMENT_MARKER,
+  GATE_FAIL_REPORT_MARKER,
   type RefineToCommentsDeps,
 } from '../../../../src/main/scheduler/refine-to-comments';
 import type { TicketEntry, TicketComment } from '../../../../src/main/control-plane/ticket-comments';
@@ -458,4 +460,59 @@ describe('buildRefineToCommentsDeps — provider reroute', () => {
     expect(result).toEqual({ processed: 0, passed: 0, failed: 0 });
   });
 
+});
+
+// ── GATE_FAIL_REPORT_MARKER + getLatestGateFailReport ────────────────────────
+
+describe('GATE_FAIL_REPORT_MARKER', () => {
+  it('is a distinct HTML comment marker string', () => {
+    expect(GATE_FAIL_REPORT_MARKER).toMatch(/^<!--.*-->$/);
+    expect(GATE_FAIL_REPORT_MARKER).not.toBe(BOT_COMMENT_MARKER);
+    expect(GATE_FAIL_REPORT_MARKER).not.toBe(ANSWER_COMMENT_MARKER);
+  });
+});
+
+describe('getLatestGateFailReport', () => {
+  it('returns null when no GATE_FAIL_REPORT_MARKER comments exist', () => {
+    const comments: TicketComment[] = [
+      { author: 'bot', body: `${BOT_COMMENT_MARKER}\nSome question`, createdAt: '2026-05-01T10:00:00Z' },
+      { author: 'user', body: 'My answer', createdAt: '2026-05-02T10:00:00Z' },
+    ];
+    expect(getLatestGateFailReport(comments)).toBeNull();
+  });
+
+  it('returns the body of the latest GATE_FAIL_REPORT_MARKER comment', () => {
+    const first: TicketComment = {
+      author: 'bot',
+      body: `${GATE_FAIL_REPORT_MARKER}\n\nFirst report`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const second: TicketComment = {
+      author: 'bot',
+      body: `${GATE_FAIL_REPORT_MARKER}\n\nSecond report`,
+      createdAt: '2026-05-02T10:00:00Z',
+    };
+    expect(getLatestGateFailReport([first, second])).toBe('Second report');
+  });
+
+  it('returns just the first report when only one exists', () => {
+    const comment: TicketComment = {
+      author: 'bot',
+      body: `${GATE_FAIL_REPORT_MARKER}\n\n## Spec Quality Gate: FAIL\n\nReport text here`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const result = getLatestGateFailReport([comment]);
+    expect(result).toBe('## Spec Quality Gate: FAIL\n\nReport text here');
+  });
+
+  it('strips the marker from the returned text', () => {
+    const comment: TicketComment = {
+      author: 'bot',
+      body: `${GATE_FAIL_REPORT_MARKER}\n\nReport without marker`,
+      createdAt: '2026-05-01T10:00:00Z',
+    };
+    const result = getLatestGateFailReport([comment]);
+    expect(result).not.toContain(GATE_FAIL_REPORT_MARKER);
+    expect(result).toBe('Report without marker');
+  });
 });

--- a/tests/unit/ticket-spec.test.ts
+++ b/tests/unit/ticket-spec.test.ts
@@ -202,7 +202,38 @@ describe('extractQuestions', () => {
     const questions = extractQuestions(r);
     expect(questions).toHaveLength(2);
     expect(questions[0].question).toBe('First gap');
+    expect(questions[0].kind).toBe('gap');
     expect(questions[1].question).toBe('Second gap');
+    expect(questions[1].kind).toBe('gap');
+  });
+
+  it('parses checkbox items under Gaps heading — mandated buildSpecCheckPrompt format (regression)', () => {
+    const r = `## Spec Quality Gate: FAIL\n\n### Gaps (if any)\n- [ ] Citation stale — update to line 42\n- [ ] Wrong version check — use < 24\n\n## Results\n`;
+    const questions = extractQuestions(r);
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions[0].question).toBe('Citation stale — update to line 42');
+    expect(questions[0].kind).toBe('gap');
+    expect(questions[1].question).toBe('Wrong version check — use < 24');
+    expect(questions[1].kind).toBe('gap');
+  });
+
+  it('combines checkbox gaps with JSON questions when both are present', () => {
+    const r = `## Spec Quality Gate: FAIL\n\n### Gaps (if any)\n- [ ] Gap item — needs fixing\n\n### Questions Requiring User Answers (if any)\n\n\`\`\`json\n[{"id":"q1","question":"Which approach?","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]\n\`\`\`\n`;
+    const questions = extractQuestions(r);
+    // Gaps appear first, then JSON questions
+    expect(questions.length).toBe(2);
+    expect(questions[0].kind).toBe('gap');
+    expect(questions[0].question).toBe('Gap item — needs fixing');
+    expect(questions[1].kind).toBeUndefined();
+    expect(questions[1].question).toBe('Which approach?');
+  });
+
+  it('marks Questions-section items with no kind (only Gaps items get kind: gap)', () => {
+    const r = `### Questions\n1. What is the approach?\n2. How should we handle it?`;
+    const questions = extractQuestions(r);
+    expect(questions).toHaveLength(2);
+    expect(questions[0].kind).toBeUndefined();
+    expect(questions[1].kind).toBeUndefined();
   });
 
   it('also captures JSON block under a Gaps heading', () => {
@@ -337,6 +368,29 @@ describe('runSpecCheck', () => {
     expect(deps.markSpecReady).not.toHaveBeenCalled();
   });
 
+  it('includes reportText on FAIL and null on PASS', async () => {
+    const failDeps = makeDeps({
+      runCheck: vi.fn().mockResolvedValue({ passed: false, report: FAIL_REPORT }),
+    });
+    const failResult = await runSpecCheck('1', '/proj', failDeps);
+    expect(failResult.reportText).toBe(FAIL_REPORT);
+
+    const passDeps = makeDeps();
+    const passResult = await runSpecCheck('1', '/proj', passDeps);
+    expect(passResult.reportText).toBeNull();
+  });
+
+  it('caps reportText at 64KB', async () => {
+    const longReport = `## Spec Quality Gate: FAIL\n\n` + 'x'.repeat(70 * 1024);
+    const deps = makeDeps({
+      runCheck: vi.fn().mockResolvedValue({ passed: false, report: longReport }),
+    });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.reportText).toBeDefined();
+    expect(result.reportText!.length).toBeLessThan(longReport.length);
+    expect(result.reportText).toContain('[Report truncated at 64KB]');
+  });
+
   it('surfaces handler errors verbatim', async () => {
     const deps = makeDeps({
       runCheck: vi.fn().mockResolvedValue({ passed: false, error: 'No quality gate configured' }),
@@ -386,5 +440,17 @@ describe('runSpecRefine', () => {
     expect(result.questions).toHaveLength(2);
     expect(result.questions[0]).toMatchObject({ question: expect.any(String), options: [] });
     expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+
+  it('includes reportText on FAIL and null on PASS (runSpecRefine)', async () => {
+    const failDeps = makeDeps({
+      runRefine: vi.fn().mockResolvedValue({ passed: false, report: FAIL_REPORT }),
+    });
+    const failResult = await runSpecRefine('1', '/proj', 'answers', failDeps);
+    expect(failResult.reportText).toBe(FAIL_REPORT);
+
+    const passDeps = makeDeps();
+    const passResult = await runSpecRefine('1', '/proj', 'answers', passDeps);
+    expect(passResult.reportText).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

When the spec gate fails, the full evaluator report was previously lost to the user unless they dug into GitHub. This change captures and surfaces that report end to end.

- `runSpecCheck`/`runSpecRefine` now return the full evaluator report text on FAIL (`reportText`), capped at 64KB via a shared `capReportText` helper exported from `ticket-spec.ts` and reused in `ipc.ts` (removing the inline duplication).
- `extractQuestions` now distinguishes interactive questions from self-resolvable spec gaps. Checkbox items (`- [ ] ...`) under a `### Gaps` heading are parsed and tagged `kind: 'gap'`, both in the JSON-block path and the legacy numbered-list fallback.
- The refine dialog renders gaps as a read-only "Spec Gaps" list above the interactive questions. They are excluded from answer slots and from the spec_refine submission. When no interactive questions are parsed, the dialog shows the full report text (or a Retry prompt if absent).
- On FAIL, the report is also posted best-effort as a ticket comment, tagged with a new `GATE_FAIL_REPORT_MARKER`, with a `getLatestGateFailReport` reader mirroring the existing answer-comment pattern.

## QA plan

1. Open the Refine Ticket dialog on a ticket whose spec gate fails with interactive questions plus `### Gaps` checkbox items. Confirm the gaps appear in a read-only "Spec Gaps" list above the questions, and that only the interactive questions have answer controls.
2. Submit answers and confirm the gap items are not included in the refine request.
3. Fail a gate that returns no parseable questions. Confirm the dialog shows the full report text in a scrollable block, or a Retry button when no report is available.
4. After a FAIL, open the ticket on GitHub and confirm the full report was posted as a comment.
5. Trigger a FAIL with a report larger than 64KB and confirm the persisted/displayed text is truncated with the `[Report truncated at 64KB]` notice.

Closes #569