### PR TITLE
[474] feat: add OpenCode backend selection to model settings

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -966,11 +966,13 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return registry.getEffectiveBackend(projectDir, surface);
   });
 
-  ipcMain.handle('backendSettings:setSecret', (_event, key: string, surface: 'inner' | 'outer', name: string, value: string) => {
+  ipcMain.handle('backendSettings:setSecret', (_event, scope: string, surface: 'inner' | 'outer', name: string, value: string) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     registry.setBackendSecret(key, surface, name, value);
   });
 
-  ipcMain.handle('backendSettings:secretStatus', (_event, key: string, surface: 'inner' | 'outer') => {
+  ipcMain.handle('backendSettings:secretStatus', (_event, scope: string, surface: 'inner' | 'outer') => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return { set: registry.hasBackendSecret(key, surface) };
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -152,8 +152,8 @@ export interface SandstormAPI {
     getProject: (projectDir: string) => Promise<{ inner_backend: string; outer_backend: string; inner_provider: string | null; inner_model: string | null; outer_provider: string | null; outer_model: string | null } | null>;
     setProject: (projectDir: string, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => Promise<void>;
     getEffective: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
-    setSecret: (key: string, surface: 'inner' | 'outer', name: string, value: string) => Promise<void>;
-    secretStatus: (key: string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
+    setSecret: (scope: 'global' | string, surface: 'inner' | 'outer', name: string, value: string) => Promise<void>;
+    secretStatus: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
   };
   modelRouting: {
     getEffective: (projectDir: string) => Promise<Record<string, { backend: string; model: string }>>;
@@ -400,8 +400,8 @@ const api: SandstormAPI = {
     getProject: (projectDir) => ipcRenderer.invoke('backendSettings:getProject', projectDir),
     setProject: (projectDir, settings) => ipcRenderer.invoke('backendSettings:setProject', projectDir, settings),
     getEffective: (projectDir, surface) => ipcRenderer.invoke('backendSettings:getEffective', projectDir, surface),
-    setSecret: (key, surface, name, value) => ipcRenderer.invoke('backendSettings:setSecret', key, surface, name, value),
-    secretStatus: (key, surface) => ipcRenderer.invoke('backendSettings:secretStatus', key, surface),
+    setSecret: (scope, surface, name, value) => ipcRenderer.invoke('backendSettings:setSecret', scope, surface, name, value),
+    secretStatus: (scope, surface) => ipcRenderer.invoke('backendSettings:secretStatus', scope, surface),
   },
   modelRouting: {
     getEffective: (projectDir) => ipcRenderer.invoke('modelRouting:getEffective', projectDir),

--- a/src/renderer/components/ModelSettings.tsx
+++ b/src/renderer/components/ModelSettings.tsx
@@ -24,6 +24,25 @@ const PROJECT_OUTER_OPTIONS = [
   ...OUTER_MODEL_OPTIONS,
 ] as const;
 
+const GLOBAL_BACKEND_OPTIONS = [
+  { id: 'claude', label: 'Claude Code' },
+  { id: 'opencode', label: 'OpenCode' },
+] as const;
+
+const PROJECT_BACKEND_OPTIONS = [
+  { id: 'global', label: 'Use Global Default' },
+  { id: 'claude', label: 'Claude Code' },
+  { id: 'opencode', label: 'OpenCode' },
+] as const;
+
+const OPENCODE_PROVIDERS = [
+  { id: 'anthropic', label: 'Anthropic' },
+  { id: 'openai', label: 'OpenAI' },
+  { id: 'amazon-bedrock', label: 'Amazon Bedrock' },
+  { id: 'ollama', label: 'Ollama' },
+  { id: 'openrouter', label: 'OpenRouter' },
+] as const;
+
 function ModelButton({
   id,
   label,
@@ -55,6 +74,100 @@ function ModelButton({
   );
 }
 
+function BackendSelector({
+  scope,
+  backend,
+  onBackendChange,
+  provider,
+  onProviderChange,
+  model,
+  onModelChange,
+  credInput,
+  onCredInputChange,
+  credSet,
+  testId,
+}: {
+  scope: 'global' | 'project';
+  backend: string;
+  onBackendChange: (v: string) => void;
+  provider: string;
+  onProviderChange: (v: string) => void;
+  model: string;
+  onModelChange: (v: string) => void;
+  credInput: string;
+  onCredInputChange: (v: string) => void;
+  credSet: boolean;
+  testId: string;
+}) {
+  const options = scope === 'global' ? GLOBAL_BACKEND_OPTIONS : PROJECT_BACKEND_OPTIONS;
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 flex-wrap">
+        {options.map((opt) => (
+          <button
+            key={opt.id}
+            onClick={() => { onBackendChange(opt.id); }}
+            className={`flex-1 px-3 py-2 text-xs font-medium rounded-lg border transition-all ${
+              backend === opt.id
+                ? 'border-sandstorm-accent bg-sandstorm-accent/10 text-sandstorm-accent'
+                : 'border-sandstorm-border bg-sandstorm-bg text-sandstorm-muted hover:border-sandstorm-border-light'
+            }`}
+            data-testid={`${testId}-${opt.id}`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {backend === 'opencode' && (
+        <div className="space-y-2 pl-1 pt-1" data-testid={`${testId}-opencode-fields`}>
+          <div>
+            <label className="block text-[10px] font-medium text-sandstorm-text-secondary mb-1">Provider</label>
+            <select
+              value={provider}
+              onChange={(e) => { onProviderChange(e.target.value); }}
+              className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
+              data-testid={`${testId}-provider`}
+            >
+              {OPENCODE_PROVIDERS.map((p) => (
+                <option key={p.id} value={p.id}>{p.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-[10px] font-medium text-sandstorm-text-secondary mb-1">Model</label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => { onModelChange(e.target.value); }}
+              placeholder="e.g. claude-sonnet-4-5"
+              className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
+              data-testid={`${testId}-model`}
+            />
+          </div>
+          <div>
+            <label className="block text-[10px] font-medium text-sandstorm-text-secondary mb-1">
+              API Credential
+              <span className="ml-2 font-normal text-sandstorm-muted" data-testid={`${testId}-cred-status`}>
+                {credSet ? '(Set)' : '(Not set)'}
+              </span>
+            </label>
+            <input
+              type="password"
+              value={credInput}
+              onChange={(e) => { onCredInputChange(e.target.value); }}
+              placeholder={credSet ? 'Enter new value to update' : 'Enter API key'}
+              className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
+              data-testid={`${testId}-cred-input`}
+              autoComplete="new-password"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function ModelSettingsModal() {
   const {
     setShowModelSettings,
@@ -68,6 +181,14 @@ export function ModelSettingsModal() {
     setProjectTicketConfig,
     getDarkFactoryEnabled,
     setDarkFactoryEnabled,
+    globalBackendSettings,
+    refreshGlobalBackendSettings,
+    setGlobalBackendSettings,
+    getProjectBackendSettings,
+    setProjectBackendSettings,
+    getEffectiveBackend,
+    setBackendSecret,
+    getBackendSecretStatus,
   } = useAppStore();
 
   const project = activeProject();
@@ -78,11 +199,41 @@ export function ModelSettingsModal() {
   const [globalOuter, setGlobalOuter] = useState(globalModelSettings.outer_model);
   const [globalDirty, setGlobalDirty] = useState(false);
 
+  // Global backend state
+  const [globalInnerBackend, setGlobalInnerBackend] = useState<string>(globalBackendSettings.inner_backend ?? 'claude');
+  const [globalInnerProvider, setGlobalInnerProvider] = useState<string>(globalBackendSettings.inner_provider ?? 'anthropic');
+  const [globalInnerModel, setGlobalInnerModel] = useState<string>(globalBackendSettings.inner_model ?? '');
+  const [globalInnerCredInput, setGlobalInnerCredInput] = useState('');
+  const [globalInnerCredSet, setGlobalInnerCredSet] = useState(false);
+  const [globalOuterBackend, setGlobalOuterBackend] = useState<string>(globalBackendSettings.outer_backend ?? 'claude');
+  const [globalOuterProvider, setGlobalOuterProvider] = useState<string>(globalBackendSettings.outer_provider ?? 'anthropic');
+  const [globalOuterModel, setGlobalOuterModel] = useState<string>(globalBackendSettings.outer_model ?? '');
+  const [globalOuterCredInput, setGlobalOuterCredInput] = useState('');
+  const [globalOuterCredSet, setGlobalOuterCredSet] = useState(false);
+  const [globalBackendLoaded, setGlobalBackendLoaded] = useState(false);
+
   // Project model settings state
   const [projectInner, setProjectInner] = useState('global');
   const [projectOuter, setProjectOuter] = useState('global');
   const [projectDirty, setProjectDirty] = useState(false);
   const [projectLoaded, setProjectLoaded] = useState(false);
+
+  // Project backend state
+  const [projectInnerBackend, setProjectInnerBackend] = useState<string>('global');
+  const [projectInnerProvider, setProjectInnerProvider] = useState<string>('anthropic');
+  const [projectInnerModel, setProjectInnerModel] = useState<string>('');
+  const [projectInnerCredInput, setProjectInnerCredInput] = useState('');
+  const [projectInnerCredSet, setProjectInnerCredSet] = useState(false);
+  const [projectOuterBackend, setProjectOuterBackend] = useState<string>('global');
+  const [projectOuterProvider, setProjectOuterProvider] = useState<string>('anthropic');
+  const [projectOuterModel, setProjectOuterModel] = useState<string>('');
+  const [projectOuterCredInput, setProjectOuterCredInput] = useState('');
+  const [projectOuterCredSet, setProjectOuterCredSet] = useState(false);
+  const [projectBackendLoaded, setProjectBackendLoaded] = useState(false);
+
+  // Effective backend for summary
+  const [effectiveInnerBackend, setEffectiveInnerBackend] = useState<{ backend: 'claude' | 'opencode'; provider?: string; model?: string } | null>(null);
+  const [effectiveOuterBackend, setEffectiveOuterBackend] = useState<{ backend: 'claude' | 'opencode'; provider?: string; model?: string } | null>(null);
 
   // Dark factory state
   const [darkFactoryEnabled, setDarkFactoryEnabledLocal] = useState(false);
@@ -119,6 +270,29 @@ export function ModelSettingsModal() {
     setGlobalOuter(globalModelSettings.outer_model);
   }, [globalModelSettings]);
 
+  const loadGlobalBackendSettings = useCallback(async () => {
+    await refreshGlobalBackendSettings();
+    const settings = useAppStore.getState().globalBackendSettings;
+    setGlobalInnerBackend(settings.inner_backend ?? 'claude');
+    setGlobalInnerProvider(settings.inner_provider ?? 'anthropic');
+    setGlobalInnerModel(settings.inner_model ?? '');
+    setGlobalOuterBackend(settings.outer_backend ?? 'claude');
+    setGlobalOuterProvider(settings.outer_provider ?? 'anthropic');
+    setGlobalOuterModel(settings.outer_model ?? '');
+
+    const [innerStatus, outerStatus] = await Promise.all([
+      getBackendSecretStatus('global', 'inner'),
+      getBackendSecretStatus('global', 'outer'),
+    ]);
+    setGlobalInnerCredSet(innerStatus.set);
+    setGlobalOuterCredSet(outerStatus.set);
+    setGlobalBackendLoaded(true);
+  }, [refreshGlobalBackendSettings, getBackendSecretStatus]);
+
+  useEffect(() => {
+    loadGlobalBackendSettings();
+  }, [loadGlobalBackendSettings]);
+
   const loadProjectSettings = useCallback(async () => {
     if (!project) return;
     const settings = await getProjectModelSettings(project.directory);
@@ -135,6 +309,44 @@ export function ModelSettingsModal() {
     setProjectLoaded(true);
     setProjectDirty(false);
   }, [project, getProjectModelSettings, getDarkFactoryEnabled]);
+
+  const loadProjectBackendSettings = useCallback(async () => {
+    if (!project) return;
+    const settings = await getProjectBackendSettings(project.directory);
+    if (settings) {
+      setProjectInnerBackend(settings.inner_backend ?? 'global');
+      setProjectInnerProvider(settings.inner_provider ?? 'anthropic');
+      setProjectInnerModel(settings.inner_model ?? '');
+      setProjectOuterBackend(settings.outer_backend ?? 'global');
+      setProjectOuterProvider(settings.outer_provider ?? 'anthropic');
+      setProjectOuterModel(settings.outer_model ?? '');
+    } else {
+      setProjectInnerBackend('global');
+      setProjectInnerProvider('anthropic');
+      setProjectInnerModel('');
+      setProjectOuterBackend('global');
+      setProjectOuterProvider('anthropic');
+      setProjectOuterModel('');
+    }
+
+    const [innerStatus, outerStatus] = await Promise.all([
+      getBackendSecretStatus(project.directory, 'inner'),
+      getBackendSecretStatus(project.directory, 'outer'),
+    ]);
+    setProjectInnerCredSet(innerStatus.set);
+    setProjectOuterCredSet(outerStatus.set);
+    setProjectBackendLoaded(true);
+  }, [project, getProjectBackendSettings, getBackendSecretStatus]);
+
+  const loadEffectiveBackend = useCallback(async () => {
+    if (!project) return;
+    const [inner, outer] = await Promise.all([
+      getEffectiveBackend(project.directory, 'inner'),
+      getEffectiveBackend(project.directory, 'outer'),
+    ]);
+    setEffectiveInnerBackend(inner);
+    setEffectiveOuterBackend(outer);
+  }, [project, getEffectiveBackend]);
 
   const loadTicketConfig = useCallback(async () => {
     if (!project) return;
@@ -162,14 +374,34 @@ export function ModelSettingsModal() {
 
   useEffect(() => {
     loadProjectSettings();
+    loadProjectBackendSettings();
+    loadEffectiveBackend();
     loadTicketConfig();
-  }, [loadProjectSettings, loadTicketConfig]);
+  }, [loadProjectSettings, loadProjectBackendSettings, loadEffectiveBackend, loadTicketConfig]);
 
   const handleSaveGlobal = async () => {
     setSaving(true);
     setError(null);
     try {
       await setGlobalModelSettings({ inner_model: globalInner, outer_model: globalOuter });
+      await setGlobalBackendSettings({
+        inner_backend: globalInnerBackend,
+        inner_provider: globalInnerBackend === 'opencode' ? (globalInnerProvider || null) : null,
+        inner_model: globalInnerBackend === 'opencode' ? (globalInnerModel || null) : null,
+        outer_backend: globalOuterBackend,
+        outer_provider: globalOuterBackend === 'opencode' ? (globalOuterProvider || null) : null,
+        outer_model: globalOuterBackend === 'opencode' ? (globalOuterModel || null) : null,
+      });
+      if (globalInnerBackend === 'opencode' && globalInnerCredInput) {
+        await setBackendSecret('global', 'inner', globalInnerCredInput);
+        setGlobalInnerCredInput('');
+        setGlobalInnerCredSet(true);
+      }
+      if (globalOuterBackend === 'opencode' && globalOuterCredInput) {
+        await setBackendSecret('global', 'outer', globalOuterCredInput);
+        setGlobalOuterCredInput('');
+        setGlobalOuterCredSet(true);
+      }
       setGlobalDirty(false);
     } catch (err) {
       setError(String(err));
@@ -188,6 +420,25 @@ export function ModelSettingsModal() {
         outer_model: projectOuter,
       });
       await setDarkFactoryEnabled(project.directory, darkFactoryEnabled);
+      await setProjectBackendSettings(project.directory, {
+        inner_backend: projectInnerBackend,
+        inner_provider: projectInnerBackend === 'opencode' ? (projectInnerProvider || null) : null,
+        inner_model: projectInnerBackend === 'opencode' ? (projectInnerModel || null) : null,
+        outer_backend: projectOuterBackend,
+        outer_provider: projectOuterBackend === 'opencode' ? (projectOuterProvider || null) : null,
+        outer_model: projectOuterBackend === 'opencode' ? (projectOuterModel || null) : null,
+      });
+      if (projectInnerBackend === 'opencode' && projectInnerCredInput) {
+        await setBackendSecret(project.directory, 'inner', projectInnerCredInput);
+        setProjectInnerCredInput('');
+        setProjectInnerCredSet(true);
+      }
+      if (projectOuterBackend === 'opencode' && projectOuterCredInput) {
+        await setBackendSecret(project.directory, 'outer', projectOuterCredInput);
+        setProjectOuterCredInput('');
+        setProjectOuterCredSet(true);
+      }
+      await loadEffectiveBackend();
       setProjectDirty(false);
     } catch (err) {
       setError(String(err));
@@ -262,6 +513,15 @@ export function ModelSettingsModal() {
   const effectiveInner = projectInner === 'global' ? globalInner : projectInner;
   const effectiveOuter = projectOuter === 'global' ? globalOuter : projectOuter;
 
+  function formatEffectiveBackendSummary(eb: { backend: 'claude' | 'opencode'; provider?: string; model?: string } | null, claudeModel: string) {
+    if (!eb) return claudeModel;
+    if (eb.backend === 'claude') return claudeModel;
+    const parts = ['OpenCode'];
+    if (eb.provider) parts.push(eb.provider);
+    if (eb.model) parts.push(eb.model);
+    return parts.join(' / ');
+  }
+
   return (
     <div
       className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in"
@@ -308,99 +568,195 @@ export function ModelSettingsModal() {
 
         {/* Content */}
         <div className="px-6 py-5 space-y-5">
-          {activeTab === 'global' && (
+          {activeTab === 'global' && globalBackendLoaded && (
             <>
               <div>
                 <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
-                  Default Inner Model
+                  Inner Agent Backend
                 </label>
                 <p className="text-[10px] text-sandstorm-muted mb-2">
-                  Model used for stack execution (inner Claude agent)
+                  Backend used for stack execution (inner agent)
                 </p>
-                <div className="flex gap-2">
-                  {INNER_MODEL_OPTIONS.map((m) => (
-                    <ModelButton
-                      key={m.id}
-                      id={m.id}
-                      label={m.label}
-                      desc={m.desc}
-                      selected={globalInner === m.id}
-                      onClick={() => { setGlobalInner(m.id); setGlobalDirty(true); }}
-                      testId={`global-inner-${m.id}`}
-                    />
-                  ))}
-                </div>
+                <BackendSelector
+                  scope="global"
+                  backend={globalInnerBackend}
+                  onBackendChange={(v) => { setGlobalInnerBackend(v); setGlobalDirty(true); }}
+                  provider={globalInnerProvider}
+                  onProviderChange={(v) => { setGlobalInnerProvider(v); setGlobalDirty(true); }}
+                  model={globalInnerModel}
+                  onModelChange={(v) => { setGlobalInnerModel(v); setGlobalDirty(true); }}
+                  credInput={globalInnerCredInput}
+                  onCredInputChange={(v) => { setGlobalInnerCredInput(v); setGlobalDirty(true); }}
+                  credSet={globalInnerCredSet}
+                  testId="global-inner-backend"
+                />
               </div>
+
+              {globalInnerBackend === 'claude' && (
+                <div>
+                  <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
+                    Default Inner Model
+                  </label>
+                  <p className="text-[10px] text-sandstorm-muted mb-2">
+                    Model used for stack execution (inner Claude agent)
+                  </p>
+                  <div className="flex gap-2">
+                    {INNER_MODEL_OPTIONS.map((m) => (
+                      <ModelButton
+                        key={m.id}
+                        id={m.id}
+                        label={m.label}
+                        desc={m.desc}
+                        selected={globalInner === m.id}
+                        onClick={() => { setGlobalInner(m.id); setGlobalDirty(true); }}
+                        testId={`global-inner-${m.id}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
 
               <div>
                 <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
-                  Default Outer Model
+                  Outer Agent Backend
                 </label>
                 <p className="text-[10px] text-sandstorm-muted mb-2">
-                  Model used for orchestration (outer Claude)
+                  Backend used for orchestration (outer agent)
                 </p>
-                <div className="flex gap-2">
-                  {OUTER_MODEL_OPTIONS.map((m) => (
-                    <ModelButton
-                      key={m.id}
-                      id={m.id}
-                      label={m.label}
-                      desc={m.desc}
-                      selected={globalOuter === m.id}
-                      onClick={() => { setGlobalOuter(m.id); setGlobalDirty(true); }}
-                      testId={`global-outer-${m.id}`}
-                    />
-                  ))}
-                </div>
+                <BackendSelector
+                  scope="global"
+                  backend={globalOuterBackend}
+                  onBackendChange={(v) => { setGlobalOuterBackend(v); setGlobalDirty(true); }}
+                  provider={globalOuterProvider}
+                  onProviderChange={(v) => { setGlobalOuterProvider(v); setGlobalDirty(true); }}
+                  model={globalOuterModel}
+                  onModelChange={(v) => { setGlobalOuterModel(v); setGlobalDirty(true); }}
+                  credInput={globalOuterCredInput}
+                  onCredInputChange={(v) => { setGlobalOuterCredInput(v); setGlobalDirty(true); }}
+                  credSet={globalOuterCredSet}
+                  testId="global-outer-backend"
+                />
               </div>
+
+              {globalOuterBackend === 'claude' && (
+                <div>
+                  <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
+                    Default Outer Model
+                  </label>
+                  <p className="text-[10px] text-sandstorm-muted mb-2">
+                    Model used for orchestration (outer Claude)
+                  </p>
+                  <div className="flex gap-2">
+                    {OUTER_MODEL_OPTIONS.map((m) => (
+                      <ModelButton
+                        key={m.id}
+                        id={m.id}
+                        label={m.label}
+                        desc={m.desc}
+                        selected={globalOuter === m.id}
+                        onClick={() => { setGlobalOuter(m.id); setGlobalDirty(true); }}
+                        testId={`global-outer-${m.id}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
             </>
           )}
 
-          {activeTab === 'project' && project && projectLoaded && darkFactoryLoaded && (
+          {activeTab === 'project' && project && projectLoaded && darkFactoryLoaded && projectBackendLoaded && (
             <>
               <div>
                 <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
-                  Inner Model Override
+                  Inner Agent Backend
                 </label>
                 <p className="text-[10px] text-sandstorm-muted mb-2">
-                  Override the global default for this project
+                  Override the global backend for the inner agent
                 </p>
-                <div className="flex gap-2 flex-wrap">
-                  {PROJECT_INNER_OPTIONS.map((m) => (
-                    <ModelButton
-                      key={m.id}
-                      id={m.id}
-                      label={m.label}
-                      desc={m.desc}
-                      selected={projectInner === m.id}
-                      onClick={() => { setProjectInner(m.id); setProjectDirty(true); }}
-                      testId={`project-inner-${m.id}`}
-                    />
-                  ))}
-                </div>
+                <BackendSelector
+                  scope="project"
+                  backend={projectInnerBackend}
+                  onBackendChange={(v) => { setProjectInnerBackend(v); setProjectDirty(true); }}
+                  provider={projectInnerProvider}
+                  onProviderChange={(v) => { setProjectInnerProvider(v); setProjectDirty(true); }}
+                  model={projectInnerModel}
+                  onModelChange={(v) => { setProjectInnerModel(v); setProjectDirty(true); }}
+                  credInput={projectInnerCredInput}
+                  onCredInputChange={(v) => { setProjectInnerCredInput(v); setProjectDirty(true); }}
+                  credSet={projectInnerCredSet}
+                  testId="project-inner-backend"
+                />
               </div>
+
+              {projectInnerBackend !== 'opencode' && (
+                <div>
+                  <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
+                    Inner Model Override
+                  </label>
+                  <p className="text-[10px] text-sandstorm-muted mb-2">
+                    Override the global default for this project
+                  </p>
+                  <div className="flex gap-2 flex-wrap">
+                    {PROJECT_INNER_OPTIONS.map((m) => (
+                      <ModelButton
+                        key={m.id}
+                        id={m.id}
+                        label={m.label}
+                        desc={m.desc}
+                        selected={projectInner === m.id}
+                        onClick={() => { setProjectInner(m.id); setProjectDirty(true); }}
+                        testId={`project-inner-${m.id}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
 
               <div>
                 <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
-                  Outer Model Override
+                  Outer Agent Backend
                 </label>
                 <p className="text-[10px] text-sandstorm-muted mb-2">
-                  Override the global default for this project
+                  Override the global backend for the outer agent
                 </p>
-                <div className="flex gap-2 flex-wrap">
-                  {PROJECT_OUTER_OPTIONS.map((m) => (
-                    <ModelButton
-                      key={m.id}
-                      id={m.id}
-                      label={m.label}
-                      desc={m.desc}
-                      selected={projectOuter === m.id}
-                      onClick={() => { setProjectOuter(m.id); setProjectDirty(true); }}
-                      testId={`project-outer-${m.id}`}
-                    />
-                  ))}
-                </div>
+                <BackendSelector
+                  scope="project"
+                  backend={projectOuterBackend}
+                  onBackendChange={(v) => { setProjectOuterBackend(v); setProjectDirty(true); }}
+                  provider={projectOuterProvider}
+                  onProviderChange={(v) => { setProjectOuterProvider(v); setProjectDirty(true); }}
+                  model={projectOuterModel}
+                  onModelChange={(v) => { setProjectOuterModel(v); setProjectDirty(true); }}
+                  credInput={projectOuterCredInput}
+                  onCredInputChange={(v) => { setProjectOuterCredInput(v); setProjectDirty(true); }}
+                  credSet={projectOuterCredSet}
+                  testId="project-outer-backend"
+                />
               </div>
+
+              {projectOuterBackend !== 'opencode' && (
+                <div>
+                  <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
+                    Outer Model Override
+                  </label>
+                  <p className="text-[10px] text-sandstorm-muted mb-2">
+                    Override the global default for this project
+                  </p>
+                  <div className="flex gap-2 flex-wrap">
+                    {PROJECT_OUTER_OPTIONS.map((m) => (
+                      <ModelButton
+                        key={m.id}
+                        id={m.id}
+                        label={m.label}
+                        desc={m.desc}
+                        selected={projectOuter === m.id}
+                        onClick={() => { setProjectOuter(m.id); setProjectDirty(true); }}
+                        testId={`project-outer-${m.id}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Dark factory toggle */}
               <div>
@@ -435,10 +791,10 @@ export function ModelSettingsModal() {
                 <p className="text-[11px] font-medium text-sandstorm-text-secondary mb-1.5">Effective Models</p>
                 <div className="flex gap-4 text-[11px]">
                   <span className="text-sandstorm-muted">
-                    Inner: <span className="text-sandstorm-text font-medium" data-testid="effective-inner">{effectiveInner}</span>
+                    Inner: <span className="text-sandstorm-text font-medium" data-testid="effective-inner">{formatEffectiveBackendSummary(effectiveInnerBackend, effectiveInner)}</span>
                   </span>
                   <span className="text-sandstorm-muted">
-                    Outer: <span className="text-sandstorm-text font-medium" data-testid="effective-outer">{effectiveOuter}</span>
+                    Outer: <span className="text-sandstorm-text font-medium" data-testid="effective-outer">{formatEffectiveBackendSummary(effectiveOuterBackend, effectiveOuter)}</span>
                   </span>
                 </div>
               </div>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -324,6 +324,15 @@ export interface ModelSettings {
   outer_model: string;
 }
 
+export interface BackendSettings {
+  inner_backend: string;
+  outer_backend: string;
+  inner_provider: string | null;
+  inner_model: string | null;
+  outer_provider: string | null;
+  outer_model: string | null;
+}
+
 export type TicketListError =
   | { reason: 'missing-creds' }
   | { reason: 'http-status'; status: number; body?: string }
@@ -468,6 +477,16 @@ interface AppState {
   getProjectModelSettings: (projectDir: string) => Promise<ModelSettings | null>;
   setProjectModelSettings: (projectDir: string, settings: Partial<ModelSettings>) => Promise<void>;
   removeProjectModelSettings: (projectDir: string) => Promise<void>;
+
+  // Backend settings
+  globalBackendSettings: BackendSettings;
+  refreshGlobalBackendSettings: () => Promise<void>;
+  setGlobalBackendSettings: (settings: Partial<BackendSettings>) => Promise<void>;
+  getProjectBackendSettings: (projectDir: string) => Promise<BackendSettings | null>;
+  setProjectBackendSettings: (projectDir: string, settings: Partial<BackendSettings>) => Promise<void>;
+  getEffectiveBackend: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
+  setBackendSecret: (scope: 'global' | string, surface: 'inner' | 'outer', value: string) => Promise<void>;
+  getBackendSecretStatus: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
 
   // Project ticket config
   getProjectTicketConfig: (projectDir: string) => Promise<ProjectTicketConfig | null>;
@@ -763,6 +782,15 @@ declare global {
         removeProject: (projectDir: string) => Promise<void>;
         getEffective: (projectDir: string) => Promise<ModelSettings>;
       };
+      backendSettings: {
+        getGlobal: () => Promise<BackendSettings>;
+        setGlobal: (settings: Partial<BackendSettings>) => Promise<void>;
+        getProject: (projectDir: string) => Promise<BackendSettings | null>;
+        setProject: (projectDir: string, settings: Partial<BackendSettings>) => Promise<void>;
+        getEffective: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
+        setSecret: (scope: 'global' | string, surface: 'inner' | 'outer', name: string, value: string) => Promise<void>;
+        secretStatus: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
+      };
       projectTicketConfig: {
         get: (projectDir: string) => Promise<ProjectTicketConfig | null>;
         set: (projectDir: string, config: ProjectTicketConfig) => Promise<void>;
@@ -1057,6 +1085,43 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   removeProjectModelSettings: async (projectDir) => {
     await window.sandstorm.modelSettings.removeProject(projectDir);
+  },
+
+  // Backend settings
+  globalBackendSettings: { inner_backend: 'claude', outer_backend: 'claude', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null },
+
+  refreshGlobalBackendSettings: async () => {
+    try {
+      const globalBackendSettings = await window.sandstorm.backendSettings.getGlobal();
+      set({ globalBackendSettings });
+    } catch {
+      // Non-fatal
+    }
+  },
+
+  setGlobalBackendSettings: async (settings) => {
+    await window.sandstorm.backendSettings.setGlobal(settings);
+    await get().refreshGlobalBackendSettings();
+  },
+
+  getProjectBackendSettings: async (projectDir) => {
+    return window.sandstorm.backendSettings.getProject(projectDir);
+  },
+
+  setProjectBackendSettings: async (projectDir, settings) => {
+    await window.sandstorm.backendSettings.setProject(projectDir, settings);
+  },
+
+  getEffectiveBackend: async (projectDir, surface) => {
+    return window.sandstorm.backendSettings.getEffective(projectDir, surface);
+  },
+
+  setBackendSecret: async (scope, surface, value) => {
+    await window.sandstorm.backendSettings.setSecret(scope, surface, 'api_key', value);
+  },
+
+  getBackendSecretStatus: async (scope, surface) => {
+    return window.sandstorm.backendSettings.secretStatus(scope, surface);
   },
 
   // Project ticket config

--- a/tests/unit/components/ModelSettings.test.tsx
+++ b/tests/unit/components/ModelSettings.test.tsx
@@ -18,6 +18,7 @@ describe('ModelSettingsModal', () => {
       activeProjectId: null,
       showModelSettings: true,
       globalModelSettings: { inner_model: 'sonnet', outer_model: 'opus' },
+      globalBackendSettings: { inner_backend: 'claude', outer_backend: 'claude', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null },
     });
   });
 
@@ -33,11 +34,20 @@ describe('ModelSettingsModal', () => {
     expect(screen.getByTestId('model-settings-tab-ticketing')).toBeDefined();
   });
 
-  it('defaults to global tab when no project is active', () => {
+  it('defaults to global tab when no project is active', async () => {
     render(<ModelSettingsModal />);
-    expect(screen.getByTestId('global-inner-auto')).toBeDefined();
-    expect(screen.getByTestId('global-inner-sonnet')).toBeDefined();
-    expect(screen.getByTestId('global-inner-opus')).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-claude')).toBeDefined();
+    });
+  });
+
+  it('shows Claude model buttons on global tab when backend is claude', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-auto')).toBeDefined();
+      expect(screen.getByTestId('global-inner-sonnet')).toBeDefined();
+      expect(screen.getByTestId('global-inner-opus')).toBeDefined();
+    });
   });
 
   it('disables project and ticketing tabs when no project is active', () => {
@@ -59,17 +69,23 @@ describe('ModelSettingsModal', () => {
     expect(useAppStore.getState().showModelSettings).toBe(false);
   });
 
-  it('enables save button when global settings change', () => {
+  it('enables save button when global settings change', async () => {
     render(<ModelSettingsModal />);
     const saveBtn = screen.getByTestId('model-settings-save');
     expect(saveBtn.hasAttribute('disabled')).toBe(true);
 
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-opus')).toBeDefined();
+    });
     fireEvent.click(screen.getByTestId('global-inner-opus'));
     expect(saveBtn.hasAttribute('disabled')).toBe(false);
   });
 
   it('calls setGlobal when saving global settings', async () => {
     render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-opus')).toBeDefined();
+    });
     fireEvent.click(screen.getByTestId('global-inner-opus'));
     fireEvent.click(screen.getByTestId('model-settings-save'));
     await waitFor(() => {
@@ -77,6 +93,160 @@ describe('ModelSettingsModal', () => {
         inner_model: 'opus',
         outer_model: 'opus',
       });
+    });
+  });
+
+  describe('backend selector — global tab', () => {
+    it('shows Claude Code and OpenCode backend options for inner surface', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-claude')).toBeDefined();
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+    });
+
+    it('shows Claude Code and OpenCode backend options for outer surface', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-outer-backend-claude')).toBeDefined();
+        expect(screen.getByTestId('global-outer-backend-opencode')).toBeDefined();
+      });
+    });
+
+    it('defaults to Claude Code for inner and outer', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        const innerClaude = screen.getByTestId('global-inner-backend-claude');
+        expect(innerClaude.className).toContain('sandstorm-accent');
+      });
+    });
+
+    it('hides Claude model buttons and shows OpenCode fields when inner backend is OpenCode', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('global-inner-auto')).toBeNull();
+        expect(screen.queryByTestId('global-inner-sonnet')).toBeNull();
+        expect(screen.queryByTestId('global-inner-opus')).toBeNull();
+        expect(screen.getByTestId('global-inner-backend-opencode-fields')).toBeDefined();
+      });
+    });
+
+    it('shows Claude model buttons and hides OpenCode fields when inner backend is Claude Code', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      // Switch to opencode then back
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      fireEvent.click(screen.getByTestId('global-inner-backend-claude'));
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-auto')).toBeDefined();
+        expect(screen.queryByTestId('global-inner-backend-opencode-fields')).toBeNull();
+      });
+    });
+
+    it('shows provider, model, and credential fields when OpenCode is selected', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-provider')).toBeDefined();
+        expect(screen.getByTestId('global-inner-backend-model')).toBeDefined();
+        expect(screen.getByTestId('global-inner-backend-cred-input')).toBeDefined();
+      });
+    });
+
+    it('credential field does not display stored value — only Set/Not set status', async () => {
+      api.backendSettings.secretStatus.mockResolvedValue({ set: true });
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-cred-status').textContent).toContain('Set');
+        const credInput = screen.getByTestId('global-inner-backend-cred-input') as HTMLInputElement;
+        expect(credInput.value).toBe('');
+      });
+    });
+
+    it('shows Not set status when no credential stored', async () => {
+      api.backendSettings.secretStatus.mockResolvedValue({ set: false });
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-cred-status').textContent).toContain('Not set');
+      });
+    });
+
+    it('calls setGlobal with opencode backend when saving', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      fireEvent.click(screen.getByTestId('model-settings-save'));
+      await waitFor(() => {
+        expect(api.backendSettings.setGlobal).toHaveBeenCalledWith(
+          expect.objectContaining({ inner_backend: 'opencode' }),
+        );
+      });
+    });
+
+    it('calls setSecret with scope=global when credential is entered', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-cred-input')).toBeDefined();
+      });
+      fireEvent.change(screen.getByTestId('global-inner-backend-cred-input'), { target: { value: 'sk-test-key' } });
+      fireEvent.click(screen.getByTestId('model-settings-save'));
+      await waitFor(() => {
+        expect(api.backendSettings.setSecret).toHaveBeenCalledWith('global', 'inner', 'api_key', 'sk-test-key');
+      });
+    });
+
+    it('does not call setSecret when credential input is empty', async () => {
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      // Don't fill cred input
+      fireEvent.click(screen.getByTestId('model-settings-save'));
+      await waitFor(() => {
+        expect(api.backendSettings.setGlobal).toHaveBeenCalled();
+      });
+      expect(api.backendSettings.setSecret).not.toHaveBeenCalled();
+    });
+
+    it('provider change does not clear credential status', async () => {
+      api.backendSettings.secretStatus.mockResolvedValue({ set: true });
+      render(<ModelSettingsModal />);
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+      });
+      fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
+      await waitFor(() => {
+        expect(screen.getByTestId('global-inner-backend-cred-status').textContent).toContain('Set');
+      });
+      // Change provider
+      fireEvent.change(screen.getByTestId('global-inner-backend-provider'), { target: { value: 'openai' } });
+      // Status should still be Set
+      expect(screen.getByTestId('global-inner-backend-cred-status').textContent).toContain('Set');
+      expect(api.backendSettings.setSecret).not.toHaveBeenCalled();
     });
   });
 
@@ -184,6 +354,148 @@ describe('ModelSettingsModal', () => {
         expect(screen.getByTestId('jira-url')).toBeDefined();
         const urlInput = screen.getByTestId('jira-url') as HTMLInputElement;
         expect(urlInput.value).toBe('https://existing.atlassian.net');
+      });
+    });
+
+    describe('backend selector — project tab', () => {
+      it('shows Use Global Default, Claude Code, and OpenCode for project inner backend', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-global')).toBeDefined();
+          expect(screen.getByTestId('project-inner-backend-claude')).toBeDefined();
+          expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
+        });
+      });
+
+      it('shows Use Global Default, Claude Code, and OpenCode for project outer backend', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-outer-backend-global')).toBeDefined();
+          expect(screen.getByTestId('project-outer-backend-claude')).toBeDefined();
+          expect(screen.getByTestId('project-outer-backend-opencode')).toBeDefined();
+        });
+      });
+
+      it('defaults inner and outer to Use Global Default', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          const globalBtn = screen.getByTestId('project-inner-backend-global');
+          expect(globalBtn.className).toContain('sandstorm-accent');
+        });
+      });
+
+      it('hides Claude model buttons and shows OpenCode fields when inner is OpenCode', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
+        });
+        fireEvent.click(screen.getByTestId('project-inner-backend-opencode'));
+        await waitFor(() => {
+          expect(screen.queryByTestId('project-inner-global')).toBeNull();
+          expect(screen.queryByTestId('project-inner-sonnet')).toBeNull();
+          expect(screen.getByTestId('project-inner-backend-opencode-fields')).toBeDefined();
+        });
+      });
+
+      it('restores Claude model buttons when switching back from OpenCode to Claude', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
+        });
+        fireEvent.click(screen.getByTestId('project-inner-backend-opencode'));
+        fireEvent.click(screen.getByTestId('project-inner-backend-claude'));
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-global')).toBeDefined();
+          expect(screen.queryByTestId('project-inner-backend-opencode-fields')).toBeNull();
+        });
+      });
+
+      it('calls setProject with opencode backend when saving', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
+        });
+        fireEvent.click(screen.getByTestId('project-inner-backend-opencode'));
+        fireEvent.click(screen.getByTestId('model-settings-save'));
+        await waitFor(() => {
+          expect(api.backendSettings.setProject).toHaveBeenCalledWith(
+            '/myapp',
+            expect.objectContaining({ inner_backend: 'opencode' }),
+          );
+        });
+      });
+
+      it('calls setSecret with scope=projectDir when credential is entered for project', async () => {
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
+        });
+        fireEvent.click(screen.getByTestId('project-inner-backend-opencode'));
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-cred-input')).toBeDefined();
+        });
+        fireEvent.change(screen.getByTestId('project-inner-backend-cred-input'), { target: { value: 'sk-proj-key' } });
+        fireEvent.click(screen.getByTestId('model-settings-save'));
+        await waitFor(() => {
+          expect(api.backendSettings.setSecret).toHaveBeenCalledWith('/myapp', 'inner', 'api_key', 'sk-proj-key');
+        });
+      });
+
+      it('effective summary uses getEffective result for backend', async () => {
+        api.backendSettings.getEffective.mockResolvedValue({ backend: 'opencode', provider: 'anthropic', model: 'claude-opus' });
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          const inner = screen.getByTestId('effective-inner');
+          expect(inner.textContent).toContain('OpenCode');
+        });
+      });
+
+      it('effective summary shows claude model when backend resolves to claude', async () => {
+        api.backendSettings.getEffective.mockResolvedValue({ backend: 'claude' });
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          const inner = screen.getByTestId('effective-inner');
+          // Should show the claude model (sonnet or opus), not OpenCode
+          expect(inner.textContent).not.toContain('OpenCode');
+        });
+      });
+
+      it('loads existing project backend settings on mount', async () => {
+        api.backendSettings.getProject.mockResolvedValue({
+          inner_backend: 'opencode',
+          outer_backend: 'global',
+          inner_provider: 'openai',
+          inner_model: 'gpt-4',
+          outer_provider: null,
+          outer_model: null,
+        });
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          const openCodeBtn = screen.getByTestId('project-inner-backend-opencode');
+          expect(openCodeBtn.className).toContain('sandstorm-accent');
+        });
+      });
+
+      it('provider change with credential Set does not invoke setSecret or clear status', async () => {
+        api.backendSettings.secretStatus.mockResolvedValue({ set: true });
+        render(<ModelSettingsModal />);
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
+        });
+        fireEvent.click(screen.getByTestId('project-inner-backend-opencode'));
+        await waitFor(() => {
+          expect(screen.getByTestId('project-inner-backend-cred-status').textContent).toContain('Set');
+        });
+        // Change provider
+        fireEvent.change(screen.getByTestId('project-inner-backend-provider'), { target: { value: 'openai' } });
+        // Status unchanged
+        expect(screen.getByTestId('project-inner-backend-cred-status').textContent).toContain('Set');
+        // Save — should not call setSecret (no new cred value entered)
+        fireEvent.click(screen.getByTestId('model-settings-save'));
+        await waitFor(() => {
+          expect(api.backendSettings.setProject).toHaveBeenCalled();
+        });
+        expect(api.backendSettings.setSecret).not.toHaveBeenCalled();
       });
     });
 

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -113,6 +113,15 @@ export function mockSandstormApi() {
       removeProject: vi.fn().mockResolvedValue(undefined),
       getEffective: vi.fn().mockResolvedValue({ inner_model: 'sonnet', outer_model: 'opus' }),
     },
