### PR TITLE
[600] fix: sweep orphaned docker volumes on teardown

### DIFF
--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -382,6 +382,11 @@ case "$COMMAND" in
       run_compose down -v --rmi local
     fi
 
+    # Safety net: down -v only removes volumes it can resolve from a present
+    # compose file. Sweep any remaining named volumes for this project by label.
+    docker volume ls -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+      | xargs -r -n1 docker volume rm > /dev/null 2>&1 || true
+
     # Prune dangling images left by previous builds (best effort, see #13)
     docker image prune -f > /dev/null 2>&1 || true
 

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -171,6 +171,22 @@ export function sanitizeComposeName(input: string): string {
   return name || 'stack';
 }
 
+/**
+ * Build the Docker Compose project name for a given project/stack pair.
+ * Matches the `COMPOSE_PROJECT` variable in the CLI: "sandstorm-<project>-<stackId>".
+ */
+export function composeProjectNameFor(projectName: string, stackId: string): string {
+  return `sandstorm-${sanitizeComposeName(projectName)}-${sanitizeComposeName(stackId)}`;
+}
+
+/**
+ * Return the docker CLI args to list volumes for a compose project by label.
+ * The returned list is suitable for `spawn('docker', args)`.
+ */
+export function volumeRemoveArgsForProject(composeProjectName: string): string[] {
+  return ['volume', 'ls', '-q', '--filter', `label=com.docker.compose.project=${composeProjectName}`];
+}
+
 // referencesGitHubIssue is removed — use referencesTicket from ticket-fetcher.ts instead.
 // Re-export for backwards compatibility with any external callers.
 export { referencesTicket, referencesTicket as referencesGitHubIssue } from './ticket-fetcher';
@@ -810,7 +826,7 @@ export class StackManager {
     }
 
     const runtime = this.getRuntimeForStack(stack);
