### PR TITLE
[603] fix: attribute ephemeral and backfilled tokens in telemetry

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -418,6 +418,7 @@ export class ClaudeBackend implements AgentBackend {
     const spawnedAt = Date.now();
     let firstChunkAt: number | null = null;
     let turnCount = 0;
+    let ephemeralTokens = 0;
     let isCancelled = false;
     let timingWritten = false;
 
@@ -462,6 +463,7 @@ export class ClaudeBackend implements AgentBackend {
         exitCode,
         promptChars: prompt.length,
         turnCount,
+        tokens: ephemeralTokens,
         cancelled: isCancelled,
         ...(errorMessage != null ? { errorMessage } : {}),
         ...(attribution?.ticketId != null ? { ticketId: attribution.ticketId } : {}),
@@ -499,7 +501,13 @@ export class ClaudeBackend implements AgentBackend {
         if (!line.trim()) continue;
         try {
           const parsed = JSON.parse(line);
-          if (parsed.type === 'assistant') turnCount += 1;
+          if (parsed.type === 'assistant') {
+            turnCount += 1;
+            const usage = parsed.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+            if (usage) {
+              ephemeralTokens += (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
+            }
+          }
           const events = extractStreamEvents(parsed);
           for (const event of events) {
             if (event.kind === 'text') fullText += event.delta;
@@ -522,7 +530,13 @@ export class ClaudeBackend implements AgentBackend {
       if (outputBuffer.trim()) {
         try {
           const parsed = JSON.parse(outputBuffer);
-          if (parsed.type === 'assistant') turnCount += 1;
+          if (parsed.type === 'assistant') {
+            turnCount += 1;
+            const usage = parsed.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+            if (usage) {
+              ephemeralTokens += (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
+            }
+          }
           const events = extractStreamEvents(parsed);
           for (const event of events) {
             if (event.kind === 'text') fullText += event.delta;

--- a/src/main/agent/ephemeral-timing.ts
+++ b/src/main/agent/ephemeral-timing.ts
@@ -15,6 +15,7 @@
  *     "exitCode": number | null,
  *     "promptChars": number,
  *     "turnCount": number (count of type:"assistant" records seen),
+ *     "tokens": number (sum of input_tokens + output_tokens across all assistant messages),
  *     "cancelled": boolean,
  *     "errorMessage"?: string (only on startup error)
  *   }
@@ -31,6 +32,7 @@ export interface EphemeralTimingRecord {
   exitCode: number | null;
   promptChars: number;
   turnCount: number;
+  tokens: number;  // input_tokens + output_tokens summed across assistant messages
   cancelled: boolean;
   errorMessage?: string;
   ticketId?: string;  // optional attribution for lifecycle tracking

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -13,6 +13,13 @@ import {
   type PresetId,
 } from './routing';
 
+/** Per-ticket phase token totals from tasks columns (backfill when task_token_steps absent). */
+export interface TaskPhaseWeightRow {
+  ticket: string;
+  phase: 'execution' | 'review';
+  totalTokens: number;
+}
+
 export interface Stack {
   id: string;
   project: string;
@@ -1073,6 +1080,34 @@ export class Registry {
       WHERE s.ticket IS NOT NULL
       GROUP BY s.ticket, tts.phase
     `).all() as { ticket: string; phase: string; totalTokens: number }[];
+  }
+
+  /**
+   * Return per-ticket phase token totals from the tasks columns as a backfill
+   * source for lifecycle cost splitting. Used when task_token_steps rows are
+   * absent (e.g. container torn down before step file read).
+   *
+   * Shape mirrors getStepWeightsByTicket: one row per (ticket, phase).
+   * Unit: input_tokens + output_tokens (no cache), same as getStepWeightsByTicket.
+   */
+  getTaskPhaseTokensByTicket(): TaskPhaseWeightRow[] {
+    return this.db.prepare(`
+      SELECT s.ticket, 'execution' AS phase,
+             SUM(t.execution_input_tokens + t.execution_output_tokens) AS totalTokens
+      FROM tasks t
+      JOIN stacks s ON s.id = t.stack_id
+      WHERE s.ticket IS NOT NULL
+      GROUP BY s.ticket
+      HAVING SUM(t.execution_input_tokens + t.execution_output_tokens) > 0
+      UNION ALL
+      SELECT s.ticket, 'review' AS phase,
+             SUM(t.review_input_tokens + t.review_output_tokens) AS totalTokens
+      FROM tasks t
+      JOIN stacks s ON s.id = t.stack_id
+      WHERE s.ticket IS NOT NULL
+      GROUP BY s.ticket
+      HAVING SUM(t.review_input_tokens + t.review_output_tokens) > 0
+    `).all() as TaskPhaseWeightRow[];
   }
 
   /**

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -823,11 +823,12 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   ipcMain.handle('stats:telemetry:byTicket', async (_event, range?: DateRange): Promise<ByTicketEntry[]> => {
     const stepWeights = registry.getStepWeightsByTicket();
+    const taskPhaseWeights = registry.getTaskPhaseTokensByTicket();
     const allEphemeral = readEphemeralTimingRecords(agentBackend.getEphemeralTimingPath());
     const ephemeralRecords = allEphemeral
       .filter((r) => r.ticketId != null && r.stage != null)
-      .map((r) => ({ ticketId: r.ticketId!, stage: r.stage!, turnCount: r.turnCount }));
-    return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords).getByTicket(range);
+      .map((r) => ({ ticketId: r.ticketId!, stage: r.stage!, tokens: r.tokens ?? 0 }));
+    return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords, taskPhaseWeights).getByTicket(range);
   });
 
   ipcMain.handle('stats:telemetry:refresh', async () => {

--- a/src/main/telemetry/aggregator.ts
+++ b/src/main/telemetry/aggregator.ts
@@ -11,6 +11,8 @@ import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry
 import { ORCHESTRATOR_TICKET_ID } from './types';
 import { computeLifecycleSplit } from './lifecycle-split';
 import type { LifecycleWeights } from './lifecycle-split';
+import type { TaskPhaseWeightRow } from '../control-plane/registry';
+export type { TaskPhaseWeightRow };
 
 /** Per-ticket step weights read from task_token_steps (injected, electron-free). */
 export interface StepWeightRow {
@@ -23,8 +25,9 @@ export interface StepWeightRow {
 export interface EphemeralWeightRecord {
   ticketId: string;
   stage: string;  // 'refine' | 'spec' | 'pr'
-  turnCount: number;
+  tokens: number;  // input_tokens + output_tokens for the spawn (same unit as StepWeightRow)
 }
+
 
 function dateOf(isoTimestamp: string): string {
   return isoTimestamp.slice(0, 10); // YYYY-MM-DD
@@ -292,6 +295,7 @@ export function aggregateByTicket(
   stackRoots: string[],
   stepWeights: StepWeightRow[] = [],
   ephemeralRecords: EphemeralWeightRecord[] = [],
+  taskPhaseWeights: TaskPhaseWeightRow[] = [],
 ): ByTicketEntry[] {
   // Build stackId → ticket map from manifests
   const stackToTicket = new Map<string, string | null>();
@@ -339,19 +343,47 @@ export function aggregateByTicket(
     return w;
   };
 
+  // Build step weight map: ticket -> phase -> tokens (primary source for execution/review)
+  const stepMap = new Map<string, Map<string, number>>();
   for (const row of stepWeights) {
     if (row.phase !== 'execution' && row.phase !== 'review') continue;
-    const w = getWeights(row.ticket);
-    const stage = row.phase as 'execution' | 'review';
-    w[stage] = (w[stage] ?? 0) + row.totalTokens;
+    if (!stepMap.has(row.ticket)) stepMap.set(row.ticket, new Map());
+    const pm = stepMap.get(row.ticket)!;
+    pm.set(row.phase, (pm.get(row.phase) ?? 0) + row.totalTokens);
   }
 
+  // Build backfill map: ticket -> phase -> tokens (fallback from tasks columns)
+  const backfillMap = new Map<string, Map<string, number>>();
+  for (const row of taskPhaseWeights) {
+    if (!backfillMap.has(row.ticket)) backfillMap.set(row.ticket, new Map());
+    const pm = backfillMap.get(row.ticket)!;
+    pm.set(row.phase, (pm.get(row.phase) ?? 0) + row.totalTokens);
+  }
+
+  // Merge execution/review: per (ticket, phase) use step weight if > 0, else backfill
+  const allExecReviewTickets = new Set([...stepMap.keys(), ...backfillMap.keys()]);
+  for (const ticketId of allExecReviewTickets) {
+    const w = getWeights(ticketId);
+    for (const phase of ['execution', 'review'] as const) {
+      const stepTokens = stepMap.get(ticketId)?.get(phase) ?? 0;
+      if (stepTokens > 0) {
+        w[phase] = (w[phase] ?? 0) + stepTokens;
+      } else {
+        const backfillTokens = backfillMap.get(ticketId)?.get(phase) ?? 0;
+        if (backfillTokens > 0) {
+          w[phase] = (w[phase] ?? 0) + backfillTokens;
+        }
+      }
+    }
+  }
+
+  // Ephemeral records contribute refine/spec/pr weights in the same token unit
   for (const rec of ephemeralRecords) {
     if (!rec.ticketId || !rec.stage) continue;
     if (rec.stage !== 'refine' && rec.stage !== 'spec' && rec.stage !== 'pr') continue;
     const w = getWeights(rec.ticketId);
     const stage = rec.stage as 'refine' | 'spec' | 'pr';
-    w[stage] = (w[stage] ?? 0) + rec.turnCount;
+    w[stage] = (w[stage] ?? 0) + rec.tokens;
   }
 
   return [...byTicket.entries()].map(([ticketId, data]) => {

--- a/src/main/telemetry/usage-engine.ts
+++ b/src/main/telemetry/usage-engine.ts
@@ -15,10 +15,10 @@
 import fs from 'fs';
 import { parseTranscriptRoots, findJSONLFiles, type ParseResult } from './parser';
 import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions, aggregateByTicket } from './aggregator';
-import type { StepWeightRow, EphemeralWeightRecord } from './aggregator';
+import type { StepWeightRow, EphemeralWeightRecord, TaskPhaseWeightRow } from './aggregator';
 import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
 
-export type { StepWeightRow, EphemeralWeightRecord };
+export type { StepWeightRow, EphemeralWeightRecord, TaskPhaseWeightRow };
 
 export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry };
 
@@ -96,6 +96,7 @@ export function createUsageEngine(
   roots: string[],
   stepWeights?: StepWeightRow[],
   ephemeralRecords?: EphemeralWeightRecord[],
+  taskPhaseWeights?: TaskPhaseWeightRow[],
 ): UsageEngine {
   const stackRoots = roots.filter((r) => !r.endsWith('/.claude/projects'));
 
@@ -128,7 +129,7 @@ export function createUsageEngine(
             return date >= range.since && date <= range.until;
           })
         : entries;
-      return aggregateByTicket(filtered, stackRoots, stepWeights, ephemeralRecords);
+      return aggregateByTicket(filtered, stackRoots, stepWeights, ephemeralRecords, taskPhaseWeights);
     },
   };
 }

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -1410,6 +1410,7 @@ describe('spawnEphemeralAgent — timing record integration', () => {
     expect(record.exitCode).toBe(0);
     expect(record.promptChars).toBe('hello world'.length);
     expect(record.turnCount).toBe(1);
+    expect(record.tokens).toBe(0); // assistant message without usage → 0
     expect(record.cancelled).toBe(false);
     expect(record.errorMessage).toBeUndefined();
     expect(record.firstChunkAt).not.toBeNull();
@@ -1451,8 +1452,39 @@ describe('spawnEphemeralAgent — timing record integration', () => {
     const record = JSON.parse(timingCalls[0][1] as string);
     expect(record.cancelled).toBe(true);
     expect(record.turnCount).toBe(1);
+    expect(record.tokens).toBe(0); // assistant message without usage → 0
     expect(record.firstChunkAt).not.toBeNull();
     expect(record.errorMessage).toBeUndefined();
+
+    backendUnderTest.destroy();
+  });
+
+  it('accumulates input+output tokens from assistant usage fields', async () => {
+    const fs = await import('fs');
+    vi.mocked(fs.appendFileSync).mockClear();
+
+    const backendUnderTest = new ClaudeBackend(60_000);
+    const { promise } = backendUnderTest.spawnEphemeralAgent('test', '/tmp', 5_000, () => {});
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+
+    // Two assistant messages with usage
+    proc.stdout.emit('data', Buffer.from(
+      JSON.stringify({ type: 'assistant', message: { content: [] }, usage: { input_tokens: 100, output_tokens: 50 } }) + '\n'
+    ));
+    proc.stdout.emit('data', Buffer.from(
+      JSON.stringify({ type: 'assistant', message: { content: [] }, usage: { input_tokens: 200, output_tokens: 80 } }) + '\n'
+    ));
+    proc.exitCode = 0;
+    proc.emit('close', 0);
+
+    await promise;
+
+    const timingCalls = vi.mocked(fs.appendFileSync).mock.calls.filter((c) =>
+      String(c[0]).endsWith('sandstorm-desktop-ephemeral-timing.jsonl')
+    );
+    const record = JSON.parse(timingCalls[0][1] as string);
+    expect(record.tokens).toBe(430); // (100+50) + (200+80)
+    expect(record.turnCount).toBe(2);
 
     backendUnderTest.destroy();
   });
@@ -1482,6 +1514,7 @@ describe('spawnEphemeralAgent — timing record integration', () => {
     expect(record.cancelled).toBe(true);
     expect(record.firstChunkAt).toBeNull();
     expect(record.turnCount).toBe(0);
+    expect(record.tokens).toBe(0);
     expect(record.errorMessage).toBeUndefined();
 
     backendUnderTest.destroy();
@@ -1507,6 +1540,7 @@ describe('spawnEphemeralAgent — timing record integration', () => {
     expect(record.exitCode).toBeNull();
     expect(record.errorMessage).toBe('ENOENT: claude not found');
     expect(record.turnCount).toBe(0);
+    expect(record.tokens).toBe(0);
     expect(record.firstChunkAt).toBeNull();
     expect(record.cancelled).toBe(false);
 

--- a/tests/unit/ephemeral-timing.test.ts
+++ b/tests/unit/ephemeral-timing.test.ts
@@ -40,6 +40,7 @@ describe('appendEphemeralTiming', () => {
       exitCode: 0,
       promptChars: 1234,
       turnCount: 3,
+      tokens: 1500,
       cancelled: false,
       ...partial,
     };
@@ -90,6 +91,12 @@ describe('appendEphemeralTiming', () => {
     expect('errorMessage' in records[0]).toBe(false);
   });
 
+  it('round-trips the tokens field correctly', () => {
+    appendEphemeralTiming(sinkPath, sampleRecord({ tokens: 4200 }));
+    const records = readRecords();
+    expect(records[0].tokens).toBe(4200);
+  });
+
   it('swallows write errors silently', () => {
     expect(() => appendEphemeralTiming('/no/such/dir/timing.jsonl', sampleRecord())).not.toThrow();
   });
@@ -105,6 +112,7 @@ describe('appendEphemeralTiming', () => {
     expect(typeof r.elapsedMs).toBe('number');
     expect(typeof r.promptChars).toBe('number');
     expect(typeof r.turnCount).toBe('number');
+    expect(typeof r.tokens).toBe('number');
     expect(typeof r.cancelled).toBe('boolean');
   });
 });

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -78,6 +78,7 @@ const {
     setDarkFactoryEnabled: vi.fn(),
     getDb: vi.fn().mockReturnValue({}),
     getStepWeightsByTicket: vi.fn().mockReturnValue([]),
+    getTaskPhaseTokensByTicket: vi.fn().mockReturnValue([]),
     getGlobalBackendSettings: vi.fn().mockReturnValue({ inner_backend: 'claude', outer_backend: 'claude', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null }),
     setGlobalBackendSettings: vi.fn(),
     getProjectBackendSettings: vi.fn().mockReturnValue(null),

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1230,6 +1230,146 @@ describe('Registry', () => {
     });
   });
 
+  // ===========================================
+  // getTaskPhaseTokensByTicket
+  // ===========================================
+  describe('getTaskPhaseTokensByTicket', () => {
+    beforeEach(() => {
+      registry.createStack(makeStack({ id: 'phase-ticket-stack', ticket: 'TICKET-1' }));
+    });
+
+    it('returns execution and review rows for a ticket with phase tokens', () => {
+      const task = registry.createTask('phase-ticket-stack', 'test task');
+      registry.updateTaskTokens(task.id, 3000, 1500, {
+        executionInput: 2000,
+        executionOutput: 1000,
+        reviewInput: 1000,
+        reviewOutput: 500,
+      });
+
+      const rows = registry.getTaskPhaseTokensByTicket();
+      const exec = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'execution');
+      const rev = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'review');
+
+      expect(exec).toBeDefined();
+      expect(exec!.totalTokens).toBe(3000); // 2000 + 1000
+      expect(rev).toBeDefined();
+      expect(rev!.totalTokens).toBe(1500); // 1000 + 500
+    });
+
+    it('excludes stacks with no ticket (ticket IS NULL)', () => {
+      registry.createStack(makeStack({ id: 'no-ticket-stack', ticket: null }));
+      const task = registry.createTask('no-ticket-stack', 'unticketed task');
+      registry.updateTaskTokens(task.id, 1000, 500, {
+        executionInput: 1000,
+        executionOutput: 500,
+        reviewInput: 0,
+        reviewOutput: 0,
+      });
+
+      const rows = registry.getTaskPhaseTokensByTicket();
+      expect(rows.every(r => r.ticket !== null)).toBe(true);
+      // no-ticket-stack should not appear
+      expect(rows.filter(r => r.phase === 'execution').some(r => r.totalTokens === 1500)).toBe(false);
+    });
+
+    it('HAVING > 0 filter excludes zero-token phases', () => {
+      const task = registry.createTask('phase-ticket-stack', 'exec only task');
+      registry.updateTaskTokens(task.id, 2000, 1000, {
+        executionInput: 2000,
+        executionOutput: 1000,
+        reviewInput: 0,
+        reviewOutput: 0,
+      });
+
+      const rows = registry.getTaskPhaseTokensByTicket();
+      const execRows = rows.filter(r => r.ticket === 'TICKET-1' && r.phase === 'execution');
+      const reviewRows = rows.filter(r => r.ticket === 'TICKET-1' && r.phase === 'review');
+
+      expect(execRows).toHaveLength(1);
+      expect(execRows[0].totalTokens).toBe(3000); // 2000 + 1000
+      expect(reviewRows).toHaveLength(0); // excluded by HAVING > 0
+    });
+
+    it('returns separate rows for each ticket (per-ticket union shape)', () => {
+      registry.createStack(makeStack({ id: 'ticket2-stack', ticket: 'TICKET-2' }));
+      const task1 = registry.createTask('phase-ticket-stack', 'task for t1');
+      registry.updateTaskTokens(task1.id, 1000, 500, {
+        executionInput: 600,
+        executionOutput: 400,
+        reviewInput: 300,
+        reviewOutput: 200,
+      });
+      const task2 = registry.createTask('ticket2-stack', 'task for t2');
+      registry.updateTaskTokens(task2.id, 2000, 1000, {
+        executionInput: 1500,
+        executionOutput: 500,
+        reviewInput: 800,
+        reviewOutput: 200,
+      });
+
+      const rows = registry.getTaskPhaseTokensByTicket();
+      const t1exec = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'execution');
+      const t1rev = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'review');
+      const t2exec = rows.find(r => r.ticket === 'TICKET-2' && r.phase === 'execution');
+      const t2rev = rows.find(r => r.ticket === 'TICKET-2' && r.phase === 'review');
+
+      expect(t1exec!.totalTokens).toBe(1000); // 600 + 400
+      expect(t1rev!.totalTokens).toBe(500);   // 300 + 200
+      expect(t2exec!.totalTokens).toBe(2000); // 1500 + 500
+      expect(t2rev!.totalTokens).toBe(1000);  // 800 + 200
+    });
+
+    it('sums across multiple tasks on the same ticket', () => {
+      const task1 = registry.createTask('phase-ticket-stack', 'first task');
+      registry.updateTaskTokens(task1.id, 1000, 500, {
+        executionInput: 800,
+        executionOutput: 200,
+        reviewInput: 0,
+        reviewOutput: 0,
+      });
+      const task2 = registry.createTask('phase-ticket-stack', 'second task');
+      registry.updateTaskTokens(task2.id, 2000, 1000, {
+        executionInput: 1500,
+        executionOutput: 500,
+        reviewInput: 700,
+        reviewOutput: 300,
+      });
+
+      const rows = registry.getTaskPhaseTokensByTicket();
+      const exec = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'execution');
+      const rev = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'review');
+
+      expect(exec!.totalTokens).toBe(3000); // (800+200) + (1500+500)
+      expect(rev!.totalTokens).toBe(1000);  // (700+300)
+    });
+
+    it('returns empty array when no tickets have phase tokens', () => {
+      const rows = registry.getTaskPhaseTokensByTicket();
+      // phase-ticket-stack has a ticket but no tasks yet with non-zero phase tokens
+      expect(rows.filter(r => r.ticket === 'TICKET-1')).toHaveLength(0);
+    });
+
+    it('row shape has ticket, phase, and totalTokens fields', () => {
+      const task = registry.createTask('phase-ticket-stack', 'shape test');
+      registry.updateTaskTokens(task.id, 500, 250, {
+        executionInput: 400,
+        executionOutput: 100,
+        reviewInput: 200,
+        reviewOutput: 50,
+      });
+
+      const rows = registry.getTaskPhaseTokensByTicket();
+      const row = rows.find(r => r.ticket === 'TICKET-1' && r.phase === 'execution')!;
+      expect(row).toHaveProperty('ticket');
+      expect(row).toHaveProperty('phase');
+      expect(row).toHaveProperty('totalTokens');
+      expect(typeof row.ticket).toBe('string');
+      expect(['execution', 'review']).toContain(row.phase);
+      expect(typeof row.totalTokens).toBe('number');
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Dark Factory
   // ---------------------------------------------------------------------------

--- a/tests/unit/telemetry/lifecycle-phase-fix.test.ts
+++ b/tests/unit/telemetry/lifecycle-phase-fix.test.ts
@@ -1,0 +1,289 @@
+/**
+ * lifecycle-phase-fix.test.ts
+ *
+ * Tests for issue #603: lifecycle phase split correctness after fixing
+ * - unit mismatch (turnCount vs tokens)
+ * - execution/review backfill from tasks columns (D2)
+ * - all five LLM stages populated when data is present
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { aggregateByTicket } from '../../../src/main/telemetry/aggregator';
+import type {
+  StepWeightRow,
+  EphemeralWeightRecord,
+  TaskPhaseWeightRow,
+} from '../../../src/main/telemetry/aggregator';
+import type { RawUsageEntry } from '../../../src/main/telemetry/parser';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lc-fix-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(sid: string, stackId: string | null, input = 1000, output = 500): RawUsageEntry {
+  return {
+    sessionId: sid,
+    stackId,
+    model: 'claude-sonnet-4-5',
+    input,
+    output,
+    cacheCreate: 0,
+    cacheRead: 0,
+    timestamp: '2024-03-01T10:00:00.000Z',
+  };
+}
+
+function makeManifest(dir: string, stackId: string, ticket: string): void {
+  fs.writeFileSync(dir + '.manifest.json', JSON.stringify({
+    stackId, ticket, project: 'p', createdAt: '2024-01-01T00:00:00.000Z',
+  }));
+}
+
+function stackDir(name: string): string {
+  const d = path.join(tmpDir, name);
+  fs.mkdirSync(d);
+  return d;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Regression: all five LLM stages > 0 when data present
+// ---------------------------------------------------------------------------
+
+describe('Regression: all five LLM stages populated', () => {
+  it('execution, review, refine, spec, pr all > 0 when each has token data', () => {
+    const sd = stackDir('stack-all');
+    makeManifest(sd, 'stack-all', 'T-ALL');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-ALL', phase: 'execution', totalTokens: 10000 },
+      { ticket: 'T-ALL', phase: 'review', totalTokens: 4000 },
+    ];
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'T-ALL', stage: 'refine', tokens: 3000 },
+      { ticketId: 'T-ALL', stage: 'spec', tokens: 2000 },
+      { ticketId: 'T-ALL', stage: 'pr', tokens: 1000 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-all')], [sd], stepWeights, ephemeralRecords);
+    const row = result.find((r) => r.ticketId === 'T-ALL');
+    expect(row).toBeDefined();
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    expect(lc.execution).toBeGreaterThan(0);
+    expect(lc.review).toBeGreaterThan(0);
+    expect(lc.refine).toBeGreaterThan(0);
+    expect(lc.spec).toBeGreaterThan(0);
+    expect(lc.pr).toBeGreaterThan(0);
+    expect(lc.verify).toBe(0); // always 0 by design
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Unit normalization: token-heavy execution doesn't swamp token-light refine
+// ---------------------------------------------------------------------------
+
+describe('Unit normalization: single token unit prevents swamping', () => {
+  it('refine is not rounded to $0 when it has real token signal', () => {
+    const sd = stackDir('stack-norm');
+    makeManifest(sd, 'stack-norm', 'T-NORM');
+
+    // execution: 10000 tokens, refine: 500 tokens
+    // With old turnCount system (refine turnCount=5), turnCount was swamped by 10000
+    // With new token unit, refine gets 500/(10000+500) ≈ 4.76% of cost
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-NORM', phase: 'execution', totalTokens: 10000 },
+    ];
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'T-NORM', stage: 'refine', tokens: 500 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-norm')], [sd], stepWeights, ephemeralRecords);
+    const row = result.find((r) => r.ticketId === 'T-NORM');
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    // refine should get ~4.76% of cost — must be > 0
+    expect(lc.refine).toBeGreaterThan(0);
+    // execution gets ~95.24%, must be >> refine
+    expect(lc.execution).toBeGreaterThan(lc.refine * 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Sum invariant: lifecycle sums to cost for mixed-stage input
+// ---------------------------------------------------------------------------
+
+describe('Sum invariant', () => {
+  it('sum(lifecycle) === cost within tolerance for all five stages populated', () => {
+    const sd = stackDir('stack-sum');
+    makeManifest(sd, 'stack-sum', 'T-SUM');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-SUM', phase: 'execution', totalTokens: 8000 },
+      { ticket: 'T-SUM', phase: 'review', totalTokens: 3000 },
+    ];
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'T-SUM', stage: 'refine', tokens: 1500 },
+      { ticketId: 'T-SUM', stage: 'spec', tokens: 2000 },
+      { ticketId: 'T-SUM', stage: 'pr', tokens: 500 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-sum')], [sd], stepWeights, ephemeralRecords);
+    const row = result.find((r) => r.ticketId === 'T-SUM');
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    const lcSum = lc.refine + lc.spec + lc.execution + lc.review + lc.verify + lc.pr;
+    expect(Math.abs(lcSum - row!.cost)).toBeLessThan(1e-10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. No-signal stage stays 0 for ticket with no stack run
+// ---------------------------------------------------------------------------
+
+describe('No-signal stages stay 0', () => {
+  it('ticket with only host-side refinement keeps execution/review/pr at 0', () => {
+    // Host-only ticket: no stackId, so ends up in orchestrator bucket
+    // We test a ticket with only ephemeral refine/spec data (no execution/review)
+    const sd = stackDir('stack-host');
+    makeManifest(sd, 'stack-host', 'T-HOST');
+
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'T-HOST', stage: 'refine', tokens: 2000 },
+      { ticketId: 'T-HOST', stage: 'spec', tokens: 1000 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-host')], [sd], [], ephemeralRecords);
+    const row = result.find((r) => r.ticketId === 'T-HOST');
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    expect(lc.execution).toBe(0);
+    expect(lc.review).toBe(0);
+    expect(lc.pr).toBe(0);
+    expect(lc.refine).toBeGreaterThan(0);
+    expect(lc.spec).toBeGreaterThan(0);
+  });
+
+  it('ticket with no weights at all → lifecycle null', () => {
+    const sd = stackDir('stack-none');
+    makeManifest(sd, 'stack-none', 'T-NONE');
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-none')], [sd]);
+    const row = result.find((r) => r.ticketId === 'T-NONE');
+    expect(row!.lifecycle).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Backfill (D2): getTaskPhaseTokensByTicket-style data as fallback
+// ---------------------------------------------------------------------------
+
+describe('Backfill D2: task phase weights as fallback for execution/review', () => {
+  it('uses taskPhaseWeights when stepWeights absent for a phase', () => {
+    const sd = stackDir('stack-bf');
+    makeManifest(sd, 'stack-bf', 'T-BF');
+
+    // No stepWeights at all — backfill should provide execution and review
+    const taskPhaseWeights: TaskPhaseWeightRow[] = [
+      { ticket: 'T-BF', phase: 'execution', totalTokens: 7000 },
+      { ticket: 'T-BF', phase: 'review', totalTokens: 3000 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-bf')], [sd], [], [], taskPhaseWeights);
+    const row = result.find((r) => r.ticketId === 'T-BF');
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    expect(lc.execution).toBeGreaterThan(0);
+    expect(lc.review).toBeGreaterThan(0);
+    // Proportions: 7000:3000 → execution ≈ 7/10 of total lifecycle
+    expect(lc.execution).toBeCloseTo(lc.review * (7000 / 3000), 6);
+  });
+
+  it('uses stepWeights when both stepWeights and taskPhaseWeights present — no double-count', () => {
+    const sd = stackDir('stack-both');
+    makeManifest(sd, 'stack-both', 'T-BOTH');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-BOTH', phase: 'execution', totalTokens: 5000 },
+    ];
+    const taskPhaseWeights: TaskPhaseWeightRow[] = [
+      { ticket: 'T-BOTH', phase: 'execution', totalTokens: 9000 }, // should NOT be used
+      { ticket: 'T-BOTH', phase: 'review', totalTokens: 2000 },    // should be used (no step weight)
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-both')], [sd], stepWeights, [], taskPhaseWeights);
+    const row = result.find((r) => r.ticketId === 'T-BOTH');
+    expect(row!.lifecycle).not.toBeNull();
+
+    const lc = row!.lifecycle!;
+    // execution uses stepWeight (5000), not backfill (9000)
+    // review uses backfill (2000) since no step weight
+    // Total weights = 5000 + 2000 = 7000
+    // execution fraction: 5000/7000 ≈ 0.714
+    // review fraction: 2000/7000 ≈ 0.286
+    const totalWeight = 5000 + 2000;
+    expect(lc.execution).toBeCloseTo(row!.cost * (5000 / totalWeight), 6);
+    expect(lc.review).toBeCloseTo(row!.cost * (2000 / totalWeight), 6);
+  });
+
+  it('per-phase fallback: stepWeight present for execution but absent for review', () => {
+    const sd = stackDir('stack-mixed');
+    makeManifest(sd, 'stack-mixed', 'T-MX');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-MX', phase: 'execution', totalTokens: 6000 },
+      // no review step weight
+    ];
+    const taskPhaseWeights: TaskPhaseWeightRow[] = [
+      { ticket: 'T-MX', phase: 'execution', totalTokens: 99000 }, // ignored — step present
+      { ticket: 'T-MX', phase: 'review', totalTokens: 2000 },     // used — no step weight
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-mixed')], [sd], stepWeights, [], taskPhaseWeights);
+    const row = result.find((r) => r.ticketId === 'T-MX');
+    const lc = row!.lifecycle!;
+
+    // execution = step weight 6000; review = backfill 2000
+    expect(lc.execution).toBeCloseTo(row!.cost * (6000 / 8000), 6);
+    expect(lc.review).toBeCloseTo(row!.cost * (2000 / 8000), 6);
+  });
+
+  it('sum invariant holds with mixed step + backfill weights', () => {
+    const sd = stackDir('stack-bfsum');
+    makeManifest(sd, 'stack-bfsum', 'T-BFSUM');
+
+    const stepWeights: StepWeightRow[] = [
+      { ticket: 'T-BFSUM', phase: 'execution', totalTokens: 5000 },
+    ];
+    const taskPhaseWeights: TaskPhaseWeightRow[] = [
+      { ticket: 'T-BFSUM', phase: 'review', totalTokens: 2000 },
+    ];
+    const ephemeralRecords: EphemeralWeightRecord[] = [
+      { ticketId: 'T-BFSUM', stage: 'refine', tokens: 800 },
+    ];
+
+    const result = aggregateByTicket([makeEntry('s1', 'stack-bfsum')], [sd], stepWeights, ephemeralRecords, taskPhaseWeights);
+    const row = result.find((r) => r.ticketId === 'T-BFSUM');
+    const lc = row!.lifecycle!;
+
+    const lcSum = lc.refine + lc.spec + lc.execution + lc.review + lc.verify + lc.pr;
+    expect(Math.abs(lcSum - row!.cost)).toBeLessThan(1e-10);
+  });
+});

--- a/tests/unit/telemetry/lifecycle-split.test.ts
+++ b/tests/unit/telemetry/lifecycle-split.test.ts
@@ -213,7 +213,7 @@ d2('aggregateByTicket lifecycle plumbing', () => {
     makeManifest(stackDir, 'stack-ep', 'T-3');
 
     const ephemeralRecords: EphemeralWeightRecord[] = [
-      { ticketId: 'T-3', stage: 'spec', turnCount: 5 },
+      { ticketId: 'T-3', stage: 'spec', tokens: 5000 },
     ];
 
     const result = aggregateByTicket([makeEntry('s1', 'stack-ep')], [stackDir], [], ephemeralRecords);

--- a/tests/unit/telemetry/usage-engine.test.ts
+++ b/tests/unit/telemetry/usage-engine.test.ts
@@ -1075,8 +1075,8 @@ describe('createUsageEngine — injected weights produce non-null lifecycle (Q2 
     writeTranscript(stackRoot, 'sess-eph');
 
     const ephemeralRecords: EphemeralWeightRecord[] = [
-      { ticketId: 'TICKET-EPH', stage: 'spec', turnCount: 5 },
-      { ticketId: 'TICKET-EPH', stage: 'pr', turnCount: 2 },
+      { ticketId: 'TICKET-EPH', stage: 'spec', tokens: 5000 },
+      { ticketId: 'TICKET-EPH', stage: 'pr', tokens: 2000 },
     ];
 
     const engine = createUsageEngine([stackRoot], [], ephemeralRecords);
@@ -1100,9 +1100,9 @@ describe('createUsageEngine — injected weights produce non-null lifecycle (Q2 
       { ticket: 'TICKET-BOTH', phase: 'review', totalTokens: 2000 },
     ];
     const ephemeralRecords: EphemeralWeightRecord[] = [
-      { ticketId: 'TICKET-BOTH', stage: 'refine', turnCount: 3 },
-      { ticketId: 'TICKET-BOTH', stage: 'spec', turnCount: 4 },
-      { ticketId: 'TICKET-BOTH', stage: 'pr', turnCount: 2 },
+      { ticketId: 'TICKET-BOTH', stage: 'refine', tokens: 3000 },
+      { ticketId: 'TICKET-BOTH', stage: 'spec', tokens: 4000 },
+      { ticketId: 'TICKET-BOTH', stage: 'pr', tokens: 2000 },
     ];
 
     const engine = createUsageEngine([stackRoot], stepWeights, ephemeralRecords);


### PR DESCRIPTION
## Summary

The by-ticket telemetry breakdown undercounted and mis-weighted lifecycle costs. Two gaps are fixed:

- Ephemeral agent spawns (refine / spec / pr stages) were weighted by `turnCount` (a raw count of assistant messages) instead of actual token usage, so their share of the per-ticket split was meaningless relative to the token-based execution/review weights. The Claude backend now sums `input_tokens + output_tokens` from each assistant record and records it as `tokens` in the ephemeral timing file, and the aggregator uses that token figure in the same unit as the other phases.

- Execution/review weights came solely from `task_token_steps`, which can be missing when a container is torn down before its step file is read, dropping those tickets from the split. A backfill source (`getTaskPhaseTokensByTicket`) reads the per-phase token columns on `tasks` and is used per `(ticket, phase)` whenever the step-weight value is absent or zero, so the breakdown stays complete.

## QA plan

1. Run several tickets through the lifecycle (refine/spec, execution, review, pr) and open the telemetry by-ticket panel.
2. Confirm refine/spec/pr stages now contribute a token-proportional slice rather than a flat per-turn weight.
3. Tear down a stack before its step file is captured, then verify the affected ticket still shows execution/review costs (sourced from the tasks-column backfill) instead of disappearing from the split.
4. Spot-check that tickets with intact `task_token_steps` data are unchanged (step weights take precedence over the backfill).

Closes #603