+    backendSettings: {
+      getGlobal: vi.fn().mockResolvedValue({ inner_backend: 'claude', outer_backend: 'claude', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null }),
+      setGlobal: vi.fn().mockResolvedValue(undefined),
+      getProject: vi.fn().mockResolvedValue(null),
+      setProject: vi.fn().mockResolvedValue(undefined),
+      getEffective: vi.fn().mockResolvedValue({ backend: 'claude' }),
+      setSecret: vi.fn().mockResolvedValue(undefined),
+      secretStatus: vi.fn().mockResolvedValue({ set: false }),
+    },
     projectTicketConfig: {
       get: vi.fn().mockResolvedValue(null),
       set: vi.fn().mockResolvedValue(undefined),

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -2843,24 +2843,42 @@ describe('IPC Handlers', () => {
   });
 
   describe('backendSettings:setSecret', () => {
-    it('calls registry.setBackendSecret and returns undefined (write-only)', async () => {
+    it('derives key="global" when scope is "global" and calls registry.setBackendSecret', async () => {
       const result = await invokeHandler('backendSettings:setSecret', 'global', 'inner', 'api_key', 'sk-test');
       expect(mockRegistry.setBackendSecret).toHaveBeenCalledWith('global', 'inner', 'api_key', 'sk-test');
       expect(result).toBeUndefined();
     });
+
+    it('derives key="project:<resolved>" when scope is a projectDir', async () => {
+      const projectDir = '/some/project';
+      const path = require('path');
+      const expectedKey = `project:${path.resolve(projectDir)}`;
+      await invokeHandler('backendSettings:setSecret', projectDir, 'outer', 'api_key', 'sk-proj');
+      expect(mockRegistry.setBackendSecret).toHaveBeenCalledWith(expectedKey, 'outer', 'api_key', 'sk-proj');
+    });
   });
 
   describe('backendSettings:secretStatus', () => {
-    it('returns { set: false } when no secret stored', async () => {
+    it('returns { set: false } when no secret stored (global scope)', async () => {
       mockRegistry.hasBackendSecret.mockReturnValueOnce(false);
       const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner');
       expect(mockRegistry.hasBackendSecret).toHaveBeenCalledWith('global', 'inner');
       expect(result).toEqual({ set: false });
     });
 
-    it('returns { set: true } when secret exists', async () => {
+    it('returns { set: true } when secret exists (global scope)', async () => {
       mockRegistry.hasBackendSecret.mockReturnValueOnce(true);
       const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner');
+      expect(result).toEqual({ set: true });
+    });
+
+    it('derives key="project:<resolved>" for project scope and returns secret status', async () => {
+      const projectDir = '/some/project';
+      const path = require('path');
+      const expectedKey = `project:${path.resolve(projectDir)}`;
+      mockRegistry.hasBackendSecret.mockReturnValueOnce(true);
+      const result = await invokeHandler('backendSettings:secretStatus', projectDir, 'inner');
+      expect(mockRegistry.hasBackendSecret).toHaveBeenCalledWith(expectedKey, 'inner');
       expect(result).toEqual({ set: true });
     });
 


### PR DESCRIPTION
## Summary

Adds a backend selector to the Model Settings modal so users can run the inner and outer agents on either Claude Code or OpenCode, at both the global and per-project scope.

- A new `BackendSelector` lets each surface (inner/outer) choose Claude Code or OpenCode; the project scope also offers "Use Global Default". Selecting OpenCode reveals provider, model, and API-credential fields, while the Claude model buttons collapse away.
- Backend settings are wired through the store (`globalBackendSettings`, project getters/setters, and effective-backend resolution) and surfaced in the "Effective Models" summary, which now reports OpenCode provider/model when that backend resolves.
- Credentials are write-only: the password field never displays a stored secret, only a Set / Not set status, and `setSecret` is called solely when a new value is entered.
- The secret IPC handlers now take a `scope` argument and derive the storage key internally (`global` vs. `project:<resolved-path>`), so callers no longer pass raw keys.

## QA plan

1. Open Model Settings on the Global tab. Confirm inner and outer default to Claude Code and the Claude model buttons show.
2. Switch a surface to OpenCode. Confirm the model buttons hide and provider, model, and API credential fields appear with a "(Not set)" status. Enter a key, save, reopen, and confirm the field is empty but status reads "(Set)".
3. On the Project tab, confirm the extra "Use Global Default" option exists; set inner to OpenCode with a credential, save, and confirm the Effective Models summary reflects the OpenCode provider/model.
4. Change the provider on a surface whose credential is already Set and confirm the status stays "(Set)" and no new secret is written until you type a new value.

Closes #474