### PR TITLE
[548] feat: per-project backlog filter configuration

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -181,6 +181,10 @@ export interface ProjectTicketConfig {
   jira_project_key?: string | null;
   jira_issue_type?: string | null;
   ticket_prefix?: string | null;
+  filter_mode?: 'assisted' | 'advanced' | null;
+  filter_ownership?: 'created' | 'assigned' | null;
+  filter_open_only?: boolean | null;
+  filter_query?: string | null;
 }
 
 export interface SessionMonitorSettingsRecord {
@@ -679,6 +683,15 @@ export class Registry {
       // Mirror selfheal_continue_used in archive so the guard survives archival inspection
       try { this.db.exec('ALTER TABLE stack_history ADD COLUMN selfheal_continue_used INTEGER NOT NULL DEFAULT 0'); } catch { /* exists */ }
       this.setSchemaVersion(23);
+    }
+
+    if (currentVersion < 24) {
+      // Per-project backlog filter config (#548)
+      try { this.db.exec('ALTER TABLE project_ticket_config ADD COLUMN filter_mode TEXT'); } catch { /* exists */ }
+      try { this.db.exec('ALTER TABLE project_ticket_config ADD COLUMN filter_ownership TEXT'); } catch { /* exists */ }
+      try { this.db.exec('ALTER TABLE project_ticket_config ADD COLUMN filter_open_only INTEGER'); } catch { /* exists */ }
+      try { this.db.exec('ALTER TABLE project_ticket_config ADD COLUMN filter_query TEXT'); } catch { /* exists */ }
+      this.setSchemaVersion(24);
     }
   }
 
