### PR TITLE
[535] fix: route models per phase in sandstorm task runner

### DIFF
--- a/sandstorm-cli/docker/Dockerfile
+++ b/sandstorm-cli/docker/Dockerfile
@@ -67,12 +67,13 @@ RUN npm install -g chrome-devtools-mcp@latest
 # Entrypoint, task runner, helper scripts, and inner Claude instructions
 COPY docker/entrypoint.sh /usr/bin/sandstorm-entrypoint.sh
 COPY docker/task-runner.sh /usr/bin/sandstorm-task-runner.sh
+COPY docker/phase-model-helper.sh /usr/bin/phase-model-helper.sh
 COPY docker/sandstorm-exec /usr/bin/sandstorm-exec
 COPY docker/token-counter.sh /usr/bin/token-counter.sh
 COPY docker/SANDSTORM_INNER.md /usr/bin/SANDSTORM_INNER.md
 COPY docker/review-prompt.md /usr/bin/review-prompt.md
 COPY docker/opencode-config.js /usr/bin/opencode-config.js
-RUN chmod +x /usr/bin/sandstorm-entrypoint.sh /usr/bin/sandstorm-task-runner.sh /usr/bin/sandstorm-exec /usr/bin/token-counter.sh
+RUN chmod +x /usr/bin/sandstorm-entrypoint.sh /usr/bin/sandstorm-task-runner.sh /usr/bin/phase-model-helper.sh /usr/bin/sandstorm-exec /usr/bin/token-counter.sh
 
 ARG SANDSTORM_APP_VERSION=unknown
 LABEL sandstorm.app-version=${SANDSTORM_APP_VERSION}

--- a/sandstorm-cli/docker/phase-model-helper.sh
+++ b/sandstorm-cli/docker/phase-model-helper.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Phase-model routing helper for the sandstorm task runner.
+#
+# Provides model_args_for_phase() — call before each run_claude invocation
+# to resolve the correct --model arg for that phase.
+#
+# Reads globals: PHASE_MODELS_JSON, MODEL_ARGS, TASK_MODEL, log_loop
+# Writes global: RESOLVED_MODEL_ARGS
+#
+# Usage:
+#   source /usr/bin/phase-model-helper.sh
+#   model_args_for_phase execution
+#   run_claude ... "${RESOLVED_MODEL_ARGS[@]}"
+
+# Select --model args for a given phase from the per-phase model map.
+# Sets global RESOLVED_MODEL_ARGS to the appropriate --model arg array.
+# Falls back to MODEL_ARGS (single-task model) when:
+#   - PHASE_MODELS_JSON is empty/absent
+#   - The phase key is missing from the JSON
+#   - The model value is an OpenCode provider/model (contains '/')
+# Logs the resolved model to the loop log.
+model_args_for_phase() {
+  local phase="$1"
+  local m=""
+
+  if [ -n "${PHASE_MODELS_JSON:-}" ]; then
+    m=$(printf '%s' "$PHASE_MODELS_JSON" | jq -r --arg p "$phase" '.[$p] // empty' 2>/dev/null || true)
+  fi
+
+  if [ -z "$m" ]; then
+    # Phase key missing from map or JSON absent — fall back to task model
+    RESOLVED_MODEL_ARGS=("${MODEL_ARGS[@]}")
+    if [ -n "${TASK_MODEL:-}" ]; then
+      log_loop "phase=$phase model=${TASK_MODEL} (task fallback)"
+    fi
+    return
+  fi
+
+  if [[ "$m" == *"/"* ]]; then
+    # OpenCode provider/model (contains '/') — not runnable in this image
+    log_loop "WARNING: phase=$phase model='$m' requires OpenCode backend (not available); using task model"
+    RESOLVED_MODEL_ARGS=("${MODEL_ARGS[@]}")
+    if [ -n "${TASK_MODEL:-}" ]; then
+      log_loop "phase=$phase model=${TASK_MODEL} (task fallback)"
+    fi
+    return
+  fi
+
+  if [ "$m" = "auto" ]; then
+    RESOLVED_MODEL_ARGS=()
+    log_loop "phase=$phase model=auto"
+  else
+    RESOLVED_MODEL_ARGS=(--model "$m")
+    log_loop "phase=$phase model=$m"
+  fi
+}