-    const composeProjectName = `sandstorm-${sanitizeComposeName(stack.project)}-${sanitizeComposeName(stack.id)}`;
+    const composeProjectName = composeProjectNameFor(stack.project, stack.id);
 
     let containers;
     try {
@@ -1009,6 +1025,33 @@ export class StackManager {
       await this.runCli(stack.project_dir, ['down', stackId]);
     } catch {
       // Best effort — if CLI fails, containers may need manual cleanup
+    }
+    // Defense-in-depth: remove any volumes the CLI may have missed (e.g. when
+    // the workspace compose file was absent and down -v couldn't resolve them).
+    await this.removeVolumesForProject(composeProjectNameFor(stack.project, stackId));
+  }
+
+  private async removeVolumesForProject(composeProjectName: string): Promise<void> {
+    try {
+      const listArgs = volumeRemoveArgsForProject(composeProjectName);
+      const stdout = await new Promise<string>((resolve) => {
+        const child = spawn('docker', listArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+        let out = '';
+        child.stdout.on('data', (d: Buffer) => (out += d.toString()));
+        child.on('close', () => resolve(out));
+        child.on('error', () => resolve(''));
+      });
+
+      const volumes = stdout.split('\n').map((v) => v.trim()).filter(Boolean);
+      for (const volume of volumes) {
+        await new Promise<void>((resolve) => {
+          const child = spawn('docker', ['volume', 'rm', volume], { stdio: ['ignore', 'pipe', 'pipe'] });
+          child.on('close', () => resolve());
+          child.on('error', () => resolve());
+        });
+      }
+    } catch {
+      // Best effort — volume cleanup must never block teardown
     }
   }
 
@@ -1296,7 +1339,7 @@ export class StackManager {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
-    const composeProjectName = `sandstorm-${sanitizeComposeName(stack.project)}-${sanitizeComposeName(stack.id)}`;
+    const composeProjectName = composeProjectNameFor(stack.project, stack.id);
     const filterName = service
       ? `${composeProjectName}-${service}`
       : composeProjectName;
@@ -1338,7 +1381,7 @@ export class StackManager {
     const stack = this.registry.getStack(stackId);
     if (!stack) return { stackId, totalMemory: 0, containers: [] };
 
-    const composeProjectName = `sandstorm-${sanitizeComposeName(stack.project)}-${sanitizeComposeName(stack.id)}`;
+    const composeProjectName = composeProjectNameFor(stack.project, stack.id);
     const runtime = this.getRuntimeForStack(stack);
     const containers = await runtime.listContainers({ name: composeProjectName });
 
@@ -1576,7 +1619,7 @@ export class StackManager {
   // --- Private helpers ---
 
   private async getServices(stack: Stack): Promise<ServiceInfo[]> {
-    const composeProjectName = `sandstorm-${sanitizeComposeName(stack.project)}-${sanitizeComposeName(stack.id)}`;
+    const composeProjectName = composeProjectNameFor(stack.project, stack.id);
     const runtime = this.getRuntimeForStack(stack);
     const containers = await runtime.listContainers({
       name: composeProjectName,
@@ -1666,7 +1709,7 @@ export class StackManager {
 
   private async findClaudeContainer(stack: Stack, runtime?: ContainerRuntime): Promise<Container> {
     const resolvedRuntime = runtime ?? this.getRuntimeForStack(stack);
-    const composeProjectName = `sandstorm-${sanitizeComposeName(stack.project)}-${sanitizeComposeName(stack.id)}`;
+    const composeProjectName = composeProjectNameFor(stack.project, stack.id);
     const containers = await resolvedRuntime.listContainers({
       name: `${composeProjectName}-claude`,
     });
@@ -1775,7 +1818,7 @@ export class StackManager {
         // Check for running containers
         let hasRunningContainers = false;
         try {
-          const composeProjectName = `sandstorm-${sanitizeComposeName(project.name)}-${sanitizeComposeName(stackId)}`;
+          const composeProjectName = composeProjectNameFor(project.name, stackId);
           const containers = await this.dockerRuntime.listContainers({ name: composeProjectName });
           hasRunningContainers = containers.some((c) => c.status === 'running');
         } catch {
@@ -1833,15 +1876,19 @@ export class StackManager {
       try {
         // Validate path is within a registered project's .sandstorm/workspaces/ directory
         const normalized = path.resolve(workspacePath);
-        const isValidPath = projects.some((project) => {
+        const owningProject = projects.find((project) => {
           const allowedDir = path.resolve(path.join(project.directory, '.sandstorm', 'workspaces'));
           return normalized.startsWith(allowedDir + path.sep) || normalized === allowedDir;
         });
 
-        if (!isValidPath) {
+        if (!owningProject) {
           results.push({ workspacePath, success: false, error: 'Path is not within a registered project workspace directory' });
           continue;
         }
+
+        // Remove volumes before the workspace dir (best effort; failure never flips success)
+        const stackId = path.basename(normalized);
+        await this.removeVolumesForProject(composeProjectNameFor(owningProject.name, stackId));
 
         // Use Docker to remove (handles files owned by container users)
         const parentDir = path.dirname(normalized);

--- a/tests/unit/claude-overlay.test.ts
+++ b/tests/unit/claude-overlay.test.ts
@@ -62,4 +62,12 @@ describe('stack.sh overlay wiring', () => {
     expect(overlayPos).toBeGreaterThan(-1);
     expect(overlayPos).toBeGreaterThan(sandstormPos);
   });
+
+  it('contains the label-based volume sweep in the down) case', () => {
+    const stackSh = fs.readFileSync(STACK_SH_PATH, 'utf-8');
+    expect(stackSh).toContain(
+      'docker volume ls -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}"'
+    );
+    expect(stackSh).toContain('xargs -r -n1 docker volume rm');
+  });
 });

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -3,6 +3,8 @@ import { spawnSync } from 'child_process';
 import {
   StackManager,
   sanitizeComposeName,
+  composeProjectNameFor,
+  volumeRemoveArgsForProject,
   referencesGitHubIssue,
   tailBytes,
   TASK_OUTPUT_MAX_BYTES,
@@ -116,6 +118,37 @@ describe('sanitizeComposeName', () => {
   it('handles mixed problematic input', () => {
     expect(sanitizeComposeName('My Cool Stack!!')).toBe('my-cool-stack');
     expect(sanitizeComposeName('  --test@name-- ')).toBe('testname');
+  });
+});
+
+describe('composeProjectNameFor', () => {
+  it('combines project and stackId with sandstorm prefix', () => {
+    expect(composeProjectNameFor('My Cool Project', '36-x')).toBe('sandstorm-my-cool-project-36-x');
+  });
+
+  it('matches the inline expression it replaces', () => {
+    const project = 'My Cool Project';
+    const stackId = '36-x';
+    const inline = `sandstorm-${sanitizeComposeName(project)}-${sanitizeComposeName(stackId)}`;
+    expect(composeProjectNameFor(project, stackId)).toBe(inline);
+  });
+
+  it('sanitizes both segments', () => {
+    expect(composeProjectNameFor('My App!', 'Ticket #1')).toBe('sandstorm-my-app-ticket-1');
+  });
+});
+
+describe('volumeRemoveArgsForProject', () => {
+  it('returns docker volume ls args with correct label filter', () => {
+    expect(volumeRemoveArgsForProject('sandstorm-p-1')).toEqual([
+      'volume', 'ls', '-q', '--filter', 'label=com.docker.compose.project=sandstorm-p-1',
+    ]);
+  });
+
+  it('includes the full compose project name in the filter value', () => {
+    const args = volumeRemoveArgsForProject('sandstorm-my-project-42');
+    const filterArg = args[args.indexOf('--filter') + 1];
+    expect(filterArg).toBe('label=com.docker.compose.project=sandstorm-my-project-42');
   });
 });
 

--- a/tests/unit/stale-workspaces.test.ts
+++ b/tests/unit/stale-workspaces.test.ts
@@ -364,4 +364,21 @@ describe('Stale Workspace Cleanup', () => {
       expect(fs.existsSync(dir)).toBe(false);
     }
   });
+
+  it('removes workspace dir and returns success even when docker volume commands fail', async () => {
+    // Verifies that a volume-removal failure (e.g. Docker unavailable) does NOT flip success —
+    // dir removal is the sole success criterion per the spec edge case.
+    const workspaceDir = path.join(tmpProjectDir, '.sandstorm', 'workspaces', 'my-stack');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, 'file.txt'), 'data');
+
+    // In the test environment Docker is unavailable, so removeVolumesForProject will
+    // silently fail (best-effort). The workspace dir should still be removed.
+    const results = await manager.cleanupStaleWorkspaces([workspaceDir]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(true);
+    expect(results[0].workspacePath).toBe(workspaceDir);
+    expect(fs.existsSync(workspaceDir)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Stack teardown could leave named Docker volumes behind whenever `compose down -v` was unable to resolve them — most often when the workspace compose file was already gone, so Docker had no manifest to map the project's volumes from. Over many stack lifecycles these orphaned volumes accumulated and consumed disk.

This change adds a defense-in-depth volume sweep at every teardown path:

- The CLI `down` case now sweeps any remaining named volumes by their `com.docker.compose.project` label after `compose down -v`, so cleanup no longer depends on the compose file being present.
- `StackManager` gains a best-effort `removeVolumesForProject` helper that lists volumes by label and removes them, invoked from both stack teardown and stale-workspace cleanup (where the stack id is derived from the workspace dir name).
- Compose project-name construction is consolidated into a shared `composeProjectNameFor` helper, replacing the duplicated inline template literals so the label filter always matches the CLI's `COMPOSE_PROJECT`.

Volume removal is strictly best-effort: failures (e.g. Docker unavailable) are swallowed and never block teardown or flip a stale-workspace cleanup result to failure — directory removal remains the sole success criterion.

## QA plan

1. Create and start a stack, then confirm its volumes exist: `docker volume ls --filter label=com.docker.compose.project=sandstorm-<project>-<stackId>`.
2. Tear the stack down and re-run the same `docker volume ls` — no volumes should remain.
3. Reproduce the original bug: start a stack, delete its workspace `.sandstorm/workspaces/<stackId>` compose file, then tear down. Confirm the label-filtered volumes are still gone.
4. Run stale-workspace cleanup with Docker stopped and verify the workspace directory is still removed and the result reports success.

Closes #600