@@ -1463,8 +1476,8 @@ export class Registry {
   getProjectTicketConfig(projectDir: string): ProjectTicketConfig | null {
     const key = `project:${path.resolve(projectDir)}`;
     const row = this.db.prepare(
-      'SELECT provider, jira_url, jira_username, jira_api_token, jira_project_key, jira_issue_type, ticket_prefix FROM project_ticket_config WHERE key = ?'
-    ).get(key) as Omit<ProjectTicketConfig, 'provider'> & { provider: string } | undefined;
+      'SELECT provider, jira_url, jira_username, jira_api_token, jira_project_key, jira_issue_type, ticket_prefix, filter_mode, filter_ownership, filter_open_only, filter_query FROM project_ticket_config WHERE key = ?'
+    ).get(key) as (Omit<ProjectTicketConfig, 'provider' | 'filter_open_only'> & { provider: string; filter_open_only: number | null }) | undefined;
     if (!row) return null;
     return {
       provider: row.provider as TicketProvider,
@@ -1474,6 +1487,10 @@ export class Registry {
       jira_project_key: row.jira_project_key,
       jira_issue_type: row.jira_issue_type,
       ticket_prefix: row.ticket_prefix,
+      filter_mode: (row.filter_mode as 'assisted' | 'advanced' | null) ?? null,
+      filter_ownership: (row.filter_ownership as 'created' | 'assigned' | null) ?? null,
+      filter_open_only: row.filter_open_only != null ? row.filter_open_only !== 0 : null,
+      filter_query: row.filter_query ?? null,
     };
   }
 
@@ -1481,8 +1498,8 @@ export class Registry {
     const key = `project:${path.resolve(projectDir)}`;
     this.db.prepare(
       `INSERT OR REPLACE INTO project_ticket_config
-        (key, provider, jira_url, jira_username, jira_api_token, jira_project_key, jira_issue_type, ticket_prefix)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        (key, provider, jira_url, jira_username, jira_api_token, jira_project_key, jira_issue_type, ticket_prefix, filter_mode, filter_ownership, filter_open_only, filter_query)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       key,
       config.provider,
@@ -1492,6 +1509,10 @@ export class Registry {
       config.jira_project_key ?? null,
       config.jira_issue_type ?? null,
       config.ticket_prefix ?? null,
+      config.filter_mode ?? null,
+      config.filter_ownership ?? null,
+      config.filter_open_only != null ? (config.filter_open_only ? 1 : 0) : null,
+      config.filter_query ?? null,
     );
   }
 

--- a/src/main/control-plane/ticket-config.ts
+++ b/src/main/control-plane/ticket-config.ts
@@ -106,20 +106,66 @@ export async function githubUpdateTicket(ticketId: string, body: string, cwd: st
   });
 }
 
+type FilterConfig = Pick<
+  import('./registry').ProjectTicketConfig,
+  'filter_mode' | 'filter_ownership' | 'filter_open_only' | 'filter_query'
+>;
+
+function buildGithubSearchQuery(config?: FilterConfig): string {
+  const mode = config?.filter_mode ?? 'assisted';
+  if (mode === 'advanced') {
+    const q = config?.filter_query?.trim();
+    if (q) return q;
+  }
+  const parts: string[] = [];
+  parts.push((config?.filter_ownership ?? 'created') === 'assigned' ? 'assignee:@me' : 'author:@me');
+  if (config?.filter_open_only !== false) parts.push('is:open');
+  return parts.join(' ');
+}
+
+function jiraLabelClause(label: string): string {
+  return ` AND labels = "${label.trim().replace(/"/g, '\\"')}"`;
+}
+
+function buildJiraFilterJql(config: FilterConfig & { jira_project_key?: string | null }): string {
+  const mode = config.filter_mode ?? 'assisted';
+  let jql: string;
+  if (mode === 'advanced' && config.filter_query?.trim()) {
+    // The user's query is wrapped in parens so the AND project clause applies to the whole expression.
+    // Limitation: a query with unmatched/leading-close parens (e.g. "a) OR (b") will break JQL precedence.
+    jql = `(${config.filter_query.trim()})`;
+  } else {
+    const parts: string[] = [];
+    parts.push((config.filter_ownership ?? 'created') === 'assigned'
+      ? 'assignee = currentUser()'
+      : 'reporter = currentUser()');
+    if (config.filter_open_only !== false) parts.push('statusCategory != Done');
+    jql = parts.join(' AND ');
+  }
+  if (config.jira_project_key?.trim()) {
+    const key = config.jira_project_key.trim().replace(/"/g, '\\"');
+    jql += ` AND project = "${key}"`;
+  }
+  return jql;
+}
+
 /**
- * List the authenticated user's open issues for the backlog board.
- * Optionally filter by label. Excludes PRs (gh issue list does so by default).
+ * List issues for the backlog board using gh issue list --search.
+ * Filter config drives ownership and open-only presets, or passes a raw query.
  * Returns { ok: false } on any failure so callers can distinguish empty-success from error.
  */
-export async function githubListTickets(cwd: string, label?: string): Promise<TicketListResult> {
+export async function githubListTickets(cwd: string, label?: string, config?: FilterConfig): Promise<TicketListResult> {
   try {
+    const searchQuery = buildGithubSearchQuery(config);
+    const mode = config?.filter_mode ?? 'assisted';
     const args = [
       'issue', 'list',
-      '--author', '@me',
-      '--state', 'open',
-      '--json', 'number,title,author',
-      '--limit', '100',
+      '--search', searchQuery,
     ];
+    if (mode !== 'advanced' && config?.filter_open_only === false) {
+      args.push('--state', 'all');
+    }
+    args.push('--json', 'number,title,author', '--limit', '100');
     if (label && label.trim()) {
       args.push('--label', label.trim());
     }
@@ -291,8 +337,8 @@ export async function jiraFetchTicket(
 }
 
 /**
- * List the reporting user's not-done issues for the backlog board.
- * Optionally filter by label. Returns { ok: false } on any failure or missing credentials.
+ * List issues for the backlog board using configured filter and always project-scoped.
+ * Returns { ok: false } on any failure or missing credentials.
  */
 export async function jiraListTickets(
   config: ProjectTicketConfig,
@@ -302,9 +348,9 @@ export async function jiraListTickets(
     return { ok: false, error: { reason: 'missing-creds' } };
   }
   try {
-    let jql = 'reporter = currentUser() AND statusCategory != Done';
+    let jql = buildJiraFilterJql(config);
     if (label && label.trim()) {
-      jql += ` AND labels = "${label.trim().replace(/"/g, '\\"')}"`;
+      jql += jiraLabelClause(label);
     }
     const url =
       `${config.jira_url.replace(/\/$/, '')}/rest/api/3/search/jql` +
@@ -491,7 +537,7 @@ export async function listTicketsWithConfig(
   label?: string,
 ): Promise<TicketListResult> {
   if (config.provider === 'github') {
-    return githubListTickets(cwd, label);
+    return githubListTickets(cwd, label, config);
   }
   return jiraListTickets(config, label);
 }
@@ -578,9 +624,14 @@ export async function testJiraConnection(params: {
   jiraUrl: string;
   jiraUsername: string;
   jiraApiToken: string;
+  jiraProjectKey?: string | null;
+  filterMode?: 'assisted' | 'advanced' | null;
+  filterOwnership?: 'created' | 'assigned' | null;
+  filterOpenOnly?: boolean | null;
+  filterQuery?: string | null;
   label?: string;
 }): Promise<TestJiraConnectionResult> {
-  const { jiraUrl, jiraUsername, jiraApiToken, label } = params;
+  const { jiraUrl, jiraUsername, jiraApiToken, jiraProjectKey, label } = params;
   const auth = Buffer.from(`${jiraUsername}:${jiraApiToken}`).toString('base64');
   const baseUrl = jiraUrl.replace(/\/$/, '');
 
@@ -597,9 +648,15 @@ export async function testJiraConnection(params: {
     };
   }
 
-  let jql = 'reporter = currentUser() AND statusCategory != Done';
+  let jql = buildJiraFilterJql({
+    filter_mode: params.filterMode,
+    filter_ownership: params.filterOwnership,
+    filter_open_only: params.filterOpenOnly,
+    filter_query: params.filterQuery,
+    jira_project_key: jiraProjectKey,
+  });
   if (label && label.trim()) {
-    jql += ` AND labels = "${label.trim().replace(/"/g, '\\"')}"`;
+    jql += jiraLabelClause(label);
   }
   const searchUrl =
     `${baseUrl}/rest/api/3/search/jql` +

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1522,6 +1522,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     jiraUrl: string;
     jiraUsername: string;
     jiraApiToken: string;
+    jiraProjectKey?: string | null;
+    filterMode?: 'assisted' | 'advanced' | null;
+    filterOwnership?: 'created' | 'assigned' | null;
+    filterOpenOnly?: boolean | null;
+    filterQuery?: string | null;
     label?: string;
   }) => {
     return testJiraConnection(params);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -235,6 +235,11 @@ export interface SandstormAPI {
       jiraUrl: string;
       jiraUsername: string;
       jiraApiToken: string;
+      jiraProjectKey?: string | null;
+      filterMode?: 'assisted' | 'advanced' | null;
+      filterOwnership?: 'created' | 'assigned' | null;
+      filterOpenOnly?: boolean | null;
+      filterQuery?: string | null;
       label?: string;
     }) => Promise<{
       auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };

--- a/src/renderer/components/ModelSettings.tsx
+++ b/src/renderer/components/ModelSettings.tsx
@@ -96,6 +96,10 @@ export function ModelSettingsModal() {
   const [jiraProjectKey, setJiraProjectKey] = useState('');
   const [jiraIssueType, setJiraIssueType] = useState('');
   const [ticketPrefix, setTicketPrefix] = useState('');
+  const [filterMode, setFilterMode] = useState<'assisted' | 'advanced'>('assisted');
+  const [filterOwnership, setFilterOwnership] = useState<'created' | 'assigned'>('created');
+  const [filterOpenOnly, setFilterOpenOnly] = useState(true);
+  const [filterQuery, setFilterQuery] = useState('');
   const [ticketDirty, setTicketDirty] = useState(false);
   const [ticketLoaded, setTicketLoaded] = useState(false);
 
@@ -147,6 +151,10 @@ export function ModelSettingsModal() {
       setJiraProjectKey(config.jira_project_key ?? '');
       setJiraIssueType(config.jira_issue_type ?? '');
       setTicketPrefix(config.ticket_prefix ?? '');
+      setFilterMode(config.filter_mode ?? 'assisted');
+      setFilterOwnership(config.filter_ownership ?? 'created');
+      setFilterOpenOnly(config.filter_open_only ?? true);
+      setFilterQuery(config.filter_query ?? '');
     } else {
       setTicketProvider('github');
       setJiraUrl('');
@@ -155,6 +163,10 @@ export function ModelSettingsModal() {
       setJiraProjectKey('');
       setJiraIssueType('');
       setTicketPrefix('');
+      setFilterMode('assisted');
+      setFilterOwnership('created');
+      setFilterOpenOnly(true);
+      setFilterQuery('');
     }
     setTicketLoaded(true);
     setTicketDirty(false);
@@ -209,6 +221,10 @@ export function ModelSettingsModal() {
         jira_project_key: ticketProvider === 'jira' ? jiraProjectKey.trim() || null : null,
         jira_issue_type: ticketProvider === 'jira' ? jiraIssueType.trim() || null : null,
         ticket_prefix: ticketPrefix.trim() || null,
+        filter_mode: filterMode,
+        filter_ownership: filterOwnership,
+        filter_open_only: filterOpenOnly,
+        filter_query: filterMode === 'advanced' ? filterQuery.trim() || null : null,
       };
       await setProjectTicketConfig(project.directory, config);
       setTicketDirty(false);
@@ -227,6 +243,11 @@ export function ModelSettingsModal() {
         jiraUrl: jiraUrl.trim(),
         jiraUsername: jiraUsername.trim(),
         jiraApiToken: jiraApiToken.trim(),
+        jiraProjectKey: jiraProjectKey.trim() || null,
+        filterMode,
+        filterOwnership,
+        filterOpenOnly,
+        filterQuery: filterMode === 'advanced' ? filterQuery.trim() || null : null,
       });
       setTestConnResult(result);
       if (!result.auth.ok) {
@@ -458,7 +479,7 @@ export function ModelSettingsModal() {
                   {(['github', 'jira'] as const).map((p) => (
                     <button
                       key={p}
-                      onClick={() => { setTicketProvider(p); setTicketDirty(true); }}
+                      onClick={() => { setTicketProvider(p); setFilterQuery(''); setFilterMode('assisted'); setFilterOwnership('created'); setFilterOpenOnly(true); setTicketDirty(true); }}
                       className={`flex-1 px-3 py-2 text-xs font-medium rounded-lg border transition-all ${
                         ticketProvider === p
                           ? 'border-sandstorm-accent bg-sandstorm-accent/10 text-sandstorm-accent'
@@ -587,6 +608,86 @@ export function ModelSettingsModal() {
                   </div>
                 </div>
               )}
+
+              <div>
+                <label className="block text-xs font-medium text-sandstorm-text-secondary mb-2">
+                  Backlog Filter
+                </label>
+                <p className="text-[10px] text-sandstorm-muted mb-2">
+                  Controls which tickets appear in the backlog board.
+                </p>
+                <div className="flex gap-2 mb-3">
+                  <button
+                    onClick={() => { setFilterMode('assisted'); setTicketDirty(true); }}
+                    className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                      filterMode === 'assisted'
+                        ? 'border-sandstorm-accent bg-sandstorm-accent/10 text-sandstorm-accent'
+                        : 'border-sandstorm-border bg-sandstorm-bg text-sandstorm-muted hover:border-sandstorm-border-light'
+                    }`}
+                    data-testid="ticket-filter-mode-assisted"
+                  >
+                    Assisted
+                  </button>
+                  <button
+                    onClick={() => { setFilterMode('advanced'); setTicketDirty(true); }}
+                    className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                      filterMode === 'advanced'
+                        ? 'border-sandstorm-accent bg-sandstorm-accent/10 text-sandstorm-accent'
+                        : 'border-sandstorm-border bg-sandstorm-bg text-sandstorm-muted hover:border-sandstorm-border-light'
+                    }`}
+                    data-testid="ticket-filter-mode-advanced"
+                  >
+                    Advanced
+                  </button>
+                </div>
+
+                {filterMode === 'assisted' && (
+                  <div className="space-y-2">
+                    <div>
+                      <label className="block text-[11px] font-medium text-sandstorm-text-secondary mb-1">
+                        Ownership
+                      </label>
+                      <select
+                        value={filterOwnership}
+                        onChange={(e) => { setFilterOwnership(e.target.value as 'created' | 'assigned'); setTicketDirty(true); }}
+                        className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
+                        data-testid="ticket-filter-ownership"
+                      >
+                        <option value="created">Created by me</option>
+                        <option value="assigned">Assigned to me</option>
+                      </select>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id="filter-open-only"
+                        checked={filterOpenOnly}
+                        onChange={(e) => { setFilterOpenOnly(e.target.checked); setTicketDirty(true); }}
+                        className="rounded border-sandstorm-border"
+                        data-testid="ticket-filter-open-only"
+                      />
+                      <label htmlFor="filter-open-only" className="text-[11px] text-sandstorm-text-secondary cursor-pointer">
+                        Open only
+                      </label>
+                    </div>
+                  </div>
+                )}
+
+                {filterMode === 'advanced' && (
+                  <div>
+                    <textarea
+                      value={filterQuery}
+                      onChange={(e) => { setFilterQuery(e.target.value); setTicketDirty(true); }}
+                      placeholder={ticketProvider === 'jira'
+                        ? 'JQL query (project clause added automatically)'
+                        : 'GitHub search qualifiers, e.g. assignee:@me is:open'}
+                      rows={3}
+                      className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs font-mono text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent resize-none"
+                      data-testid="ticket-filter-query"
+                    />
+                  </div>
+                )}
+              </div>
 
               <div>
                 <label className="block text-[11px] font-medium text-sandstorm-text-secondary mb-1">

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -348,6 +348,10 @@ export interface ProjectTicketConfig {
   jira_project_key?: string | null;
   jira_issue_type?: string | null;
   ticket_prefix?: string | null;
+  filter_mode?: 'assisted' | 'advanced' | null;
+  filter_ownership?: 'created' | 'assigned' | null;
+  filter_open_only?: boolean | null;
+  filter_query?: string | null;
 }
 
 export { KANBAN_COLUMNS };
@@ -817,6 +821,11 @@ declare global {
           jiraUrl: string;
           jiraUsername: string;
           jiraApiToken: string;
+          jiraProjectKey?: string | null;
+          filterMode?: 'assisted' | 'advanced' | null;
+          filterOwnership?: 'created' | 'assigned' | null;
+          filterOpenOnly?: boolean | null;
+          filterQuery?: string | null;
           label?: string;
         }) => Promise<{
           auth: { ok: true; displayName: string } | { ok: false; status?: number; message: string };

--- a/tests/unit/components/ModelSettings.test.tsx
+++ b/tests/unit/components/ModelSettings.test.tsx
@@ -187,6 +187,143 @@ describe('ModelSettingsModal', () => {
       });
     });
 
+    describe('Backlog filter controls (#548)', () => {
+      beforeEach(async () => {
+        render(<ModelSettingsModal />);
+        fireEvent.click(screen.getByTestId('model-settings-tab-ticketing'));
+        await waitFor(() => {
+          expect(screen.getByTestId('ticket-filter-mode-assisted')).toBeDefined();
+        });
+      });
+
+      it('renders assisted and advanced mode toggle buttons', () => {
+        expect(screen.getByTestId('ticket-filter-mode-assisted')).toBeDefined();
+        expect(screen.getByTestId('ticket-filter-mode-advanced')).toBeDefined();
+      });
+
+      it('shows ownership dropdown and open-only toggle in assisted mode by default', () => {
+        expect(screen.getByTestId('ticket-filter-ownership')).toBeDefined();
+        expect(screen.getByTestId('ticket-filter-open-only')).toBeDefined();
+        expect(screen.queryByTestId('ticket-filter-query')).toBeNull();
+      });
+
+      it('shows advanced textarea and hides assisted controls when advanced is selected', () => {
+        fireEvent.click(screen.getByTestId('ticket-filter-mode-advanced'));
+        expect(screen.getByTestId('ticket-filter-query')).toBeDefined();
+        expect(screen.queryByTestId('ticket-filter-ownership')).toBeNull();
+        expect(screen.queryByTestId('ticket-filter-open-only')).toBeNull();
+      });
+
+      it('saves filter config via setProjectTicketConfig', async () => {
+        const select = screen.getByTestId('ticket-filter-ownership') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'assigned' } });
+        const checkbox = screen.getByTestId('ticket-filter-open-only') as HTMLInputElement;
+        fireEvent.click(checkbox);
+        fireEvent.click(screen.getByTestId('model-settings-save'));
+        await waitFor(() => {
+          expect(api.projectTicketConfig.set).toHaveBeenCalledWith(
+            '/myapp',
+            expect.objectContaining({
+              filter_mode: 'assisted',
+              filter_ownership: 'assigned',
+              filter_open_only: false,
+            }),
+          );
+        });
+      });
+
+      it('saves advanced query when in advanced mode', async () => {
+        fireEvent.click(screen.getByTestId('ticket-filter-mode-advanced'));
+        fireEvent.change(screen.getByTestId('ticket-filter-query'), { target: { value: 'priority = High' } });
+        fireEvent.click(screen.getByTestId('model-settings-save'));
+        await waitFor(() => {
+          expect(api.projectTicketConfig.set).toHaveBeenCalledWith(
+            '/myapp',
+            expect.objectContaining({
+              filter_mode: 'advanced',
+              filter_query: 'priority = High',
+            }),
+          );
+        });
+      });
+
+      it('loads filter config from getProjectTicketConfig on mount', async () => {
+        api.projectTicketConfig.get.mockResolvedValue({
+          provider: 'github',
+          jira_url: null,
+          jira_username: null,
+          jira_api_token: null,
+          jira_project_key: null,
+          jira_issue_type: null,
+          ticket_prefix: null,
+          filter_mode: 'advanced',
+          filter_ownership: 'assigned',
+          filter_open_only: false,
+          filter_query: 'is:open assignee:@me',
+        });
+        // Re-render to trigger load
+        const { unmount } = render(<ModelSettingsModal />);
+        fireEvent.click(screen.getAllByTestId('model-settings-tab-ticketing')[1]);
+        await waitFor(() => {
+          const queryTextarea = screen.getAllByTestId('ticket-filter-query');
+          expect((queryTextarea[queryTextarea.length - 1] as HTMLTextAreaElement).value).toBe('is:open assignee:@me');
+        });
+        unmount();
+      });
+
+      it('clears filter_query and resets filter_mode to assisted when switching provider', async () => {
+        fireEvent.click(screen.getByTestId('ticket-filter-mode-advanced'));
+        fireEvent.change(screen.getByTestId('ticket-filter-query'), { target: { value: 'some query' } });
+        // Switch to Jira and back to GitHub — both should reset
+        fireEvent.click(screen.getByTestId('ticket-provider-jira'));
+        expect(screen.queryByTestId('ticket-filter-query')).toBeNull();
+        expect(screen.getByTestId('ticket-filter-mode-assisted')).toBeDefined();
+        expect(screen.getByTestId('ticket-filter-ownership')).toBeDefined();
+        // Switch back to advanced and confirm the query was actually cleared
+        fireEvent.click(screen.getByTestId('ticket-filter-mode-advanced'));
+        const queryTextarea = screen.getByTestId('ticket-filter-query') as HTMLTextAreaElement;
+        expect(queryTextarea.value).toBe('');
+      });
+
+      it('resets filterOwnership and filterOpenOnly to defaults when switching provider', async () => {
+        const ownershipSelect = screen.getByTestId('ticket-filter-ownership') as HTMLSelectElement;
+        fireEvent.change(ownershipSelect, { target: { value: 'assigned' } });
+        const checkbox = screen.getByTestId('ticket-filter-open-only') as HTMLInputElement;
+        fireEvent.click(checkbox);
+        expect(ownershipSelect.value).toBe('assigned');
+        expect(checkbox.checked).toBe(false);
+        fireEvent.click(screen.getByTestId('ticket-provider-jira'));
+        const ownershipAfter = screen.getByTestId('ticket-filter-ownership') as HTMLSelectElement;
+        expect(ownershipAfter.value).toBe('created');
+        const checkboxAfter = screen.getByTestId('ticket-filter-open-only') as HTMLInputElement;
+        expect(checkboxAfter.checked).toBe(true);
+      });
+
+      it('renders open-only checkbox as unchecked when loaded from config with filter_open_only: false', async () => {
+        api.projectTicketConfig.get.mockResolvedValue({
+          provider: 'github',
+          jira_url: null,
+          jira_username: null,
+          jira_api_token: null,
+          jira_project_key: null,
+          jira_issue_type: null,
+          ticket_prefix: null,
+          filter_mode: 'assisted',
+          filter_ownership: 'created',
+          filter_open_only: false,
+          filter_query: null,
+        });
+        const { unmount } = render(<ModelSettingsModal />);
+        fireEvent.click(screen.getAllByTestId('model-settings-tab-ticketing')[1]);
+        await waitFor(() => {
+          const checkboxes = screen.getAllByTestId('ticket-filter-open-only');
+          const cb = checkboxes[checkboxes.length - 1] as HTMLInputElement;
+          expect(cb.checked).toBe(false);
+        });
+        unmount();
+      });
+    });
+
     describe('Test Connection button (#435)', () => {
       beforeEach(async () => {
         render(<ModelSettingsModal />);

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1382,6 +1382,75 @@ describe('Registry', () => {
     });
   });
 
+  describe('migration v24 — per-project backlog filter columns (#548)', () => {
+    it('adds filter columns to project_ticket_config on a fresh DB', () => {
+      const db = registry.getDb();
+      const cols = (db.prepare('PRAGMA table_info(project_ticket_config)').all() as { name: string }[]).map(r => r.name);
+      expect(cols).toContain('filter_mode');
+      expect(cols).toContain('filter_ownership');
+      expect(cols).toContain('filter_open_only');
+      expect(cols).toContain('filter_query');
+    });
+
+    it('round-trips all four filter fields through set/get', () => {
+      registry.setProjectTicketConfig('/tmp/filter-test', {
+        provider: 'jira',
+        jira_url: 'https://acme.atlassian.net',
+        jira_username: 'user@acme.com',
+        jira_api_token: 'tok',
+        jira_project_key: 'ACME',
+        filter_mode: 'advanced',
+        filter_ownership: 'assigned',
+        filter_open_only: false,
+        filter_query: 'priority = High',
+      });
+      const config = registry.getProjectTicketConfig('/tmp/filter-test');
+      expect(config).not.toBeNull();
+      expect(config!.filter_mode).toBe('advanced');
+      expect(config!.filter_ownership).toBe('assigned');
+      expect(config!.filter_open_only).toBe(false);
+      expect(config!.filter_query).toBe('priority = High');
+    });
+
+    it('returns null for filter fields when columns are NULL (existing rows preserve behavior)', () => {
+      registry.setProjectTicketConfig('/tmp/filter-null-test', {
+        provider: 'github',
+      });
+      const config = registry.getProjectTicketConfig('/tmp/filter-null-test');
+      expect(config).not.toBeNull();
+      expect(config!.filter_mode).toBeNull();
+      expect(config!.filter_ownership).toBeNull();
+      expect(config!.filter_open_only).toBeNull();
+      expect(config!.filter_query).toBeNull();
+    });
+
+    it('round-trips filter_open_only=true correctly (INTEGER 1)', () => {
+      registry.setProjectTicketConfig('/tmp/filter-open-test', {
+        provider: 'github',
+        filter_open_only: true,
+      });
+      const config = registry.getProjectTicketConfig('/tmp/filter-open-test');
+      expect(config!.filter_open_only).toBe(true);
+    });
+
+    it('is idempotent — running migration twice does not error', async () => {
+      const tmpPath = require('path').join(require('os').tmpdir(), `reg-v24-idem-${Date.now()}.db`);
+      try {
+        const r1 = await (await import('../../src/main/control-plane/registry')).Registry.create(tmpPath);
+        r1.close();
+        // Opening a second time re-runs runMigrations — all try/catch so no throw
+        const r2 = await (await import('../../src/main/control-plane/registry')).Registry.create(tmpPath);
+        const cols = (r2.getDb().prepare('PRAGMA table_info(project_ticket_config)').all() as { name: string }[]).map(r => r.name);
+        expect(cols).toContain('filter_mode');
+        r2.close();
+      } finally {
+        try { require('fs').unlinkSync(tmpPath); } catch { /* ok */ }
+        try { require('fs').unlinkSync(tmpPath + '-wal'); } catch { /* ok */ }
+        try { require('fs').unlinkSync(tmpPath + '-shm'); } catch { /* ok */ }
+      }
+    });
+  });
+
   // ==========================================================================
   // Model Routing CRUD
   // ==========================================================================

--- a/tests/unit/ticket-config.test.ts
+++ b/tests/unit/ticket-config.test.ts
@@ -344,15 +344,58 @@ describe('githubListTickets', () => {
     });
   });
 
-  it('invokes gh with @me open-issue args and no label filter by default', async () => {
+  it('uses --search with default assisted preset (author:@me is:open) when no config', async () => {
     mockExecFileSuccess('[]');
     await githubListTickets('/myproj');
     expect(mockExecFile).toHaveBeenCalledWith(
       'gh',
-      ['issue', 'list', '--author', '@me', '--state', 'open', '--json', 'number,title,author', '--limit', '100'],
+      ['issue', 'list', '--search', 'author:@me is:open', '--json', 'number,title,author', '--limit', '100'],
       expect.objectContaining({ cwd: '/myproj' }),
       expect.any(Function),
     );
+  });
+
+  it('uses author:@me is:open when all filter columns are NULL (null defaults)', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: null, filter_ownership: null, filter_open_only: null });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args[args.indexOf('--search') + 1]).toBe('author:@me is:open');
+  });
+
+  it('uses author:@me is:open for assisted created+openOnly', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: 'assisted', filter_ownership: 'created', filter_open_only: true });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args).toContain('--search');
+    expect(args[args.indexOf('--search') + 1]).toBe('author:@me is:open');
+  });
+
+  it('uses assignee:@me is:open for assisted assigned+openOnly', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: 'assisted', filter_ownership: 'assigned', filter_open_only: true });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args[args.indexOf('--search') + 1]).toBe('assignee:@me is:open');
+  });
+
+  it('omits is:open when open-only is false in assisted mode', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: 'assisted', filter_ownership: 'created', filter_open_only: false });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args[args.indexOf('--search') + 1]).toBe('author:@me');
+  });
+
+  it('passes filter_query verbatim in advanced mode', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: 'advanced', filter_query: 'assignee:@me label:bug is:open' });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args[args.indexOf('--search') + 1]).toBe('assignee:@me label:bug is:open');
+  });
+
+  it('falls back to default when advanced mode has empty filter_query', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: 'advanced', filter_query: '' });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args[args.indexOf('--search') + 1]).toBe('author:@me is:open');
   });
 
   it('appends --label when a label is provided', async () => {
@@ -462,6 +505,73 @@ describe('jiraListTickets', () => {
     const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
     expect(opts.path).toMatch(/^\/rest\/api\/3\/search\/jql/);
     expect(opts.path).not.toMatch(/\/rest\/api\/2\/search/);
+  });
+
+  it('always includes project = KEY in JQL when jira_project_key is set (bug regression)', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    await jiraListTickets(JIRA_CONFIG);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    expect(decodeURIComponent(opts.path)).toContain('project = "ACME"');
+  });
+
+  it('omits project clause when jira_project_key is empty', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = { ...JIRA_CONFIG, jira_project_key: null };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    expect(decodeURIComponent(opts.path)).not.toContain('project =');
+  });
+
+  it('uses reporter = currentUser() and statusCategory != Done by default (null filter columns)', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = { ...JIRA_CONFIG, filter_mode: null, filter_ownership: null, filter_open_only: null };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    const jql = decodeURIComponent(opts.path);
+    expect(jql).toContain('reporter = currentUser()');
+    expect(jql).toContain('statusCategory != Done');
+  });
+
+  it('uses assignee = currentUser() in assisted assigned mode', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = { ...JIRA_CONFIG, filter_mode: 'assisted', filter_ownership: 'assigned', filter_open_only: true };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    const jql = decodeURIComponent(opts.path);
+    expect(jql).toContain('assignee = currentUser()');
+    expect(jql).toContain('statusCategory != Done');
+    expect(jql).toContain('project = "ACME"');
+  });
+
+  it('omits statusCategory != Done when open-only is false', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = { ...JIRA_CONFIG, filter_mode: 'assisted', filter_ownership: 'created', filter_open_only: false };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    const jql = decodeURIComponent(opts.path);
+    expect(jql).not.toContain('statusCategory != Done');
+    expect(jql).toContain('reporter = currentUser()');
+  });
+
+  it('wraps custom JQL in parens and appends project key in advanced mode', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = { ...JIRA_CONFIG, filter_mode: 'advanced', filter_query: 'priority = High OR assignee = currentUser()' };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    const jql = decodeURIComponent(opts.path);
+    expect(jql).toContain('(priority = High OR assignee = currentUser())');
+    expect(jql).toContain('AND project = "ACME"');
+  });
+
+  it('falls back to default JQL when advanced mode has empty filter_query', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = { ...JIRA_CONFIG, filter_mode: 'advanced', filter_query: '' };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    const jql = decodeURIComponent(opts.path);
+    expect(jql).toContain('reporter = currentUser()');
+    expect(jql).toContain('statusCategory != Done');
+    expect(jql).toContain('project = "ACME"');
   });
 });
 
@@ -787,6 +897,61 @@ describe('testJiraConnection', () => {
       expect(result.jql.count).toBe(2);
       expect(result.jql.hasMore).toBe(false);
     }
+  });
+
+  it('includes project = KEY in JQL when jiraProjectKey is provided', async () => {
+    let callCount = 0;
+    mockHttpsRequest.mockImplementation((_opts: unknown, callback?: Function) => {
+      callCount++;
+      const body = callCount === 1
+        ? JSON.stringify({ displayName: 'Alice' })
+        : JSON.stringify({ issues: [] });
+      const mockResponse = {
+        statusCode: 200,
+        on: vi.fn((event: string, handler: Function) => {
+          if (event === 'data') handler(body);
+          if (event === 'end') handler();
+        }),
+      };
+      const mockReq = { on: vi.fn().mockReturnThis(), write: vi.fn(), end: vi.fn(), setTimeout: vi.fn().mockReturnThis(), destroy: vi.fn() };
+      if (callback) callback(mockResponse);
+      return mockReq as unknown as ReturnType<typeof https.request>;
+    });
+    await testJiraConnection({
+      jiraUrl: 'https://acme.atlassian.net',
+      jiraUsername: 'user@acme.com',
+      jiraApiToken: 'token',
+      jiraProjectKey: 'ACME',
+    });
+    const searchOpts = mockHttpsRequest.mock.calls[1][0] as { path: string };
+    expect(decodeURIComponent(searchOpts.path)).toContain('project = "ACME"');
+  });
+
+  it('omits project clause from JQL when jiraProjectKey is not provided', async () => {
+    let callCount = 0;
+    mockHttpsRequest.mockImplementation((_opts: unknown, callback?: Function) => {
+      callCount++;
+      const body = callCount === 1
+        ? JSON.stringify({ displayName: 'Alice' })
+        : JSON.stringify({ issues: [] });
+      const mockResponse = {
+        statusCode: 200,
+        on: vi.fn((event: string, handler: Function) => {
+          if (event === 'data') handler(body);
+          if (event === 'end') handler();
+        }),
+      };
+      const mockReq = { on: vi.fn().mockReturnThis(), write: vi.fn(), end: vi.fn(), setTimeout: vi.fn().mockReturnThis(), destroy: vi.fn() };
+      if (callback) callback(mockResponse);
+      return mockReq as unknown as ReturnType<typeof https.request>;
+    });
+    await testJiraConnection({
+      jiraUrl: 'https://acme.atlassian.net',
+      jiraUsername: 'user@acme.com',
+      jiraApiToken: 'token',
+    });
+    const searchOpts = mockHttpsRequest.mock.calls[1][0] as { path: string };
+    expect(decodeURIComponent(searchOpts.path)).not.toContain('project =');
   });
 
   it('sets hasMore:true when response contains nextPageToken', async () => {


### PR DESCRIPTION
## Summary

Adds a configurable backlog filter to each project's ticket settings, controlling which tickets appear on the backlog board for both GitHub and Jira providers.

A new "Backlog Filter" section in the project ticket settings offers two modes:

- **Assisted** — pick ownership (created by me / assigned to me) and toggle open-only. These presets are translated into the right `gh issue list --search` qualifiers (`author:@me`/`assignee:@me`, `is:open`) or Jira JQL (`reporter`/`assignee = currentUser()`, `statusCategory != Done`).
- **Advanced** — supply a raw GitHub search string or JQL expression. For Jira the project clause is appended automatically; the user's query is wrapped in parens so the `AND project` clause applies to the whole expression.

The config (`filter_mode`, `filter_ownership`, `filter_open_only`, `filter_query`) is persisted per project via a schema v24 migration that adds the four columns to `project_ticket_config`, and is wired through the registry, IPC, preload, and renderer store. Switching providers resets the filter to assisted defaults. The Jira connection test now also accepts these filter params (camelCase across the IPC boundary, snake_case for the DB columns) so the configured filter is validated when testing.

## QA plan

1. Open a project's ticket settings, choose the GitHub provider, and confirm the new Backlog Filter section appears.
2. In Assisted mode, set ownership to "Assigned to me" and uncheck "Open only"; save, reopen settings, and confirm the choices persisted.
3. Verify the backlog board now lists issues matching that filter (assigned to you, including closed).
4. Switch to Advanced mode, enter a GitHub search string (e.g. `author:@me is:open label:bug`), save, and confirm the board reflects it.
5. Switch the provider to Jira and confirm the filter resets to Assisted / Created by me / Open only.
6. In Jira Advanced mode, enter a JQL fragment, run the connection test, and confirm it succeeds and the project clause is applied automatically.
7. Toggle between Assisted and Advanced and confirm the relevant inputs show/hide and the dirty/save state behaves correctly.

Closes #548