--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -30,6 +30,16 @@ log_loop() {
   echo "[LOOP] $1"
 }
 
+# Source per-phase model routing helper (defines model_args_for_phase).
+# Tries the installed path first, falls back to the repo source for dev.
+_phase_helper="/usr/bin/phase-model-helper.sh"
+if [ ! -f "$_phase_helper" ]; then
+  _phase_helper="/app/sandstorm-cli/docker/phase-model-helper.sh"
+fi
+# shellcheck source=/dev/null
+source "$_phase_helper"
+unset _phase_helper
+
 # Check if the execution agent emitted a STOP_AND_ASK signal in its output.
 # If found, writes the reason to /tmp/claude-stop-reason.txt and returns 0.
 # Returns 1 if no STOP_AND_ASK found.
@@ -200,7 +210,8 @@ run_review() {
   log_loop "Starting review agent with fresh context..."
 
   # Run claude with separate log files to preserve execution agent logs
-  run_claude "$review_prompt_file" /tmp/claude-review-raw.log /tmp/claude-review-task.log review "$iteration" "${MODEL_ARGS[@]}"
+  model_args_for_phase review
+  run_claude "$review_prompt_file" /tmp/claude-review-raw.log /tmp/claude-review-task.log review "$iteration" "${RESOLVED_MODEL_ARGS[@]}"
   local review_exit=$?
 
   rm -f "$review_prompt_file"
@@ -312,7 +323,8 @@ run_meta_review() {
     echo "META_VERDICT: NO_VIABLE_PATH means you conclude there is no automatic fix available and the task needs human intervention."
   } > "$meta_prompt_file"
 
-  run_claude "$meta_prompt_file" "$meta_raw_log" "$meta_task_log" "meta_review" "$iteration" "${MODEL_ARGS[@]}"
+  model_args_for_phase meta_review
+  run_claude "$meta_prompt_file" "$meta_raw_log" "$meta_task_log" "meta_review" "$iteration" "${RESOLVED_MODEL_ARGS[@]}"
   local meta_exit=$?
 
   rm -f "$meta_prompt_file"
@@ -459,6 +471,18 @@ while true; do
       rm -f /tmp/claude-task-model.txt
     fi
 
+    # Read per-phase model map if provided (written by stack.sh --models-json).
+    # Falls back to single MODEL_ARGS when absent or malformed.
+    PHASE_MODELS_JSON=""
+    if [ -f /tmp/claude-task-models.json ]; then
+      PHASE_MODELS_JSON=$(cat /tmp/claude-task-models.json 2>/dev/null || true)
+      if ! printf '%s' "$PHASE_MODELS_JSON" | jq . > /dev/null 2>&1; then
+        log_loop "WARNING: /tmp/claude-task-models.json is malformed — ignoring per-phase routing"
+        PHASE_MODELS_JSON=""
+      fi
+      rm -f /tmp/claude-task-models.json
+    fi
+
     # Read resume session id if provided (set by --resume flag in dispatchContinuation)
     RESUME_ARGS=()
     if [ -f /tmp/claude-task-resume.txt ]; then
@@ -503,7 +527,8 @@ while true; do
 
     log_loop "Starting initial execution pass..."
     echo "execution_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
-    run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}" "${RESUME_ARGS[@]}"
+    model_args_for_phase execution
+    run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${RESOLVED_MODEL_ARGS[@]}" "${RESUME_ARGS[@]}"
     EXIT_CODE=${PIPESTATUS[0]}
 
     # Edge Case 6: if --resume failed, fall back to a fresh dispatch with the original prompt
@@ -513,7 +538,7 @@ while true; do
       echo "⚠️ WARNING: Session resume failed (session data unavailable). Starting fresh dispatch." >> /tmp/claude-task.log
       > /tmp/claude-raw.log
       RESUME_ARGS=()
