### PR TITLE
[477] feat: add OpenCode as an alternative inner-agent backend

### DIFF
--- a/sandstorm-cli/docker/Dockerfile
+++ b/sandstorm-cli/docker/Dockerfile
@@ -69,10 +69,12 @@ COPY docker/entrypoint.sh /usr/bin/sandstorm-entrypoint.sh
 COPY docker/task-runner.sh /usr/bin/sandstorm-task-runner.sh
 COPY docker/sandstorm-exec /usr/bin/sandstorm-exec
 COPY docker/token-counter.sh /usr/bin/token-counter.sh
+COPY docker/opencode-token-counter.sh /usr/bin/opencode-token-counter.sh
+COPY docker/opencode-ndjson-parser.sh /usr/bin/opencode-ndjson-parser.sh
 COPY docker/SANDSTORM_INNER.md /usr/bin/SANDSTORM_INNER.md
 COPY docker/review-prompt.md /usr/bin/review-prompt.md
 COPY docker/opencode-config.js /usr/bin/opencode-config.js
-RUN chmod +x /usr/bin/sandstorm-entrypoint.sh /usr/bin/sandstorm-task-runner.sh /usr/bin/sandstorm-exec /usr/bin/token-counter.sh
+RUN chmod +x /usr/bin/sandstorm-entrypoint.sh /usr/bin/sandstorm-task-runner.sh /usr/bin/sandstorm-exec /usr/bin/token-counter.sh /usr/bin/opencode-token-counter.sh /usr/bin/opencode-ndjson-parser.sh
 
 ARG SANDSTORM_APP_VERSION=unknown
 LABEL sandstorm.app-version=${SANDSTORM_APP_VERSION}

--- a/sandstorm-cli/docker/entrypoint.sh
+++ b/sandstorm-cli/docker/entrypoint.sh
@@ -160,6 +160,10 @@ echo "  Workspace: /app"
 echo "=========================================="
 echo ""
 
+# OPENCODE_CONFIG must be set before handing off so run_opencode() inherits it.
+# Claude stacks are unaffected (claude ignores this variable).
+export OPENCODE_CONFIG=/tmp/sandstorm-opencode.json
+
 # -------------------------------------------------------------------
 # 4. Start task runner (PID 1 — output goes to docker logs)
 # -------------------------------------------------------------------

