### PR TITLE
[475] fix: add BackendRouter to route agent calls by backend type

### DIFF
--- a/src/main/agent/backend-router.ts
+++ b/src/main/agent/backend-router.ts
@@ -1,0 +1,214 @@
+/**
+ * BackendRouter — routes AgentBackend calls to a concrete backend per tab/project.
+ *
+ * The outer Claude session is a singleton with per-tabId sessions. BackendRouter
+ * sits in front of the concrete backends (ClaudeBackend, OpenCodeBackend, …) and
+ * multiplexes method calls based on which backend owns each tab.
+ *
+ * Routing rules:
+ *  - sendMessage with projectDir: call selector(projectDir) → record tabId ownership.
+ *  - sendMessage without projectDir: look up existing ownership; default to 'claude'.
+ *  - Ownership is sticky until resetSession(tabId), which clears it. A backend
+ *    change for a project applies on the next new/reset session — intentional.
+ *  - getHistory/cancelSession/resetSession/getSessionTokens: look up owner;
+ *    unknown tab → default to 'claude' (back-compat).
+ *  - getAuthStatus/login: route to lastProjectBackendId (most-recently resolved
+ *    by any sendMessage or ephemeral call); fall back to 'claude'.
+ *  - getEphemeralTimingPath: always delegates to claude (OpenCode timing in #478).
+ *  - syncCredentials/initialize/destroy/setMainWindow: fan out to all instantiated
+ *    backends.
+ *  - Ephemeral calls (run/spawn/spawnSession): call selector(projectDir) → delegate.
+ */
+
+import type { BrowserWindow } from 'electron';
+import type {
+  AgentBackend,
+  AgentSessionHistory,
+  AuthStatus,
+  EphemeralSessionHandle,
+  EphemeralStreamEvent,
+  OuterClaudeSessionTokens,
+  StackInfo,
+} from './types';
+import type { BackendType } from '../control-plane/backend-resolution';
+
+export class BackendRouter implements AgentBackend {
+  private readonly factories: Partial<Record<BackendType, () => AgentBackend>>;
+  private readonly selector: (projectDir: string) => BackendType;
+  private readonly instances: Partial<Record<BackendType, AgentBackend>> = {};
+
+  // tabId → backend type. Sticky until resetSession clears it.
+  private readonly tabOwnership = new Map<string, BackendType>();
+
+  // Last backend type resolved by any sendMessage or ephemeral call.
+  // Routes auth calls (getAuthStatus/login) to the relevant backend.
+  // Falls back to 'claude' before any call has been made.
+  private lastProjectBackendId: BackendType = 'claude';
+
+  // Stored so newly-instantiated backends receive the current window reference.
+  private mainWindow: BrowserWindow | null = null;
+
+  readonly name = 'BackendRouter';
+
+  constructor(
+    factories: Partial<Record<BackendType, () => AgentBackend>>,
+    selector: (projectDir: string) => BackendType,
+  ) {
+    this.factories = factories;
+    this.selector = selector;
+  }
+
+  /**
+   * Return the cached concrete backend for `type`, creating it on first call.
+   * Does NOT call initialize() — that is the caller's responsibility.
+   * Throws if no factory is registered for the requested type.
+   */
+  private getBackend(type: BackendType): AgentBackend {
+    if (!this.instances[type]) {
+      const factory = this.factories[type];
+      if (!factory) {
+        throw new Error(`BackendRouter: no factory registered for backend type '${type}'`);
+      }
+      const backend = factory();
+      if (this.mainWindow !== null) {
+        backend.setMainWindow(this.mainWindow);
+      }
+      this.instances[type] = backend;
+    }
+    return this.instances[type]!;
+  }
+
+  /**
+   * Resolve which backend owns a tab, recording the mapping when projectDir
+   * is provided. Defaults to 'claude' if the tab has no prior ownership.
+   */
+  private resolveTabOwner(tabId: string, projectDir?: string): BackendType {
+    if (projectDir) {
+      const type = this.selector(projectDir);
+      this.tabOwnership.set(tabId, type);
+      this.lastProjectBackendId = type;
+      return type;
+    }
+    const existing = this.tabOwnership.get(tabId);
+    if (existing) return existing;
+    // No projectDir and no prior ownership (e.g. outer-claude tab without project):
+    // default to claude and record it.
+    this.tabOwnership.set(tabId, 'claude');
+    return 'claude';
+  }
+
+  // --- Lifecycle (fan out to all instantiated backends) ---
+
+  async initialize(): Promise<void> {
+    // Eagerly instantiate the claude backend so it is ready before any user
+    // interaction. Other backends are created on first use.
+    this.getBackend('claude');
+    await Promise.all(
+      (Object.values(this.instances) as AgentBackend[]).map(b => b.initialize()),
+    );
+  }
+
+  destroy(): void {
+    for (const backend of Object.values(this.instances) as AgentBackend[]) {
+      backend.destroy();
+    }
+  }
+
+  setMainWindow(win: BrowserWindow | null): void {
+    this.mainWindow = win;
+    for (const backend of Object.values(this.instances) as AgentBackend[]) {
+      backend.setMainWindow(win);
+    }
+  }
+
+  // --- Session management ---
+
+  sendMessage(tabId: string, message: string, projectDir?: string): void {
+    const type = this.resolveTabOwner(tabId, projectDir);
+    this.getBackend(type).sendMessage(tabId, message, projectDir);
+  }
+
+  getHistory(tabId: string): AgentSessionHistory {
+    const type = this.tabOwnership.get(tabId) ?? 'claude';
+    return this.getBackend(type).getHistory(tabId);
+  }
+
+  cancelSession(tabId: string): void {
+    const type = this.tabOwnership.get(tabId) ?? 'claude';
+    this.getBackend(type).cancelSession(tabId);
+  }
+
+  resetSession(tabId: string): void {
+    const type = this.tabOwnership.get(tabId) ?? 'claude';
+    this.getBackend(type).resetSession(tabId);
+    // Clear ownership so the next sendMessage can re-establish the backend.
+    // A backend change for a project takes effect on the next new/reset session.
+    this.tabOwnership.delete(tabId);
+  }
+
+  getSessionTokens(tabId: string): OuterClaudeSessionTokens {
+    const type = this.tabOwnership.get(tabId) ?? 'claude';
+    return this.getBackend(type).getSessionTokens(tabId);
+  }
+
+  // --- Ephemeral agents ---
+
+  getEphemeralTimingPath(): string {
+    // Always delegates to claude — OpenCode ephemeral timing is addressed in #478.
+    // Constructs the claude backend without calling initialize() if not yet cached.
+    return this.getBackend('claude').getEphemeralTimingPath();
+  }
+
+  runEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    attribution?: { ticketId?: string; stage?: string },
+  ): Promise<string> {
+    const type = this.selector(projectDir);
+    this.lastProjectBackendId = type;
+    return this.getBackend(type).runEphemeralAgent(prompt, projectDir, timeoutMs, attribution);
+  }
+
+  spawnEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+    attribution?: { ticketId?: string; stage?: string },
+  ): { promise: Promise<string>; cancel: () => void } {
+    const type = this.selector(projectDir);
+    this.lastProjectBackendId = type;
+    return this.getBackend(type).spawnEphemeralAgent(prompt, projectDir, timeoutMs, onChunk, attribution);
+  }
+
+  spawnEphemeralSession(
+    initialPrompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+  ): EphemeralSessionHandle {
+    const type = this.selector(projectDir);
+    this.lastProjectBackendId = type;
+    return this.getBackend(type).spawnEphemeralSession(initialPrompt, projectDir, timeoutMs, onChunk);
+  }
+
+  // --- Authentication ---
+
+  getAuthStatus(): Promise<AuthStatus> {
+    // Route to the most recently resolved backend; fall back to claude.
+    // Auth is backend-specific — the last used backend is the best proxy for
+    // which credentials the user cares about right now.
+    return this.getBackend(this.lastProjectBackendId).getAuthStatus();
+  }
+
+  login(mainWindow?: BrowserWindow): Promise<{ success: boolean; error?: string }> {
+    return this.getBackend(this.lastProjectBackendId).login(mainWindow);
+  }
+
+  syncCredentials(stacks: StackInfo[]): Promise<void> {
+    return Promise.all(
+      (Object.values(this.instances) as AgentBackend[]).map(b => b.syncCredentials(stacks)),
+    ).then(() => undefined);
+  }
+}

