### PR TITLE
[587] fix: remove gap items from ticket refinement flow

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -292,10 +292,6 @@ Respond in EXACTLY this format (no other text before or after):
 | <criterion name> | PASS/FAIL | <notes> |
 ...
 
-### Gaps (if any)
-- [ ] Specific gap 1 — what needs to be clarified and how to fix it
-...
-
 ### Questions Requiring User Answers (if any)
 
 Every question MUST be phrased as an actionable multiple-choice question — never a statement. Provide 2 or more options when reasonable choices exist.

--- a/src/main/control-plane/ticket-spec.ts
+++ b/src/main/control-plane/ticket-spec.ts
@@ -15,8 +15,6 @@ export interface RefineQuestion {
   id: string;
   question: string;
   options: RefineQuestionOption[];
-  /** 'gap' = self-resolvable spec correction (read-only in UI, not fed to spec_refine) */
-  kind?: 'gap';
 }
 
 /**
@@ -66,39 +64,27 @@ export function extractGateSummary(report: string): string {
 
 /**
  * Parses structured questions from a spec gate report. Looks for a ```json
- * fence under a `### Questions` or `### Gaps` heading and parses it as
- * RefineQuestion[]. Falls back to the legacy numbered-list parser (coercing
- * each line to a RefineQuestion with no options) when no valid JSON block is found.
- * Also parses checkbox items (`- [ ] …`) under `### Gaps` and marks them `kind:'gap'`.
+ * fence under a `### Questions` heading and parses it as RefineQuestion[].
+ * Falls back to the legacy numbered-list parser (coercing each line to a
+ * RefineQuestion with no options) when no valid JSON block is found.
+ * Any `### Gaps` sections in the report are ignored entirely.
  */
 export function extractQuestions(report: string): RefineQuestion[] {
   if (!report) return [];
 
-  // Try JSON block parser first for interactive questions.
   const jsonResult = tryParseJsonBlock(report);
-  // Also extract checkbox gaps regardless (they appear alongside JSON questions).
-  const checkboxGaps = extractCheckboxGaps(report);
-
   if (jsonResult !== null) {
-    // Gaps render above interactive questions in the UI.
-    return [...checkboxGaps, ...jsonResult];
+    return jsonResult;
   }
 
-  // Fallback: numbered-item + checkbox-gap parser.
+  // Fallback: numbered-item parser for `### Questions` sections only.
   const lines = report.split('\n');
   let capture = false;
-  let captureKind: 'question' | 'gap' = 'question';
   const out: RefineQuestion[] = [];
   let idx = 0;
   for (const line of lines) {
     if (/^### Questions/i.test(line)) {
       capture = true;
-      captureKind = 'question';
-      continue;
-    }
-    if (/^### Gaps/i.test(line)) {
-      capture = true;
-      captureKind = 'gap';
       continue;
     }
     if (/^## /.test(line)) {
@@ -106,49 +92,9 @@ export function extractQuestions(report: string): RefineQuestion[] {
       continue;
     }
     if (!capture) continue;
-    // Numbered items work for both sections.
     const numbered = line.match(/^[0-9]+\.\s*(.*)$/);
     if (numbered && numbered[1].trim()) {
-      const item: RefineQuestion = { id: `q${idx + 1}`, question: numbered[1].trim(), options: [] };
-      if (captureKind === 'gap') item.kind = 'gap';
-      out.push(item);
-      idx++;
-      continue;
-    }
-    // Checkbox items (mandated format for Gaps section by buildSpecCheckPrompt).
-    if (captureKind === 'gap') {
-      const checkbox = line.match(/^-\s+\[[ x?]\]\s+(.*)$/);
-      if (checkbox && checkbox[1].trim()) {
-        out.push({ id: `g${idx + 1}`, question: checkbox[1].trim(), options: [], kind: 'gap' });
-        idx++;
-      }
-    }
-  }
-  return out;
-}
-
-/**
- * Extract checkbox items (`- [ ] …`) from the `### Gaps` section only.
- * Used when a JSON block is present so gaps are combined with JSON questions.
- */
-function extractCheckboxGaps(report: string): RefineQuestion[] {
-  const lines = report.split('\n');
-  let capture = false;
-  const out: RefineQuestion[] = [];
-  let idx = 0;
-  for (const line of lines) {
-    if (/^### Gaps/i.test(line)) {
-      capture = true;
-      continue;
-    }
-    // Stop at any other section heading (## or ###).
-    if (capture && (/^## /.test(line) || /^### /.test(line))) {
-      break;
-    }
-    if (!capture) continue;
-    const m = line.match(/^-\s+\[[ x?]\]\s+(.*)$/);
-    if (m && m[1].trim()) {
-      out.push({ id: `g${idx + 1}`, question: m[1].trim(), options: [], kind: 'gap' });
+      out.push({ id: `q${idx + 1}`, question: numbered[1].trim(), options: [] });
       idx++;
     }
   }
@@ -156,7 +102,7 @@ function extractCheckboxGaps(report: string): RefineQuestion[] {
 }
 
 /**
- * Locate the first ```json fence following a ### Questions/Gaps heading and
+ * Locate the first ```json fence following a ### Questions heading and
  * parse it as RefineQuestion[]. Returns null on missing block, parse error,
  * or invalid shape.
  */
@@ -167,7 +113,7 @@ function tryParseJsonBlock(report: string): RefineQuestion[] | null {
   const fenceLines: string[] = [];
 
   for (const line of lines) {
-    if (/^### (Questions|Gaps)/i.test(line)) {
+    if (/^### Questions/i.test(line)) {
       inSection = true;
       continue;
     }

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -79,10 +79,9 @@ export function RefineTicketDialog() {
   const sessionError = session?.error ?? null;
 
   // Initialise answers when gate questions change, restoring from draft if available.
-  // Only interactive questions (kind !== 'gap') get answer slots.
   useEffect(() => {
     if (gate && !gate.passed) {
-      const interactive = gate.questions.filter((q) => q.kind !== 'gap');
+      const interactive = gate.questions;
       if (interactive.length === 0) return;
       const normalized = interactive.map((q, i) => normalizeQuestion(q, i));
       // Read draft imperatively to avoid adding refineAnswerDrafts as a reactive dep.
@@ -188,8 +187,7 @@ export function RefineTicketDialog() {
 
   const handleSubmitAnswers = useCallback(async () => {
     if (!session || !projectDir) return;
-    const rawQuestions = (gate?.questions ?? []).filter((q) => q.kind !== 'gap');
-    const questions = rawQuestions.map((q, i) => normalizeQuestion(q, i));
+    const questions = (gate?.questions ?? []).map((q, i) => normalizeQuestion(q, i));
     const combined = combineAnswers(questions, answers);
     setLocalError(null);
     // Update session optimistically to 'running' while we wait
@@ -454,52 +452,35 @@ export function RefineTicketDialog() {
               </div>
             )}
 
-            {showFailState && gate && (() => {
-              const gapItems = gate.questions.filter((q) => q.kind === 'gap');
-              const interactiveQuestions = gate.questions.filter((q) => q.kind !== 'gap');
-              return (
-                <div className="space-y-3" data-testid="refine-fail">
-                  <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
-                    Spec gate failed. {gate.gateSummary}
-                  </div>
-                  {gapItems.length > 0 && (
-                    <div data-testid="refine-gap-items">
-                      <div className="text-xs font-medium text-sandstorm-text-secondary mb-1.5">Spec Gaps</div>
-                      <ul className="space-y-1">
-                        {gapItems.map((gap) => (
-                          <li key={gap.id} className="text-xs text-sandstorm-muted flex gap-2" data-testid="refine-gap-item">
-                            <span className="mt-0.5 text-amber-400 shrink-0">•</span>
-                            <span>{gap.question}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {interactiveQuestions.length > 0 ? (
-                    <QuestionList
-                      questions={interactiveQuestions.map((q, i) => normalizeQuestion(q, i))}
-                      answers={answers}
-                      onAnswersChange={(next) => {
-                        setAnswers(next);
-                        if (session) setRefineAnswerDraft(session.id, next);
-                      }}
-                      testIdPrefix="refine"
-                    />
-                  ) : gate.reportText ? (
-                    <pre
-                      className="text-xs font-mono text-sandstorm-text bg-sandstorm-bg border border-sandstorm-border rounded-lg p-3 max-h-48 overflow-y-auto whitespace-pre-wrap break-words"
-                      data-testid="refine-report-text"
-                    >
-                      {gate.reportText}
-                    </pre>
-                  ) : (
-                    <div className="text-xs text-sandstorm-muted" data-testid="refine-no-report">
-                      No structured questions parsed. Use Retry to re-run the gate.
-                    </div>
-                  )}
+            {showFailState && gate && (
+              <div className="space-y-3" data-testid="refine-fail">
+                <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
+                  Spec gate failed. {gate.gateSummary}
                 </div>
-              );
-            })()}
+                {gate.questions.length > 0 ? (
+                  <QuestionList
+                    questions={gate.questions.map((q, i) => normalizeQuestion(q, i))}
+                    answers={answers}
+                    onAnswersChange={(next) => {
+                      setAnswers(next);
+                      if (session) setRefineAnswerDraft(session.id, next);
+                    }}
+                    testIdPrefix="refine"
+                  />
+                ) : gate.reportText ? (
+                  <pre
+                    className="text-xs font-mono text-sandstorm-text bg-sandstorm-bg border border-sandstorm-border rounded-lg p-3 max-h-48 overflow-y-auto whitespace-pre-wrap break-words"
+                    data-testid="refine-report-text"
+                  >
+                    {gate.reportText}
+                  </pre>
+                ) : (
+                  <div className="text-xs text-sandstorm-muted" data-testid="refine-no-report">
+                    No structured questions parsed. Use Retry to re-run the gate.
+                  </div>
+                )}
+              </div>
+            )}
 
             {(showErrorState) && !confirmingCancel && (
               <div className="text-xs text-sandstorm-muted" data-testid="refine-error-state">
@@ -555,7 +536,7 @@ export function RefineTicketDialog() {
                   </button>
                 )}
 
-                {showFailState && gate && gate.questions.filter((q) => q.kind !== 'gap').length > 0 && (
+                {showFailState && gate && gate.questions.length > 0 && (
                   <button
                     onClick={handleSubmitAnswers}
                     disabled={isSubmitDisabled(answers)}
@@ -566,7 +547,7 @@ export function RefineTicketDialog() {
                   </button>
                 )}
 
-                {showFailState && gate && gate.questions.filter((q) => q.kind !== 'gap').length === 0 && (
+                {showFailState && gate && gate.questions.length === 0 && (
                   <button
                     onClick={handleRetry}
                     className="px-5 py-2 bg-sandstorm-accent hover:bg-sandstorm-accent-hover text-white text-xs font-medium rounded-lg transition-all active:scale-[0.98] shadow-glow"

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -909,8 +909,6 @@ export interface RefineQuestion {
   id: string;
   question: string;
   options: RefineQuestionOption[];
-  /** 'gap' = self-resolvable spec correction (read-only in UI, not fed to spec_refine) */
-  kind?: 'gap';
 }
 
 /** Renderer-side mirror of `SpecGateResult` from main/control-plane/ticket-spec.ts. */

--- a/tests/unit/components/RefineTicketDialog.test.tsx
+++ b/tests/unit/components/RefineTicketDialog.test.tsx
@@ -1746,73 +1746,37 @@ describe('RefineTicketDialog', () => {
       expect(screen.queryByText(/committed to the ticket/i)).toBeNull();
     });
 
-    it('renders gap items as read-only list when questions contain only gaps', () => {
+    it('refine-gap-items testid is absent (gap display removed)', () => {
       useAppStore.setState({
         refinementSessions: [{
           id: 'session-1', ticketId: '310', projectDir: '/proj',
           status: 'ready', phase: 'check', startedAt: Date.now(),
           result: {
             passed: false,
-            questions: [
-              { id: 'g1', question: 'Citation stale — update to line 42', options: [], kind: 'gap' },
-              { id: 'g2', question: 'Wrong version check', options: [], kind: 'gap' },
-            ],
+            questions: MULTI_OPT_QUESTIONS,
             gateSummary: 'Gate=FAIL, questions=2',
             ticketUrl: null,
             cached: false,
-            reportText: 'Full report here',
           },
         }],
         currentRefinementSessionId: 'session-1',
       });
       render(<RefineTicketDialog />);
-      expect(screen.getByTestId('refine-gap-items')).toBeDefined();
-      const gapItems = screen.getAllByTestId('refine-gap-item');
-      expect(gapItems).toHaveLength(2);
-      expect(gapItems[0].textContent).toContain('Citation stale');
-      // No interactive question inputs
-      expect(screen.queryByTestId('refine-answer-0')).toBeNull();
-      // Submit not shown — only Retry
-      expect(screen.queryByTestId('refine-submit-answers')).toBeNull();
-      expect(screen.getByTestId('refine-run-gate')).toBeDefined();
-    });
-
-    it('renders gap items read-only alongside QuestionList for interactive questions', () => {
-      useAppStore.setState({
-        refinementSessions: [{
-          id: 'session-1', ticketId: '310', projectDir: '/proj',
-          status: 'ready', phase: 'check', startedAt: Date.now(),
-          result: {
-            passed: false,
-            questions: [
-              { id: 'g1', question: 'Fix the citation', options: [], kind: 'gap' },
-              ...MULTI_OPT_QUESTIONS,
-            ],
-            gateSummary: 'Gate=FAIL, questions=3',
-            ticketUrl: null,
-            cached: false,
-          },
-        }],
-        currentRefinementSessionId: 'session-1',
-      });
-      render(<RefineTicketDialog />);
-      // Gap items rendered read-only
-      expect(screen.getByTestId('refine-gap-items')).toBeDefined();
-      // Interactive questions rendered in QuestionList
+      expect(screen.queryByTestId('refine-gap-items')).toBeNull();
+      // Interactive questions still render
       expect(screen.getByTestId('refine-answer-0')).toBeDefined();
-      // Submit button shows (interactive questions present)
       expect(screen.getByTestId('refine-submit-answers')).toBeDefined();
     });
 
-    it('Retry button shown when questions are all gaps (no interactive questions)', () => {
+    it('shows Retry when questions array is empty (no interactive questions)', () => {
       useAppStore.setState({
         refinementSessions: [{
           id: 'session-1', ticketId: '310', projectDir: '/proj',
           status: 'ready', phase: 'check', startedAt: Date.now(),
           result: {
             passed: false,
-            questions: [{ id: 'g1', question: 'Fix it', options: [], kind: 'gap' }],
-            gateSummary: 'Gate=FAIL, questions=1',
+            questions: [],
+            gateSummary: 'Gate=FAIL, questions=0',
             ticketUrl: null,
             cached: false,
           },

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -1117,6 +1117,54 @@ describe('TicketCard', () => {
     expect(screen.getByText('2 questions awaiting')).toBeDefined();
   });
 
+  it('refining: question count reflects only interactive questions (regression #587)', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess1',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [
+            { id: 'q1', question: 'Q1?', options: [] },
+            { id: 'q2', question: 'Q2?', options: [] },
+            { id: 'q3', question: 'Q3?', options: [] },
+          ],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.getByText('3 questions awaiting')).toBeDefined();
+  });
+
+  it('refining: no badge shown when questions array is empty', () => {
+    useAppStore.setState({
+      refinementSessions: [{
+        id: 'sess1',
+        ticketId: '42',
+        projectDir: PROJECT_DIR,
+        status: 'ready',
+        phase: 'check',
+        result: {
+          passed: false,
+          questions: [],
+          gateSummary: '',
+          ticketUrl: null,
+          cached: false,
+        },
+        startedAt: 0,
+      }],
+    });
+    render(<TicketCard ticket={makeTicket('refining') as any} stacks={[]} />);
+    expect(screen.queryByText(/questions awaiting/)).toBeNull();
+  });
+
   // =========================================================================
   // Discard (trash) icon — #446
   // =========================================================================

--- a/tests/unit/ticket-spec.test.ts
+++ b/tests/unit/ticket-spec.test.ts
@@ -197,51 +197,26 @@ describe('extractQuestions', () => {
     expect(questions[1].options).toEqual([]);
   });
 
-  it('also captures items under a Gaps heading (fallback)', () => {
-    const r = `### Gaps\n1. First gap\n2. Second gap\n## Next\n3. Outside`;
+  it('ignores ### Gaps section entirely — returns only Questions items (regression)', () => {
+    const r = `## Spec Quality Gate: FAIL\n\n### Gaps (if any)\n- [ ] Citation stale — update to line 42\n- [ ] Wrong version check — use < 24\n\n### Questions Requiring User Answers (if any)\n\n\`\`\`json\n[{"id":"q1","question":"Which approach?","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]\n\`\`\`\n`;
     const questions = extractQuestions(r);
-    expect(questions).toHaveLength(2);
-    expect(questions[0].question).toBe('First gap');
-    expect(questions[0].kind).toBe('gap');
-    expect(questions[1].question).toBe('Second gap');
-    expect(questions[1].kind).toBe('gap');
+    // Gaps section must be completely ignored; only the JSON Questions block counts
+    expect(questions).toHaveLength(1);
+    expect(questions[0].question).toBe('Which approach?');
   });
 
-  it('parses checkbox items under Gaps heading — mandated buildSpecCheckPrompt format (regression)', () => {
-    const r = `## Spec Quality Gate: FAIL\n\n### Gaps (if any)\n- [ ] Citation stale — update to line 42\n- [ ] Wrong version check — use < 24\n\n## Results\n`;
+  it('ignores ### Gaps section when no JSON block is present (fallback regression)', () => {
+    const r = `## Spec Quality Gate: FAIL\n\n### Gaps (if any)\n- [ ] Citation stale — update to line 42\n\n## Results\n`;
     const questions = extractQuestions(r);
-    expect(questions.length).toBeGreaterThan(0);
-    expect(questions[0].question).toBe('Citation stale — update to line 42');
-    expect(questions[0].kind).toBe('gap');
-    expect(questions[1].question).toBe('Wrong version check — use < 24');
-    expect(questions[1].kind).toBe('gap');
+    // Gaps-only report yields no questions
+    expect(questions).toHaveLength(0);
   });
 
-  it('combines checkbox gaps with JSON questions when both are present', () => {
-    const r = `## Spec Quality Gate: FAIL\n\n### Gaps (if any)\n- [ ] Gap item — needs fixing\n\n### Questions Requiring User Answers (if any)\n\n\`\`\`json\n[{"id":"q1","question":"Which approach?","options":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}]\n\`\`\`\n`;
-    const questions = extractQuestions(r);
-    // Gaps appear first, then JSON questions
-    expect(questions.length).toBe(2);
-    expect(questions[0].kind).toBe('gap');
-    expect(questions[0].question).toBe('Gap item — needs fixing');
-    expect(questions[1].kind).toBeUndefined();
-    expect(questions[1].question).toBe('Which approach?');
-  });
-
-  it('marks Questions-section items with no kind (only Gaps items get kind: gap)', () => {
-    const r = `### Questions\n1. What is the approach?\n2. How should we handle it?`;
-    const questions = extractQuestions(r);
-    expect(questions).toHaveLength(2);
-    expect(questions[0].kind).toBeUndefined();
-    expect(questions[1].kind).toBeUndefined();
-  });
-
-  it('also captures JSON block under a Gaps heading', () => {
-    const r = `### Gaps\n\n\`\`\`json\n[{"id":"q1","question":"Gap Q?","options":[{"id":"a","label":"Yes"},{"id":"b","label":"No"}]}]\n\`\`\`\n## Next`;
+  it('RefineQuestion has no kind field (gap concept fully removed)', () => {
+    const r = `### Questions Requiring User Answers\n\n\`\`\`json\n[{"id":"q1","question":"Approach?","options":[{"id":"a","label":"A"}]}]\n\`\`\`\n`;
     const questions = extractQuestions(r);
     expect(questions).toHaveLength(1);
-    expect(questions[0].question).toBe('Gap Q?');
-    expect(questions[0].options).toHaveLength(2);
+    expect(Object.prototype.hasOwnProperty.call(questions[0], 'kind')).toBe(false);
   });
 
   it('returns empty array when no Questions/Gaps heading exists', () => {


### PR DESCRIPTION
## Summary

The spec-check refinement flow previously surfaced two kinds of items: clarifying questions and "gaps." Gaps added noise and inflated the unresolved-item count shown on ticket cards without giving reviewers anything actionable to answer. This change removes the gap concept end-to-end so refinement only ever produces clarifying questions.

The spec-check prompt no longer asks the model to emit a gaps section, the parsing layer drops gap extraction and the `kind: 'gap'` discriminator, and the renderer no longer special-cases or filters gap items. As a result the question count on a ticket card now reflects exactly the clarifying questions a reviewer must resolve.

## QA plan

1. Open a ticket and trigger the refine flow.
2. Confirm the dialog shows only clarifying questions — there is no separate gaps section.
3. Confirm the unresolved-item badge on the ticket card matches the number of questions shown in the dialog.
4. Answer the questions and confirm the count clears as expected.
5. Sanity-check that a spec-check response which would have previously contained gap items now ignores them and renders only questions.

Closes #587