### PR TITLE
[592] fix: preserve provider sort order on ticket board

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -1618,6 +1618,29 @@ export class Registry {
   }
 
   /**
+   * Returns ticket_board rows for a project ordered by provider fetch position.
+   * Rows present in orderedIds appear first, in that order.
+   * Rows absent from the fetch (closed/filtered-out) are appended after, ordered by created_at ASC.
+   */
+  listBoardTicketsInOrder(
+    projectDir: string,
+    orderedIds: string[],
+  ): { ticket_id: string; project_dir: string; column: string; title: string; created_at: string; updated_at: string }[] {
+    const allRows = this.listBoardTickets(projectDir);
+    const rowMap = new Map(allRows.map(r => [r.ticket_id, r]));
+    const fetchedSet = new Set(orderedIds);
+    const result: typeof allRows = [];
+    for (const id of orderedIds) {
+      const row = rowMap.get(id);
+      if (row) result.push(row);
+    }
+    for (const row of allRows) {
+      if (!fetchedSet.has(row.ticket_id)) result.push(row);
+    }
+    return result;
+  }
+
+  /**
    * Hard-deletes board tickets in early columns (backlog, refining, spec_ready) whose ticket_id
    * is not in openTicketIds. Called after a successful provider sync to remove closed tickets.
    * Tickets in started columns (in_stack, pr_open, merged) are never touched.

--- a/src/main/control-plane/ticket-config.ts
+++ b/src/main/control-plane/ticket-config.ts
@@ -130,10 +130,21 @@ function jiraLabelClause(label: string): string {
 function buildJiraFilterJql(config: FilterConfig & { jira_project_key?: string | null }): string {
   const mode = config.filter_mode ?? 'assisted';
   let jql: string;
+  let trailingOrderBy: string | null = null;
   if (mode === 'advanced' && config.filter_query?.trim()) {
-    // The user's query is wrapped in parens so the AND project clause applies to the whole expression.
-    // Limitation: a query with unmatched/leading-close parens (e.g. "a) OR (b") will break JQL precedence.
-    jql = `(${config.filter_query.trim()})`;
+    const raw = config.filter_query.trim();
+    // JQL requires ORDER BY to be last. If the user's advanced query ends with ORDER BY ...,
+    // extract it so any appended "AND project = ..." clause is placed before it.
+    // The greedy [\s\S]* matches as much as possible, finding the LAST ORDER BY occurrence.
+    const orderByMatch = raw.match(/^([\s\S]*\S)\s+\b(ORDER\s+BY\b[\s\S]*)$/i);
+    if (orderByMatch) {
+      jql = `(${orderByMatch[1].trim()})`;
+      trailingOrderBy = orderByMatch[2];
+    } else {
+      // The user's query is wrapped in parens so the AND project clause applies to the whole expression.
+      // Limitation: a query with unmatched/leading-close parens (e.g. "a) OR (b") will break JQL precedence.
+      jql = `(${raw})`;
+    }
   } else {
     const parts: string[] = [];
     parts.push((config.filter_ownership ?? 'created') === 'assigned'
@@ -145,6 +156,9 @@ function buildJiraFilterJql(config: FilterConfig & { jira_project_key?: string |
   if (config.jira_project_key?.trim()) {
     const key = config.jira_project_key.trim().replace(/"/g, '\\"');
     jql += ` AND project = "${key}"`;
+  }
+  if (trailingOrderBy) {
+    jql += ` ${trailingOrderBy}`;
   }
   return jql;
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1487,6 +1487,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     // Fetch from the project's configured ticket provider (built-in, no per-project
     // script). When no provider is configured, skip and return existing board rows.
     let listError: TicketListError | null = null;
+    let fetchedIds: string[] | null = null;
     const config = registry.getProjectTicketConfig(normalizedDir);
     if (config) {
       try {
@@ -1495,8 +1496,8 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
           for (const ticket of result.tickets) {
             registry.seedBoardTicket(ticket.id, normalizedDir, ticket.title);
           }
-          const openIds = result.tickets.map(t => t.id);
-          const deletedCount = registry.deleteClosedEarlyColumnTickets(normalizedDir, openIds);
+          fetchedIds = result.tickets.map(t => t.id);
+          const deletedCount = registry.deleteClosedEarlyColumnTickets(normalizedDir, fetchedIds);
           if (deletedCount > 0) {
             console.log(`[tickets:list] Removed ${deletedCount} closed early-column ticket(s) from board for project: ${normalizedDir}`);
           }
@@ -1509,7 +1510,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       }
     }
 
-    return { tickets: registry.listBoardTickets(normalizedDir), error: listError };
+    const tickets = fetchedIds !== null
+      ? registry.listBoardTicketsInOrder(normalizedDir, fetchedIds)
+      : registry.listBoardTickets(normalizedDir);
+    return { tickets, error: listError };
   });
 
   ipcMain.handle('tickets:testJiraConnection', async (_event, params: {

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -70,6 +70,7 @@ const {
     setProjectTicketConfig: vi.fn(),
     seedBoardTicket: vi.fn(),
     listBoardTickets: vi.fn().mockReturnValue([]),
+    listBoardTicketsInOrder: vi.fn().mockReturnValue([]),
     setBoardTicketColumn: vi.fn(),
     deleteClosedEarlyColumnTickets: vi.fn().mockReturnValue(0),
     deleteBoardTicket: vi.fn(),
@@ -1626,7 +1627,7 @@ describe('IPC Handlers', () => {
         { id: 'T-2', title: 'Second ticket', author: 'bob' },
       ];
       mockListTicketsWithConfig.mockResolvedValueOnce({ ok: true, tickets: providerTickets });
-      mockRegistry.listBoardTickets.mockReturnValue([]);
+      mockRegistry.listBoardTicketsInOrder.mockReturnValueOnce([]);
       mockRegistry.seedBoardTicket.mockClear();
       mockRegistry.deleteClosedEarlyColumnTickets.mockClear();
 
@@ -1637,6 +1638,7 @@ describe('IPC Handlers', () => {
       expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('T-1', '/proj', 'First ticket');
       expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('T-2', '/proj', 'Second ticket');
       expect(mockRegistry.deleteClosedEarlyColumnTickets).toHaveBeenCalledWith('/proj', ['T-1', 'T-2']);
+      expect(mockRegistry.listBoardTicketsInOrder).toHaveBeenCalledWith('/proj', ['T-1', 'T-2']);
     });
 
     it('calls deleteClosedEarlyColumnTickets with empty array on ok:true empty fetch', async () => {
@@ -1672,7 +1674,7 @@ describe('IPC Handlers', () => {
           tickets: [{ id: 'T-1', title: 'Open ticket', author: 'alice' }],
         });
         mockRegistry.deleteClosedEarlyColumnTickets.mockReturnValue(2);
-        mockRegistry.listBoardTickets.mockReturnValue([]);
+        mockRegistry.listBoardTicketsInOrder.mockReturnValueOnce([]);
 
         await invokeHandler('tickets:list', '/proj');
 
@@ -1693,12 +1695,51 @@ describe('IPC Handlers', () => {
         ok: true,
         tickets: [{ id: 'REOPEN-1', title: 'Reopened ticket', author: 'alice' }],
       });
-      mockRegistry.listBoardTickets.mockReturnValue([]);
+      mockRegistry.listBoardTicketsInOrder.mockReturnValueOnce([]);
       mockRegistry.seedBoardTicket.mockClear();
 
       await invokeHandler('tickets:list', '/proj');
 
       expect(mockRegistry.seedBoardTicket).toHaveBeenCalledWith('REOPEN-1', '/proj', 'Reopened ticket');
+    });
+
+    it('preserves provider fetch order — returns tickets in [C,A,B] when provider returns [C,A,B] regardless of DB created_at order', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
+      // Provider returns tickets in C, A, B order (not created_at order A, B, C)
+      mockListTicketsWithConfig.mockResolvedValueOnce({
+        ok: true,
+        tickets: [
+          { id: 'T-C', title: 'C', author: 'alice' },
+          { id: 'T-A', title: 'A', author: 'alice' },
+          { id: 'T-B', title: 'B', author: 'alice' },
+        ],
+      });
+      const orderedBoardRows = [
+        { ticket_id: 'T-C', project_dir: '/proj', column: 'backlog', title: 'C', created_at: '2024-01-03', updated_at: '' },
+        { ticket_id: 'T-A', project_dir: '/proj', column: 'backlog', title: 'A', created_at: '2024-01-01', updated_at: '' },
+        { ticket_id: 'T-B', project_dir: '/proj', column: 'backlog', title: 'B', created_at: '2024-01-02', updated_at: '' },
+      ];
+      mockRegistry.listBoardTicketsInOrder.mockReturnValueOnce(orderedBoardRows);
+
+      const result = await invokeHandler('tickets:list', '/proj') as { tickets: Array<{ ticket_id: string }> };
+
+      expect(mockRegistry.listBoardTicketsInOrder).toHaveBeenCalledWith('/proj', ['T-C', 'T-A', 'T-B']);
+      expect(result.tickets.map(t => t.ticket_id)).toEqual(['T-C', 'T-A', 'T-B']);
+    });
+
+    it('falls back to listBoardTickets when provider fetch throws (does not call listBoardTicketsInOrder)', async () => {
+      mockRegistry.getProjectTicketConfig.mockReturnValueOnce({ provider: 'github' });
+      mockListTicketsWithConfig.mockRejectedValueOnce(new Error('provider unavailable'));
+      const boardRows = [
+        { ticket_id: 'T-1', project_dir: '/proj', column: 'backlog', title: 'First', created_at: '2024-01-01', updated_at: '' },
+      ];
+      mockRegistry.listBoardTickets.mockReturnValueOnce(boardRows);
+      mockRegistry.listBoardTicketsInOrder.mockClear();
+
+      const result = await invokeHandler('tickets:list', '/proj') as { tickets: Array<{ ticket_id: string }> };
+
+      expect(mockRegistry.listBoardTicketsInOrder).not.toHaveBeenCalled();
+      expect(result.tickets.map(t => t.ticket_id)).toEqual(['T-1']);
     });
   });
 

--- a/tests/unit/ticket-config.test.ts
+++ b/tests/unit/ticket-config.test.ts
@@ -391,6 +391,13 @@ describe('githubListTickets', () => {
     expect(args[args.indexOf('--search') + 1]).toBe('assignee:@me label:bug is:open');
   });
 
+  it('passes filter_query containing sort: qualifier verbatim in advanced mode (sort: passthrough regression)', async () => {
+    mockExecFileSuccess('[]');
+    await githubListTickets('/myproj', undefined, { filter_mode: 'advanced', filter_query: 'is:open sort:updated-desc label:bug' });
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args[args.indexOf('--search') + 1]).toBe('is:open sort:updated-desc label:bug');
+  });
+
   it('falls back to default when advanced mode has empty filter_query', async () => {
     mockExecFileSuccess('[]');
     await githubListTickets('/myproj', undefined, { filter_mode: 'advanced', filter_query: '' });
@@ -572,6 +579,43 @@ describe('jiraListTickets', () => {
     expect(jql).toContain('reporter = currentUser()');
     expect(jql).toContain('statusCategory != Done');
     expect(jql).toContain('project = "ACME"');
+  });
+
+  it('places project clause BEFORE trailing ORDER BY in advanced mode (Jira ORDER BY regression)', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = {
+      ...JIRA_CONFIG,
+      filter_mode: 'advanced',
+      filter_query: 'status = "Open" ORDER BY created DESC',
+    };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    // Extract the JQL value from the URL path (before &fields=)
+    const jqlEncoded = opts.path.split('?jql=')[1].split('&')[0];
+    const jql = decodeURIComponent(jqlEncoded);
+    // project clause must come before ORDER BY so the JQL is valid
+    const projectIdx = jql.indexOf('project = "ACME"');
+    const orderByIdx = jql.indexOf('ORDER BY');
+    expect(projectIdx).toBeGreaterThan(-1);
+    expect(orderByIdx).toBeGreaterThan(-1);
+    expect(projectIdx).toBeLessThan(orderByIdx);
+    // ORDER BY must be last in the JQL
+    expect(jql.endsWith('ORDER BY created DESC')).toBe(true);
+  });
+
+  it('handles ORDER BY with multiple sort keys in advanced mode', async () => {
+    mockJiraRequest(JSON.stringify({ issues: [] }));
+    const cfg: ProjectTicketConfig = {
+      ...JIRA_CONFIG,
+      filter_mode: 'advanced',
+      filter_query: 'priority = High ORDER BY created DESC, updated ASC',
+    };
+    await jiraListTickets(cfg);
+    const opts = mockHttpsRequest.mock.calls[0][0] as { path: string };
+    const jqlEncoded = opts.path.split('?jql=')[1].split('&')[0];
+    const jql = decodeURIComponent(jqlEncoded);
+    expect(jql.endsWith('ORDER BY created DESC, updated ASC')).toBe(true);
+    expect(jql.indexOf('project = "ACME"')).toBeLessThan(jql.indexOf('ORDER BY'));
   });
 });
 

--- a/tests/unit/ticketBoard.test.ts
+++ b/tests/unit/ticketBoard.test.ts
@@ -122,6 +122,59 @@ describe('listBoardTickets', () => {
   });
 });
 
+describe('listBoardTicketsInOrder', () => {
+  it('returns tickets in the order of the provided ids', () => {
+    // Seed A, B, C in that created_at order
+    registry.seedBoardTicket('A', '/proj', 'Alpha');
+    registry.seedBoardTicket('B', '/proj', 'Beta');
+    registry.seedBoardTicket('C', '/proj', 'Gamma');
+
+    // Provider returns them in C, A, B order
+    const rows = registry.listBoardTicketsInOrder('/proj', ['C', 'A', 'B']);
+    expect(rows.map(r => r.ticket_id)).toEqual(['C', 'A', 'B']);
+  });
+
+  it('appends board rows absent from the fetch after fetched rows, in created_at ASC order', () => {
+    registry.seedBoardTicket('A', '/proj', 'Alpha');
+    registry.seedBoardTicket('B', '/proj', 'Beta');
+    registry.seedBoardTicket('C', '/proj', 'Gamma');
+
+    // Provider only returns B — A and C are closed/filtered out
+    const rows = registry.listBoardTicketsInOrder('/proj', ['B']);
+    expect(rows.map(r => r.ticket_id)).toEqual(['B', 'A', 'C']);
+  });
+
+  it('preserves the column of a ticket moved to a non-backlog column', () => {
+    registry.seedBoardTicket('T-1', '/proj', 'In-progress');
+    registry.setBoardTicketColumn('T-1', '/proj', 'in_stack');
+    registry.seedBoardTicket('T-2', '/proj', 'Backlog ticket');
+
+    const rows = registry.listBoardTicketsInOrder('/proj', ['T-2', 'T-1']);
+    expect(rows.find(r => r.ticket_id === 'T-1')?.column).toBe('in_stack');
+    expect(rows.find(r => r.ticket_id === 'T-2')?.column).toBe('backlog');
+  });
+
+  it('returns empty array when no tickets exist', () => {
+    const rows = registry.listBoardTicketsInOrder('/proj', ['X', 'Y']);
+    expect(rows).toEqual([]);
+  });
+
+  it('returns all board rows in created_at ASC when orderedIds is empty', () => {
+    registry.seedBoardTicket('A', '/proj', 'Alpha');
+    registry.seedBoardTicket('B', '/proj', 'Beta');
+
+    const rows = registry.listBoardTicketsInOrder('/proj', []);
+    expect(rows.map(r => r.ticket_id)).toEqual(['A', 'B']);
+  });
+
+  it('ignores ids in orderedIds that have no board row', () => {
+    registry.seedBoardTicket('A', '/proj', 'Alpha');
+
+    const rows = registry.listBoardTicketsInOrder('/proj', ['GHOST', 'A']);
+    expect(rows.map(r => r.ticket_id)).toEqual(['A']);
+  });
+});
+
 // --- tickets:create board-seeding simulation ---
 // Simulates the main-process behavior added in #385: after tickets:create
 // resolves, the handler calls registry.seedBoardTicket so the card appears


### PR DESCRIPTION
## Summary

The ticket board was rendering rows in local `created_at ASC` order, discarding the sort order returned by the upstream provider (Jira/GitHub). This change preserves the provider's fetch order when listing board tickets, and fixes a JQL bug that produced invalid queries when a Jira filter already contained an `ORDER BY` clause.

- `tickets:list` now tracks the ids returned by a successful provider fetch and lists board rows in that order. Rows that were not part of the fetch are appended afterward in `created_at ASC`. Error and throw paths still fall back to the existing `created_at`-ordered listing.
- `buildJiraFilterJql` now extracts a trailing `ORDER BY` clause before appending the `AND project = "..."` filter, then re-appends it, so the resulting JQL stays valid. GitHub `sort:` qualifiers continue to pass through untouched.

## QA plan

1. Configure a Jira-backed project whose filter JQL ends with an `ORDER BY` clause (e.g. `ORDER BY updated DESC`). Open the ticket board and confirm tickets load without a JQL error and appear in the provider's order.
2. Configure a GitHub-backed project with a `sort:` qualifier in the search and confirm the board reflects that order.
3. Refresh the board and confirm the order returned by the provider is preserved rather than re-sorted by creation date.
4. Simulate a provider fetch failure (e.g. invalid credentials) and confirm the board still renders cached rows in `created_at` order rather than breaking.

Closes #592