### PR TITLE
[604] fix: group telemetry pipeline panel by lifecycle stage

### DIFF
--- a/src/renderer/components/TelemetryView.tsx
+++ b/src/renderer/components/TelemetryView.tsx
@@ -7,7 +7,7 @@ import { Donut } from './telemetry/Donut';
 import { StackedBars } from './telemetry/StackedBars';
 import type { TokenClass } from './telemetry/StackedBars';
 import { TOKEN_COLORS, TOKEN_LABELS } from './telemetry/StackedBars';
-import { groupByPipeline, ORCHESTRATOR_TICKET_ID } from './telemetry/utils';
+import { groupByLifecycleStage, LIFECYCLE_STAGES, LIFECYCLE_COLORS, ORCHESTRATOR_TICKET_ID } from './telemetry/utils';
 import { formatTokensCompact } from '../utils/format';
 import { StackedHBar } from './telemetry/StackedHBar';
 
@@ -22,16 +22,6 @@ const RANGE_LABELS: Record<RangeOption, string> = {
   all: 'All',
 };
 
-const LIFECYCLE_STAGES: LifecycleStage[] = ['refine', 'spec', 'execution', 'review', 'verify', 'pr'];
-
-const LIFECYCLE_COLORS: Record<LifecycleStage, string> = {
-  refine: '#c9a227',
-  spec: '#4a7fb5',
-  execution: '#7b5ea7',
-  review: '#d4a854',
-  verify: '#4a8c6e',
-  pr: '#e87b5a',
-};
 
 const MODEL_PALETTE = ['#d4a854', '#7b5ea7', '#4a7fb5', '#4a8c6e', '#c9a227', '#e87b5a'];
 