--- a/sandstorm-cli/docker/opencode-ndjson-parser.sh
+++ b/sandstorm-cli/docker/opencode-ndjson-parser.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Normalize OpenCode NDJSON stream (--format json output) to the same
+# formatted-text shape that run_claude / jq produces from Claude stream-json.
+#
+# Mapping:
+#   type=text       → emit .content as-is (text delta)
+#   type=tool_use   → emit "\n── <name> ──\n" marker
+#   type=step_finish → emit "\n<result>\n"
+#   type=error      → emit "\n❌ ERROR: <message>\n"
+#
+# Reads NDJSON from stdin; writes formatted text to stdout.
+# Used by run_opencode() in task-runner.sh and tested independently.
+#
+jq -rj --unbuffered '
+  if .type == "text" then
+    .content // ""
+  elif .type == "tool_use" then
+    "\n── \(.name) ──\n"
+  elif .type == "step_finish" then
+    "\n" + (.result // "") + "\n"
+  elif .type == "error" then
+    "\n❌ ERROR: " + (.message // "unknown error") + "\n"
+  else
+    empty
+  end
+' 2>/dev/null

--- a/sandstorm-cli/docker/opencode-token-counter.sh
+++ b/sandstorm-cli/docker/opencode-token-counter.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Token counter for OpenCode NDJSON output (--format json mode).
+# Reads NDJSON lines from stdin, extracts token counts from step_finish events,
+# and appends one line per event to the output file.
+#
+# Token mapping from OpenCode step_finish:
+#   tokens.input  → in
+#   tokens.output → out
+#   tokens.cache_write (or 0 when absent) → cc
+#   tokens.cache_read (preferred) or tokens.cache (single field) → cr
+#
+# Usage: opencode-token-counter.sh <output-file> [iteration] [phase]
+#
+# Each appended line has the format:
+#   {"in":N,"out":N,"cc":N,"cr":N[,"iter":I,"phase":"P"]}
+#
+
+OUTPUT_FILE="${1:?Usage: opencode-token-counter.sh <output-file> [iteration] [phase]}"
+ITERATION="${2:-}"
+PHASE="${3:-}"
+
+while IFS= read -r line; do
+  case "$line" in
+    *'"type":"step_finish"'*|*'"type": "step_finish"'*)
+      in_tokens=$(echo "$line" | jq -r '.tokens.input // 0' 2>/dev/null)
+      out_tokens=$(echo "$line" | jq -r '.tokens.output // 0' 2>/dev/null)
+      # cache_write maps to cc; if absent, 0
+      cc_tokens=$(echo "$line" | jq -r '(.tokens.cache_write // 0)' 2>/dev/null)
+      # cache_read takes priority over single cache field; both fall back to 0
+      cr_tokens=$(echo "$line" | jq -r '(.tokens.cache_read // .tokens.cache // 0)' 2>/dev/null)
+
+      if [ "${in_tokens:-0}" -gt 0 ] || [ "${out_tokens:-0}" -gt 0 ] 2>/dev/null; then
+        entry="{\"in\":${in_tokens:-0},\"out\":${out_tokens:-0},\"cc\":${cc_tokens:-0},\"cr\":${cr_tokens:-0}"
+        if [ -n "$ITERATION" ] && [ -n "$PHASE" ]; then
+          entry="${entry},\"iter\":${ITERATION},\"phase\":\"${PHASE}\""
+        fi
+        entry="${entry}}"
+        echo "$entry" >> "$OUTPUT_FILE"
+      fi
+      ;;
+  esac
+done

--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -152,6 +152,59 @@ run_claude() {
   return ${PIPESTATUS[0]}
 }
 
+# Run the OpenCode CLI with NDJSON output, normalizing into the same formatted-text
+# stream that run_claude emits so the dual-loop is backend-agnostic.
+# Args: $1 = prompt file path, $2 = raw log path, $3 = task log path, $4 = phase, $5 = iteration
+# Extra args ($6+) are Claude-specific (model, resume) and are intentionally ignored here.
+run_opencode() {
+  local prompt_file="$1"
+  local raw_log="${2:-/tmp/claude-raw.log}"
+  local task_log="${3:-/tmp/claude-task.log}"
+  local phase="${4:-execution}"
+  local iteration="${5:-1}"
+
+  local token_file="/tmp/claude-tokens-${phase}"
+  local counter_script="/usr/bin/opencode-token-counter.sh"
+  if [ ! -f "$counter_script" ]; then
+    counter_script="/app/sandstorm-cli/docker/opencode-token-counter.sh"
+  fi
+
+  local parser_script="/usr/bin/opencode-ndjson-parser.sh"
+  if [ ! -f "$parser_script" ]; then
+    parser_script="/app/sandstorm-cli/docker/opencode-ndjson-parser.sh"
+  fi
+
+  local oc_args=(run --format json --dangerously-skip-permissions)
+  if [ -n "${OPENCODE_MODEL:-}" ]; then
+    oc_args+=(--model "$OPENCODE_MODEL")
+  fi
+  # Session forwarding: forward-compat plumbing (not populated by this ticket's wiring)
+  if [ -n "${OPENCODE_SESSION_ID:-}" ]; then
+    oc_args+=(--session "$OPENCODE_SESSION_ID")
+  fi
+
+  # Deliver prompt via argv, NOT stdin (stdin can hang in OpenCode headless mode)
+  local prompt_content
+  prompt_content=$(cat "$prompt_file")
+
+  opencode "${oc_args[@]}" "$prompt_content" 2>&1 \
+    | stdbuf -o0 tee -a "$raw_log" \
+    | stdbuf -o0 tee >(bash "$counter_script" "$token_file" "$iteration" "$phase") \
+    | bash "$parser_script" \
+    | stdbuf -o0 tee "$task_log"
+  return ${PIPESTATUS[0]}
+}
+
+# Dispatch to run_claude or run_opencode based on AGENT_BACKEND.
+# Same signature as run_claude — Claude-specific extra args are dropped for OpenCode.
+run_agent() {
+  if [ "${AGENT_BACKEND:-claude}" = "opencode" ]; then
+    run_opencode "$1" "$2" "$3" "$4" "$5"
+  else
+    run_claude "$@"
+  fi
+}
+
 # Check if there are code changes in the workspace.
 check_for_diff() {
   local diff_output
@@ -200,7 +253,7 @@ run_review() {
   log_loop "Starting review agent with fresh context..."
 
   # Run claude with separate log files to preserve execution agent logs
-  run_claude "$review_prompt_file" /tmp/claude-review-raw.log /tmp/claude-review-task.log review "$iteration" "${MODEL_ARGS[@]}"
+  run_agent "$review_prompt_file" /tmp/claude-review-raw.log /tmp/claude-review-task.log review "$iteration" "${MODEL_ARGS[@]}"
   local review_exit=$?
 
   rm -f "$review_prompt_file"
@@ -312,7 +365,7 @@ run_meta_review() {
     echo "META_VERDICT: NO_VIABLE_PATH means you conclude there is no automatic fix available and the task needs human intervention."
   } > "$meta_prompt_file"
 
-  run_claude "$meta_prompt_file" "$meta_raw_log" "$meta_task_log" "meta_review" "$iteration" "${MODEL_ARGS[@]}"
+  run_agent "$meta_prompt_file" "$meta_raw_log" "$meta_task_log" "meta_review" "$iteration" "${MODEL_ARGS[@]}"
   local meta_exit=$?
 
   rm -f "$meta_prompt_file"
@@ -469,11 +522,32 @@ while true; do
       rm -f /tmp/claude-task-resume.txt
     fi
 
+    # Read agent backend selection (written by stack.sh --backend flag)
+    AGENT_BACKEND="claude"
+    if [ -f /tmp/claude-task-backend.txt ]; then
+      AGENT_BACKEND=$(cat /tmp/claude-task-backend.txt 2>/dev/null | tr -d '[:space:]')
+      [ -n "$AGENT_BACKEND" ] || AGENT_BACKEND="claude"
+      rm -f /tmp/claude-task-backend.txt
+    fi
+    export AGENT_BACKEND
+
+    # Read OpenCode provider/model (written by stack.sh --backend-model flag)
+    OPENCODE_MODEL=""
+    if [ -f /tmp/claude-task-backend-model.txt ]; then
+      OPENCODE_MODEL=$(cat /tmp/claude-task-backend-model.txt 2>/dev/null | tr -d '[:space:]')
+      rm -f /tmp/claude-task-backend-model.txt
+    fi
+    export OPENCODE_MODEL
+
     echo ""
     echo "=========================================="
     echo "  Task: $LABEL"
     if [ ${#MODEL_ARGS[@]} -gt 0 ]; then
       echo "  Model: $TASK_MODEL"
+    fi
+    if [ "$AGENT_BACKEND" = "opencode" ]; then
+      echo "  Backend: opencode"
+      [ -n "$OPENCODE_MODEL" ] && echo "  OpenCode model: $OPENCODE_MODEL"
     fi
     echo "=========================================="
     echo "running" > /tmp/claude-task.status
@@ -503,7 +577,7 @@ while true; do
 
     log_loop "Starting initial execution pass..."
     echo "execution_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
-    run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}" "${RESUME_ARGS[@]}"
+    run_agent /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}" "${RESUME_ARGS[@]}"
     EXIT_CODE=${PIPESTATUS[0]}
 
     # Edge Case 6: if --resume failed, fall back to a fresh dispatch with the original prompt
@@ -513,7 +587,7 @@ while true; do
       echo "⚠️ WARNING: Session resume failed (session data unavailable). Starting fresh dispatch." >> /tmp/claude-task.log
       > /tmp/claude-raw.log
       RESUME_ARGS=()
-      run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}"
+      run_agent /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}"
       EXIT_CODE=${PIPESTATUS[0]}
     fi
 
@@ -738,7 +812,7 @@ while true; do
             echo "  on its own line, then stop immediately. Do not make any further changes."
           } > "$local_fix_prompt"
 