--- a/src/main/agent/index.ts
+++ b/src/main/agent/index.ts
@@ -1,2 +1,3 @@
 export type { AgentBackend, ChatMessage, AuthStatus, AgentSessionHistory, StackInfo, StackServiceInfo } from './types';
 export { ClaudeBackend } from './claude-backend';
+export { BackendRouter } from './backend-router';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,7 @@ import { DockerRuntime } from './runtime/docker';
 import { PodmanRuntime } from './runtime/podman';
 import { ContainerRuntime } from './runtime/types';
 import { DockerConnectionManager } from './runtime/docker-connection';
-import { AgentBackend, ClaudeBackend } from './agent';
+import { AgentBackend, ClaudeBackend, BackendRouter } from './agent';
 import { registerIpcHandlers } from './ipc';
 import { createTray } from './tray';
 import { SessionMonitor } from './control-plane/session-monitor';
@@ -170,9 +170,10 @@ async function initializeApp(): Promise<void> {
   // backend; the renderer reads it via `agent:tokenUsage` / listens to
   // `agent:token-usage:<tabId>` events. No DB persistence — "New Session"
   // resets the counter by design.
-  agentBackend = new ClaudeBackend(
-    undefined,
-    (projectDir) => registry.getEffectiveModels(projectDir).outer_model
+  const modelResolver = (projectDir: string) => registry.getEffectiveModels(projectDir).outer_model;
+  agentBackend = new BackendRouter(
+    { claude: () => new ClaudeBackend(undefined, modelResolver) },
+    (projectDir) => registry.getEffectiveBackend(projectDir, 'outer').backend,
   );
   await agentBackend.initialize();
 

--- a/tests/unit/agent/agent-backend-conformance.test.ts
+++ b/tests/unit/agent/agent-backend-conformance.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Shared AgentBackend conformance suite.
+ *
+ * Tests the full AgentBackend contract independent of the implementation.
+ * Parameterised so future backends (#478 OpenCodeBackend, etc.) can be wired
+ * in with a single call to createConformanceSuite() and validated against the
+ * same assertions.
+ *
+ * Usage (in e.g. opencode-backend.test.ts):
+ *   import { createConformanceSuite } from './agent-backend-conformance.test';
+ *   createConformanceSuite('OpenCodeBackend', () => new OpenCodeBackend(...));
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+  AgentBackend,
+  AgentSessionHistory,
+  AuthStatus,
+  EphemeralSessionHandle,
+  EphemeralStreamEvent,
+  OuterClaudeSessionTokens,
+  StackInfo,
+} from '../../../src/main/agent/types';
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory fake backend used as the default conformance target.
+// It records messages, supports resetSession, and delegates to vi.fn() for
+// everything else so assertions can be made on call counts where needed.
+// ---------------------------------------------------------------------------
+
+export class FakeAgentBackend implements AgentBackend {
+  readonly name: string;
+  private messages = new Map<string, { role: 'user' | 'assistant'; content: string }[]>();
+  private processing = new Map<string, boolean>();
+
+  readonly initializeMock = vi.fn().mockResolvedValue(undefined);
+  readonly destroyMock = vi.fn();
+  readonly setMainWindowMock = vi.fn();
+  readonly cancelSessionMock = vi.fn();
+  readonly getAuthStatusMock = vi.fn<[], Promise<AuthStatus>>().mockResolvedValue({
+    loggedIn: true,
+    email: 'test@example.com',
+    expired: false,
+  });
+  readonly loginMock = vi.fn<[unknown?], Promise<{ success: boolean; error?: string }>>().mockResolvedValue({
+    success: true,
+  });
+  readonly syncCredentialsMock = vi.fn<[StackInfo[]], Promise<void>>().mockResolvedValue(undefined);
+  readonly runEphemeralAgentMock = vi.fn<[string, string, number?, object?], Promise<string>>().mockResolvedValue('ephemeral-result');
+  readonly spawnEphemeralAgentMock = vi.fn().mockImplementation(() => ({
+    promise: Promise.resolve('ephemeral-result'),
+    cancel: vi.fn(),
+  }));
+  readonly spawnEphemeralSessionMock = vi.fn().mockImplementation(() => ({
+    initialResult: Promise.resolve('session-result'),
+    sendFollowUp: vi.fn<[string], Promise<string>>().mockResolvedValue('followup-result'),
+    dispose: vi.fn(),
+  }));
+
+  constructor(name = 'FakeBackend') {
+    this.name = name;
+  }
+
+  initialize(): Promise<void> { return this.initializeMock(); }
+  destroy(): void { this.destroyMock(); }
+  setMainWindow(win: unknown): void { this.setMainWindowMock(win); }
+
+  sendMessage(tabId: string, message: string): void {
+    if (!this.messages.has(tabId)) this.messages.set(tabId, []);
+    this.messages.get(tabId)!.push({ role: 'user', content: message });
+    this.processing.set(tabId, false);
+  }
+
+  getHistory(tabId: string): AgentSessionHistory {
+    return {
+      messages: this.messages.get(tabId) ?? [],
+      processing: this.processing.get(tabId) ?? false,
+    };
+  }
+
+  cancelSession(tabId: string): void { this.cancelSessionMock(tabId); }
+
+  resetSession(tabId: string): void {
+    this.messages.delete(tabId);
+    this.processing.delete(tabId);
+  }
+
+  getSessionTokens(_tabId: string): OuterClaudeSessionTokens {
+    return {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    };
+  }
+
+  getEphemeralTimingPath(): string { return '/tmp/fake-ephemeral-timing.jsonl'; }
+
+  runEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    attribution?: { ticketId?: string; stage?: string },
+  ): Promise<string> {
+    return this.runEphemeralAgentMock(prompt, projectDir, timeoutMs, attribution);
+  }
+
+  spawnEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+    attribution?: { ticketId?: string; stage?: string },
+  ): { promise: Promise<string>; cancel: () => void } {
+    return this.spawnEphemeralAgentMock(prompt, projectDir, timeoutMs, onChunk, attribution);
+  }
+
+  spawnEphemeralSession(
+    initialPrompt: string,
+    projectDir: string,
+    timeoutMs?: number,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+  ): EphemeralSessionHandle {
+    return this.spawnEphemeralSessionMock(initialPrompt, projectDir, timeoutMs, onChunk);
+  }
+
+  getAuthStatus(): Promise<AuthStatus> { return this.getAuthStatusMock(); }
+  login(mainWindow?: unknown): Promise<{ success: boolean; error?: string }> {
+    return this.loginMock(mainWindow);
+  }
+  syncCredentials(stacks: StackInfo[]): Promise<void> { return this.syncCredentialsMock(stacks); }
+}
+
+// ---------------------------------------------------------------------------
+// Conformance suite factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a full AgentBackend conformance suite for the given factory.
+ * Call this from any backend's test file to validate conformance:
+ *
+ *   createConformanceSuite('MyBackend', () => new MyBackend());
+ */
+export function createConformanceSuite(
+  suiteName: string,
+  factory: () => AgentBackend,
+): void {
+  describe(`AgentBackend conformance: ${suiteName}`, () => {
+    let backend: AgentBackend;
+
+    beforeEach(() => {
+      backend = factory();
+    });
+
+    // --- Identity ---
+
+    it('exposes a non-empty name string', () => {
+      expect(typeof backend.name).toBe('string');
+      expect(backend.name.length).toBeGreaterThan(0);
+    });
+
+    // --- Lifecycle ---
+
+    it('initialize() returns a Promise', async () => {
+      const result = backend.initialize();
+      expect(result).toBeInstanceOf(Promise);
+      await result;
+    });
+
+    it('destroy() is callable without error', () => {
+      expect(() => backend.destroy()).not.toThrow();
+    });
+
+    it('setMainWindow(null) is callable without error', () => {
+      expect(() => backend.setMainWindow(null)).not.toThrow();
+    });
+
+    // --- Session management ---
+
+    it('getHistory returns empty history for unknown tab', () => {
+      const history = backend.getHistory('unknown-tab');
+      expect(history).toMatchObject({ messages: [], processing: false });
+    });
+
+    it('sendMessage stores the message in history', () => {
+      backend.sendMessage('tab-1', 'hello world', '/project');
+      const history = backend.getHistory('tab-1');
+      expect(history.messages).toHaveLength(1);
+      expect(history.messages[0]).toMatchObject({ role: 'user', content: 'hello world' });
+    });
+
+    it('sendMessage on separate tabs keeps histories independent', () => {
+      backend.sendMessage('tab-a', 'message for a', '/project-a');
+      backend.sendMessage('tab-b', 'message for b', '/project-b');
+      expect(backend.getHistory('tab-a').messages).toHaveLength(1);
+      expect(backend.getHistory('tab-b').messages).toHaveLength(1);
+      expect(backend.getHistory('tab-a').messages[0].content).toBe('message for a');
+      expect(backend.getHistory('tab-b').messages[0].content).toBe('message for b');
+    });
+
+    it('resetSession clears the tab history', () => {
+      backend.sendMessage('tab-reset', 'before reset', '/project');
+      expect(backend.getHistory('tab-reset').messages).toHaveLength(1);
+      backend.resetSession('tab-reset');
+      expect(backend.getHistory('tab-reset').messages).toHaveLength(0);
+    });
+
+    it('resetSession on unknown tab does not throw', () => {
+      expect(() => backend.resetSession('never-existed')).not.toThrow();
+    });
+
+    it('cancelSession is callable without error', () => {
+      backend.sendMessage('tab-cancel', 'msg', '/project');
+      expect(() => backend.cancelSession('tab-cancel')).not.toThrow();
+    });
+
+    it('cancelSession on unknown tab does not throw', () => {
+      expect(() => backend.cancelSession('unknown-cancel')).not.toThrow();
+    });
+
+    it('getSessionTokens returns a token object with numeric fields', () => {
+      const tokens = backend.getSessionTokens('any-tab');
+      expect(typeof tokens.input_tokens).toBe('number');
+      expect(typeof tokens.output_tokens).toBe('number');
+      expect(typeof tokens.cache_creation_input_tokens).toBe('number');
+      expect(typeof tokens.cache_read_input_tokens).toBe('number');
+    });
+
+    it('getSessionTokens for unknown tab returns zero-value object', () => {
+      const tokens = backend.getSessionTokens('nonexistent-tab');
+      expect(tokens.input_tokens).toBe(0);
+      expect(tokens.output_tokens).toBe(0);
+      expect(tokens.cache_creation_input_tokens).toBe(0);
+      expect(tokens.cache_read_input_tokens).toBe(0);
+    });
+
+    // --- Ephemeral agents ---
+
+    it('getEphemeralTimingPath returns a non-empty string', () => {
+      const p = backend.getEphemeralTimingPath();
+      expect(typeof p).toBe('string');
+      expect(p.length).toBeGreaterThan(0);
+    });
+
+    it('runEphemeralAgent returns a Promise resolving to a string', async () => {
+      const result = backend.runEphemeralAgent('prompt', '/project');
+      expect(result).toBeInstanceOf(Promise);
+      const text = await result;
+      expect(typeof text).toBe('string');
+    });
+
+    it('spawnEphemeralAgent returns { promise, cancel }', async () => {
+      const { promise, cancel } = backend.spawnEphemeralAgent('prompt', '/project');
+      expect(promise).toBeInstanceOf(Promise);
+      expect(typeof cancel).toBe('function');
+      await promise;
+    });
+
+    it('spawnEphemeralAgent cancel is callable without error', () => {
+      const { cancel } = backend.spawnEphemeralAgent('prompt', '/project');
+      expect(() => cancel()).not.toThrow();
+    });
+
+    it('spawnEphemeralSession returns a handle with initialResult, sendFollowUp, dispose', async () => {
+      const handle = backend.spawnEphemeralSession('initial prompt', '/project');
+      expect(handle.initialResult).toBeInstanceOf(Promise);
+      expect(typeof handle.sendFollowUp).toBe('function');
+      expect(typeof handle.dispose).toBe('function');
+      await handle.initialResult;
+    });
+
+    it('spawnEphemeralSession dispose is callable without error', () => {
+      const handle = backend.spawnEphemeralSession('prompt', '/project');
+      expect(() => handle.dispose()).not.toThrow();
+    });
+
+    // --- Authentication ---
+
+    it('getAuthStatus returns a Promise with loggedIn and expired fields', async () => {
+      const status = await backend.getAuthStatus();
+      expect(typeof status.loggedIn).toBe('boolean');
+      expect(typeof status.expired).toBe('boolean');
+    });
+
+    it('login returns a Promise with a success boolean', async () => {
+      const result = await backend.login();
+      expect(typeof result.success).toBe('boolean');
+    });
+
+    it('syncCredentials returns a Promise', async () => {
+      const result = backend.syncCredentials([]);
+      expect(result).toBeInstanceOf(Promise);
+      await result;
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Run the conformance suite against FakeAgentBackend as a baseline check.
+// #478 will call createConformanceSuite('OpenCodeBackend', ...) here too.
+// ---------------------------------------------------------------------------
+
+createConformanceSuite('FakeAgentBackend', () => new FakeAgentBackend());

--- a/tests/unit/agent/backend-router.test.ts
+++ b/tests/unit/agent/backend-router.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for BackendRouter.
+ *
+ * Uses two FakeAgentBackend instances (wired as 'claude' and 'opencode') to
+ * verify routing logic without any Electron or Docker dependencies.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BackendRouter } from '../../../src/main/agent/backend-router';
+import { FakeAgentBackend } from './agent-backend-conformance.test';
+import type { AgentBackend } from '../../../src/main/agent/types';
+import type { BackendType } from '../../../src/main/control-plane/backend-resolution';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRouter(
+  claudeBackend: AgentBackend,
+  opencodeBackend: AgentBackend,
+  selector: (projectDir: string) => BackendType = (dir) =>
+    dir.includes('opencode') ? 'opencode' : 'claude',
+): BackendRouter {
+  return new BackendRouter(
+    {
+      claude: () => claudeBackend,
+      opencode: () => opencodeBackend,
+    },
+    selector,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BackendRouter', () => {
+  let claudeFake: FakeAgentBackend;
+  let opencodeFake: FakeAgentBackend;
+  let router: BackendRouter;
+
+  beforeEach(() => {
+    claudeFake = new FakeAgentBackend('Claude');
+    opencodeFake = new FakeAgentBackend('OpenCode');
+    router = makeRouter(claudeFake, opencodeFake);
+  });
+
+  // --- Identity ---
+
+  it('has name "BackendRouter"', () => {
+    expect(router.name).toBe('BackendRouter');
+  });
+
+  // --- Lifecycle fan-out ---
+
+  it('initialize() calls initialize() on the claude backend eagerly', async () => {
+    await router.initialize();
+    expect(claudeFake.initializeMock).toHaveBeenCalledOnce();
+    // opencode not yet instantiated — not called
+    expect(opencodeFake.initializeMock).not.toHaveBeenCalled();
+  });
+
+  it('initialize() fans out to all instantiated backends', async () => {
+    // Force both backends to be instantiated before initialize
+    router.sendMessage('tab-claude', 'hello', '/claude-project');
+    router.sendMessage('tab-opencode', 'hello', '/opencode-project');
+    await router.initialize();
+    expect(claudeFake.initializeMock).toHaveBeenCalledOnce();
+    expect(opencodeFake.initializeMock).toHaveBeenCalledOnce();
+  });
+
+  it('destroy() fans out to all instantiated backends', async () => {
+    await router.initialize();
+    router.sendMessage('tab-opencode', 'hi', '/opencode-project');
+    router.destroy();
+    expect(claudeFake.destroyMock).toHaveBeenCalledOnce();
+    expect(opencodeFake.destroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('destroy() does not throw when no backends have been instantiated (except claude)', () => {
+    expect(() => router.destroy()).not.toThrow();
+  });
+
+  it('setMainWindow fans out to all instantiated backends', async () => {
+    await router.initialize();
+    router.sendMessage('tab-opencode', 'hi', '/opencode-project');
+    const fakeWin = {} as never;
+    router.setMainWindow(fakeWin);
+    expect(claudeFake.setMainWindowMock).toHaveBeenCalledWith(fakeWin);
+    expect(opencodeFake.setMainWindowMock).toHaveBeenCalledWith(fakeWin);
+  });
+
+  it('setMainWindow(null) fans out to all instantiated backends', async () => {
+    await router.initialize();
+    router.setMainWindow(null);
+    expect(claudeFake.setMainWindowMock).toHaveBeenCalledWith(null);
+  });
+
+  it('newly instantiated backend receives current mainWindow at creation time', async () => {
+    await router.initialize();
+    const fakeWin = {} as never;
+    router.setMainWindow(fakeWin);
+    // opencode not yet instantiated; first sendMessage creates it
+    router.sendMessage('tab-opencode', 'hi', '/opencode-project');
+    expect(opencodeFake.setMainWindowMock).toHaveBeenCalledWith(fakeWin);
+  });
+
+  // --- Per-tab routing ---
+
+  it('routes sendMessage to claude backend for claude project', () => {
+    router.sendMessage('tab-1', 'hello', '/my-claude-project');
+    expect(claudeFake.getHistory('tab-1').messages).toHaveLength(1);
+    expect(opencodeFake.getHistory('tab-1').messages).toHaveLength(0);
+  });
+
+  it('routes sendMessage to opencode backend for opencode project', () => {
+    router.sendMessage('tab-2', 'hello', '/my-opencode-project');
+    expect(opencodeFake.getHistory('tab-2').messages).toHaveLength(1);
+    expect(claudeFake.getHistory('tab-2').messages).toHaveLength(0);
+  });
+
+  it('routes different tabs to different backends independently', () => {
+    router.sendMessage('tab-c', 'for claude', '/claude-project');
+    router.sendMessage('tab-o', 'for opencode', '/opencode-project');
+    expect(claudeFake.getHistory('tab-c').messages[0].content).toBe('for claude');
+    expect(opencodeFake.getHistory('tab-o').messages[0].content).toBe('for opencode');
+  });
+
+  // --- Sticky ownership ---
+
+  it('subsequent sendMessage without projectDir uses established ownership', () => {
+    router.sendMessage('tab-sticky', 'first', '/opencode-project');
+    router.sendMessage('tab-sticky', 'second'); // no projectDir
+    expect(opencodeFake.getHistory('tab-sticky').messages).toHaveLength(2);
+    expect(claudeFake.getHistory('tab-sticky').messages).toHaveLength(0);
+  });
+
+  it('ownership persists across multiple messages without projectDir', () => {
+    router.sendMessage('tab-persist', 'msg1', '/opencode-project');
+    for (let i = 0; i < 5; i++) {
+      router.sendMessage('tab-persist', `msg${i + 2}`);
+    }
+    expect(opencodeFake.getHistory('tab-persist').messages).toHaveLength(6);
+  });
+
+  // --- resetSession clears ownership ---
+
+  it('resetSession clears tab ownership so next sendMessage can re-establish it', () => {
+    router.sendMessage('tab-flip', 'first', '/claude-project');
+    expect(claudeFake.getHistory('tab-flip').messages).toHaveLength(1);
+
+    router.resetSession('tab-flip');
+
+    router.sendMessage('tab-flip', 'second', '/opencode-project');
+    expect(opencodeFake.getHistory('tab-flip').messages).toHaveLength(1);
+    // claude backend's resetSession was called
+    expect(claudeFake.cancelSessionMock).not.toHaveBeenCalled(); // not cancel
+  });
+
+  it('resetSession delegates to the owning backend', () => {
+    router.sendMessage('tab-reset', 'hi', '/opencode-project');
+    router.resetSession('tab-reset');
+    // After reset, history on the opencode backend is cleared
+    expect(opencodeFake.getHistory('tab-reset').messages).toHaveLength(0);
+  });
+
+  // --- Unknown tab defaults to claude ---
+
+  it('getHistory for unknown tab defaults to claude backend', () => {
+    const history = router.getHistory('never-sent-to');
+    // Claude fake returns empty history for unknown tabs
+    expect(history).toMatchObject({ messages: [], processing: false });
+    // Opencode was not instantiated for this call
+    expect(opencodeFake.getHistory('never-sent-to').messages).toHaveLength(0);
+  });
+
+  it('cancelSession for unknown tab defaults to claude backend', () => {
+    router.cancelSession('unknown-tab');
+    expect(claudeFake.cancelSessionMock).toHaveBeenCalledWith('unknown-tab');
+    expect(opencodeFake.cancelSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('getSessionTokens for unknown tab defaults to claude backend', () => {
+    const tokens = router.getSessionTokens('unknown-tab');
+    expect(tokens).toMatchObject({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+  });
+
+  it('sendMessage without projectDir and no prior ownership defaults to claude', () => {
+    router.sendMessage('fresh-tab', 'no project dir given');
+    expect(claudeFake.getHistory('fresh-tab').messages).toHaveLength(1);
+    expect(opencodeFake.getHistory('fresh-tab').messages).toHaveLength(0);
+  });
+
+  // --- Ephemeral routing by projectDir ---
+
+  it('runEphemeralAgent routes to claude for non-opencode project', async () => {
+    await router.runEphemeralAgent('prompt', '/claude-project');
+    expect(claudeFake.runEphemeralAgentMock).toHaveBeenCalledOnce();
+    expect(opencodeFake.runEphemeralAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('runEphemeralAgent routes to opencode for opencode project', async () => {
+    await router.runEphemeralAgent('prompt', '/opencode-project');
+    expect(opencodeFake.runEphemeralAgentMock).toHaveBeenCalledOnce();
+    expect(claudeFake.runEphemeralAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('spawnEphemeralAgent routes by projectDir', async () => {
+    const { promise } = router.spawnEphemeralAgent('prompt', '/opencode-project');
+    await promise;
+    expect(opencodeFake.spawnEphemeralAgentMock).toHaveBeenCalledOnce();
+    expect(claudeFake.spawnEphemeralAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('spawnEphemeralSession routes by projectDir', async () => {
+    const handle = router.spawnEphemeralSession('prompt', '/opencode-project');
+    await handle.initialResult;
+    expect(opencodeFake.spawnEphemeralSessionMock).toHaveBeenCalledOnce();
+    expect(claudeFake.spawnEphemeralSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('ephemeral calls pass through all arguments', async () => {
+    const onChunk = vi.fn();
+    const attribution = { ticketId: 'T-1', stage: 'spec' };
+    router.spawnEphemeralAgent('p', '/claude-project', 5000, onChunk, attribution);
+    expect(claudeFake.spawnEphemeralAgentMock).toHaveBeenCalledWith(
+      'p', '/claude-project', 5000, onChunk, attribution,
+    );
+  });
+
+  // --- getEphemeralTimingPath always delegates to claude ---
+
+  it('getEphemeralTimingPath delegates to claude regardless of last backend', async () => {
+    // Use opencode as last backend
+    await router.runEphemeralAgent('prompt', '/opencode-project');
+    const path = router.getEphemeralTimingPath();
+    expect(typeof path).toBe('string');
+    // The path comes from the claude fake
+    expect(path).toBe(claudeFake.getEphemeralTimingPath());
+  });
+
+  it('getEphemeralTimingPath instantiates claude if not yet created (no initialize)', () => {
+    const routerFresh = makeRouter(claudeFake, opencodeFake);
+    // No initialize() called, no sendMessage — claude not yet instantiated
+    const path = routerFresh.getEphemeralTimingPath();
+    expect(typeof path).toBe('string');
+    // Claude backend was constructed to answer this call
+    expect(path).toBe(claudeFake.getEphemeralTimingPath());
+  });
+
+  // --- Auth routing ---
+
+  it('getAuthStatus defaults to claude before any backend is used', async () => {
+    await router.getAuthStatus();
+    expect(claudeFake.getAuthStatusMock).toHaveBeenCalledOnce();
+    expect(opencodeFake.getAuthStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('getAuthStatus routes to last backend resolved by sendMessage', async () => {
+    router.sendMessage('tab-x', 'hi', '/opencode-project');
+    await router.getAuthStatus();
+    expect(opencodeFake.getAuthStatusMock).toHaveBeenCalledOnce();
+    expect(claudeFake.getAuthStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('login routes to last backend resolved by ephemeral call', async () => {
+    await router.runEphemeralAgent('p', '/opencode-project');
+    await router.login();
+    expect(opencodeFake.loginMock).toHaveBeenCalledOnce();
+    expect(claudeFake.loginMock).not.toHaveBeenCalled();
+  });
+
+  it('auth reverts to claude if last call was claude', async () => {
+    router.sendMessage('tab-oc', 'a', '/opencode-project');
+    router.sendMessage('tab-cl', 'b', '/claude-project');
+    await router.getAuthStatus();
+    expect(claudeFake.getAuthStatusMock).toHaveBeenCalledOnce();
+    expect(opencodeFake.getAuthStatusMock).not.toHaveBeenCalled();
+  });
+
+  // --- syncCredentials fan-out ---
+
+  it('syncCredentials fans out to all instantiated backends', async () => {
+    await router.initialize();
+    router.sendMessage('tab-oc', 'hi', '/opencode-project'); // instantiate opencode
+    const stacks = [{ status: 'running' }];
+    await router.syncCredentials(stacks);
+    expect(claudeFake.syncCredentialsMock).toHaveBeenCalledWith(stacks);
+    expect(opencodeFake.syncCredentialsMock).toHaveBeenCalledWith(stacks);
+  });
+
+  it('syncCredentials only calls instantiated backends (not all factories)', async () => {
+    // Only claude is instantiated after initialize()
+    await router.initialize();
+    await router.syncCredentials([]);
+    expect(claudeFake.syncCredentialsMock).toHaveBeenCalledOnce();
+    expect(opencodeFake.syncCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  // --- Factory errors ---
+
+  it('throws if selector returns a backend type with no registered factory', () => {
+    const routerNoOpencode = new BackendRouter(
+      { claude: () => claudeFake },
+      () => 'opencode',
+    );
+    expect(() => routerNoOpencode.sendMessage('t', 'msg', '/project')).toThrow(
+      /no factory registered for backend type 'opencode'/,
+    );
+  });
+
+  // --- Claude-only zero-behavior-change ---
+
+  it('with claude-only factories behaves as if directly using the claude backend', async () => {
+    const claudeOnly = new BackendRouter(
+      { claude: () => claudeFake },
+      () => 'claude',
+    );
+    await claudeOnly.initialize();
+    claudeOnly.sendMessage('tab-z', 'test message', '/any-project');
+    expect(claudeFake.getHistory('tab-z').messages[0].content).toBe('test message');
+    claudeOnly.resetSession('tab-z');
+    expect(claudeFake.getHistory('tab-z').messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `BackendRouter`, an `AgentBackend` implementation that dispatches method calls to the correct backend based on a selector callback. The router maintains per-tab sticky ownership so a session stays on the same backend once chosen, fans out lifecycle calls (`initialize`, `destroy`, `setMainWindow`, `syncCredentials`) to all instantiated backends, and defaults to claude for unknown tabs or missing registrations.

The claude backend is now constructed inside the router via a lazy factory map, and `index.ts` passes `registry.getEffectiveBackend()` as the selector. This is the plumbing needed for `#478` to wire in `OpenCodeBackend` without touching the main process bootstrap again.

Also adds two new test files: a conformance suite parameterized against any `AgentBackend` implementation, and 43 router-specific tests covering sticky ownership, fan-out, ephemeral routing, auth routing, and the claude default path.

## QA plan

- Launch the app and open a project; confirm claude sessions start and respond normally (no regression from the router wrapping).
- Check that `resetSession` clears tab ownership: start a session, call reset, start another session in the same tab, and confirm routing still resolves cleanly.
- Verify the ephemeral timing path delegates to claude regardless of which backend is selected for the tab.

Closes #475