### PR TITLE
[534] fix: wire per-stage model routing to ephemeral agent calls

### DIFF
--- a/src/main/agent/backend-router.ts
+++ b/src/main/agent/backend-router.ts
@@ -164,10 +164,11 @@ export class BackendRouter implements AgentBackend {
     projectDir: string,
     timeoutMs?: number,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): Promise<string> {
     const type = this.selector(projectDir);
     this.lastProjectBackendId = type;
-    return this.getBackend(type).runEphemeralAgent(prompt, projectDir, timeoutMs, attribution);
+    return this.getBackend(type).runEphemeralAgent(prompt, projectDir, timeoutMs, attribution, model);
   }
 
   spawnEphemeralAgent(
@@ -176,10 +177,11 @@ export class BackendRouter implements AgentBackend {
     timeoutMs?: number,
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): { promise: Promise<string>; cancel: () => void } {
     const type = this.selector(projectDir);
     this.lastProjectBackendId = type;
-    return this.getBackend(type).spawnEphemeralAgent(prompt, projectDir, timeoutMs, onChunk, attribution);
+    return this.getBackend(type).spawnEphemeralAgent(prompt, projectDir, timeoutMs, onChunk, attribution, model);
   }
 
   spawnEphemeralSession(

--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -405,12 +405,14 @@ export class ClaudeBackend implements AgentBackend {
     timeoutMs = 300_000,
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): { promise: Promise<string>; cancel: () => void } {
     const claudeBin = getClaudeBin();
     const args = [
       '-p', prompt,
       '--output-format', 'stream-json',
       '--dangerously-skip-permissions',
+      ...(model && model !== 'auto' ? ['--model', model] : []),
     ];
 
     const spawnedAt = Date.now();
@@ -566,8 +568,9 @@ export class ClaudeBackend implements AgentBackend {
     projectDir: string,
     timeoutMs = 300_000,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): Promise<string> {
-    return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs, undefined, attribution).promise;
+    return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs, undefined, attribution, model).promise;
   }
 
   /**

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -121,6 +121,7 @@ export interface AgentBackend {
     projectDir: string,
     timeoutMs?: number,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): Promise<string>;
 
   /** Spawn a cancellable one-shot agent process; returns a promise and a cancel function */
@@ -130,6 +131,7 @@ export interface AgentBackend {
     timeoutMs?: number,
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): { promise: Promise<string>; cancel: () => void };
 
   /**

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -317,6 +317,15 @@ Mark at most one option per question with \`"recommended": true\` when you have 
 `;
 }
 
+function resolveRefineModel(projectDir: string): string | undefined {
+  const routing = registry.getEffectiveRoutingFor(projectDir, 'refine');
+  if (routing.backend === 'opencode') {
+    console.warn('[refine] backend=opencode unsupported for host path; falling back to legacy outer model');
+    return registry.getLegacyEffectiveModels(projectDir).outer_model;
+  }
+  return routing.model;
+}
+
 async function handleSpecCheck(
   ticketId: string,
   projectDir: string
@@ -326,7 +335,7 @@ async function handleSpecCheck(
   const { ctx } = res;
 
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' });
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -524,13 +533,13 @@ async function handleSpecRefine(
 
   if (!userAnswers) {
     const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody);
-    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' });
+    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, resolveRefineModel(projectDir));
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   }
 
   const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' });
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, resolveRefineModel(projectDir));
   return applySpecRefineResult(ticketId, projectDir, result, true);
 }
 
@@ -556,7 +565,7 @@ export function spawnSpecCheck(
     if (cancelled) throw new Error('Cancelled');
 
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' });
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 
@@ -651,7 +660,7 @@ export function spawnSpecRefine(
       // No pooled session (timed out, app restarted, etc.) — fall back to a
       // cold ephemeral so the user's answers still produce a result.
       const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(
-        answerPrompt, projectDir, 0, onChunk, { ticketId, stage: 'refine' },
+        answerPrompt, projectDir, 0, onChunk, { ticketId, stage: 'refine' }, resolveRefineModel(projectDir),
       );
       activeDispose = epCancel;
       if (cancelled) { epCancel(); throw new Error('Cancelled'); }

--- a/src/main/control-plane/dark-factory-orchestrator.ts
+++ b/src/main/control-plane/dark-factory-orchestrator.ts
@@ -206,13 +206,19 @@ export class DarkFactoryOrchestrator {
 
     const workspace = workspacePathFor(projectDir, stackId);
 
+    const prRouting = this.registry.getEffectiveRoutingFor(projectDir, 'pr_description');
+    const prModel = prRouting.backend === 'opencode'
+      ? (console.warn('[pr_description] backend=opencode unsupported for host path; falling back to legacy outer model'),
+         this.registry.getLegacyEffectiveModels(projectDir).outer_model)
+      : prRouting.model;
+
     let draft: { title: string; body: string };
     try {
       draft = await draftPullRequest(
         { stackId, workspace, ticket: stack.ticket },
         {
           runEphemeral: (prompt, dir, timeoutMs) =>
-            this.agentBackend.runEphemeralAgent(prompt, dir, timeoutMs),
+            this.agentBackend.runEphemeralAgent(prompt, dir, timeoutMs, undefined, prModel),
           fetchTaskTail: (id) => this.stackManager.getTaskOutput(id, 50).catch(() => ''),
         },
       );
@@ -331,7 +337,12 @@ export class DarkFactoryOrchestrator {
           `Merge the base branch (main) into the PR branch, resolve all conflicts, and push the result. ` +
           `Use git fetch origin, git merge origin/main, resolve conflicts, git add, git commit, then git push.`;
 
-        await this.agentBackend.runEphemeralAgent(prompt, projectDir, 300_000);
+        const mcRouting = this.registry.getEffectiveRoutingFor(projectDir, 'merge_conflict');
+        const mcModel = mcRouting.backend === 'opencode'
+          ? (console.warn('[merge_conflict] backend=opencode unsupported for host path; falling back to legacy inner model'),
+             this.registry.getLegacyEffectiveModels(projectDir).inner_model)
+          : mcRouting.model;
+        await this.agentBackend.runEphemeralAgent(prompt, projectDir, 300_000, undefined, mcModel);
 
         // Push the resolved state
         await this.stackManager.push(stackId, `fix: resolve merge conflicts for PR #${prNumber}`);

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -1363,7 +1363,7 @@ export class Registry {
     }
   }
 
-  private getLegacyEffectiveModels(projectDir: string): ModelSettings {
+  getLegacyEffectiveModels(projectDir: string): ModelSettings {
     const global = this.getGlobalModelSettings();
     const project = this.getProjectModelSettings(projectDir);
     if (!project) return global;

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -2128,7 +2128,12 @@ export class StackManager {
     ].join('\n');
 
     try {
-      const dispatchResult = await this.dispatchTask(stackId!, resolvePrompt, undefined, {
+      const mcRouting = this.registry.getEffectiveRoutingFor(projectDir, 'merge_conflict');
+      const mcModel = mcRouting.backend === 'opencode'
+        ? (console.warn('[merge_conflict] backend=opencode unsupported for container path; falling back to legacy inner model'),
+           this.registry.getLegacyEffectiveModels(projectDir).inner_model)
+        : mcRouting.model;
+      const dispatchResult = await this.dispatchTask(stackId!, resolvePrompt, mcModel, {
         gateApproved: true,
         skipTicketFetch: true,
       });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -170,7 +170,14 @@ async function initializeApp(): Promise<void> {
   // backend; the renderer reads it via `agent:tokenUsage` / listens to
   // `agent:token-usage:<tabId>` events. No DB persistence — "New Session"
   // resets the counter by design.
-  const modelResolver = (projectDir: string) => registry.getEffectiveModels(projectDir).outer_model;
+  const modelResolver = (projectDir: string) => {
+    const routing = registry.getEffectiveRoutingFor(projectDir, 'outer');
+    if (routing.backend === 'opencode') {
+      console.warn('[outer] backend=opencode unsupported for host path; falling back to legacy outer model');
+      return registry.getLegacyEffectiveModels(projectDir).outer_model;
+    }
+    return routing.model;
+  };
   agentBackend = new BackendRouter(
     { claude: () => new ClaudeBackend(undefined, modelResolver) },
     (projectDir) => registry.getEffectiveBackend(projectDir, 'outer').backend,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1580,6 +1580,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   ipcMain.handle('pr:draftBody', async (_event, stackId: string) => {
     const stack = await stackManager.getStackWithServices(stackId);
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
+    const prRouting = registry.getEffectiveRoutingFor(stack.project_dir, 'pr_description');
+    const prModel = prRouting.backend === 'opencode'
+      ? (console.warn('[pr_description] backend=opencode unsupported for host path; falling back to legacy outer model'),
+         registry.getLegacyEffectiveModels(stack.project_dir).outer_model)
+      : prRouting.model;
     return draftPullRequest(
       {
         stackId,
@@ -1588,7 +1593,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       },
       {
         runEphemeral: (prompt, projectDir, timeoutMs) =>
-          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }),
+          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }, prModel),
         fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
       },
     );
@@ -1668,6 +1673,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
 
     const workspace = workspacePathFor(stack.project_dir, stackId);
+    const prRouting = registry.getEffectiveRoutingFor(stack.project_dir, 'pr_description');
+    const prModel = prRouting.backend === 'opencode'
+      ? (console.warn('[pr_description] backend=opencode unsupported for host path; falling back to legacy outer model'),
+         registry.getLegacyEffectiveModels(stack.project_dir).outer_model)
+      : prRouting.model;
 
     let draft: { title: string; body: string };
     try {
@@ -1675,7 +1685,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         { stackId, workspace, ticket: stack.ticket },
         {
           runEphemeral: (prompt, projectDir, timeoutMs) =>
-            agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }),
+            agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }, prModel),
           fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
         },
       );

--- a/tests/unit/agent/agent-backend-conformance.test.ts
+++ b/tests/unit/agent/agent-backend-conformance.test.ts
@@ -101,8 +101,9 @@ export class FakeAgentBackend implements AgentBackend {
     projectDir: string,
     timeoutMs?: number,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): Promise<string> {
-    return this.runEphemeralAgentMock(prompt, projectDir, timeoutMs, attribution);
+    return this.runEphemeralAgentMock(prompt, projectDir, timeoutMs, attribution, model);
   }
 
   spawnEphemeralAgent(
@@ -111,8 +112,9 @@ export class FakeAgentBackend implements AgentBackend {
     timeoutMs?: number,
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
+    model?: string,
   ): { promise: Promise<string>; cancel: () => void } {
-    return this.spawnEphemeralAgentMock(prompt, projectDir, timeoutMs, onChunk, attribution);
+    return this.spawnEphemeralAgentMock(prompt, projectDir, timeoutMs, onChunk, attribution, model);
   }
 
   spawnEphemeralSession(

--- a/tests/unit/agent/backend-router.test.ts
+++ b/tests/unit/agent/backend-router.test.ts
@@ -227,9 +227,10 @@ describe('BackendRouter', () => {
   it('ephemeral calls pass through all arguments', async () => {
     const onChunk = vi.fn();
     const attribution = { ticketId: 'T-1', stage: 'spec' };
-    router.spawnEphemeralAgent('p', '/claude-project', 5000, onChunk, attribution);
+    const model = 'claude-opus-4-5';
+    router.spawnEphemeralAgent('p', '/claude-project', 5000, onChunk, attribution, model);
     expect(claudeFake.spawnEphemeralAgentMock).toHaveBeenCalledWith(
-      'p', '/claude-project', 5000, onChunk, attribution,
+      'p', '/claude-project', 5000, onChunk, attribution, model,
     );
   });
 

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1079,6 +1079,64 @@ describe('spawnEphemeralAgent — env trim and CLI args (#370)', () => {
 
     backendUnderTest.destroy();
   });
+
+  it('passes --model <model> when model override is provided', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000, undefined, undefined, 'claude-opus-4-5');
+
+    const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+    expect(spawnedArgs).toContain('--model');
+    expect(spawnedArgs).toContain('claude-opus-4-5');
+
+    backendUnderTest.destroy();
+  });
+
+  it('does NOT pass --model when model is "auto"', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000, undefined, undefined, 'auto');
+
+    const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+    expect(spawnedArgs).not.toContain('--model');
+
+    backendUnderTest.destroy();
+  });
+
+  it('does NOT pass --model when model param is omitted (legacy behavior unchanged)', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.spawnEphemeralAgent('prompt', '/tmp', 5_000);
+
+    const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+    expect(spawnedArgs).not.toContain('--model');
+
+    backendUnderTest.destroy();
+  });
+
+  it('runEphemeralAgent threads model override to spawnEphemeralAgent', async () => {
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    backendUnderTest.runEphemeralAgent('prompt', '/tmp', 5_000, undefined, 'claude-haiku-4-5');
+
+    const spawnedArgs: string[] = spawnMock.mock.calls[spawnMock.mock.calls.length - 1][1];
+    expect(spawnedArgs).toContain('--model');
+    expect(spawnedArgs).toContain('claude-haiku-4-5');
+
+    backendUnderTest.destroy();
+  });
 });
 
 describe('Outer-Claude session token accumulation (agent:token-usage IPC)', () => {

--- a/tests/unit/dark-factory-orchestrator.test.ts
+++ b/tests/unit/dark-factory-orchestrator.test.ts
@@ -67,6 +67,8 @@ function makeRegistry(overrides: Partial<{
   setBoardTicketColumn: () => void;
   listBoardTickets: (dir: string) => unknown[];
   listProjects: () => { directory: string }[];
+  getEffectiveRoutingFor: (dir: string, touchpoint: string) => { backend: string; model: string };
+  getLegacyEffectiveModels: (dir: string) => { inner_model: string; outer_model: string };
 }> = {}) {
   return {
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
@@ -75,6 +77,8 @@ function makeRegistry(overrides: Partial<{
     setBoardTicketColumn: vi.fn(),
     listBoardTickets: vi.fn().mockReturnValue([]),
     listProjects: vi.fn().mockReturnValue([]),
+    getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'sonnet' }),
+    getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
     ...overrides,
   };
 }
@@ -799,6 +803,8 @@ describe('DarkFactoryOrchestrator', () => {
         expect.stringContaining('resolve'),
         '/proj',
         300_000,
+        undefined,
+        expect.any(String),
       );
       expect(registry.setBoardTicketColumn).toHaveBeenCalledWith('T-1', '/proj', 'merged');
     });
@@ -830,6 +836,144 @@ describe('DarkFactoryOrchestrator', () => {
         (c) => c[2] === 'merged',
       );
       expect(mergedCalls).toHaveLength(0);
+    });
+
+    it('passes resolved merge_conflict model to runEphemeralAgent', async () => {
+      registry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+
+      let viewCallCount = 0;
+      mockExecFile.mockImplementation(
+        (_cmd: unknown, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
+          if ((args as string[]).includes('view')) {
+            viewCallCount++;
+            if (viewCallCount <= 1) {
+              cb(null, JSON.stringify({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }), '');
+            } else {
+              cb(null, JSON.stringify({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }), '');
+            }
+          } else {
+            cb(null, '', '');
+          }
+          return {} as never;
+        },
+      );
+
+      orchestrator.handlePrCreated('stack-1', 99);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Number),
+        undefined,
+        'haiku',
+      );
+    });
+
+    it('falls back to legacy inner model and warns when merge_conflict backend is opencode', async () => {
+      registry.getEffectiveRoutingFor.mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
+      registry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      let viewCallCount = 0;
+      mockExecFile.mockImplementation(
+        (_cmd: unknown, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
+          if ((args as string[]).includes('view')) {
+            viewCallCount++;
+            if (viewCallCount <= 1) {
+              cb(null, JSON.stringify({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }), '');
+            } else {
+              cb(null, JSON.stringify({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }), '');
+            }
+          } else {
+            cb(null, '', '');
+          }
+          return {} as never;
+        },
+      );
+
+      orchestrator.handlePrCreated('stack-1', 99);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Number),
+        undefined,
+        'sonnet',
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+      warnSpy.mockRestore();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PR description routing
+  // -------------------------------------------------------------------------
+  describe('createPR — pr_description routing', () => {
+    beforeEach(() => {
+      registry.getStack.mockReturnValue({ ticket: 'T-1', project_dir: '/proj' });
+      registry.getDarkFactoryEnabled.mockReturnValue(true);
+      vi.mocked(draftPullRequest).mockResolvedValue({ title: 'feat: T-1', body: 'body' });
+      vi.mocked(createPullRequest).mockResolvedValue({ url: 'https://gh/pr/1', number: 1 });
+      mockExecFile.mockImplementation(
+        (_cmd: unknown, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
+          if ((args as string[]).includes('view')) {
+            cb(null, JSON.stringify({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }), '');
+          } else {
+            cb(null, '', '');
+          }
+          return {} as never;
+        },
+      );
+    });
+
+    it('passes resolved pr_description model via runEphemeral closure', async () => {
+      registry.getEffectiveRoutingFor.mockImplementation((_dir: string, touchpoint: string) => {
+        if (touchpoint === 'pr_description') return { backend: 'claude', model: 'haiku' };
+        return { backend: 'claude', model: 'sonnet' };
+      });
+
+      orchestrator.handleTaskCompleted('stack-1', {} as never);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [, deps] = vi.mocked(draftPullRequest).mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
+      agentBackend.runEphemeralAgent.mockResolvedValue('draft');
+      await deps.runEphemeral('test prompt', '/proj');
+
+      expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        'test prompt',
+        '/proj',
+        undefined,
+        undefined,
+        'haiku',
+      );
+    });
+
+    it('falls back to legacy outer model and warns when pr_description backend is opencode', async () => {
+      registry.getEffectiveRoutingFor.mockImplementation((_dir: string, touchpoint: string) => {
+        if (touchpoint === 'pr_description') return { backend: 'opencode', model: 'gpt-4' };
+        return { backend: 'claude', model: 'sonnet' };
+      });
+      registry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      orchestrator.handleTaskCompleted('stack-1', {} as never);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [, deps] = vi.mocked(draftPullRequest).mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
+      agentBackend.runEphemeralAgent.mockResolvedValue('draft');
+      await deps.runEphemeral('test prompt', '/proj');
+
+      expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        'test prompt',
+        '/proj',
+        undefined,
+        undefined,
+        'opus',
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+      warnSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -85,6 +85,8 @@ const {
     setBackendSecret: vi.fn(),
     hasBackendSecret: vi.fn().mockReturnValue(false),
     getEffectiveRouting: vi.fn().mockReturnValue({}),
+    getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'haiku' }),
+    getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
     getProjectRouting: vi.fn().mockReturnValue(null),
     setProjectRouting: vi.fn(),
     removeProjectRouting: vi.fn(),
@@ -141,6 +143,7 @@ const {
     login: vi.fn(),
     syncCredentials: vi.fn(),
     getEphemeralTimingPath: vi.fn().mockReturnValue('/tmp/mock-ephemeral-timing.jsonl'),
+    runEphemeralAgent: vi.fn().mockResolvedValue(''),
   };
 
   const mockDockerConnectionManager = {
@@ -326,6 +329,14 @@ vi.mock('../../src/main/control-plane/ticket-config', () => ({
 
 vi.mock('../../src/main/control-plane/retry-with-backoff', () => ({
   withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+const mockDraftPullRequest = vi.fn().mockResolvedValue({ title: 'feat: T-1', body: 'PR body' });
+const mockCreatePullRequest = vi.fn().mockResolvedValue({ url: 'https://gh/pr/1', number: 1 });
+vi.mock('../../src/main/control-plane/pr-creator', () => ({
+  draftPullRequest: (...args: unknown[]) => mockDraftPullRequest(...args),
+  createPullRequest: (...args: unknown[]) => mockCreatePullRequest(...args),
+  workspacePathFor: vi.fn((projectDir: string, stackId: string) => `${projectDir}/.sandstorm/workspaces/${stackId}`),
 }));
 
 vi.mock('../../src/main/claude/tools', () => ({
@@ -2887,6 +2898,116 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner') as Record<string, unknown>;
       expect(Object.keys(result)).toEqual(['set']);
       expect(result['set']).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // PR description routing
+  // =========================================================================
+  describe('pr_description routing', () => {
+    const STACK = { id: 'stack-1', project_dir: '/proj', ticket: 'T-1', services: [] };
+
+    beforeEach(() => {
+      mockStackManager.getStackWithServices.mockResolvedValue(STACK);
+      mockStackManager.getTaskOutput = vi.fn().mockResolvedValue('');
+      mockDraftPullRequest.mockResolvedValue({ title: 'feat: T-1', body: 'PR body' });
+      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+      mockRegistry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+    });
+
+    it('pr:draftBody forwards resolved pr_description model to runEphemeralAgent', async () => {
+      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+      mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
+
+      await invokeHandler('pr:draftBody', 'stack-1');
+
+      const [, deps] = mockDraftPullRequest.mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
+      await deps.runEphemeral('test prompt', '/proj');
+
+      expect(mockAgentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        'test prompt',
+        '/proj',
+        undefined,
+        expect.objectContaining({ stage: 'pr' }),
+        'haiku',
+      );
+    });
+
+    it('pr:draftBody falls back to legacy outer model and warns when pr_description backend is opencode', async () => {
+      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
+      mockRegistry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
+
+      await invokeHandler('pr:draftBody', 'stack-1');
+
+      const [, deps] = mockDraftPullRequest.mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
+      await deps.runEphemeral('test prompt', '/proj');
+
+      expect(mockAgentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        'test prompt',
+        '/proj',
+        undefined,
+        expect.objectContaining({ stage: 'pr' }),
+        'opus',
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+      warnSpy.mockRestore();
+    });
+
+    it('pr:createAuto forwards resolved pr_description model to runEphemeralAgent', async () => {
+      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+      mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
+      mockStackManager.push = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+      const { execFile } = await import('child_process');
+      vi.mocked(execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (_cmd: unknown, _args: unknown, _opts: unknown, cb: (...a: unknown[]) => void) => {
+          cb(null, JSON.stringify({ url: 'https://gh/pr/1', number: 1 }), '');
+          return {} as never;
+        },
+      );
+
+      await invokeHandler('pr:createAuto', 'stack-1');
+
+      const [, deps] = mockDraftPullRequest.mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
+      await deps.runEphemeral('test prompt', '/proj');
+
+      expect(mockAgentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        'test prompt',
+        '/proj',
+        undefined,
+        expect.objectContaining({ stage: 'pr' }),
+        'haiku',
+      );
+    });
+
+    it('pr:createAuto falls back to legacy outer model and warns when pr_description backend is opencode', async () => {
+      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
+      mockRegistry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
+      const { execFile } = await import('child_process');
+      vi.mocked(execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (_cmd: unknown, _args: unknown, _opts: unknown, cb: (...a: unknown[]) => void) => {
+          cb(null, JSON.stringify({ url: 'https://gh/pr/1', number: 1 }), '');
+          return {} as never;
+        },
+      );
+
+      await invokeHandler('pr:createAuto', 'stack-1');
+
+      const [, deps] = mockDraftPullRequest.mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
+      await deps.runEphemeral('test prompt', '/proj');
+
+      expect(mockAgentBackend.runEphemeralAgent).toHaveBeenCalledWith(
+        'test prompt',
+        '/proj',
+        undefined,
+        expect.objectContaining({ stage: 'pr' }),
+        'opus',
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+      warnSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/stack-manager-auto-resolve.test.ts
+++ b/tests/unit/stack-manager-auto-resolve.test.ts
@@ -197,7 +197,7 @@ describe('StackManager.autoResolveConflicts internals', () => {
       expect(dispatchTaskSpy).toHaveBeenCalledWith(
         'stack-1',
         expect.any(String),
-        undefined,
+        expect.anything(),
         expect.objectContaining({ gateApproved: true })
       );
     });
@@ -328,7 +328,7 @@ describe('StackManager.autoResolveConflicts internals', () => {
       expect(dispatchTaskSpy).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
-        undefined,
+        expect.anything(),
         expect.objectContaining({ gateApproved: true })
       );
     });
@@ -377,6 +377,56 @@ describe('StackManager.autoResolveConflicts internals', () => {
       vi.spyOn(registry, 'listStackHistory').mockReturnValue([]);
 
       await expect(manager.autoResolveConflicts(TICKET, PROJECT_DIR)).rejects.toThrow();
+    });
+  });
+
+  // ==========================================================================
+  // merge_conflict routing
+  // ==========================================================================
+  describe('merge_conflict routing', () => {
+    beforeEach(() => {
+      registry.createStack({
+        id: 'stack-1',
+        project: 'test',
+        project_dir: PROJECT_DIR,
+        ticket: TICKET,
+        branch: BRANCH,
+        description: null,
+        status: 'pr_created',
+        runtime: 'docker',
+      });
+      registry.setPullRequest('stack-1', PR_URL, PR_NUMBER);
+      mockGhFn.mockResolvedValue(ghViewJson('CONFLICTING'));
+    });
+
+    it('dispatches with legacy inner model when no routing configured', async () => {
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      const [, , model] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, ...unknown[]];
+      const legacy = registry.getLegacyEffectiveModels(PROJECT_DIR);
+      expect(model).toBe(legacy.inner_model);
+    });
+
+    it('dispatches with resolved merge_conflict model when routing is configured', async () => {
+      registry.setProjectRouting(PROJECT_DIR, { assignments: { merge_conflict: { backend: 'claude', model: 'haiku' } }, preset: null });
+
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      const [, , model] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, ...unknown[]];
+      expect(model).toBe('haiku');
+    });
+
+    it('falls back to legacy inner model and logs warning when merge_conflict backend is opencode', async () => {
+      registry.setProjectRouting(PROJECT_DIR, { assignments: { merge_conflict: { backend: 'opencode', model: 'some-opencode-model' } }, preset: null });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
+
+      const [, , model] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, ...unknown[]];
+      const legacy = registry.getLegacyEffectiveModels(PROJECT_DIR);
+      expect(model).toBe(legacy.inner_model);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+      warnSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -16,6 +16,8 @@ vi.mock('../../src/main/index', () => ({
   },
   registry: {
     getProjectTicketConfig: vi.fn().mockReturnValue({ provider: 'github' }),
+    getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'sonnet' }),
+    getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
   },
 }));
 
@@ -189,7 +191,8 @@ describe('MCP tools', () => {
         expect.stringContaining('Fix bug'),
         '/proj',
         1_800_000,
-        { ticketId: '42', stage: 'spec' }
+        { ticketId: '42', stage: 'spec' },
+        expect.anything(),
       );
       expect(result.passed).toBe(true);
       expect(result.report).toContain('PASS');
@@ -562,7 +565,8 @@ describe('MCP tools', () => {
         expect.stringContaining('auth tokens expire silently'),
         '/proj',
         1_800_000,
-        { ticketId: '42', stage: 'refine' }
+        { ticketId: '42', stage: 'refine' },
+        expect.anything(),
       );
       expect(result.passed).toBe(true);
       expect(result.updatedBody).toContain('Better spec');
@@ -923,6 +927,108 @@ describe('MCP tools', () => {
       await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
       const [, , timeoutArg] = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls[0];
       expect(timeoutArg).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refine routing — model passthrough tests
+  // -------------------------------------------------------------------------
+  describe('refine routing — model passthrough', () => {
+    beforeEach(() => {
+      _clearTicketBodyCacheForTests();
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: T-99\nbody text');
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue('## Spec Quality Gate: PASS\nAll good.');
+      vi.mocked(agentBackend.spawnEphemeralAgent).mockReturnValue({
+        promise: Promise.resolve('## Spec Quality Gate: PASS'),
+        cancel: vi.fn(),
+      });
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'sonnet' });
+      vi.mocked(registry.getLegacyEffectiveModels).mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+    });
+
+    it('handleSpecCheck forwards resolved refine model to runEphemeralAgent', async () => {
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'haiku' });
+
+      await handleToolCall('spec_check', { ticketId: 'T-99', projectDir: '/proj' });
+
+      const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[4]).toBe('haiku');
+    });
+
+    it('spawnSpecCheck forwards resolved refine model to spawnEphemeralAgent', async () => {
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'opus' });
+
+      spawnSpecCheck('T-99', '/proj');
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
+
+      const calls = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[5]).toBe('opus');
+    });
+
+    it('falls back to legacy outer model and warns when refine backend is opencode', async () => {
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
+      vi.mocked(registry.getLegacyEffectiveModels).mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await handleToolCall('spec_check', { ticketId: 'T-99', projectDir: '/proj' });
+
+      const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[4]).toBe('opus');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+      warnSpy.mockRestore();
+    });
+
+    it('handleSpecRefine initial forwards resolved refine model to runEphemeralAgent', async () => {
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'haiku' });
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Spec Quality Gate: FAIL\n\n### Questions Requiring User Answers\n1. What?',
+      );
+
+      await handleToolCall('spec_refine', { ticketId: 'T-99', projectDir: '/proj' });
+
+      const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[4]).toBe('haiku');
+    });
+
+    it('handleSpecRefine answer forwards resolved refine model to runEphemeralAgent', async () => {
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'haiku' });
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Updated Ticket Body\n\n# Issue: Updated\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+      );
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      await handleToolCall('spec_refine', { ticketId: 'T-99', projectDir: '/proj', userAnswers: 'some answers' });
+
+      const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[4]).toBe('haiku');
+    });
+
+    it('spawnSpecRefine cold fallback forwards resolved refine model to spawnEphemeralAgent', async () => {
+      _disposeAllRefineSessionsForTests();
+      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'opus' });
+      vi.mocked(agentBackend.spawnEphemeralAgent).mockReturnValue({
+        promise: Promise.resolve(
+          '## Updated Ticket Body\n\n# Issue: Cold\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+        ),
+        cancel: vi.fn(),
+      });
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      const { promise } = spawnSpecRefine('T-99', '/proj', 'Answer text');
+      await promise;
+
+      const calls = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[5]).toBe('opus');
     });
   });
 });


### PR DESCRIPTION
## Summary

Ephemeral agent calls were ignoring per-stage model routing — every stage (spec check, spec refine, PR description, merge conflict resolution, outer agent) always ran with the default model regardless of what the registry had configured.

Added an optional `model` parameter to `AgentBackend.runEphemeralAgent` and `spawnEphemeralAgent` (interface, `ClaudeBackend`, `BackendRouter`, and the test fake). When a model is provided and is not `'auto'`, `ClaudeBackend` appends `--model <model>` to the CLI invocation.

Each call site now resolves its model via `registry.getEffectiveRoutingFor(projectDir, stage)` before dispatching. The `opencode` backend is not supported for host-path calls; those sites log a warning and fall back to the legacy model setting. `getLegacyEffectiveModels` was made public to allow the fallback from call sites outside `Registry`.

Coverage added across all affected layers: conformance test fake, `BackendRouter`, `ClaudeBackend`, `DarkFactoryOrchestrator`, IPC handlers, `StackManager`, and `tools`.

## QA plan

- Open a project that has a non-default model configured for the `refine` stage. Trigger spec check and spec refine; confirm the ephemeral Claude process launches with `--model <configured-model>` visible in process args or logs.
- Repeat for `pr_description`: open the PR draft flow and confirm the correct model is used.
- Repeat for `merge_conflict`: trigger an auto-merge-conflict resolution and confirm the model matches the registry setting.
- Configure a project with `backend=opencode` for any routed stage; confirm a warning is logged and the call falls back to the legacy outer/inner model without crashing.
- Verify that projects with no per-stage override continue to behave as before (no model flag passed, default Claude model used).

Closes #534