-          run_claude "$local_fix_prompt" /tmp/claude-raw.log /tmp/claude-task.log execution "$TOTAL_REVIEW_ITERATIONS" "${MODEL_ARGS[@]}"
+          run_agent "$local_fix_prompt" /tmp/claude-raw.log /tmp/claude-task.log execution "$TOTAL_REVIEW_ITERATIONS" "${MODEL_ARGS[@]}"
           fix_exit=$?
           echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
           rm -f "$local_fix_prompt"
@@ -893,7 +967,7 @@ while true; do
           echo "  on its own line, then stop immediately. Do not make any further changes."
         } > "$local_verify_fix"
 
-        run_claude "$local_verify_fix" /tmp/claude-raw.log /tmp/claude-task.log execution "$((TOTAL_REVIEW_ITERATIONS + 1))" "${MODEL_ARGS[@]}"
+        run_agent "$local_verify_fix" /tmp/claude-raw.log /tmp/claude-task.log execution "$((TOTAL_REVIEW_ITERATIONS + 1))" "${MODEL_ARGS[@]}"
         verify_fix_exit=$?
         echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
         rm -f "$local_verify_fix"

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -417,12 +417,16 @@ case "$COMMAND" in
     TICKET=""
     TASK_MODEL=""
     TASK_RESUME_SESSION_ID=""
