### PR TITLE
[533] fix: models pane badge, async pane build, stale closure

### DIFF
--- a/src/renderer/components/config/ModelsPane.tsx
+++ b/src/renderer/components/config/ModelsPane.tsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  TOUCHPOINTS,
+  TouchpointId,
+  PRESETS,
+  PresetId,
+  AvailableModel,
+  RoutingAssignment,
+} from '../../../main/control-plane/routing';
+import { ConfigPane, ConfigPaneContext } from './types';
+
+const TOUCHPOINT_META: Record<TouchpointId, { label: string; description: string }> = {
+  outer: { label: 'Outer orchestrator', description: 'Drives the chat session, plans & dispatches' },
+  refine: { label: 'Refine', description: 'Turns a ticket into a detailed spec' },
+  execution: { label: 'Execution', description: 'Inner worker that writes the code' },
+  review: { label: 'Review', description: 'Reviews the diff for bugs & quality' },
+  meta_review: { label: 'Meta-review', description: 'Final gate; reviews the reviewer' },
+  merge_conflict: { label: 'Merge conflicts', description: 'Resolves rebase / merge conflicts' },
+  pr_description: { label: 'PR description', description: 'Writes the PR title & body' },
+};
+
+const PRESET_META: Record<PresetId, { title: string; costHint: string; description: string }> = {
+  max_quality: {
+    title: 'Max quality',
+    costHint: '~$0.90 / ticket',
+    description: 'Opus everywhere reasoning matters. Best results, highest cost.',
+  },
+  balanced: {
+    title: 'Balanced',
+    costHint: '~$0.42 / ticket',
+    description: 'Opus for review & orchestration, Sonnet for execution, Haiku for cheap steps.',
+  },
+  budget: {
+    title: 'Budget',
+    costHint: '~$0.11 / ticket',
+    description: 'Haiku & local/open models wherever they hold up. Cheapest.',
+  },
+};
+
+const PRESET_ORDER: PresetId[] = ['max_quality', 'balanced', 'budget'];
+
+type BufferedState = {
+  preset: PresetId | null;
+  assignments: Partial<Record<TouchpointId, RoutingAssignment>>;
+};
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function computeBadge(buffered: BufferedState): string | undefined {
+  const overrideCount = Object.keys(buffered.assignments).length;
+  if (buffered.preset !== null) {
+    const title = PRESET_META[buffered.preset].title;
+    if (overrideCount > 0) {
+      return `${title} · ${overrideCount} override${overrideCount === 1 ? '' : 's'}`;
+    }
+    return title;
+  }
+  if (overrideCount > 0) {
+    return 'Custom';
+  }
+  return undefined;
+}
+
+interface ModelsPaneBodyProps {
+  ctx: ConfigPaneContext;
+}
+
+function ModelsPaneBody({ ctx }: ModelsPaneBodyProps) {
+  const { projectDir, routing, onDirtyChange, registerSave } = ctx;
+
+  const [baseline, setBaseline] = useState<BufferedState>({ preset: null, assignments: {} });
+  const [buffered, setBuffered] = useState<BufferedState>({ preset: null, assignments: {} });
+  const [customize, setCustomize] = useState(false);
+  const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
+  const [effectiveRouting, setEffectiveRouting] = useState<Record<string, { backend: string; model: string }>>({});
+
+  const bufferedRef = useRef(buffered);
+  bufferedRef.current = buffered;
+  const baselineRef = useRef(baseline);
+  baselineRef.current = baseline;
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const [projectConfig, models, effective] = await Promise.all([
+        routing.getProject(projectDir),
+        routing.getAvailableModels(projectDir),
+        routing.getEffective(projectDir),
+      ]);
+      if (cancelled) return;
+      const initial: BufferedState = projectConfig
+        ? {
+            preset: (projectConfig.preset as PresetId | null),
+            assignments: (projectConfig.assignments as Partial<Record<TouchpointId, RoutingAssignment>>),
+          }
+        : { preset: null, assignments: {} };
+      setBaseline(initial);
+      setBuffered(initial);
+      setAvailableModels(models as AvailableModel[]);
+      setEffectiveRouting(effective);
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [projectDir]);
+
+  useEffect(() => {
+    registerSave(async () => {
+      const current = bufferedRef.current;
+      await routing.setProject(projectDir, {
+        preset: current.preset,
+        assignments: current.assignments,
+      });
+      setBaseline({ ...current });
+    });
+  }, [projectDir]);
+
+  useEffect(() => {
+    onDirtyChange(!deepEqual(buffered, baseline));
+  }, [buffered, baseline]);
+
+  function handlePresetClick(presetId: PresetId) {
+    setBuffered({ preset: presetId, assignments: {} });
+  }
+
+  function handleToggleCustomize() {
+    setCustomize((v) => !v);
+  }
+
+  function getDisplayAssignment(touchpoint: TouchpointId): { backend: string; model: string } | null {
+    if (buffered.preset !== null && PRESETS[buffered.preset]) {
+      return PRESETS[buffered.preset][touchpoint];
+    }
+    return effectiveRouting[touchpoint] ?? null;
+  }
+
+  function handleRowChange(touchpoint: TouchpointId, backend: string, model: string) {
+    const display = getDisplayAssignment(touchpoint);
+    const isPresetValue =
+      buffered.preset !== null &&
+      display?.backend === backend &&
+      display?.model === model;
+
+    if (isPresetValue) {
+      setBuffered((prev) => {
+        const next = { ...prev.assignments };
+        delete next[touchpoint];
+        return { ...prev, assignments: next };
+      });
+    } else {
+      setBuffered((prev) => ({
+        ...prev,
+        assignments: {
+          ...prev.assignments,
+          [touchpoint]: { backend: backend as 'claude' | 'opencode', model },
+        },
+      }));
+    }
+  }
+
+  const ccModels = availableModels.filter((m) => m.backend === 'claude');
+  const ocModels = availableModels.filter((m) => m.backend === 'opencode');
+  const hasOC = ocModels.length > 0;
+  const overrideCount = Object.keys(buffered.assignments).length;
+
+  return (
+    <div className="space-y-6" data-testid="models-pane">
+      {/* Preset cards */}
+      <div>
+        <h3 className="text-xs font-semibold text-sandstorm-text-secondary uppercase tracking-wide mb-3">
+          Preset
+        </h3>
+        <div className="grid grid-cols-3 gap-3" data-testid="preset-cards">
+          {PRESET_ORDER.map((presetId) => {
+            const meta = PRESET_META[presetId];
+            const isActive = buffered.preset === presetId;
+            return (
+              <button
+                key={presetId}
+                onClick={() => handlePresetClick(presetId)}
+                data-testid={`preset-card-${presetId}`}
+                className={`text-left p-3 rounded-lg border transition-all ${
+                  isActive
+                    ? 'border-sandstorm-accent bg-sandstorm-accent/10 text-sandstorm-text'
+                    : 'border-sandstorm-border hover:border-sandstorm-border-light text-sandstorm-text-secondary hover:text-sandstorm-text'
+                }`}
+              >
+                <div className="text-xs font-semibold mb-0.5">{meta.title}</div>
+                <div className="text-[10px] text-sandstorm-muted mb-1">{meta.costHint}</div>
+                <div className="text-[10px] leading-tight">{meta.description}</div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Customize per step toggle */}
+      <div>
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-xs font-semibold text-sandstorm-text">Customize per step</div>
+            <div className="text-[10px] text-sandstorm-muted mt-0.5">
+              Override individual touchpoints on top of the preset.
+            </div>
+          </div>
+          <button
+            role="switch"
+            aria-checked={customize}
+            onClick={handleToggleCustomize}
+            data-testid="customize-toggle"
+            className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${
+              customize ? 'bg-sandstorm-accent' : 'bg-sandstorm-border'
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                customize ? 'translate-x-4' : 'translate-x-0'
+              }`}
+            />
+          </button>
+        </div>
+
+        {!customize && overrideCount > 0 && (
+          <div
+            className="mt-2 text-[10px] text-sandstorm-muted"
+            data-testid="overrides-hidden-hint"
+          >
+            {overrideCount} override{overrideCount === 1 ? '' : 's'} hidden
+          </div>
+        )}
+      </div>
+
+      {/* Touchpoint rows */}
+      {customize && (
+        <div data-testid="touchpoint-rows">
+          <h3 className="text-xs font-semibold text-sandstorm-text-secondary uppercase tracking-wide mb-3">
+            Per-step model
+          </h3>
+          <div className="space-y-2">
+            {TOUCHPOINTS.map((touchpoint) => {
+              const meta = TOUCHPOINT_META[touchpoint];
+              const isOverridden = touchpoint in buffered.assignments;
+              const current = isOverridden
+                ? buffered.assignments[touchpoint]!
+                : (getDisplayAssignment(touchpoint) ?? { backend: 'claude', model: 'auto' });
+
+              // Build the list of models including any unknown stored model
+              const storedInCatalog =
+                !isOverridden ||
+                availableModels.some(
+                  (m) =>
+                    m.backend === current.backend && m.model === current.model
+                );
+
+              return (
+                <div
+                  key={touchpoint}
+                  className="flex items-center gap-3 py-2"
+                  data-testid={`touchpoint-row-${touchpoint}`}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs font-medium text-sandstorm-text">
+                      {meta.label}
+                    </div>
+                    <div className="text-[10px] text-sandstorm-muted truncate">
+                      {meta.description}
+                    </div>
+                  </div>
+                  {isOverridden && (
+                    <span
+                      className="text-[9px] px-1.5 py-0.5 rounded-full bg-sandstorm-accent/20 text-sandstorm-accent font-medium flex-shrink-0"
+                      data-testid={`override-badge-${touchpoint}`}
+                    >
+                      overridden
+                    </span>
+                  )}
+                  <select
+                    value={`${current.backend}:${current.model}`}
+                    onChange={(e) => {
+                      const [b, m] = e.target.value.split(':');
+                      handleRowChange(touchpoint, b, m);
+                    }}
+                    data-testid={`model-select-${touchpoint}`}
+                    className="text-xs bg-sandstorm-surface border border-sandstorm-border rounded-lg px-2 py-1 text-sandstorm-text flex-shrink-0 max-w-[180px]"
+                  >
+                    {/* Unknown stored model not in catalog */}
+                    {isOverridden && !storedInCatalog && (
+                      <option
+                        value={`${current.backend}:${current.model}`}
+                        disabled
+                        data-testid={`unknown-model-${touchpoint}`}
+                      >
+                        unknown ({current.model})
+                      </option>
+                    )}
+
+                    {/* Claude Code group */}
+                    {ccModels.length > 0 && (
+                      <optgroup label="Claude Code" data-testid={`optgroup-claude-${touchpoint}`}>
+                        {ccModels.map((m) => (
+                          <option
+                            key={`claude:${m.model}`}
+                            value={`claude:${m.model}`}
+                            disabled={!m.available}
+                          >
+                            {m.label} ({m.version}){!m.available ? ' — unavailable' : ''}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+
+                    {/* OpenCode group — hidden when no OC models */}
+                    {hasOC && (
+                      <optgroup label="OpenCode" data-testid={`optgroup-opencode-${touchpoint}`}>
+                        {ocModels.map((m) => (
+                          <option
+                            key={`opencode:${m.model}`}
+                            value={`opencode:${m.model}`}
+                            disabled={!m.available}
+                            title={
+                              !m.available
+                                ? 'Enable the OpenCode backend — #472'
+                                : undefined
+                            }
+                          >
+                            {m.label} ({m.version}){!m.available ? ' — unavailable' : ''}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export async function buildModelsPane(ctx: ConfigPaneContext): Promise<ConfigPane> {
+  const projectConfig = await ctx.routing.getProject(ctx.projectDir);
+  const initial: BufferedState = projectConfig
+    ? {
+        preset: (projectConfig.preset as PresetId | null),
+        assignments: (projectConfig.assignments as Partial<Record<TouchpointId, RoutingAssignment>>),
+      }
+    : { preset: null, assignments: {} };
+  const badge = computeBadge(initial);
+
+  return {
+    id: 'models',
+    label: 'Models',
+    icon: <span className="text-sm">⚙</span>,
+    badge,
+    render: () => <ModelsPaneBody ctx={ctx} />,
+  };
+}

--- a/src/renderer/components/config/panes.tsx
+++ b/src/renderer/components/config/panes.tsx
@@ -1,29 +1,27 @@
 import React from 'react';
-import { ConfigPane } from './types';
+import { ConfigPane, ConfigPaneContext } from './types';
+import { buildModelsPane } from './ModelsPane';
 
-export const configPanes: ConfigPane[] = [
-  {
-    id: 'models',
-    label: 'Models',
-    icon: <span className="text-sm">⚙</span>,
-    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-  },
-  {
-    id: 'providers',
-    label: 'Providers',
-    icon: <span className="text-sm">🔌</span>,
-    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-  },
-  {
-    id: 'automation',
-    label: 'Automation',
-    icon: <span className="text-sm">⚡</span>,
-    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-  },
-  {
-    id: 'ticketing',
-    label: 'Ticketing',
-    icon: <span className="text-sm">🎫</span>,
-    render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-  },
-];
+export async function buildConfigPanes(ctx: ConfigPaneContext): Promise<ConfigPane[]> {
+  return [
+    await buildModelsPane(ctx),
+    {
+      id: 'providers',
+      label: 'Providers',
+      icon: <span className="text-sm">🔌</span>,
+      render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+    },
+    {
+      id: 'automation',
+      label: 'Automation',
+      icon: <span className="text-sm">⚡</span>,
+      render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+    },
+    {
+      id: 'ticketing',
+      label: 'Ticketing',
+      icon: <span className="text-sm">🎫</span>,
+      render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
+    },
+  ];
+}

--- a/src/renderer/components/config/types.ts
+++ b/src/renderer/components/config/types.ts
@@ -8,3 +8,21 @@ export interface ConfigPane {
   disabled?: boolean;
   render: () => ReactNode;
 }
+
+export interface ModelRoutingApi {
+  getEffective: (projectDir: string) => Promise<Record<string, { backend: string; model: string }>>;
+  getProject: (projectDir: string) => Promise<{ assignments: Record<string, { backend: string; model: string }>; preset: string | null } | null>;
+  setProject: (projectDir: string, config: { assignments?: Record<string, { backend: string; model: string }>; preset?: string | null }) => Promise<void>;
+  removeProject: (projectDir: string) => Promise<void>;
+  getGlobal: () => Promise<{ assignments: Record<string, { backend: string; model: string }>; preset: string | null }>;
+  setGlobal: (config: { assignments?: Record<string, { backend: string; model: string }>; preset?: string | null }) => Promise<void>;
+  applyPreset: (projectDir: string, presetId: string) => Promise<void>;
+  getAvailableModels: (projectDir: string) => Promise<Array<{ backend: string; model: string; label: string; version: string; provider: string; needsKey?: boolean; available: boolean }>>;
+}
+
+export interface ConfigPaneContext {
+  projectDir: string;
+  routing: ModelRoutingApi;
+  onDirtyChange: (dirty: boolean) => void;
+  registerSave: (save: () => Promise<void>) => void;
+}

--- a/tests/unit/components/ModelsPane.test.tsx
+++ b/tests/unit/components/ModelsPane.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
+import { buildModelsPane } from '../../../src/renderer/components/config/ModelsPane';
+import { TOUCHPOINTS } from '../../../src/main/control-plane/routing';
+import { ConfigPaneContext, ModelRoutingApi } from '../../../src/renderer/components/config/types';
+
+afterEach(cleanup);
+
+const CC_MODELS = [
+  { backend: 'claude', model: 'opus', label: 'Opus 4.8', version: 'claude-opus-4-8', provider: 'anthropic', available: true },
+  { backend: 'claude', model: 'sonnet', label: 'Sonnet 4.6', version: 'claude-sonnet-4-6', provider: 'anthropic', available: true },
+  { backend: 'claude', model: 'haiku', label: 'Haiku 4.5', version: 'claude-haiku-4-5', provider: 'anthropic', available: true },
+];
+
+const CC_MODELS_WITH_OC = [
+  ...CC_MODELS,
+  { backend: 'opencode', model: 'gpt-4o', label: 'GPT-4o', version: 'gpt-4o-2024-11', provider: 'openai', available: true },
+];
+
+const CC_MODELS_WITH_OC_DISABLED = [
+  ...CC_MODELS,
+  { backend: 'opencode', model: 'gpt-4o', label: 'GPT-4o', version: 'gpt-4o-2024-11', provider: 'openai', available: false },
+];
+
+function makeRouting(overrides: Partial<ModelRoutingApi> = {}): ModelRoutingApi {
+  return {
+    getEffective: vi.fn().mockResolvedValue({
+      outer: { backend: 'claude', model: 'opus' },
+      refine: { backend: 'claude', model: 'sonnet' },
+      execution: { backend: 'claude', model: 'sonnet' },
+      review: { backend: 'claude', model: 'opus' },
+      meta_review: { backend: 'claude', model: 'opus' },
+      merge_conflict: { backend: 'claude', model: 'sonnet' },
+      pr_description: { backend: 'claude', model: 'haiku' },
+    }),
+    getProject: vi.fn().mockResolvedValue(null),
+    setProject: vi.fn().mockResolvedValue(undefined),
+    removeProject: vi.fn().mockResolvedValue(undefined),
+    getGlobal: vi.fn().mockResolvedValue({ assignments: {}, preset: null }),
+    setGlobal: vi.fn().mockResolvedValue(undefined),
+    applyPreset: vi.fn().mockResolvedValue(undefined),
+    getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS),
+    ...overrides,
+  };
+}
+
+function makeCtx(routing: ModelRoutingApi, overrides: Partial<ConfigPaneContext> = {}): ConfigPaneContext {
+  return {
+    projectDir: '/test/project',
+    routing,
+    onDirtyChange: vi.fn(),
+    registerSave: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Render the pane and flush all pending async effects (load completes before returning).
+async function renderPane(ctx: ConfigPaneContext) {
+  const pane = await buildModelsPane(ctx);
+  await act(async () => {
+    render(<>{pane.render()}</>);
+    // Yield past all microtasks so the async useEffect load resolves before we interact.
+    await new Promise<void>((r) => setTimeout(r, 0));
+  });
+}
+
+describe('ModelsPane', () => {
+  describe('preset cards', () => {
+    it('renders 3 preset cards with verbatim copy', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+
+      expect(screen.getByTestId('preset-card-max_quality')).toBeDefined();
+      expect(screen.getByTestId('preset-card-balanced')).toBeDefined();
+      expect(screen.getByTestId('preset-card-budget')).toBeDefined();
+
+      expect(screen.getByText('Max quality')).toBeDefined();
+      expect(screen.getByText('~$0.90 / ticket')).toBeDefined();
+      expect(screen.getByText('Opus everywhere reasoning matters. Best results, highest cost.')).toBeDefined();
+
+      expect(screen.getByText('Balanced')).toBeDefined();
+      expect(screen.getByText('~$0.42 / ticket')).toBeDefined();
+      expect(screen.getByText('Opus for review & orchestration, Sonnet for execution, Haiku for cheap steps.')).toBeDefined();
+
+      expect(screen.getByText('Budget')).toBeDefined();
+      expect(screen.getByText('~$0.11 / ticket')).toBeDefined();
+      expect(screen.getByText('Haiku & local/open models wherever they hold up. Cheapest.')).toBeDefined();
+    });
+
+    it('clicking a preset card selects it and marks dirty with no IPC call', async () => {
+      const routing = makeRouting();
+      const onDirtyChange = vi.fn();
+      const ctx = makeCtx(routing, { onDirtyChange });
+      await renderPane(ctx);
+
+      onDirtyChange.mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('preset-card-balanced'));
+      });
+
+      expect(routing.setProject).not.toHaveBeenCalled();
+      expect(onDirtyChange).toHaveBeenCalledWith(true);
+    });
+
+    it('preset card is highlighted when active', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({ preset: 'budget', assignments: {} }),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      const card = screen.getByTestId('preset-card-budget');
+      expect(card.className).toContain('border-sandstorm-accent');
+    });
+
+    it('no preset card highlighted when project has no preset', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+
+      const maxCard = screen.getByTestId('preset-card-max_quality');
+      const balancedCard = screen.getByTestId('preset-card-balanced');
+      const budgetCard = screen.getByTestId('preset-card-budget');
+      expect(maxCard.className).not.toContain('border-sandstorm-accent');
+      expect(balancedCard.className).not.toContain('border-sandstorm-accent');
+      expect(budgetCard.className).not.toContain('border-sandstorm-accent');
+    });
+
+    it('preset click clears buffered overrides', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({
+          preset: 'balanced',
+          assignments: { execution: { backend: 'claude', model: 'opus' } },
+        }),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      expect(screen.getByTestId('override-badge-execution')).toBeDefined();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('preset-card-max_quality'));
+      });
+
+      expect(screen.queryByTestId('override-badge-execution')).toBeNull();
+    });
+  });
+
+  describe('customize toggle', () => {
+    it('toggle is off by default', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+      const toggle = screen.getByTestId('customize-toggle');
+      expect(toggle.getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('toggle reveals 7 touchpoint rows in TOUCHPOINTS order', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      const rows = screen.getAllByTestId(/^touchpoint-row-/);
+      expect(rows).toHaveLength(7);
+      expect(rows.map((r) => r.getAttribute('data-testid'))).toEqual(
+        TOUCHPOINTS.map((t) => `touchpoint-row-${t}`)
+      );
+    });
+
+    it('touchpoint rows show verbatim labels', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      expect(screen.getByText('Outer orchestrator')).toBeDefined();
+      expect(screen.getByText('Refine')).toBeDefined();
+      expect(screen.getByText('Execution')).toBeDefined();
+      expect(screen.getByText('Review')).toBeDefined();
+      expect(screen.getByText('Meta-review')).toBeDefined();
+      expect(screen.getByText('Merge conflicts')).toBeDefined();
+      expect(screen.getByText('PR description')).toBeDefined();
+    });
+
+    it('toggle off with overrides shows "N overrides hidden" hint and retains them', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({
+          preset: null,
+          assignments: {
+            execution: { backend: 'claude', model: 'opus' },
+            review: { backend: 'claude', model: 'sonnet' },
+          },
+        }),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      // Toggle is off by default; overrides are loaded in buffered state → hint shows
+      const hint = screen.getByTestId('overrides-hidden-hint');
+      expect(hint.textContent).toContain('2 overrides hidden');
+    });
+
+    it('no hint shown when toggle off and no overrides', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+      expect(screen.queryByTestId('overrides-hidden-hint')).toBeNull();
+    });
+  });
+
+  describe('model dropdowns', () => {
+    it('rows list injected CC models; OC group absent when no OC entries', async () => {
+      const ctx = makeCtx(makeRouting());
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      expect(screen.queryByTestId('optgroup-opencode-outer')).toBeNull();
+      expect(screen.getByTestId('optgroup-claude-outer')).toBeDefined();
+    });
+
+    it('OC group appears when fixtures contain OC entries', async () => {
+      const routing = makeRouting({
+        getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS_WITH_OC),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      expect(screen.getByTestId('optgroup-opencode-outer')).toBeDefined();
+    });
+
+    it('OC rows are disabled when available:false', async () => {
+      const routing = makeRouting({
+        getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS_WITH_OC_DISABLED),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      const select = screen.getByTestId('model-select-outer') as HTMLSelectElement;
+      const ocOption = Array.from(select.options).find((o) => o.value === 'opencode:gpt-4o');
+      expect(ocOption).toBeDefined();
+      expect(ocOption!.disabled).toBe(true);
+    });
+
+    it('changing a row marks it overridden and dirty, with no immediate IPC', async () => {
+      const routing = makeRouting();
+      const onDirtyChange = vi.fn();
+      const ctx = makeCtx(routing, { onDirtyChange });
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      onDirtyChange.mockClear();
+
+      await act(async () => {
+        const select = screen.getByTestId('model-select-execution') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'claude:opus' } });
+      });
+
+      expect(routing.setProject).not.toHaveBeenCalled();
+      expect(screen.getByTestId('override-badge-execution')).toBeDefined();
+      expect(onDirtyChange).toHaveBeenCalledWith(true);
+    });
+
+    it('unknown stored model renders as disabled "unknown (<id>)" entry', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({
+          preset: null,
+          assignments: { outer: { backend: 'claude', model: 'unknown-model-xyz' } },
+        }),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      const unknownOpt = screen.getByTestId('unknown-model-outer') as HTMLOptionElement;
+      expect(unknownOpt).toBeDefined();
+      expect(unknownOpt.disabled).toBe(true);
+      expect(unknownOpt.textContent).toContain('unknown');
+      expect(unknownOpt.textContent).toContain('unknown-model-xyz');
+    });
+  });
+
+  describe('save handler', () => {
+    it('registerSave is called on mount', async () => {
+      const registerSave = vi.fn();
+      const ctx = makeCtx(makeRouting(), { registerSave });
+      await renderPane(ctx);
+      expect(registerSave).toHaveBeenCalledOnce();
+    });
+
+    it('save handler calls setProject exactly once with buffered state', async () => {
+      const routing = makeRouting();
+      const registerSave = vi.fn();
+      const ctx = makeCtx(routing, { registerSave });
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('preset-card-balanced'));
+      });
+
+      const saveFn = registerSave.mock.calls[0][0] as () => Promise<void>;
+      await act(async () => {
+        await saveFn();
+      });
+
+      expect(routing.setProject).toHaveBeenCalledOnce();
+      expect(routing.setProject).toHaveBeenCalledWith('/test/project', {
+        preset: 'balanced',
+        assignments: {},
+      });
+    });
+
+    it('save handler captures latest buffered state via ref', async () => {
+      const routing = makeRouting();
+      const registerSave = vi.fn();
+      const ctx = makeCtx(routing, { registerSave });
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('preset-card-max_quality'));
+      });
+
+      await act(async () => {
+        const select = screen.getByTestId('model-select-execution') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'claude:haiku' } });
+      });
+
+      const saveFn = registerSave.mock.calls[0][0] as () => Promise<void>;
+      await act(async () => {
+        await saveFn();
+      });
+
+      expect(routing.setProject).toHaveBeenCalledWith('/test/project', {
+        preset: 'max_quality',
+        assignments: { execution: { backend: 'claude', model: 'haiku' } },
+      });
+    });
+
+    it('dirty resets to false after save', async () => {
+      const routing = makeRouting();
+      const registerSave = vi.fn();
+      const onDirtyChange = vi.fn();
+      const ctx = makeCtx(routing, { registerSave, onDirtyChange });
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('preset-card-balanced'));
+      });
+
+      onDirtyChange.mockClear();
+
+      const saveFn = registerSave.mock.calls[0][0] as () => Promise<void>;
+      await act(async () => {
+        await saveFn();
+      });
+
+      expect(onDirtyChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('badge', () => {
+    it('badge is preset title when preset set with no overrides', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({ preset: 'balanced', assignments: {} }),
+      });
+      const pane = await buildModelsPane(makeCtx(routing));
+      expect(pane.badge).toBe('Balanced');
+    });
+
+    it('badge is preset title with override count (plural) when preset set with multiple overrides', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({
+          preset: 'max_quality',
+          assignments: {
+            execution: { backend: 'claude', model: 'haiku' },
+            review: { backend: 'claude', model: 'sonnet' },
+          },
+        }),
+      });
+      const pane = await buildModelsPane(makeCtx(routing));
+      expect(pane.badge).toBe('Max quality · 2 overrides');
+    });
+
+    it('badge is preset title with singular "override" when exactly one override', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({
+          preset: 'budget',
+          assignments: { execution: { backend: 'claude', model: 'opus' } },
+        }),
+      });
+      const pane = await buildModelsPane(makeCtx(routing));
+      expect(pane.badge).toBe('Budget · 1 override');
+    });
+
+    it('badge is "Custom" when overrides exist with no preset', async () => {
+      const routing = makeRouting({
+        getProject: vi.fn().mockResolvedValue({
+          preset: null,
+          assignments: { execution: { backend: 'claude', model: 'opus' } },
+        }),
+      });
+      const pane = await buildModelsPane(makeCtx(routing));
+      expect(pane.badge).toBe('Custom');
+    });
+
+    it('badge is undefined when no preset and no overrides', async () => {
+      const routing = makeRouting({ getProject: vi.fn().mockResolvedValue(null) });
+      const pane = await buildModelsPane(makeCtx(routing));
+      expect(pane.badge).toBeUndefined();
+    });
+  });
+
+  describe('cross-project isolation', () => {
+    it('rebuilding with a different projectDir loads fresh state', async () => {
+      const routingA = makeRouting({
+        getProject: vi.fn().mockResolvedValue({ preset: 'balanced', assignments: {} }),
+      });
+      const ctxA = makeCtx(routingA, { projectDir: '/project/a' });
+      const paneA = await buildModelsPane(ctxA);
+      let unmountA!: () => void;
+      await act(async () => {
+        const result = render(<>{paneA.render()}</>);
+        unmountA = result.unmount;
+        await new Promise<void>((r) => setTimeout(r, 0));
+      });
+
+      const balancedCard = screen.getByTestId('preset-card-balanced');
+      expect(balancedCard.className).toContain('border-sandstorm-accent');
+
+      unmountA();
+
+      const routingB = makeRouting({
+        getProject: vi.fn().mockResolvedValue({ preset: 'budget', assignments: {} }),
+      });
+      const ctxB = makeCtx(routingB, { projectDir: '/project/b' });
+      await renderPane(ctxB);
+
+      const budgetCard = screen.getByTestId('preset-card-budget');
+      expect(budgetCard.className).toContain('border-sandstorm-accent');
+      const balancedCardB = screen.getByTestId('preset-card-balanced');
+      expect(balancedCardB.className).not.toContain('border-sandstorm-accent');
+    });
+  });
+});

--- a/tests/unit/components/ProjectConfigModal.test.tsx
+++ b/tests/unit/components/ProjectConfigModal.test.tsx
@@ -8,8 +8,8 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 afterEach(cleanup);
 
 import { ProjectConfigModal } from '../../../src/renderer/components/ProjectConfigModal';
-import { configPanes } from '../../../src/renderer/components/config/panes';
-import { ConfigPane } from '../../../src/renderer/components/config/types';
+import { buildConfigPanes } from '../../../src/renderer/components/config/panes';
+import { ConfigPane, ConfigPaneContext } from '../../../src/renderer/components/config/types';
 
 function makePane(id: string, label: string, disabled?: boolean): ConfigPane {
   return {
@@ -160,10 +160,30 @@ describe('ProjectConfigModal', () => {
   });
 });
 
-describe('configPanes registry', () => {
-  it('exports exactly four panes in order: models, providers, automation, ticketing', () => {
-    expect(configPanes).toHaveLength(4);
-    expect(configPanes.map((p) => p.id)).toEqual([
+describe('buildConfigPanes registry', () => {
+  function makeCtx(): ConfigPaneContext {
+    return {
+      projectDir: '/test/project',
+      routing: {
+        getEffective: vi.fn().mockResolvedValue({}),
+        getProject: vi.fn().mockResolvedValue(null),
+        setProject: vi.fn().mockResolvedValue(undefined),
+        removeProject: vi.fn().mockResolvedValue(undefined),
+        getGlobal: vi.fn().mockResolvedValue({ assignments: {}, preset: null }),
+        setGlobal: vi.fn().mockResolvedValue(undefined),
+        applyPreset: vi.fn().mockResolvedValue(undefined),
+        getAvailableModels: vi.fn().mockResolvedValue([]),
+      },
+      onDirtyChange: vi.fn(),
+      registerSave: vi.fn(),
+    };
+  }
+
+  it('returns exactly four panes in order: models, providers, automation, ticketing', async () => {
+    const ctx = makeCtx();
+    const panes = await buildConfigPanes(ctx);
+    expect(panes).toHaveLength(4);
+    expect(panes.map((p) => p.id)).toEqual([
       'models',
       'providers',
       'automation',
@@ -171,13 +191,24 @@ describe('configPanes registry', () => {
     ]);
   });
 
-  it('shell renders with configPanes registry without crashing', () => {
+  it('models pane renders the ModelsPane body component', async () => {
+    const ctx = makeCtx();
+    const panes = await buildConfigPanes(ctx);
+    const modelsPane = panes.find((p) => p.id === 'models')!;
+    expect(modelsPane).toBeDefined();
+    render(<>{modelsPane.render()}</>);
+    expect(screen.getByTestId('models-pane')).toBeDefined();
+  });
+
+  it('shell renders with buildConfigPanes registry without crashing', async () => {
+    const ctx = makeCtx();
+    const panes = await buildConfigPanes(ctx);
     expect(() =>
       render(
         <ProjectConfigModal
           open={true}
           title="Config"
-          panes={configPanes}
+          panes={panes}
           onClose={vi.fn()}
           onSave={vi.fn()}
         />


### PR DESCRIPTION
## Summary

Fixes a stale-closure bug in the models pane and implements the badge requirement for the project config modal.

- `handleRowChange` previously read `buffered.assignments` from a closed-over value, so rapid successive edits could drop changes. The spread-and-delete now happens entirely inside the `setBuffered` functional updater, reading from the latest `prev.assignments`.
- `buildModelsPane` is now async: it fetches the project via `ctx.routing.getProject` at build time and computes the pane badge from the result (preset-only, preset plus N overrides with singular/plural handling, "custom" when overrides exist without a preset, and no badge when neither is set). `buildConfigPanes` was updated to be async accordingly.
- Added badge tests covering all four spec cases plus the undefined case, and updated all `buildModelsPane`/`buildConfigPanes` call sites in tests to await the now-async functions. All 46 tests pass.

## QA plan

1. Open the project config modal for a project that uses a model preset with no overrides — the Models pane badge should show the preset name only.
2. Add one model override to that project and reopen the modal — the badge should reflect the preset plus "1 override" (singular).
3. Add a second override — the badge should use the plural form.
4. Remove the preset but keep overrides — the badge should read "custom".
5. Clear both preset and overrides — no badge should appear on the Models pane.
6. In the Models pane, change several row assignments in quick succession (including clearing one back to default) and save — all edits should persist, with none silently dropped.

Closes #533