### PR TITLE
[531] feat: project config modal shell with pane registry

### DIFF
--- a/src/renderer/components/ProjectConfigModal.tsx
+++ b/src/renderer/components/ProjectConfigModal.tsx
@@ -1,0 +1,172 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { ConfigPane } from './config/types';
+
+interface ProjectConfigModalProps {
+  open: boolean;
+  title: string;
+  subtitle?: string;
+  panes: ConfigPane[];
+  initialPaneId?: string;
+  onClose: () => void;
+  onSave: () => void;
+  saving?: boolean;
+  dirty?: boolean;
+}
+
+function resolveInitialPane(panes: ConfigPane[], initialPaneId?: string): string | null {
+  const enabled = panes.filter((p) => !p.disabled);
+  if (enabled.length === 0) return null;
+
+  if (initialPaneId) {
+    const target = panes.find((p) => p.id === initialPaneId);
+    if (target && !target.disabled) return target.id;
+  }
+
+  return enabled[0].id;
+}
+
+export function ProjectConfigModal({
+  open,
+  title,
+  subtitle,
+  panes,
+  initialPaneId,
+  onClose,
+  onSave,
+  saving = false,
+  dirty = false,
+}: ProjectConfigModalProps) {
+  const [activePaneId, setActivePaneId] = useState<string | null>(() =>
+    resolveInitialPane(panes, initialPaneId)
+  );
+
+  useEffect(() => {
+    setActivePaneId(resolveInitialPane(panes, initialPaneId));
+  }, [panes, initialPaneId]);
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose]
+  );
+
+  const handlePaneClick = useCallback(
+    (pane: ConfigPane) => {
+      if (!pane.disabled) setActivePaneId(pane.id);
+    },
+    []
+  );
+
+  if (!open) return null;
+
+  const activePane = panes.find((p) => p.id === activePaneId);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in"
+      onClick={handleOverlayClick}
+      onKeyDown={handleKeyDown}
+      data-testid="project-config-modal-overlay"
+    >
+      <div
+        className="bg-sandstorm-surface border border-sandstorm-border rounded-xl w-[720px] max-h-[90vh] shadow-dialog animate-slide-up flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        data-testid="project-config-modal"
+      >
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-sandstorm-border flex-shrink-0">
+          <h2 className="text-base font-semibold text-sandstorm-text">{title}</h2>
+          {subtitle && (
+            <p className="text-xs text-sandstorm-muted mt-0.5">{subtitle}</p>
+          )}
+        </div>
+
+        {/* Body: left rail + content */}
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          {/* Left rail */}
+          <nav
+            className="w-44 flex-shrink-0 border-r border-sandstorm-border py-3 flex flex-col gap-0.5 px-2"
+            data-testid="project-config-rail"
+          >
+            {panes.map((pane) => {
+              const isActive = pane.id === activePaneId;
+              const isDisabled = !!pane.disabled;
+              return (
+                <button
+                  key={pane.id}
+                  onClick={() => handlePaneClick(pane)}
+                  disabled={isDisabled}
+                  aria-disabled={isDisabled}
+                  aria-pressed={isActive}
+                  data-testid={`config-rail-item-${pane.id}`}
+                  className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all w-full text-left ${
+                    isDisabled
+                      ? 'text-sandstorm-muted/40 cursor-not-allowed'
+                      : isActive
+                        ? 'bg-sandstorm-accent/10 text-sandstorm-accent'
+                        : 'text-sandstorm-text-secondary hover:bg-sandstorm-surface-hover hover:text-sandstorm-text'
+                  }`}
+                >
+                  <span className="flex-shrink-0">{pane.icon}</span>
+                  <span className="flex-1 truncate">{pane.label}</span>
+                  {pane.badge && (
+                    <span className="ml-auto text-[10px] bg-sandstorm-accent/20 text-sandstorm-accent rounded-full px-1.5 py-0.5 leading-none flex-shrink-0">
+                      {pane.badge}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+
+          {/* Content area */}
+          <div
+            className="flex-1 overflow-y-auto px-6 py-5"
+            data-testid="project-config-content"
+          >
+            {activePane ? activePane.render() : null}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-sandstorm-border flex items-center justify-end gap-3 flex-shrink-0">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-xs font-medium rounded-lg border border-sandstorm-border text-sandstorm-text-secondary hover:text-sandstorm-text hover:border-sandstorm-border-light transition-all"
+            data-testid="project-config-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSave}
+            disabled={!dirty || saving}
+            className={`px-4 py-2 text-xs font-medium rounded-lg transition-all flex items-center gap-2 ${
+              dirty && !saving
+                ? 'bg-sandstorm-accent text-sandstorm-bg hover:bg-sandstorm-accent/90'
+                : 'bg-sandstorm-accent/30 text-sandstorm-muted cursor-not-allowed'
+            }`}
+            data-testid="project-config-save"
+          >
+            {saving && (
+              <span
+                className="w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin"
+                data-testid="project-config-save-spinner"
+              />
+            )}
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/config/panes.tsx
+++ b/src/renderer/components/config/panes.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ConfigPane } from './types';
+
+export const configPanes: ConfigPane[] = [
+  {
+    id: 'models',
+    label: 'Models',
+    icon: <span className="text-sm">⚙</span>,
+    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+  },
+  {
+    id: 'providers',
+    label: 'Providers',
+    icon: <span className="text-sm">🔌</span>,
+    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+  },
+  {
+    id: 'automation',
+    label: 'Automation',
+    icon: <span className="text-sm">⚡</span>,
+    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+  },
+  {
+    id: 'ticketing',
+    label: 'Ticketing',
+    icon: <span className="text-sm">🎫</span>,
+    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+  },
+];

--- a/src/renderer/components/config/types.ts
+++ b/src/renderer/components/config/types.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+export interface ConfigPane {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  badge?: string;
+  disabled?: boolean;
+  render: () => ReactNode;
+}

--- a/tests/unit/components/ProjectConfigModal.test.tsx
+++ b/tests/unit/components/ProjectConfigModal.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
+
+import { ProjectConfigModal } from '../../../src/renderer/components/ProjectConfigModal';
+import { configPanes } from '../../../src/renderer/components/config/panes';
+import { ConfigPane } from '../../../src/renderer/components/config/types';
+
+function makePane(id: string, label: string, disabled?: boolean): ConfigPane {
+  return {
+    id,
+    label,
+    icon: <span>{label[0]}</span>,
+    disabled,
+    render: () => <div data-testid={`pane-content-${id}`}>{label} content</div>,
+  };
+}
+
+const defaultProps = {
+  open: true,
+  title: 'Settings',
+  onClose: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe('ProjectConfigModal', () => {
+  it('renders rail items from panes array', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} />);
+    expect(screen.getByTestId('config-rail-item-alpha')).toBeDefined();
+    expect(screen.getByTestId('config-rail-item-beta')).toBeDefined();
+  });
+
+  it('renders first enabled pane content by default', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} />);
+    expect(screen.getByTestId('pane-content-alpha')).toBeDefined();
+  });
+
+  it('clicking a rail item switches the active pane', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} />);
+    fireEvent.click(screen.getByTestId('config-rail-item-beta'));
+    expect(screen.getByTestId('pane-content-beta')).toBeDefined();
+  });
+
+  it('honors initialPaneId when it names an enabled pane', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} initialPaneId="beta" />);
+    expect(screen.getByTestId('pane-content-beta')).toBeDefined();
+  });
+
+  it('falls back to first enabled pane when initialPaneId is not in panes', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} initialPaneId="nonexistent" />);
+    expect(screen.getByTestId('pane-content-alpha')).toBeDefined();
+  });
+
+  it('falls back to first enabled pane when initialPaneId names a disabled pane', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta', true)];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} initialPaneId="beta" />);
+    expect(screen.getByTestId('pane-content-alpha')).toBeDefined();
+  });
+
+  it('renders disabled rail item as aria-disabled and non-interactive', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta', true)];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} />);
+    const betaItem = screen.getByTestId('config-rail-item-beta');
+    expect(betaItem.getAttribute('aria-disabled')).toBe('true');
+    expect((betaItem as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('clicking a disabled rail item does not switch panes', () => {
+    const panes = [makePane('alpha', 'Alpha'), makePane('beta', 'Beta', true)];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} />);
+    fireEvent.click(screen.getByTestId('config-rail-item-beta'));
+    expect(screen.getByTestId('pane-content-alpha')).toBeDefined();
+  });
+
+  it('renders without crashing when all panes are disabled', () => {
+    const panes = [makePane('alpha', 'Alpha', true), makePane('beta', 'Beta', true)];
+    expect(() =>
+      render(<ProjectConfigModal {...defaultProps} panes={panes} />)
+    ).not.toThrow();
+    expect(screen.getByTestId('project-config-content')).toBeDefined();
+  });
+
+  it('renders without crashing with empty panes array', () => {
+    expect(() =>
+      render(<ProjectConfigModal {...defaultProps} panes={[]} />)
+    ).not.toThrow();
+    expect(screen.getByTestId('project-config-content')).toBeDefined();
+  });
+
+  it('Save button is disabled when dirty is false', () => {
+    const panes = [makePane('alpha', 'Alpha')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} dirty={false} />);
+    const save = screen.getByTestId('project-config-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it('Save button is enabled when dirty is true', () => {
+    const panes = [makePane('alpha', 'Alpha')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} dirty={true} />);
+    const save = screen.getByTestId('project-config-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+  });
+
+  it('calls onSave when Save is clicked and dirty', () => {
+    const onSave = vi.fn();
+    const panes = [makePane('alpha', 'Alpha')];
+    render(
+      <ProjectConfigModal {...defaultProps} panes={panes} dirty={true} onSave={onSave} />
+    );
+    fireEvent.click(screen.getByTestId('project-config-save'));
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it('shows spinner when saving', () => {
+    const panes = [makePane('alpha', 'Alpha')];
+    render(
+      <ProjectConfigModal {...defaultProps} panes={panes} dirty={true} saving={true} />
+    );
+    expect(screen.getByTestId('project-config-save-spinner')).toBeDefined();
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn();
+    const panes = [makePane('alpha', 'Alpha')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('project-config-cancel'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when overlay backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const panes = [makePane('alpha', 'Alpha')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('project-config-modal-overlay'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    const panes = [makePane('alpha', 'Alpha')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} onClose={onClose} />);
+    fireEvent.keyDown(screen.getByTestId('project-config-modal-overlay'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders nothing when open is false', () => {
+    const panes = [makePane('alpha', 'Alpha')];
+    render(<ProjectConfigModal {...defaultProps} panes={panes} open={false} />);
+    expect(screen.queryByTestId('project-config-modal')).toBeNull();
+  });
+});
+
+describe('configPanes registry', () => {
+  it('exports exactly four panes in order: models, providers, automation, ticketing', () => {
+    expect(configPanes).toHaveLength(4);
+    expect(configPanes.map((p) => p.id)).toEqual([
+      'models',
+      'providers',
+      'automation',
+      'ticketing',
+    ]);
+  });
+
+  it('shell renders with configPanes registry without crashing', () => {
+    expect(() =>
+      render(
+        <ProjectConfigModal
+          open={true}
+          title="Config"
+          panes={configPanes}
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+        />
+      )
+    ).not.toThrow();
+    expect(screen.getByTestId('project-config-modal')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable project configuration modal shell with a left sidebar of config panes, built as a presentational (Electron-free) component so future panes can plug in without touching the shell.

- `ProjectConfigModal` renders a sidebar rail of panes from an ordered registry, tracks the active pane (with `initialPaneId` falling back to the first enabled pane), and supports overlay-click and Escape to close. The footer has Cancel and Save buttons, with Save disabled unless `dirty` and showing a spinner while `saving`. Disabled panes are grayed out, non-clickable, and marked `aria-disabled`.
- `config/types.ts` defines the `ConfigPane` contract (`id`, `label`, `icon`, optional `badge`/`disabled`, `render`).
- `config/panes.tsx` registers four stub panes (models, providers, automation, ticketing) with "Coming soon" placeholders to be filled in by follow-up tickets.

The shell uses existing skin tokens (`bg-sandstorm-surface`, `border-sandstorm-border`, `shadow-dialog`, `animate-slide-up`) for visual consistency. No existing files are modified; the component is exported but not yet mounted in the app UI, per scope. Covered by 20 new unit tests.

## QA plan

The modal is not yet wired into the app, so validation is done by rendering it in isolation (e.g. temporarily mounting `<ProjectConfigModal open onClose={...} />` in a dev view or Storybook-style harness):

1. Open the modal and confirm the sidebar lists Models, Providers, Automation, and Ticketing, with the first enabled pane active by default.
2. Click each enabled pane and confirm the content area switches to its "Coming soon" placeholder; confirm disabled panes are grayed out and do not respond to clicks.
3. Pass an `initialPaneId` and confirm that pane is active on open; pass an id for a disabled/unknown pane and confirm it falls back to the first enabled pane.
4. Press Escape and click the overlay backdrop — both should close the modal; clicking inside the dialog should not.
5. Confirm Save is disabled when `dirty` is false, enabled when `dirty` is true, and shows a spinner with the button disabled while `saving`.
6. Verify the modal's surface, border, and slide-up animation match other dialogs in the app.

Closes #531