+    TASK_BACKEND=""
+    TASK_BACKEND_MODEL=""
     while true; do
       case "${1:-}" in
         --sync) SYNC_MODE=true; shift ;;
         --ticket) TICKET="$2"; shift 2 ;;
         --model) TASK_MODEL="$2"; shift 2 ;;
         --resume) TASK_RESUME_SESSION_ID="$2"; shift 2 ;;
+        --backend) TASK_BACKEND="$2"; shift 2 ;;
+        --backend-model) TASK_BACKEND_MODEL="$2"; shift 2 ;;
         *) break ;;
       esac
     done
@@ -482,6 +486,18 @@ case "$COMMAND" in
       if [ -n "$TASK_RESUME_SESSION_ID" ]; then
         echo "$TASK_RESUME_SESSION_ID" | docker exec -i -u claude "$CONTAINER_NAME" \
           bash -c "cat > /tmp/claude-task-resume.txt"
+      fi
+
+      # Write agent backend selection file if specified
+      if [ -n "$TASK_BACKEND" ]; then
+        echo "$TASK_BACKEND" | docker exec -i -u claude "$CONTAINER_NAME" \
+          bash -c "cat > /tmp/claude-task-backend.txt"
+      fi
+
+      # Write OpenCode provider/model file if specified
+      if [ -n "$TASK_BACKEND_MODEL" ]; then
+        echo "$TASK_BACKEND_MODEL" | docker exec -i -u claude "$CONTAINER_NAME" \
+          bash -c "cat > /tmp/claude-task-backend-model.txt"
       fi
 
       # Trigger the task runner (runs as the container's main process, output goes to docker logs)

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -1037,9 +1037,10 @@ export class StackManager {
       }
 
       try {
-        // Fallback: check if claude process is running
+        // Fallback: check if claude or opencode process is running.
+        // The marker file check above is load-bearing; this is a secondary signal only.
         const psResult = await runtime.exec(containerId, [
-          'pgrep', '-f', 'claude',
+          'pgrep', '-f', 'claude|opencode',
         ]);
         if (psResult.exitCode === 0 && psResult.stdout.trim()) return;
       } catch {
@@ -1129,6 +1130,17 @@ export class StackManager {
       // preventing the infinite-loop and not-logged-in bugs.
       const cliArgs = ['task', stackId];
       if (model) cliArgs.push('--model', model);
+
+      // Resolve the project's effective inner backend and pass it to the CLI
+      // so the runner can dispatch to the correct agent (claude or opencode).
+      const effectiveBackend = this.registry.getEffectiveBackend(stack.project_dir, 'inner');
+      if (effectiveBackend.backend === 'opencode') {
+        cliArgs.push('--backend', 'opencode');
+        if (effectiveBackend.provider && effectiveBackend.model) {
+          cliArgs.push('--backend-model', `${effectiveBackend.provider}/${effectiveBackend.model}`);
+        }
+      }
+
       cliArgs.push(prompt);
       const result = await this.runCli(stack.project_dir, cliArgs);
 

--- a/tests/unit/fixtures/opencode-basic.ndjson
+++ b/tests/unit/fixtures/opencode-basic.ndjson
@@ -1,0 +1,4 @@
+{"type":"text","content":"Analyzing the task..."}
+{"type":"tool_use","name":"read_file","input":{"path":"src/main.ts"}}
+{"type":"text","content":"The implementation looks correct."}
+{"type":"step_finish","result":"Task completed successfully.","tokens":{"input":1234,"output":567,"cache_read":100,"cache_write":0}}

--- a/tests/unit/fixtures/opencode-error.ndjson
+++ b/tests/unit/fixtures/opencode-error.ndjson
@@ -1,0 +1,2 @@
+{"type":"text","content":"Starting task..."}
+{"type":"error","message":"API error: context length exceeded"}

--- a/tests/unit/fixtures/opencode-tokens-split-cache.ndjson
+++ b/tests/unit/fixtures/opencode-tokens-split-cache.ndjson
@@ -1,0 +1,2 @@
+{"type":"text","content":"Working..."}
+{"type":"step_finish","result":"Done.","tokens":{"input":2000,"output":800,"cache_read":300,"cache_write":150}}

--- a/tests/unit/fixtures/opencode-tool-use.ndjson
+++ b/tests/unit/fixtures/opencode-tool-use.ndjson
@@ -1,0 +1,3 @@
+{"type":"tool_use","name":"bash","input":{"command":"npm test"}}
+{"type":"text","content":"Tests are passing."}
+{"type":"step_finish","result":"All tests passed.","tokens":{"input":500,"output":100,"cache":50}}

--- a/tests/unit/opencode-ndjson-parser.test.ts
+++ b/tests/unit/opencode-ndjson-parser.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for sandstorm-cli/docker/opencode-ndjson-parser.sh
+ *
+ * Pipes OpenCode NDJSON fixtures through the parser and verifies the output
+ * matches the same formatted-text shape that run_claude's jq filter produces.
+ *
+ * Skipped if jq is unavailable (same guard as token-counter.test.ts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const PARSER = resolve(__dirname, '../../sandstorm-cli/docker/opencode-ndjson-parser.sh');
+const FIXTURES = resolve(__dirname, 'fixtures');
+
+const hasJq = spawnSync('which', ['jq'], { encoding: 'utf-8' }).status === 0;
+
+function runParser(input: string): string {
+  const result = spawnSync('bash', [PARSER], {
+    input: input.endsWith('\n') ? input : input + '\n',
+    encoding: 'utf-8',
+  });
+  return result.stdout ?? '';
+}
+
+function fixtureContent(name: string): string {
+  return readFileSync(resolve(FIXTURES, name), 'utf-8');
+}
+
+describe.skipIf(!hasJq)('opencode-ndjson-parser.sh', () => {
+  it('emits text content as-is', () => {
+    const input = JSON.stringify({ type: 'text', content: 'Hello world' });
+    const output = runParser(input);
+    expect(output).toContain('Hello world');
+  });
+
+  it('emits tool_use marker in the exact run_claude shape', () => {
+    const input = JSON.stringify({ type: 'tool_use', name: 'read_file', input: {} });
+    const output = runParser(input);
+    expect(output).toBe('\n── read_file ──\n');
+  });
+
+  it('emits step_finish result text with surrounding newlines', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'Done.',
+      tokens: { input: 100, output: 50, cache_read: 0, cache_write: 0 },
+    });
+    const output = runParser(input);
+    expect(output).toBe('\nDone.\n');
+  });
+
+  it('emits error line with exact ❌ ERROR: prefix', () => {
+    const input = JSON.stringify({ type: 'error', message: 'context length exceeded' });
+    const output = runParser(input);
+    expect(output).toBe('\n❌ ERROR: context length exceeded\n');
+  });
+
+  it('handles step_finish with empty result', () => {
+    const input = JSON.stringify({ type: 'step_finish', result: '', tokens: {} });
+    const output = runParser(input);
+    expect(output).toBe('\n\n');
+  });
+
+  it('handles missing result field in step_finish', () => {
+    const input = JSON.stringify({ type: 'step_finish', tokens: {} });
+    const output = runParser(input);
+    expect(output).toBe('\n\n');
+  });
+
+  it('handles missing message field in error', () => {
+    const input = JSON.stringify({ type: 'error' });
+    const output = runParser(input);
+    expect(output).toBe('\n❌ ERROR: unknown error\n');
+  });
+
+  it('emits nothing for unknown event types', () => {
+    const input = JSON.stringify({ type: 'unknown_event', data: 'whatever' });
+    const output = runParser(input);
+    expect(output.trim()).toBe('');
+  });
+
+  it('processes opencode-basic.ndjson fixture correctly', () => {
+    const input = fixtureContent('opencode-basic.ndjson');
+    const output = runParser(input);
+    expect(output).toContain('Analyzing the task...');
+    expect(output).toContain('\n── read_file ──\n');
+    expect(output).toContain('The implementation looks correct.');
+    expect(output).toContain('\nTask completed successfully.\n');
+  });
+
+  it('processes opencode-error.ndjson fixture correctly', () => {
+    const input = fixtureContent('opencode-error.ndjson');
+    const output = runParser(input);
+    expect(output).toContain('Starting task...');
+    expect(output).toContain('\n❌ ERROR: API error: context length exceeded\n');
+  });
+
+  it('processes opencode-tool-use.ndjson fixture correctly', () => {
+    const input = fixtureContent('opencode-tool-use.ndjson');
+    const output = runParser(input);
+    expect(output).toContain('\n── bash ──\n');
+    expect(output).toContain('Tests are passing.');
+    expect(output).toContain('\nAll tests passed.\n');
+  });
+
+  it('handles multiple text events concatenated', () => {
+    const input = [
+      JSON.stringify({ type: 'text', content: 'Hello ' }),
+      JSON.stringify({ type: 'text', content: 'world' }),
+    ].join('\n');
+    const output = runParser(input);
+    expect(output).toBe('Hello world');
+  });
+
+  it('interleaves tool markers between text deltas', () => {
+    const input = [
+      JSON.stringify({ type: 'text', content: 'Before' }),
+      JSON.stringify({ type: 'tool_use', name: 'list_files', input: {} }),
+      JSON.stringify({ type: 'text', content: 'After' }),
+    ].join('\n');
+    const output = runParser(input);
+    expect(output).toBe('Before\n── list_files ──\nAfter');
+  });
+});

