### PR TITLE
[593] fix: show error and Continue button for failed stacks in TicketCard

### DIFF
--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -51,6 +51,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const [showMoveToBacklogDialog, setShowMoveToBacklogDialog] = useState(false);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
+  const [isContinuing, setIsContinuing] = useState(false);
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
   const stackKey = `${ticket.ticket_id}|${ticket.project_dir}`;
@@ -97,6 +98,19 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const handleResume = () => {
     if (stack) {
       void resumeStackWithContinuation(stack.id, true);
+    }
+  };
+
+  const handleContinue = async () => {
+    if (!stack || isContinuing) return;
+    setIsContinuing(true);
+    try {
+      await window.sandstorm.stacks.selfHealContinue(stack.id);
+      await refreshStacks();
+    } catch (err) {
+      alert(`Failed to continue: ${err}`);
+    } finally {
+      setIsContinuing(false);
     }
   };
 
@@ -391,6 +405,25 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
               data-testid={`ticket-card-in-stack-answer-${ticket.ticket_id}`}
             >
               Answer
+            </button>
+          )}
+          {stack && stack.status === 'failed' && stack.error && (
+            <div
+              className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-2 py-1.5 break-words"
+              data-testid={`ticket-card-stack-error-${ticket.ticket_id}`}
+              title={stack.error}
+            >
+              {stack.error}
+            </div>
+          )}
+          {stack && stack.status === 'failed' && (
+            <button
+              onClick={() => void handleContinue()}
+              disabled={isContinuing}
+              className="w-full text-xs py-1.5 px-3 rounded-md bg-sandstorm-accent/10 text-sandstorm-accent border border-sandstorm-accent/30 hover:bg-sandstorm-accent/20 transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+              data-testid={`ticket-card-continue-${ticket.ticket_id}`}
+            >
+              {isContinuing ? 'Continuing…' : 'Continue — reset reviews & run 5 more'}
             </button>
           )}
           {stack && (makePrEligible(stack) || prInFlight) && (

--- a/src/renderer/utils/duration.ts
+++ b/src/renderer/utils/duration.ts
@@ -58,6 +58,9 @@ export function getStackDuration(
 /** Duration update interval in milliseconds (5 seconds). */
 export const DURATION_UPDATE_INTERVAL = 5000;
 
+// `failed` stays eligible: a failed stack may have partial work worth pushing.
+// The TicketCard surfaces Continue as the primary recovery affordance — Create PR
+// remains as a secondary option for capturing whatever work was completed.
 const PR_ELIGIBLE_STATUSES = new Set([
   'completed',
   'failed',

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -634,6 +634,116 @@ describe('TicketCard', () => {
     expect(screen.queryByTestId('ticket-card-create-pr-42')).toBeNull();
   });
 
+  // =========================================================================
+  // #593 — Failed stack recovery UX on the Kanban card
+  // =========================================================================
+
+  it('in_stack: shows stack error message when stack.status === failed and stack.error is set', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'verify.sh exited 1', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    const badge = screen.getByTestId('ticket-card-stack-error-42');
+    expect(badge.textContent).toContain('verify.sh exited 1');
+    expect(badge.getAttribute('title')).toBe('verify.sh exited 1');
+  });
+
+  it('in_stack: does not show stack error message when stack.error is null on a failed stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: null, pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-stack-error-42')).toBeNull();
+  });
+
+  it('in_stack: does not show stack error message when stack.error is empty string on a failed stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: '', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-stack-error-42')).toBeNull();
+  });
+
+  it('in_stack: does not show stack error message for non-failed statuses even with stack.error set', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', error: 'stale error', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-stack-error-42')).toBeNull();
+  });
+
+  it('in_stack: shows Continue button when stack.status === failed', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'boom', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    const btn = screen.getByTestId('ticket-card-continue-42');
+    expect(btn.textContent).toContain('Continue — reset reviews & run 5 more');
+  });
+
+  it('in_stack: does not show Continue button when no linked stack', () => {
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[]} />);
+    expect(screen.queryByTestId('ticket-card-continue-42')).toBeNull();
+  });
+
+  it('in_stack: does not show Continue button for non-failed statuses', () => {
+    const nonFailedStatuses = ['running', 'building', 'completed', 'session_paused', 'needs_human', 'pushed'];
+    nonFailedStatuses.forEach((status) => {
+      const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status, pr_url: null, pr_number: null } as any;
+      const { unmount } = render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+      expect(screen.queryByTestId('ticket-card-continue-42')).toBeNull();
+      unmount();
+    });
+  });
+
+  it('in_stack: clicking Continue calls window.sandstorm.stacks.selfHealContinue with stack.id', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'boom', pr_url: null, pr_number: null } as any;
+    api.stacks.selfHealContinue.mockResolvedValue(undefined);
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-continue-42'));
+    await waitFor(() => expect(api.stacks.selfHealContinue).toHaveBeenCalledWith('s1'));
+  });
+
+  it('in_stack: Continue button is disabled while in-flight and shows Continuing…', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'boom', pr_url: null, pr_number: null } as any;
+    let resolveContinue!: () => void;
+    api.stacks.selfHealContinue.mockReturnValue(new Promise<void>((r) => { resolveContinue = r; }));
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    const btn = screen.getByTestId('ticket-card-continue-42') as HTMLButtonElement;
+    fireEvent.click(btn);
+    await waitFor(() => expect((screen.getByTestId('ticket-card-continue-42') as HTMLButtonElement).disabled).toBe(true));
+    expect(screen.getByTestId('ticket-card-continue-42').textContent).toContain('Continuing…');
+    await act(async () => {
+      resolveContinue();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect((screen.getByTestId('ticket-card-continue-42') as HTMLButtonElement).disabled).toBe(false));
+  });
+
+  it('in_stack: double-click on Continue calls selfHealContinue only once', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'boom', pr_url: null, pr_number: null } as any;
+    let resolveContinue!: () => void;
+    api.stacks.selfHealContinue.mockReturnValueOnce(new Promise<void>((r) => { resolveContinue = r; }));
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    const btn = screen.getByTestId('ticket-card-continue-42');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    await act(async () => {
+      resolveContinue();
+      await Promise.resolve();
+    });
+    expect(api.stacks.selfHealContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it('in_stack: Continue failure surfaces alert and re-enables the button', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'boom', pr_url: null, pr_number: null } as any;
+    api.stacks.selfHealContinue.mockRejectedValueOnce(new Error('IPC crash'));
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    fireEvent.click(screen.getByTestId('ticket-card-continue-42'));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    expect(alertSpy.mock.calls[0][0]).toContain('IPC crash');
+    expect((screen.getByTestId('ticket-card-continue-42') as HTMLButtonElement).disabled).toBe(false);
+    alertSpy.mockRestore();
+  });
+
+  it('in_stack: failed stack shows Continue alongside Create PR (Create PR remains as secondary option)', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', error: 'boom', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-continue-42')).toBeDefined();
+    expect(screen.getByTestId('ticket-card-create-pr-42')).toBeDefined();
+  });
+
   it('in_stack: shows Answer button when stack.status === needs_human', () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
     render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);


### PR DESCRIPTION
## Summary

- Failed stacks in the Kanban board's `in_stack` column now show the `stack.error` message (red callout) and a "Continue — reset reviews & run 5 more" button, matching what `StackCard` already showed
- "Create PR" remains as a secondary option — a failed stack may have partial work worth pushing
- Root cause: three consecutive PRs (#554, #561, #564) added this UX only to `StackCard.tsx`, never to `TicketCard.tsx`; existing tests confirmed "Create PR shows for failed" without checking that Continue was also present

## Test plan

- 10 new tests in `TicketCard.test.tsx` covering: error callout shown/hidden, Continue button visibility across statuses, click invokes `selfHealContinue`, in-flight disabled state, double-click guard, alert on rejection, Continue + Create PR coexist for failed stacks
- All 3637 tests pass; `tsc --noEmit` clean

Closes #593