### PR TITLE
[582] fix: move claude mounts to a compose overlay

### DIFF
--- a/sandstorm-cli/compose/claude-overlay.yml
+++ b/sandstorm-cli/compose/claude-overlay.yml
@@ -1,0 +1,31 @@
+# Sandstorm claude-service overlay — injected by stack.sh as the LAST -f file
+# on every docker compose invocation. App-owned: ships with the CLI bundle, so
+# every stack always runs the current app version's claude service definition,
+# regardless of how old the project's .sandstorm/docker-compose.yml is.
+#
+# Do not run standalone. Do not copy into project directories.
+services:
+  claude:
+    image: sandstorm-${SANDSTORM_PROJECT_NAME:?set by stack.sh run_compose}-claude
+    build:
+      context: ${SANDSTORM_DIR}
+      dockerfile: docker/Dockerfile
+      args:
+        SANDSTORM_APP_VERSION: ${SANDSTORM_APP_VERSION:-unknown}
+    environment:
+      - GIT_USER_NAME
+      - GIT_USER_EMAIL
+      - SANDSTORM_PROJECT
+      - SANDSTORM_STACK_ID
+    volumes:
+      - ${SANDSTORM_WORKSPACE}:/app
+      - ${SANDSTORM_CONTEXT}:/sandstorm-context:ro
+      - ${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 60
+    tty: true
+    stdin_open: true

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -164,6 +164,7 @@ COMPOSE_PROJECT="sandstorm-${PROJECT_NAME}-${STACK_ID}"
 CONTAINER_NAME="${COMPOSE_PROJECT}-claude-1"
 
 SANDSTORM_COMPOSE="$PROJECT_ROOT/.sandstorm/docker-compose.yml"
+CLAUDE_OVERLAY="$SANDSTORM_DIR/compose/claude-overlay.yml"
 PROJECT_COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
 
 # Workspace directory — the cloned repo for this stack
@@ -226,11 +227,13 @@ run_compose() {
   SANDSTORM_USAGE_DIR="$usage_dir" \
   SANDSTORM_PROJECT="$COMPOSE_PROJECT" \
   SANDSTORM_STACK_ID="$STACK_ID" \
+  SANDSTORM_PROJECT_NAME="$PROJECT_NAME" \
   GIT_USER_NAME="$GIT_AUTHOR_NAME" \
   GIT_USER_EMAIL="$GIT_AUTHOR_EMAIL" \
   docker compose \
     -f "$WORKSPACE_COMPOSE" \
     -f "$SANDSTORM_COMPOSE" \
+    -f "$CLAUDE_OVERLAY" \
     -p "$COMPOSE_PROJECT" \
     "$@"
 }

--- a/src/main/compose-generator.ts
+++ b/src/main/compose-generator.ts
@@ -446,37 +446,3 @@ export function cleanupLegacyPorts(projectDir: string): { success: boolean; erro
   }
 }
 