--- a/tests/unit/opencode-token-counter.test.ts
+++ b/tests/unit/opencode-token-counter.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for sandstorm-cli/docker/opencode-token-counter.sh
+ *
+ * Pipes OpenCode NDJSON fixtures through the counter and verifies that
+ * step_finish token counts are extracted in the same {"in","out","cc","cr"}
+ * line format that token-counter.sh produces for Claude output.
+ *
+ * Skipped if jq is unavailable (same guard as token-counter.test.ts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, readFileSync, unlinkSync, rmdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const SCRIPT = resolve(__dirname, '../../sandstorm-cli/docker/opencode-token-counter.sh');
+const FIXTURES = resolve(__dirname, 'fixtures');
+
+const hasJq = spawnSync('which', ['jq'], { encoding: 'utf-8' }).status === 0;
+
+function runScript(input: string, args: string[] = []): string {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'oc-token-test-'));
+  const outputFile = join(tmpDir, 'tokens.jsonl');
+
+  try {
+    const stdinInput = input.endsWith('\n') ? input : input + '\n';
+    spawnSync('bash', [SCRIPT, outputFile, ...args], {
+      input: stdinInput,
+      encoding: 'utf-8',
+    });
+    try {
+      return readFileSync(outputFile, 'utf-8');
+    } catch {
+      return '';
+    }
+  } finally {
+    try { unlinkSync(outputFile); } catch { /* ignore */ }
+    try { rmdirSync(tmpDir); } catch { /* ignore */ }
+  }
+}
+
+function parseLines(output: string): Record<string, unknown>[] {
+  return output
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+function fixtureContent(name: string): string {
+  return readFileSync(resolve(FIXTURES, name), 'utf-8');
+}
+
+describe.skipIf(!hasJq)('opencode-token-counter.sh', () => {
+  it('writes nothing for empty input', () => {
+    expect(runScript('').trim()).toBe('');
+  });
+
+  it('writes nothing for non-step_finish events', () => {
+    const input = [
+      JSON.stringify({ type: 'text', content: 'hello' }),
+      JSON.stringify({ type: 'tool_use', name: 'bash', input: {} }),
+    ].join('\n');
+    expect(runScript(input).trim()).toBe('');
+  });
+
+  it('captures step_finish with split cache fields', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'done',
+      tokens: { input: 1234, output: 567, cache_read: 100, cache_write: 0 },
+    });
+    const output = runScript(input);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].in).toBe(1234);
+    expect(lines[0].out).toBe(567);
+    expect(lines[0].cr).toBe(100);
+    expect(lines[0].cc).toBe(0);
+    expect(lines[0].partial).toBeUndefined();
+  });
+
+  it('maps single cache field to cr, sets cc=0', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'done',
+      tokens: { input: 500, output: 100, cache: 50 },
+    });
+    const output = runScript(input);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].in).toBe(500);
+    expect(lines[0].out).toBe(100);
+    expect(lines[0].cc).toBe(0);
+    expect(lines[0].cr).toBe(50);
+  });
+
+  it('maps cache_write to cc when present', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'done',
+      tokens: { input: 2000, output: 800, cache_read: 300, cache_write: 150 },
+    });
+    const output = runScript(input);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].cc).toBe(150);
+    expect(lines[0].cr).toBe(300);
+  });
+
+  it('includes iter and phase metadata when provided', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'done',
+      tokens: { input: 100, output: 50, cache_read: 0, cache_write: 0 },
+    });
+    const output = runScript(input, ['2', 'execution']);
+    const lines = parseLines(output);
+    expect(lines[0].iter).toBe(2);
+    expect(lines[0].phase).toBe('execution');
+  });
+
+  it('omits iter/phase when not provided', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'done',
+      tokens: { input: 100, output: 50, cache_read: 0, cache_write: 0 },
+    });
+    const output = runScript(input);
+    const lines = parseLines(output);
+    expect(lines[0]).not.toHaveProperty('iter');
+    expect(lines[0]).not.toHaveProperty('phase');
+  });
+
+  it('writes nothing when token counts are both zero', () => {
+    const input = JSON.stringify({
+      type: 'step_finish',
+      result: 'done',
+      tokens: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+    });
+    const output = runScript(input);
+    expect(output.trim()).toBe('');
+  });
+
+  it('handles missing tokens field gracefully', () => {
+    const input = JSON.stringify({ type: 'step_finish', result: 'done' });
+    const output = runScript(input);
+    expect(output.trim()).toBe('');
+  });
+
+  it('processes opencode-basic.ndjson fixture — split cache read', () => {
+    const input = fixtureContent('opencode-basic.ndjson');
+    const output = runScript(input, ['1', 'execution']);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].in).toBe(1234);
+    expect(lines[0].out).toBe(567);
+    expect(lines[0].cr).toBe(100);
+    expect(lines[0].cc).toBe(0);
+    expect(lines[0].iter).toBe(1);
+    expect(lines[0].phase).toBe('execution');
+  });
+
+  it('processes opencode-tool-use.ndjson fixture — single cache field', () => {
+    const input = fixtureContent('opencode-tool-use.ndjson');
+    const output = runScript(input);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].in).toBe(500);
+    expect(lines[0].out).toBe(100);
+    expect(lines[0].cr).toBe(50);
+    expect(lines[0].cc).toBe(0);
+  });
+
+  it('processes opencode-tokens-split-cache.ndjson fixture', () => {
+    const input = fixtureContent('opencode-tokens-split-cache.ndjson');
+    const output = runScript(input, ['2', 'review']);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].in).toBe(2000);
+    expect(lines[0].out).toBe(800);
+    expect(lines[0].cr).toBe(300);
+    expect(lines[0].cc).toBe(150);
+    expect(lines[0].iter).toBe(2);
+    expect(lines[0].phase).toBe('review');
+  });
+
+  it('handles non-step_finish lines in mixed input', () => {
+    const input = [
+      JSON.stringify({ type: 'text', content: 'Working...' }),
+      JSON.stringify({ type: 'step_finish', result: 'done', tokens: { input: 300, output: 75, cache_read: 0, cache_write: 0 } }),
+      JSON.stringify({ type: 'text', content: 'More text' }),
+    ].join('\n');
+    const output = runScript(input);
+    const lines = parseLines(output);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].in).toBe(300);
+    expect(lines[0].out).toBe(75);
+  });
+});

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -480,6 +480,64 @@ describe('StackManager', () => {
         ['task', 'no-model', '--model', 'sonnet', 'Simple task']
       );
     });