@@ -188,9 +178,9 @@ export function TelemetryView() {
   // Max ticket cost for bar scaling (zero-cost tickets get affordance, not bars)
   const maxTicketCost = sortedTickets.reduce((m, t) => Math.max(m, t.cost), 0);
 
-  // Pipeline groups
-  const pipelineGroups = groupByPipeline(telemetryByTicket, boardTickets);
-  const pipelineTotal = pipelineGroups.reduce((s, g) => s + g.totalCost, 0);
+  // Pipeline stage groups (lifecycle-based)
+  const lifecycleGroups = groupByLifecycleStage(telemetryByTicket);
+  const lifecycleTotal = lifecycleGroups.reduce((s, g) => s + g.totalCost, 0);
 
   // Month-vs-last bar scaling
   const monthMax = Math.max(
@@ -552,23 +542,23 @@ export function TelemetryView() {
         {/* Panel 5: Spend by pipeline stage */}
         <div className="bg-sandstorm-surface rounded-xl border border-sandstorm-border p-4" data-testid="panel-pipeline">
           <div className="text-sm font-medium text-sandstorm-text mb-3">Spend by Pipeline Stage</div>
-          {/* Single 100% stacked bar */}
+          {/* Single 100% stacked bar — verify excluded (always $0) */}
           <div className="mb-3" data-testid="pipeline-bar">
             <StackedHBar
-              segments={pipelineGroups
+              segments={lifecycleGroups
                 .filter((g) => g.totalCost > 0)
                 .map((g) => ({
                   value: g.totalCost,
                   color: g.color,
-                  label: `${g.displayName}: ${fmt$(g.totalCost)} (${pipelineTotal > 0 ? g.pct.toFixed(1) : '0'}%)`,
+                  label: `${g.displayName}: ${fmt$(g.totalCost)} (${lifecycleTotal > 0 ? g.pct.toFixed(1) : '0'}%)`,
                 }))}
               height={16}
             />
           </div>
-          {/* Per-column figure rows */}
+          {/* Per-stage figure rows */}
           <div className="flex flex-col gap-2">
-            {pipelineGroups.map((group) => (
-              <div key={group.column} className="flex items-center gap-3" data-testid={`pipeline-row-${group.column}`}>
+            {lifecycleGroups.map((group) => (
+              <div key={group.stage} className="flex items-center gap-3" data-testid={`pipeline-row-${group.stage}`}>
                 <span
                   className="w-2 h-2 rounded-full shrink-0"
                   style={{ backgroundColor: group.color }}
@@ -576,15 +566,19 @@ export function TelemetryView() {
                 <span className="text-xs text-sandstorm-text-secondary shrink-0 w-24">{group.displayName}</span>
                 {group.totalCost > 0 ? (
                   <>
-                    <span className="text-xs font-mono text-sandstorm-text" data-testid={`pipeline-cost-${group.column}`}>
+                    <span className="text-xs font-mono text-sandstorm-text" data-testid={`pipeline-cost-${group.stage}`}>
                       {fmt$(group.totalCost)}
                     </span>
-                    <span className="text-xs font-mono text-sandstorm-muted" data-testid={`pipeline-pct-${group.column}`}>
-                      {pipelineTotal > 0 ? `${group.pct.toFixed(1)}%` : '0%'}
+                    <span className="text-xs font-mono text-sandstorm-muted" data-testid={`pipeline-pct-${group.stage}`}>
+                      {lifecycleTotal > 0 ? `${group.pct.toFixed(1)}%` : '0%'}
                     </span>
                   </>
+                ) : group.stage === 'verify' ? (
+                  <span className="text-xs text-sandstorm-muted" data-testid="pipeline-empty-verify">
+                    $0 — no LLM spend
+                  </span>
                 ) : (
-                  <span className="text-xs text-sandstorm-muted" data-testid={`pipeline-empty-${group.column}`}>
+                  <span className="text-xs text-sandstorm-muted" data-testid={`pipeline-empty-${group.stage}`}>
                     $0 — not yet started
                   </span>
                 )}

--- a/src/renderer/components/telemetry/utils.ts
+++ b/src/renderer/components/telemetry/utils.ts
@@ -1,61 +1,58 @@
 import { ORCHESTRATOR_TICKET_ID } from '../../../shared/constants';
-import type { ByTicketEntry } from '@main/telemetry/types';
+import type { ByTicketEntry, LifecycleCosts } from '@main/telemetry/types';
 export { ORCHESTRATOR_TICKET_ID };
-import type { TicketBoardEntry } from '../../store';
-import { KANBAN_COLUMNS } from '../../types/kanban';
-import type { KanbanColumn } from '../../types/kanban';
 
-export const KANBAN_COLUMN_LABELS: Record<KanbanColumn, string> = {
-  backlog: 'Backlog',
-  refining: 'Refining',
-  spec_ready: 'Spec Ready',
-  in_stack: 'In Stack',
-  pr_open: 'PR Open',
-  merged: 'Merged',
+export type LifecycleStage = keyof LifecycleCosts;
+
+export const LIFECYCLE_STAGES: LifecycleStage[] = ['refine', 'spec', 'execution', 'review', 'verify', 'pr'];
+
+export const LIFECYCLE_STAGE_NAMES: Record<LifecycleStage, string> = {
+  refine: 'Refine',
+  spec: 'Spec',
+  execution: 'Execution',
+  review: 'Review',
+  verify: 'Verify',
+  pr: 'PR',
 };
 
-export const KANBAN_COLUMN_COLORS: Record<KanbanColumn, string> = {
-  backlog: '#7a7094',
-  refining: '#c9a227',
-  spec_ready: '#4a7fb5',
-  in_stack: '#c9a227',
-  pr_open: '#7b5ea7',
-  merged: '#4a8c6e',
+export const LIFECYCLE_COLORS: Record<LifecycleStage, string> = {
+  refine: '#c9a227',
+  spec: '#4a7fb5',
+  execution: '#7b5ea7',
+  review: '#d4a854',
+  verify: '#4a8c6e',
+  pr: '#e87b5a',
 };
 
-export interface PipelineGroup {
-  column: KanbanColumn | 'unattributed';
+export interface LifecycleStageGroup {
+  stage: LifecycleStage;
   displayName: string;
   color: string;
   totalCost: number;
   pct: number;
 }
 
-export function groupByPipeline(
-  byTicket: ByTicketEntry[],
-  boardTickets: TicketBoardEntry[],
-): PipelineGroup[] {
-  const costByColumn: Record<string, number> = {};
+export function groupByLifecycleStage(byTicket: ByTicketEntry[]): LifecycleStageGroup[] {
+  const stageTotals: Partial<Record<LifecycleStage, number>> = {};
 
   for (const entry of byTicket) {
     if (entry.ticketId === ORCHESTRATOR_TICKET_ID) continue;
-    const board = boardTickets.find((t) => t.ticket_id === entry.ticketId);
-    const col = board?.column ?? 'unattributed';
-    costByColumn[col] = (costByColumn[col] ?? 0) + entry.cost;
+    if (entry.lifecycle === null) continue;
+
+    for (const stage of LIFECYCLE_STAGES) {
+      stageTotals[stage] = (stageTotals[stage] ?? 0) + entry.lifecycle[stage];
+    }
   }
 
-  const grandTotal = Object.values(costByColumn).reduce((s, v) => s + v, 0);
+  const grandTotal = LIFECYCLE_STAGES.reduce((s, st) => s + (stageTotals[st] ?? 0), 0);
 
-  const columns: Array<KanbanColumn | 'unattributed'> = [...KANBAN_COLUMNS, 'unattributed'];
-
-  return columns.map((col) => {
-    const totalCost = costByColumn[col] ?? 0;
+  return LIFECYCLE_STAGES.map((stage) => {
+    const totalCost = stageTotals[stage] ?? 0;
     const pct = grandTotal > 0 ? (totalCost / grandTotal) * 100 : 0;
-    const isReal = col !== 'unattributed';
     return {
-      column: col,
-      displayName: isReal ? KANBAN_COLUMN_LABELS[col as KanbanColumn] : 'Unattributed',
-      color: isReal ? KANBAN_COLUMN_COLORS[col as KanbanColumn] : '#b8b0cc',
+      stage,
+      displayName: LIFECYCLE_STAGE_NAMES[stage],
+      color: LIFECYCLE_COLORS[stage],
       totalCost,
       pct,
     };

--- a/tests/unit/components/TelemetryView.test.tsx
+++ b/tests/unit/components/TelemetryView.test.tsx
@@ -291,12 +291,17 @@ describe('TelemetryView', () => {
   });
 
   describe('Pipeline panel', () => {
-    it('renders pipeline rows for kanban columns', () => {
+    it('renders lifecycle stage rows (not kanban column rows)', () => {
       render(<TelemetryView />);
-      // Should have rows for each KANBAN_COLUMN + unattributed
-      expect(screen.getByTestId('pipeline-row-backlog')).toBeDefined();
-      expect(screen.getByTestId('pipeline-row-merged')).toBeDefined();
-      expect(screen.getByTestId('pipeline-row-unattributed')).toBeDefined();
+      expect(screen.getByTestId('pipeline-row-refine')).toBeDefined();
+      expect(screen.getByTestId('pipeline-row-execution')).toBeDefined();
+      expect(screen.getByTestId('pipeline-row-review')).toBeDefined();
+      expect(screen.getByTestId('pipeline-row-verify')).toBeDefined();
+      expect(screen.getByTestId('pipeline-row-pr')).toBeDefined();
+      // Old kanban-column rows must not exist
+      expect(screen.queryByTestId('pipeline-row-merged')).toBeNull();
+      expect(screen.queryByTestId('pipeline-row-backlog')).toBeNull();
+      expect(screen.queryByTestId('pipeline-row-unattributed')).toBeNull();
     });
 
     it('renders a single stacked bar in the pipeline panel', () => {
@@ -305,29 +310,60 @@ describe('TelemetryView', () => {
       expect(pipelineBar.querySelector('[data-testid="stacked-hbar"]')).toBeTruthy();
     });
 
-    it('shows $0 hint for empty columns', () => {
+    it('verify stage renders "$0 — no LLM spend" label', () => {
       render(<TelemetryView />);
-      // backlog has no tickets → empty hint
-      expect(screen.getByTestId('pipeline-empty-backlog').textContent).toContain('$0 — not yet started');
+      // verify is always $0 by design — must show the explicit label, not look like a bug
+      expect(screen.getByTestId('pipeline-empty-verify').textContent).toContain('$0 — no LLM spend');
     });
 
-    it('shows cost for columns with tickets', () => {
+    it('shows summed lifecycle cost across tickets for execution stage', () => {
       render(<TelemetryView />);
-      // ticket 43 is in 'merged' column with cost 4.5
-      expect(screen.getByTestId('pipeline-cost-merged').textContent).toBe('$4.50');
+      // ticket 42 execution=3.0 + ticket 43 execution=2.5 → $5.50
+      expect(screen.getByTestId('pipeline-cost-execution').textContent).toBe('$5.50');
     });
 
-    it('orchestrator entry is excluded from pipeline grouping (not counted in Unattributed)', () => {
+    it('shows summed lifecycle cost for refine stage', () => {
+      render(<TelemetryView />);
+      // ticket 42 refine=1.0 + ticket 43 refine=0.5 → $1.50
+      expect(screen.getByTestId('pipeline-cost-refine').textContent).toBe('$1.50');
+    });
+
+    it('orchestrator entry is excluded from lifecycle stage rollup', () => {
       setupStore({
         byTicket: [
-          { ticketId: '__orchestrator__', model: null, cost: 2.0, tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 }, cacheHit: 0, lifecycle: null, unpriced: false },
+          {
+            ticketId: '__orchestrator__',
+            model: null,
+            cost: 2.0,
+            tokens: { input: 10, output: 5, cacheCreate: 0, cacheRead: 0, total: 15 },
+            cacheHit: 0,
+            lifecycle: { refine: 1.0, spec: 0.5, execution: 0.5, review: 0.0, verify: 0.0, pr: 0.0 },
+            unpriced: false,
+          },
         ],
       });
       render(<TelemetryView />);
-      const unattribRow = screen.getByTestId('pipeline-row-unattributed');
-      // orchestrator is excluded — unattributed row should show empty state
-      expect(unattribRow.textContent).not.toContain('$2.00');
-      expect(unattribRow.textContent).toContain('$0 — not yet started');
+      // orchestrator excluded — all stages should show empty state
+      expect(screen.getByTestId('pipeline-empty-refine').textContent).toContain('$0');
+    });
+
+    it('tickets with null lifecycle are excluded from stage rollup', () => {
+      setupStore({
+        byTicket: [
+          {
+            ticketId: '99',
+            model: null,
+            cost: 5.0,
+            tokens: { input: 50, output: 25, cacheCreate: 0, cacheRead: 0, total: 75 },
+            cacheHit: 0,
+            lifecycle: null,
+            unpriced: false,
+          },
+        ],
+      });
+      render(<TelemetryView />);
+      // null lifecycle excluded — all stages should show empty state
+      expect(screen.getByTestId('pipeline-empty-execution').textContent).toContain('$0');
     });
   });
 

--- a/tests/unit/components/telemetry/utils.test.ts
+++ b/tests/unit/components/telemetry/utils.test.ts
@@ -1,83 +1,124 @@
 import { describe, it, expect } from 'vitest';
-import { groupByPipeline } from '../../../../src/renderer/components/telemetry/utils';
+import { groupByLifecycleStage } from '../../../../src/renderer/components/telemetry/utils';
 import type { ByTicketEntry } from '../../../../src/main/telemetry/types';
-import type { TicketBoardEntry } from '../../../../src/renderer/store';
 
-const makeEntry = (ticketId: string, cost: number): ByTicketEntry => ({
+const makeEntry = (
+  ticketId: string,
+  cost: number,
+  lifecycle: ByTicketEntry['lifecycle'] = null,
+): ByTicketEntry => ({
   ticketId,
   model: null,
   cost,
   tokens: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, total: 0 },
   cacheHit: 0,
-  lifecycle: null,
+  lifecycle,
   unpriced: false,
 });
 
-const makeBoardTicket = (ticket_id: string, column: TicketBoardEntry['column']): TicketBoardEntry => ({
-  ticket_id,
-  project_dir: '/test',
-  column,
-  title: `Ticket ${ticket_id}`,
-  updated_at: '',
+const makeLifecycle = (
+  overrides: Partial<{ refine: number; spec: number; execution: number; review: number; verify: number; pr: number }> = {},
+) => ({
+  refine: 0,
+  spec: 0,
+  execution: 0,
+  review: 0,
+  verify: 0,
+  pr: 0,
+  ...overrides,
 });
 
-describe('groupByPipeline', () => {
-  it('groups costs by board column', () => {
-    const byTicket = [makeEntry('1', 3.0), makeEntry('2', 2.0)];
-    const boardTickets = [
-      makeBoardTicket('1', 'merged'),
-      makeBoardTicket('2', 'pr_open'),
+describe('groupByLifecycleStage', () => {
+  it('regression: tickets all in merged column spread cost across lifecycle stages (not collapsed)', () => {
+    // Both tickets happen to be "in merged" on the board — the old column-based approach would
+    // collapse their entire cost into a single Merged bucket. The new function must distribute
+    // costs across the actual lifecycle stages instead.
+    const byTicket = [
+      makeEntry('1', 5.0, makeLifecycle({ refine: 1.0, spec: 0.5, execution: 2.5, review: 0.8, pr: 0.2 })),
+      makeEntry('2', 3.0, makeLifecycle({ refine: 0.5, spec: 0.3, execution: 1.5, review: 0.5, pr: 0.2 })),
     ];
-    const groups = groupByPipeline(byTicket, boardTickets);
-    const merged = groups.find((g) => g.column === 'merged')!;
-    const prOpen = groups.find((g) => g.column === 'pr_open')!;
-    expect(merged.totalCost).toBe(3.0);
-    expect(prOpen.totalCost).toBe(2.0);
+    const groups = groupByLifecycleStage(byTicket);
+
+    const refine = groups.find((g) => g.stage === 'refine')!;
+    const spec = groups.find((g) => g.stage === 'spec')!;
+    const execution = groups.find((g) => g.stage === 'execution')!;
+    const review = groups.find((g) => g.stage === 'review')!;
+    const pr = groups.find((g) => g.stage === 'pr')!;
+
+    expect(refine.totalCost).toBeCloseTo(1.5, 10);
+    expect(spec.totalCost).toBeCloseTo(0.8, 10);
+    expect(execution.totalCost).toBeCloseTo(4.0, 10);
+    expect(review.totalCost).toBeCloseTo(1.3, 10);
+    expect(pr.totalCost).toBeCloseTo(0.4, 10);
+
+    // Multiple stages have non-zero cost — not collapsed to a single bucket
+    const nonZeroStages = groups.filter((g) => g.totalCost > 0);
+    expect(nonZeroStages.length).toBeGreaterThan(1);
   });
 
-  it('empty column has $0 and 0%', () => {
-    const byTicket = [makeEntry('1', 5.0)];
-    const boardTickets = [makeBoardTicket('1', 'merged')];
-    const groups = groupByPipeline(byTicket, boardTickets);
-    const backlog = groups.find((g) => g.column === 'backlog')!;
-    expect(backlog.totalCost).toBe(0);
-    expect(backlog.pct).toBe(0);
-  });
-
-  it('unmatched ticketId goes to Unattributed', () => {
-    const byTicket = [makeEntry('999', 4.0)];
-    const boardTickets: TicketBoardEntry[] = [];
-    const groups = groupByPipeline(byTicket, boardTickets);
-    const unattr = groups.find((g) => g.column === 'unattributed')!;
-    expect(unattr.totalCost).toBe(4.0);
-    expect(unattr.displayName).toBe('Unattributed');
-  });
-
-  it('__orchestrator__ is excluded from pipeline grouping entirely', () => {
-    const byTicket = [makeEntry('__orchestrator__', 2.5)];
-    const boardTickets: TicketBoardEntry[] = [];
-    const groups = groupByPipeline(byTicket, boardTickets);
-    const unattr = groups.find((g) => g.column === 'unattributed')!;
-    // orchestrator excluded — does not count toward any column, including unattributed
-    expect(unattr.totalCost).toBe(0);
-    const grandTotal = groups.reduce((s, g) => s + g.totalCost, 0);
-    expect(grandTotal).toBe(0);
-  });
-
-  it('percentages sum to 100', () => {
-    const byTicket = [makeEntry('1', 3.0), makeEntry('2', 2.0)];
-    const boardTickets = [
-      makeBoardTicket('1', 'merged'),
-      makeBoardTicket('2', 'pr_open'),
+  it('per-stage percentages sum to ~100% when total > 0', () => {
+    const byTicket = [
+      makeEntry('1', 6.0, makeLifecycle({ refine: 1.0, spec: 1.0, execution: 2.0, review: 1.0, pr: 1.0 })),
     ];
-    const groups = groupByPipeline(byTicket, boardTickets);
+    const groups = groupByLifecycleStage(byTicket);
     const totalPct = groups.reduce((s, g) => s + g.pct, 0);
     expect(totalPct).toBeCloseTo(100, 1);
   });
 
-  it('returns all KANBAN_COLUMNS plus unattributed even with no data', () => {
-    const groups = groupByPipeline([], []);
-    expect(groups).toHaveLength(7); // 6 columns + unattributed
-    expect(groups.every((g) => g.totalCost === 0)).toBe(true);
+  it('verify stage always has $0 totalCost and 0% pct', () => {
+    const byTicket = [
+      makeEntry('1', 5.0, makeLifecycle({ execution: 5.0 })),
+    ];
+    const groups = groupByLifecycleStage(byTicket);
+    const verify = groups.find((g) => g.stage === 'verify')!;
+    expect(verify.totalCost).toBe(0);
+    expect(verify.pct).toBe(0);
+  });
+
+  it('tickets with lifecycle === null are excluded from stage rollup', () => {
+    const byTicket = [
+      makeEntry('1', 5.0, null),
+      makeEntry('2', 3.0, makeLifecycle({ execution: 3.0 })),
+    ];
+    const groups = groupByLifecycleStage(byTicket);
+    const execution = groups.find((g) => g.stage === 'execution')!;
+    // Only ticket 2 counted; ticket 1 (null lifecycle) must not contribute
+    expect(execution.totalCost).toBeCloseTo(3.0, 10);
+    const grandTotal = groups.reduce((s, g) => s + g.totalCost, 0);
+    expect(grandTotal).toBeCloseTo(3.0, 10);
+  });
+
+  it('empty input → all stages $0 and 0%, no NaN', () => {
+    const groups = groupByLifecycleStage([]);
+    expect(groups).toHaveLength(6);
+    for (const g of groups) {
+      expect(g.totalCost).toBe(0);
+      expect(g.pct).toBe(0);
+      expect(Number.isNaN(g.totalCost)).toBe(false);
+      expect(Number.isNaN(g.pct)).toBe(false);
+    }
+  });
+
+  it('orchestrator ticket is excluded from stage rollup', () => {
+    const byTicket = [
+      makeEntry('__orchestrator__', 10.0, makeLifecycle({ execution: 10.0 })),
+    ];
+    const groups = groupByLifecycleStage(byTicket);
+    const grandTotal = groups.reduce((s, g) => s + g.totalCost, 0);
+    expect(grandTotal).toBe(0);
+  });
+
+  it('returns all 6 lifecycle stages in order', () => {
+    const groups = groupByLifecycleStage([]);
+    expect(groups.map((g) => g.stage)).toEqual(['refine', 'spec', 'execution', 'review', 'verify', 'pr']);
+  });
+
+  it('each stage group carries the correct display name and color', () => {
+    const groups = groupByLifecycleStage([]);
+    const execution = groups.find((g) => g.stage === 'execution')!;
+    expect(execution.displayName).toBe('Execution');
+    expect(execution.color).toBe('#7b5ea7');
+    const verify = groups.find((g) => g.stage === 'verify')!;
+    expect(verify.displayName).toBe('Verify');
   });
 });


### PR DESCRIPTION
## Summary

The telemetry Pipeline panel grouped per-ticket cost by kanban column, which misattributed spend and could not reflect where cost is actually incurred across a ticket's lifecycle. This change replaces the kanban-column grouping with lifecycle-stage grouping.

Cost is now summed per lifecycle stage (refine, spec, execution, review, verify, pr) across all in-range tickets, skipping orchestrator entries and tickets without lifecycle data. The panel renders the six stages with each stage's total cost and percentage share. The `verify` stage is always zero and now displays "$0 — no LLM spend" so the absence of cost reads as intentional rather than a bug.

The old `groupByPipeline` helper and its kanban label/color maps are removed in favor of `groupByLifecycleStage`, with the stage list and colors exported from the telemetry utils module.

## QA plan

1. Open the Telemetry view in the app.
2. Confirm the Pipeline panel now lists six rows: refine, spec, execution, review, verify, pr.
3. Verify each non-verify stage shows a dollar total and a percentage, and that the percentages sum to ~100%.
4. Confirm the verify row shows "$0 — no LLM spend".
5. Change the date range and confirm the per-stage totals update and exclude orchestrator and tickets with no lifecycle data.

Closes #604