-      run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${MODEL_ARGS[@]}"
+      run_claude /tmp/claude-task-prompt.txt /tmp/claude-raw.log /tmp/claude-task.log execution 1 "${RESOLVED_MODEL_ARGS[@]}"
       EXIT_CODE=${PIPESTATUS[0]}
     fi
 
@@ -738,7 +763,8 @@ while true; do
             echo "  on its own line, then stop immediately. Do not make any further changes."
           } > "$local_fix_prompt"
 
-          run_claude "$local_fix_prompt" /tmp/claude-raw.log /tmp/claude-task.log execution "$TOTAL_REVIEW_ITERATIONS" "${MODEL_ARGS[@]}"
+          model_args_for_phase execution
+          run_claude "$local_fix_prompt" /tmp/claude-raw.log /tmp/claude-task.log execution "$TOTAL_REVIEW_ITERATIONS" "${RESOLVED_MODEL_ARGS[@]}"
           fix_exit=$?
           echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
           rm -f "$local_fix_prompt"
@@ -893,7 +919,8 @@ while true; do
           echo "  on its own line, then stop immediately. Do not make any further changes."
         } > "$local_verify_fix"
 
-        run_claude "$local_verify_fix" /tmp/claude-raw.log /tmp/claude-task.log execution "$((TOTAL_REVIEW_ITERATIONS + 1))" "${MODEL_ARGS[@]}"
+        model_args_for_phase execution
+        run_claude "$local_verify_fix" /tmp/claude-raw.log /tmp/claude-task.log execution "$((TOTAL_REVIEW_ITERATIONS + 1))" "${RESOLVED_MODEL_ARGS[@]}"
         verify_fix_exit=$?
         echo "execution_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> /tmp/claude-phase-timing.txt
         rm -f "$local_verify_fix"

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -416,12 +416,14 @@ case "$COMMAND" in
     SYNC_MODE=false
     TICKET=""
     TASK_MODEL=""
+    TASK_MODELS_JSON=""
     TASK_RESUME_SESSION_ID=""
     while true; do
       case "${1:-}" in
         --sync) SYNC_MODE=true; shift ;;
         --ticket) TICKET="$2"; shift 2 ;;
         --model) TASK_MODEL="$2"; shift 2 ;;
+        --models-json) TASK_MODELS_JSON="$2"; shift 2 ;;
         --resume) TASK_RESUME_SESSION_ID="$2"; shift 2 ;;
         *) break ;;
       esac
@@ -476,6 +478,12 @@ case "$COMMAND" in
       if [ -n "$TASK_MODEL" ]; then
         echo "$TASK_MODEL" | docker exec -i -u claude "$CONTAINER_NAME" \
           bash -c "cat > /tmp/claude-task-model.txt"