+
+    it('passes --backend opencode and --backend-model when inner backend is opencode with provider+model', async () => {
+      registry.createStack(makeStack('oc-backend'));
+      vi.spyOn(registry, 'getEffectiveBackend').mockReturnValue({
+        backend: 'opencode',
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+      });
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('oc-backend', 'Do the work', 'sonnet');
+
+      expect(runCliSpy).toHaveBeenCalledWith(
+        '/proj',
+        ['task', 'oc-backend', '--model', 'sonnet', '--backend', 'opencode', '--backend-model', 'anthropic/claude-sonnet-4-6', 'Do the work']
+      );
+    });
+
+    it('passes --backend opencode without --backend-model when provider/model absent', async () => {
+      registry.createStack(makeStack('oc-no-model'));
+      vi.spyOn(registry, 'getEffectiveBackend').mockReturnValue({
+        backend: 'opencode',
+      });
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('oc-no-model', 'Do work', 'sonnet');
+
+      const callArgs = runCliSpy.mock.calls[0][1] as string[];
+      expect(callArgs).toContain('--backend');
+      expect(callArgs).toContain('opencode');
+      expect(callArgs).not.toContain('--backend-model');
+    });
+
+    it('does NOT pass --backend when inner backend is claude (default)', async () => {
+      registry.createStack(makeStack('claude-backend'));
+      vi.spyOn(registry, 'getEffectiveBackend').mockReturnValue({
+        backend: 'claude',
+      });
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('claude-backend', 'Fix bug', 'sonnet');
+
+      const callArgs = runCliSpy.mock.calls[0][1] as string[];
+      expect(callArgs).not.toContain('--backend');
+      expect(callArgs).not.toContain('--backend-model');
+    });
   });
 
   describe('dispatchTask env-friction fixes (spec-gate resume exemption + container auto-start)', () => {

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -434,8 +434,8 @@ describe('task-runner.sh dual-loop workflow', () => {
   describe('no local keyword outside function scope', () => {
     it('does not use `local` in the outer/inner while loops', () => {
       // Find all `local ` usages and verify they are inside function bodies.
-      // Functions in the script: log_loop, run_claude, check_for_diff, run_review, run_verify, check_for_stop_and_ask
-      const functionNames = ['log_loop', 'run_claude', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance']
+      // Functions in the script: log_loop, run_claude, run_opencode, run_agent, check_for_diff, run_review, run_verify, check_for_stop_and_ask
+      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance']
 
       // Collect the line ranges of all function bodies
       const functionRanges: Array<{ start: number; end: number }> = []


### PR DESCRIPTION
## Summary

Adds support for running tasks against an OpenCode backend as an alternative to the default Claude agent inside the task runner.

The task runner now dispatches through a backend-agnostic `run_agent` wrapper. When the OpenCode backend is selected it invokes `run_opencode`, which streams OpenCode's NDJSON output through two new normalizers: `opencode-ndjson-parser.sh` converts it into the same formatted-text stream `run_claude` already emits, and `opencode-token-counter.sh` extracts `step_finish` token counts into the existing `{"in","out","cc","cr"}` shape. This keeps downstream consumers (UI streaming, token accounting) unchanged regardless of backend.

Backend selection flows end to end: `stack.sh` gains `--backend` and `--backend-model` flags that write trigger files (`/tmp/claude-task-backend.txt`, `/tmp/claude-task-backend-model.txt`), the task runner reads them as `AGENT_BACKEND`/`OPENCODE_MODEL`, and `stack-manager.ts` resolves the effective backend in `dispatchTask` and passes the flags through. `entrypoint.sh` exports `OPENCODE_CONFIG`, the Dockerfile installs the new scripts, and `waitForClaudeReady`'s pgrep fallback now matches `claude|opencode`.

## QA plan

1. Dispatch a task with the default (Claude) backend and confirm streamed output and token counts appear exactly as before — no regression.
2. Dispatch a task selecting the OpenCode backend (with `--backend opencode` and a `--backend-model`) and confirm the task runs, streams normalized text to the UI, and reports token usage.
3. Confirm the stack reaches ready state for an OpenCode task (pgrep fallback matches the `opencode` process).
4. Verify an OpenCode run that emits an error event surfaces the error in the task output.

Closes #477