-/**
- * Detect whether a sandstorm compose file has the usage mount for transcript ingestion.
- * The mount bridges inner-stack transcripts to the host for telemetry attribution.
- */
-export function hasUsageMount(projectDir: string): boolean {
-  const composePath = path.join(projectDir, '.sandstorm', 'docker-compose.yml');
-  if (!fs.existsSync(composePath)) return false;
-  const content = fs.readFileSync(composePath, 'utf-8');
-  return content.includes('${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects');
-}
-
-/**
- * Add the usage mount to an existing .sandstorm/docker-compose.yml by regenerating it.
- * Idempotent — no-op if the mount is already present.
- * Mirrors cleanupLegacyPorts: re-parses the project compose and regenerates the sandstorm compose.
- */
-export function migrateUsageMount(projectDir: string): { success: boolean; error?: string } {
-  if (hasUsageMount(projectDir)) return { success: true };
-
-  try {
-    const configComposeFile = readComposeFileFromConfig(projectDir);
-    const composeFile = findProjectComposeFile(projectDir, configComposeFile);
-    if (!composeFile) {
-      return { success: false, error: 'No project compose file found' };
-    }
-
-    const analysis = parseProjectCompose(projectDir, composeFile);
-    const yaml = generateComposeYaml(analysis);
-    return saveComposeSetup(projectDir, yaml, false);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { success: false, error: msg };
-  }
-}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -52,7 +52,6 @@ import {
   validateComposeYaml,
   hasLegacyPortMappings,
   cleanupLegacyPorts,
-  migrateUsageMount,
 } from './compose-generator';
 import { getDefaultReviewPrompt } from './review-prompt';
 import {
@@ -452,13 +451,6 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       let networksMigrated = false;
       try {
         networksMigrated = migrateNetworkOverrides(directory);
-      } catch {
-        // Non-critical — don't block migration check
-      }
-
-      // Auto-migrate usage mount so inner-stack transcripts reach the host for telemetry
-      try {
-        migrateUsageMount(directory);
       } catch {
         // Non-critical — don't block migration check
       }

--- a/tests/unit/claude-overlay.test.ts
+++ b/tests/unit/claude-overlay.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const OVERLAY_PATH = path.join(__dirname, '../../sandstorm-cli/compose/claude-overlay.yml');
+const STACK_SH_PATH = path.join(__dirname, '../../sandstorm-cli/lib/stack.sh');
+
+describe('claude-overlay.yml', () => {
+  it('exists at sandstorm-cli/compose/claude-overlay.yml', () => {
+    expect(fs.existsSync(OVERLAY_PATH)).toBe(true);
+  });
+
+  it('contains the usage mount for per-ticket telemetry (regression for #582)', () => {
+    const content = fs.readFileSync(OVERLAY_PATH, 'utf-8');
+    expect(content).toContain(
+      '${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects'
+    );
+  });
+
+  it('contains the workspace mount', () => {
+    const content = fs.readFileSync(OVERLAY_PATH, 'utf-8');
+    expect(content).toContain('${SANDSTORM_WORKSPACE}:/app');
+  });
+
+  it('contains the context mount as read-only', () => {
+    const content = fs.readFileSync(OVERLAY_PATH, 'utf-8');
+    expect(content).toContain('${SANDSTORM_CONTEXT}:/sandstorm-context:ro');
+  });
+
+  it('contains the docker.sock mount', () => {
+    const content = fs.readFileSync(OVERLAY_PATH, 'utf-8');
+    expect(content).toContain('/var/run/docker.sock:/var/run/docker.sock');
+  });
+
+  it('contains the healthcheck', () => {
+    const content = fs.readFileSync(OVERLAY_PATH, 'utf-8');
+    expect(content).toContain('test: ["CMD", "test", "-f", "/tmp/.sandstorm-ready"]');
+  });
+
+  it('uses :? guard on SANDSTORM_PROJECT_NAME to fail fast on missing variable', () => {
+    const content = fs.readFileSync(OVERLAY_PATH, 'utf-8');
+    expect(content).toContain('${SANDSTORM_PROJECT_NAME:?');
+  });
+});
+
+describe('stack.sh overlay wiring', () => {
+  it('defines CLAUDE_OVERLAY pointing at compose/claude-overlay.yml under $SANDSTORM_DIR', () => {
+    const stackSh = fs.readFileSync(STACK_SH_PATH, 'utf-8');
+    expect(stackSh).toContain('CLAUDE_OVERLAY="$SANDSTORM_DIR/compose/claude-overlay.yml"');
+  });
+
+  it('exports SANDSTORM_PROJECT_NAME in run_compose', () => {
+    const stackSh = fs.readFileSync(STACK_SH_PATH, 'utf-8');
+    expect(stackSh).toContain('SANDSTORM_PROJECT_NAME=');
+  });
+
+  it('chains -f "$CLAUDE_OVERLAY" after -f "$SANDSTORM_COMPOSE" in run_compose', () => {
+    const stackSh = fs.readFileSync(STACK_SH_PATH, 'utf-8');
+    const sandstormPos = stackSh.indexOf('-f "$SANDSTORM_COMPOSE"');
+    const overlayPos = stackSh.indexOf('-f "$CLAUDE_OVERLAY"');
+    expect(sandstormPos).toBeGreaterThan(-1);
+    expect(overlayPos).toBeGreaterThan(-1);
+    expect(overlayPos).toBeGreaterThan(sandstormPos);
+  });
+});

--- a/tests/unit/compose-generator.test.ts
+++ b/tests/unit/compose-generator.test.ts
@@ -15,8 +15,6 @@ import {
   validateComposeYaml,
   hasLegacyPortMappings,
   cleanupLegacyPorts,
-  hasUsageMount,
-  migrateUsageMount,
 } from '../../src/main/compose-generator';
 
 describe('compose-generator', () => {
@@ -487,92 +485,4 @@ describe('compose-generator', () => {
     });
   });
 
-  describe('hasUsageMount', () => {
-    it('returns false when no sandstorm compose exists', () => {
-      expect(hasUsageMount(tmpDir)).toBe(false);
-    });
-
-    it('returns false when compose lacks the usage mount', () => {
-      const sandstormDir = path.join(tmpDir, '.sandstorm');
-      fs.mkdirSync(sandstormDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(sandstormDir, 'docker-compose.yml'),
-        'services:\n  claude:\n    volumes:\n      - ${SANDSTORM_WORKSPACE}:/app\n'
-      );
-      expect(hasUsageMount(tmpDir)).toBe(false);
-    });
-
-    it('returns true when compose has the usage mount', () => {
-      const sandstormDir = path.join(tmpDir, '.sandstorm');
-      fs.mkdirSync(sandstormDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(sandstormDir, 'docker-compose.yml'),
-        'services:\n  claude:\n    volumes:\n      - ${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects\n'
-      );
-      expect(hasUsageMount(tmpDir)).toBe(true);
-    });
-  });
-
-  describe('migrateUsageMount', () => {
-    function setupProject(sandstormDir: string) {
-      fs.mkdirSync(sandstormDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(tmpDir, 'docker-compose.yml'),
-        'services:\n  app:\n    image: node\n'
-      );
-      fs.writeFileSync(
-        path.join(sandstormDir, 'config'),
-        'PROJECT_NAME=test\nCOMPOSE_FILE=docker-compose.yml\nPORT_MAP=\n'
-      );
-    }
-
-    it('regenerates compose to include usage mount when mount is absent', () => {
-      const sandstormDir = path.join(tmpDir, '.sandstorm');
-      setupProject(sandstormDir);
-      // Write a stale compose without the usage mount
-      fs.writeFileSync(
-        path.join(sandstormDir, 'docker-compose.yml'),
-        'services:\n  claude:\n    volumes:\n      - ${SANDSTORM_WORKSPACE}:/app\n'
-      );
-
-      expect(hasUsageMount(tmpDir)).toBe(false);
-      const result = migrateUsageMount(tmpDir);
-      expect(result.success).toBe(true);
-
-      const newCompose = fs.readFileSync(path.join(sandstormDir, 'docker-compose.yml'), 'utf-8');
-      expect(newCompose).toContain('${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects');
-    });
-
-    it('is idempotent — no-op when usage mount already present', () => {
-      const sandstormDir = path.join(tmpDir, '.sandstorm');
-      fs.mkdirSync(sandstormDir, { recursive: true });
-      const mountedCompose =
-        'services:\n  claude:\n    volumes:\n      - ${SANDSTORM_USAGE_DIR}/${SANDSTORM_STACK_ID}:/home/claude/.claude/projects\n';
-      fs.writeFileSync(path.join(sandstormDir, 'docker-compose.yml'), mountedCompose);
-
-      const result = migrateUsageMount(tmpDir);
-      expect(result.success).toBe(true);
-
-      // File content must be unchanged (idempotent)
-      const after = fs.readFileSync(path.join(sandstormDir, 'docker-compose.yml'), 'utf-8');
-      expect(after).toBe(mountedCompose);
-    });
-
-    it('returns error when no project compose file exists', () => {
-      const sandstormDir = path.join(tmpDir, '.sandstorm');
-      fs.mkdirSync(sandstormDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(sandstormDir, 'config'),
-        'PROJECT_NAME=test\nCOMPOSE_FILE=nonexistent.yml\n'
-      );
-      // Write stale compose so hasUsageMount returns false
-      fs.writeFileSync(
-        path.join(sandstormDir, 'docker-compose.yml'),
-        'services:\n  claude:\n    volumes:\n      - ${SANDSTORM_WORKSPACE}:/app\n'
-      );
-
-      const result = migrateUsageMount(tmpDir);
-      expect(result.success).toBe(false);
-    });
-  });
 });


