### PR TITLE
[586] fix: exclude orchestrator from telemetry ticket rows

### DIFF
--- a/src/renderer/components/TelemetryView.tsx
+++ b/src/renderer/components/TelemetryView.tsx
@@ -163,17 +163,18 @@ export function TelemetryView() {
   // Derived: daily cost for sparkline
   const dailyCosts = telemetryDaily.map((d) => d.cost);
 
-  // Derived: per-ticket rows (join with boardTickets for title/column)
-  const ticketRows = telemetryByTicket.map((entry) => {
-    const isOrchestrator = entry.ticketId === ORCHESTRATOR_TICKET_ID;
-    const board = isOrchestrator ? undefined : boardTickets.find((t) => t.ticket_id === entry.ticketId);
-    return {
-      ...entry,
-      title: isOrchestrator ? 'Orchestrator · ad-hoc' : (board?.title ?? `#${entry.ticketId}`),
-      column: isOrchestrator ? undefined : (board?.column as KanbanColumn | undefined),
-      displayId: isOrchestrator ? '—' : `#${entry.ticketId}`,
-    };
-  });
+  // Derived: per-ticket rows (join with boardTickets for title/column), orchestrator excluded
+  const ticketRows = telemetryByTicket
+    .filter((entry) => entry.ticketId !== ORCHESTRATOR_TICKET_ID)
+    .map((entry) => {
+      const board = boardTickets.find((t) => t.ticket_id === entry.ticketId);
+      return {
+        ...entry,
+        title: board?.title ?? `#${entry.ticketId}`,
+        column: board?.column as KanbanColumn | undefined,
+        displayId: `#${entry.ticketId}`,
+      };
+    });
 
   // Sort tickets
   const sortedTickets = [...ticketRows].sort((a, b) => {

--- a/tests/unit/components/TelemetryView.test.tsx
+++ b/tests/unit/components/TelemetryView.test.tsx
@@ -332,27 +332,41 @@ describe('TelemetryView', () => {
   });
 
   describe('Orchestrator row', () => {
-    it('renders orchestrator as "Orchestrator · ad-hoc" title, not #__orchestrator__', () => {
+    it('does not render orchestrator row when mixed with real tickets', () => {
       setupStore({
         byTicket: [
           { ticketId: '__orchestrator__', model: null, cost: 2.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
+          { ticketId: '42', model: null, cost: 3.0, tokens: { input: 30, output: 15, cacheCreate: 0, cacheRead: 0, total: 45 }, cacheHit: 0, lifecycle: null, unpriced: false },
         ],
       });
       render(<TelemetryView />);
-      const row = screen.getByTestId('ticket-row-__orchestrator__');
-      expect(row.textContent).toContain('Orchestrator · ad-hoc');
-      expect(row.textContent).not.toContain('#__orchestrator__');
+      expect(screen.queryByTestId('ticket-row-__orchestrator__')).toBeNull();
+      expect(screen.getByTestId('ticket-row-42')).toBeDefined();
     });
 
-    it('orchestrator row shows — as displayId', () => {
+    it('shows "No ticket data" empty state when orchestrator is the only entry', () => {
       setupStore({
         byTicket: [
           { ticketId: '__orchestrator__', model: null, cost: 2.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
         ],
       });
       render(<TelemetryView />);
-      const row = screen.getByTestId('ticket-row-__orchestrator__');
-      expect(row.textContent).toContain('—');
+      expect(screen.queryByTestId('ticket-row-__orchestrator__')).toBeNull();
+      expect(screen.getByText('No ticket data')).toBeDefined();
+    });
+
+    it('large orchestrator cost does not appear and does not affect real-ticket bar scaling', () => {
+      setupStore({
+        byTicket: [
+          { ticketId: '__orchestrator__', model: null, cost: 1000.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
+          { ticketId: '55', model: null, cost: 5.0, tokens: { input: 50, output: 25, cacheCreate: 0, cacheRead: 0, total: 75 }, cacheHit: 0, lifecycle: null, unpriced: false },
+        ],
+      });
+      render(<TelemetryView />);
+      expect(screen.queryByTestId('ticket-row-__orchestrator__')).toBeNull();
+      const bar = screen.getByTestId('ticket-bar-55');
+      // bar should be 100% wide (it's the only real ticket, so maxTicketCost === its cost)
+      expect(bar.getAttribute('style')).toContain('width: 100%');
     });
   });
 


### PR DESCRIPTION
## Summary

The telemetry view listed the orchestrator alongside real tickets and let its cost participate in bar scaling. Because the orchestrator's cost is typically much larger than any individual ticket, its bar compressed every real ticket bar, making per-ticket costs hard to compare.

This change filters the orchestrator entry out before building the ticket rows, so it no longer renders and no longer influences scaling. Both `maxTicketCost` and `sortedTickets` now derive from the filtered set, so real-ticket bars scale relative to each other. The now-dead `isOrchestrator` rendering branch is removed.

## QA plan

1. Open the Telemetry view with telemetry data that includes both the orchestrator and one or more real tickets.
2. Confirm the orchestrator row no longer appears in the ticket list.
3. Confirm real ticket bars are scaled relative to each other (the largest real ticket fills the bar) rather than being compressed by the orchestrator's cost.
4. With only orchestrator data present (no real tickets), confirm the "No ticket data" empty state shows.

Closes #586