### PR TITLE
fix: install opencode-ai as root in Dockerfile

### DIFF
--- a/sandstorm-cli/docker/Dockerfile
+++ b/sandstorm-cli/docker/Dockerfile
@@ -59,7 +59,7 @@ ENV PATH="/home/claude/.local/bin:$PATH"
 
 # OpenCode CLI (installed as the claude user, pinned to exact version)
 # resolved via 'npm view opencode-ai version' on 2026-06-10; bump deliberately
-RUN su claude -c "npm install -g opencode-ai@1.17.3"
+RUN npm install -g opencode-ai@1.17.3
 
 # Pre-install Chrome DevTools MCP server (avoids npx cold-start)
 RUN npm install -g chrome-devtools-mcp@latest


### PR DESCRIPTION
## Summary

PR #590 added `su claude -c "npm install -g opencode-ai@1.17.3"` to the Dockerfile. This fails with EACCES because npm global installs write to `/usr/lib/node_modules`, which is root-owned — the `claude` user doesn't have access.

Fix: drop the `su claude -c` wrapper and install as root, consistent with the `chrome-devtools-mcp` install on the next line.

## Impact

This broke every stack build after #590 merged. Any stack created after that PR would fail to build the claude image, causing the container to never start and the stack to land in `failed` with "Agent container not found". Affected stacks include ticket-535 and ticket-477.

## Test plan

- Stack image builds successfully (verified locally — ticket-593 stack built and ran with this fix)