+      fi
+
+      # Write per-phase model map if provided
+      if [ -n "$TASK_MODELS_JSON" ]; then
+        printf '%s' "$TASK_MODELS_JSON" | docker exec -i -u claude "$CONTAINER_NAME" \
+          bash -c "cat > /tmp/claude-task-models.json"
       fi
 
       # Write resume session id file if specified

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -1127,8 +1127,15 @@ export class StackManager {
       // handles credential sync (OAuth), writes files as the correct user
       // (`-u claude`), and creates the trigger file with proper ownership —
       // preventing the infinite-loop and not-logged-in bugs.
+      const phaseModels = this.registry.getContainerPhaseModels(stack.project_dir);
+      const phaseModelsJson = JSON.stringify({
+        execution:   phaseModels.execution.model   || 'auto',
+        review:      phaseModels.review.model      || 'auto',
+        meta_review: phaseModels.meta_review.model || 'auto',
+      });
       const cliArgs = ['task', stackId];
       if (model) cliArgs.push('--model', model);
+      cliArgs.push('--models-json', phaseModelsJson);
       cliArgs.push(prompt);
       const result = await this.runCli(stack.project_dir, cliArgs);
 

--- a/tests/integration/phase-model-helper.test.ts
+++ b/tests/integration/phase-model-helper.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for the model_args_for_phase bash helper.
+ *
+ * Sources sandstorm-cli/docker/phase-model-helper.sh and exercises
+ * model_args_for_phase() via child_process, verifying that the correct
+ * --model args are emitted for every documented edge case:
+ *
+ *   - Normal phase resolution (execution / review / meta_review)
+ *   - 'auto' phase model → no --model flag
+ *   - JSON absent → falls back to single task model
+ *   - Phase key missing from JSON → falls back to single task model
+ *   - Malformed JSON → treated as absent (fallback)
+ *   - OpenCode provider/model (contains '/') → falls back + warning logged
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+const HELPER_PATH = path.resolve(
+  __dirname,
+  '../../sandstorm-cli/docker/phase-model-helper.sh'
+);
+
+/** Run model_args_for_phase in an isolated bash sub-shell and return stdout. */
+function runHelper(opts: {
+  phase: string;
+  phaseModelsJson?: string;
+  taskModel?: string;
+}): { stdout: string; stderr: string; exitCode: number } {
+  const { phase, phaseModelsJson = '', taskModel = '' } = opts;
+
+  // Inline script: source the helper, set up globals, call the function.
+  const script = `
+set -euo pipefail
+
+# Stub log_loop so output is predictable
+log_loop() { echo "[LOOP] \$1"; }
+
+# Source helper under test
+source "${HELPER_PATH}"
+
+# Set globals used by model_args_for_phase
+MODEL_ARGS=()
+TASK_MODEL="${taskModel}"
+if [ -n "${taskModel}" ]; then
+  MODEL_ARGS=(--model "${taskModel}")
+fi
+
+PHASE_MODELS_JSON='${phaseModelsJson.replace(/'/g, "'\\''")}'
+
+RESOLVED_MODEL_ARGS=()
+model_args_for_phase "${phase}"
+
+# Emit results in a parseable form
+echo "RESOLVED_COUNT=\${#RESOLVED_MODEL_ARGS[@]}"
+for arg in "\${RESOLVED_MODEL_ARGS[@]}"; do
+  echo "ARG=\$arg"
+done
+`;
+
+  const result = spawnSync('bash', ['-c', script], { encoding: 'utf8' });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? -1,
+  };
+}
+
+/** Parse the bash output into an args array. */
+function parseArgs(stdout: string): string[] {
+  const args: string[] = [];
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('ARG=')) args.push(line.slice(4));
+  }
+  return args;
+}
+
+describe('model_args_for_phase (shell helper)', () => {
+  it('helper file exists', () => {
+    expect(fs.existsSync(HELPER_PATH)).toBe(true);
+  });
+
+  it('resolves execution phase to --model flag', () => {
+    const json = '{"execution":"sonnet","review":"opus","meta_review":"haiku"}';
+    const { stdout, exitCode } = runHelper({ phase: 'execution', phaseModelsJson: json });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'sonnet']);
+  });
+
+  it('resolves review phase to --model flag', () => {
+    const json = '{"execution":"haiku","review":"opus","meta_review":"sonnet"}';
+    const { stdout, exitCode } = runHelper({ phase: 'review', phaseModelsJson: json });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'opus']);
+  });
+
+  it('resolves meta_review phase to --model flag', () => {
+    const json = '{"execution":"haiku","review":"sonnet","meta_review":"opus"}';
+    const { stdout, exitCode } = runHelper({ phase: 'meta_review', phaseModelsJson: json });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'opus']);
+  });
+
+  it('auto phase model produces empty args (no --model flag)', () => {
+    const json = '{"execution":"auto","review":"opus","meta_review":"sonnet"}';
+    const { stdout, exitCode } = runHelper({ phase: 'execution', phaseModelsJson: json });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual([]);
+    expect(stdout).toContain('[LOOP] phase=execution model=auto');
+  });
+
+  it('falls back to single task model when JSON is absent', () => {
+    const { stdout, exitCode } = runHelper({
+      phase: 'execution',
+      phaseModelsJson: '',
+      taskModel: 'opus',
+    });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'opus']);
+    expect(stdout).toContain('task fallback');
+  });
+
+  it('falls back to single task model when phase key is missing', () => {
+    const json = '{"review":"opus","meta_review":"sonnet"}';
+    const { stdout, exitCode } = runHelper({
+      phase: 'execution',
+      phaseModelsJson: json,
+      taskModel: 'haiku',
+    });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'haiku']);
+    expect(stdout).toContain('task fallback');
+  });
+
+  it('falls back to single task model when JSON is malformed (tested at runner level)', () => {
+    // Note: malformed JSON validation happens in task-runner.sh before calling
+    // model_args_for_phase — at that point PHASE_MODELS_JSON is already cleared.
+    // Passing malformed JSON directly to the helper results in jq returning empty,
+    // which triggers the same fallback path as a missing phase key.
+    const { stdout, exitCode } = runHelper({
+      phase: 'execution',
+      phaseModelsJson: 'not-valid-json',
+      taskModel: 'sonnet',
+    });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'sonnet']);
+    expect(stdout).toContain('task fallback');
+  });
+
+  it('falls back and logs warning when model contains / (OpenCode provider/model)', () => {
+    const json = '{"execution":"openai/gpt-4o","review":"opus","meta_review":"sonnet"}';
+    const { stdout, exitCode } = runHelper({
+      phase: 'execution',
+      phaseModelsJson: json,
+      taskModel: 'sonnet',
+    });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual(['--model', 'sonnet']);
+    expect(stdout).toContain('WARNING');
+    expect(stdout).toContain('openai/gpt-4o');
+    expect(stdout).toContain('task fallback');
+  });
+
+  it('produces empty RESOLVED_MODEL_ARGS when task model is also absent', () => {
+    // No JSON and no task model → MODEL_ARGS is empty → RESOLVED_MODEL_ARGS is empty
+    const { stdout, exitCode } = runHelper({ phase: 'execution' });
+    expect(exitCode).toBe(0);
+    expect(parseArgs(stdout)).toEqual([]);
+  });
+
+  it('logs phase=<p> model=<m> for resolved phase', () => {
+    const json = '{"execution":"haiku","review":"opus","meta_review":"sonnet"}';
+    const { stdout } = runHelper({ phase: 'review', phaseModelsJson: json });
+    expect(stdout).toContain('[LOOP] phase=review model=opus');
+  });
+});

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -386,10 +386,11 @@ describe('StackManager', () => {
       expect(persisted[0].prompt).toBe('Fix the bug');
 
       // Should delegate to CLI `task` command (handles cred sync + user perms)
-      // When no model is specified, the effective default (sonnet) is used
+      // When no model is specified, the effective default (sonnet) is used.
+      // --models-json carries the per-phase routing map (all sonnet with no routing configured).
       expect(runCliSpy).toHaveBeenCalledWith(
         '/proj',
-        ['task', 'dispatch-test', '--model', 'sonnet', 'Fix the bug']
+        ['task', 'dispatch-test', '--model', 'sonnet', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Fix the bug']
       );
     });
 
@@ -435,9 +436,11 @@ describe('StackManager', () => {
       // response no longer echoes it.
       const persisted = registry.getTasksForStack('model-test');
       expect(persisted[0].model).toBe('opus');
+      // Single --model is for attribution; --models-json carries per-phase routing
+      // (registry default is sonnet for all phases when no routing is configured).
       expect(runCliSpy).toHaveBeenCalledWith(
         '/proj',
-        ['task', 'model-test', '--model', 'opus', 'Complex task']
+        ['task', 'model-test', '--model', 'opus', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Complex task']
       );
     });
 
@@ -454,10 +457,10 @@ describe('StackManager', () => {
       // "auto" should resolve to null in the DB (undefined → null via registry)
       const persisted = registry.getTasksForStack('auto-model');
       expect(persisted[0].model).toBeNull();
-      // CLI args should NOT contain --model
+      // Single --model is omitted for 'auto'; --models-json is still sent.
       expect(runCliSpy).toHaveBeenCalledWith(
         '/proj',
-        ['task', 'auto-model', 'Simple task']
+        ['task', 'auto-model', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Simple task']
       );
     });
 
@@ -475,10 +478,76 @@ describe('StackManager', () => {
       // on the registry Task, not echoed in the MCP response.
       const persisted = registry.getTasksForStack('no-model');
       expect(persisted[0].model).toBe('sonnet');
+      // Legacy/no-routing: all phases use the same model as the single task model.
       expect(runCliSpy).toHaveBeenCalledWith(
         '/proj',
-        ['task', 'no-model', '--model', 'sonnet', 'Simple task']
+        ['task', 'no-model', '--model', 'sonnet', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Simple task']
       );
+    });
+
+    it('includes per-phase model map in CLI args', async () => {
+      registry.createStack(makeStack('phase-map-test'));
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('phase-map-test', 'Fix the bug');
+
+      const [, args] = runCliSpy.mock.calls[0];
+      const jsonIdx = args.indexOf('--models-json');
+      expect(jsonIdx).toBeGreaterThan(-1);
+      const parsed = JSON.parse(args[jsonIdx + 1]);
+      expect(parsed).toHaveProperty('execution');
+      expect(parsed).toHaveProperty('review');
+      expect(parsed).toHaveProperty('meta_review');
+    });
+
+    it('reflects per-phase routing config in models-json', async () => {
+      registry.createStack(makeStack('routing-config-test'));
+      registry.setProjectRouting('/proj', {
+        assignments: {
+          execution:   { backend: 'claude', model: 'haiku' },
+          review:      { backend: 'claude', model: 'opus' },
+          meta_review: { backend: 'claude', model: 'sonnet' },
+        },
+      });
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      await manager.dispatchTask('routing-config-test', 'Complex task');
+
+      const [, args] = runCliSpy.mock.calls[0];
+      const jsonIdx = args.indexOf('--models-json');
+      expect(jsonIdx).toBeGreaterThan(-1);
+      const parsed = JSON.parse(args[jsonIdx + 1]);
+      expect(parsed.execution).toBe('haiku');
+      expect(parsed.review).toBe('opus');
+      expect(parsed.meta_review).toBe('sonnet');
+    });
+
+    it('all phases equal single model for legacy/no-routing dispatch', async () => {
+      registry.createStack(makeStack('legacy-no-routing'));
+      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+        stdout: 'Task dispatched.',
+        stderr: '',
+        exitCode: 0,
+      });
+
+      // No routing configured — effective default for all phases is 'sonnet'
+      await manager.dispatchTask('legacy-no-routing', 'Simple task');
+
+      const [, args] = runCliSpy.mock.calls[0];
+      const singleModel = args[args.indexOf('--model') + 1];
+      const jsonIdx = args.indexOf('--models-json');
+      const parsed = JSON.parse(args[jsonIdx + 1]);
+      expect(parsed.execution).toBe(singleModel);
+      expect(parsed.review).toBe(singleModel);
+      expect(parsed.meta_review).toBe(singleModel);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds per-phase model routing to the Sandstorm task runner so each phase of a ticket run (dispatch, code, review, etc.) can target a distinct model instead of using a single model for the whole run. The control plane resolves a phase-to-model map from ticket config and the registry, then passes it to the container via a `--models-json` flag. Inside the container, a `phase-model-helper.sh` reads that map and resolves the correct model arguments for each phase, which the task runner applies at every agent invocation.

This branch also merges in the OpenCode inner-agent backend work from main, so the two features coexist: the stack manager now emits both `--models-json` (per-phase routing) and `--backend`/`--backend-model` (backend selection) flags, and the task runner invokes `run_agent` with the resolved model args regardless of which backend is active. Supporting scripts for OpenCode NDJSON parsing and token counting are included, along with unit and integration coverage for the helper, parsers, IPC handlers, ticket config, and stack manager.

## QA plan

1. Open a ticket and configure different models for different phases (e.g. a cheaper model for dispatch, a stronger model for code/review).
2. Spin up a stack and dispatch the ticket; confirm the container receives a `--models-json` argument carrying the phase map.
3. Watch the task runner logs and verify each phase invokes its configured model rather than a single global one.
4. Repeat with the OpenCode backend selected and confirm both the backend flags and per-phase routing are honored together.
5. Confirm a ticket with no per-phase config falls back to the default model with no regression.

Closes #535