### PR DESCRIPTION
## Summary

The usage mount, workspace, context, and docker.sock mounts for the Claude container were previously injected at runtime by `migrateUsageMount` / `hasUsageMount` in the TypeScript compose generator. This approach was fragile and hard to inspect.

Those two functions are removed entirely. In their place, a static `sandstorm-cli/compose/claude-overlay.yml` declares all Claude-specific mounts, the healthcheck, and a `:?` guard on `SANDSTORM_PROJECT_NAME`. `stack.sh` exports `SANDSTORM_PROJECT_NAME` and chains `-f "$CLAUDE_OVERLAY"` last in the `docker compose` invocation, so the overlay is applied on every stack operation without any TypeScript involvement.

Test coverage follows the same split: the two deleted functions' test blocks are removed from `compose-generator.test.ts`, and a new `claude-overlay.test.ts` asserts both the overlay file content and the `stack.sh` wiring.

## QA plan

1. Start a new stack and confirm the Claude container comes up with the usage mount, workspace, and docker.sock visible inside the container.
2. Confirm `SANDSTORM_PROJECT_NAME` is set in the environment before `docker compose` runs; deliberately unset it and verify the stack refuses to start with the `:?` error.
3. Confirm no `migrateUsageMount` or `hasUsageMount` references remain in `src/` or `tests/` (both were fully deleted).
4. Tear down and recreate a stack to verify the overlay is applied on both `up` and subsequent operations.

Closes #582