### PR TITLE
[478] feat: add OpenCode agent backend

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -22,7 +22,10 @@ export default defineConfig({
     build: {
       outDir: 'dist/main',
       lib: {
-        entry: resolve(__dirname, 'src/main/index.ts'),
+        entry: {
+          index: resolve(__dirname, 'src/main/index.ts'),
+          'orchestration-mcp-shim': resolve(__dirname, 'src/main/agent/orchestration-mcp-shim.ts'),
+        },
       },
       rollupOptions: {
         output: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sandstorm",
       "version": "0.1.0",
       "dependencies": {
+        "@opencode-ai/sdk": "1.17.7",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "better-sqlite3": "^12.8.0",
@@ -2283,6 +2284,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.7.tgz",
+      "integrity": "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4808,7 +4818,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7152,7 +7161,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -8509,7 +8517,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9535,7 +9542,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9548,7 +9554,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11250,7 +11255,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@opencode-ai/sdk": "1.17.7",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "better-sqlite3": "^12.8.0",

--- a/sandstorm-cli/docker/opencode-config.js
+++ b/sandstorm-cli/docker/opencode-config.js
@@ -21,7 +21,8 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 var opencode_config_exports = {};
 __export(opencode_config_exports, {
   STATIC_INPUTS: () => STATIC_INPUTS,
-  generateOpencodeConfig: () => generateOpencodeConfig
+  generateOpencodeConfig: () => generateOpencodeConfig,
+  generateOuterOpencodeConfig: () => generateOuterOpencodeConfig
 });
 module.exports = __toCommonJS(opencode_config_exports);
 var STATIC_INPUTS = {};
@@ -60,11 +61,35 @@ function generateOpencodeConfig(_inputs) {
     }
   };
 }
+function generateOuterOpencodeConfig(inputs) {
+  const shimMcpServer = {
+    type: "local",
+    command: [process.execPath, inputs.shimPath],
+    environment: {
+      SANDSTORM_BRIDGE_URL: inputs.bridgeUrl,
+      SANDSTORM_BRIDGE_TOKEN: inputs.bridgeToken
+    }
+  };
+  return {
+    model: "anthropic/claude-sonnet-4-6",
+    provider: {
+      anthropic: {
+        apiKey: "{env:ANTHROPIC_API_KEY}"
+      }
+    },
+    permission: "allow",
+    instructions: [inputs.instructionsPath],
+    mcp: {
+      "sandstorm-bridge": shimMcpServer
+    }
+  };
+}
 if (require.main === module) {
   process.stdout.write(JSON.stringify(generateOpencodeConfig(STATIC_INPUTS), null, 2) + "\n");
 }
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   STATIC_INPUTS,
-  generateOpencodeConfig
+  generateOpencodeConfig,
+  generateOuterOpencodeConfig
 });

--- a/src/main/agent/backend-router.ts
+++ b/src/main/agent/backend-router.ts
@@ -14,7 +14,7 @@
  *    unknown tab → default to 'claude' (back-compat).
  *  - getAuthStatus/login: route to lastProjectBackendId (most-recently resolved
  *    by any sendMessage or ephemeral call); fall back to 'claude'.
- *  - getEphemeralTimingPath: always delegates to claude (OpenCode timing in #478).
+ *  - getEphemeralTimingPath: delegates to claude; OpenCode shares the same timing file via OpenCodeBackend.getEphemeralTimingPath().
  *  - syncCredentials/initialize/destroy/setMainWindow: fan out to all instantiated
  *    backends.
  *  - Ephemeral calls (run/spawn/spawnSession): call selector(projectDir) → delegate.
@@ -48,6 +48,14 @@ export class BackendRouter implements AgentBackend {
   // Stored so newly-instantiated backends receive the current window reference.
   private mainWindow: BrowserWindow | null = null;
 
+  // Set to true after initialize() completes. Ensures lazily-created backends
+  // are initialized immediately on first use rather than left un-initialized.
+  private _initialized = false;
+
+  // Per-type init promise stored when a backend is created post-initialize().
+  // Callers can await this to ensure the backend is ready before use.
+  private readonly _initPromises: Partial<Record<BackendType, Promise<void>>> = {};
+
   readonly name = 'BackendRouter';
 
   constructor(
@@ -74,6 +82,11 @@ export class BackendRouter implements AgentBackend {
         backend.setMainWindow(this.mainWindow);
       }
       this.instances[type] = backend;
+      if (this._initialized) {
+        // Router already initialized — kick off initialization for this lazily-created
+        // backend. Store the promise so callers can await readiness if needed.
+        this._initPromises[type] = backend.initialize();
+      }
     }
     return this.instances[type]!;
   }
@@ -106,6 +119,10 @@ export class BackendRouter implements AgentBackend {
     await Promise.all(
       (Object.values(this.instances) as AgentBackend[]).map(b => b.initialize()),
     );
+    // Set after all current instances are initialized so that getBackend() can
+    // distinguish "during initialize()" from "after initialize() completed" and
+    // avoid double-initializing backends that were created during this call.
+    this._initialized = true;
   }
 
   destroy(): void {
@@ -154,8 +171,8 @@ export class BackendRouter implements AgentBackend {
   // --- Ephemeral agents ---
 
   getEphemeralTimingPath(): string {
-    // Always delegates to claude — OpenCode ephemeral timing is addressed in #478.
-    // Constructs the claude backend without calling initialize() if not yet cached.
+    // Delegates to claude for the shared timing file. OpenCode ephemeral timing
+    // goes to the same file via OpenCodeBackend.getEphemeralTimingPath().
     return this.getBackend('claude').getEphemeralTimingPath();
   }
 

--- a/src/main/agent/bridge-server.ts
+++ b/src/main/agent/bridge-server.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared, backend-neutral HTTP bridge singleton.
+ *
+ * Both ClaudeBackend and OpenCodeBackend call acquireBridge() in initialize().
+ * The first caller starts the server; subsequent callers reuse it (ref-counted).
+ * The last caller to release() shuts it down.
+ *
+ * The bridge accepts POST /tool-call with an X-Auth-Token header and dispatches
+ * to the provided ToolHandler. This lets skill scripts (curl-based) reach the
+ * Sandstorm control-plane tools without importing Electron.
+ */
+
+import { createServer, Server } from 'http';
+import { randomUUID } from 'crypto';
+
+export type ToolHandler = (name: string, input: Record<string, unknown>) => Promise<unknown>;
+
+export interface BridgeHandle {
+  /** Full URL of the bridge, e.g. http://127.0.0.1:PORT */
+  url: string;
+  /** Auth token; pass as X-Auth-Token in requests */
+  token: string;
+  /** Decrement ref-count; shuts down the bridge when the last holder releases */
+  release(): void;
+}
+
+// --- Singleton state ---
+let _server: Server | null = null;
+let _port = 0;
+let _token = '';
+let _refCount = 0;
+let _startPromise: Promise<void> | null = null;
+let _handler: ToolHandler | null = null;
+
+/**
+ * Acquire a reference to the shared bridge server.
+ *
+ * @param handler  Tool handler to register (only used by the first caller;
+ *                 subsequent callers reuse the already-running bridge).
+ * @returns  BridgeHandle with url, token, and a release() teardown callback.
+ */
+export async function acquireBridge(handler: ToolHandler): Promise<BridgeHandle> {
+  _refCount++;
+  if (!_startPromise) {
+    _handler = handler;
+    _startPromise = _startBridge();
+  }
+  await _startPromise;
+
+  const url = `http://127.0.0.1:${_port}`;
+  const token = _token;
+  let released = false;
+
+  return {
+    url,
+    token,
+    release() {
+      if (released) return;
+      released = true;
+      _refCount--;
+      if (_refCount <= 0) {
+        _refCount = 0;
+        _server?.close();
+        _server = null;
+        _port = 0;
+        _token = '';
+        _startPromise = null;
+        _handler = null;
+      }
+    },
+  };
+}
+
+function _startBridge(): Promise<void> {
+  _token = randomUUID();
+  return new Promise<void>((resolve) => {
+    _server = createServer(async (req, res) => {
+      if (req.method !== 'POST' || req.url !== '/tool-call') {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      if (req.headers['x-auth-token'] !== _token) {
+        res.writeHead(403);
+        res.end();
+        return;
+      }
+      let body = '';
+      req.on('data', (chunk: Buffer) => { body += chunk; });
+      req.on('end', async () => {
+        try {
+          const { name, input } = JSON.parse(body) as {
+            name: string;
+            input: Record<string, unknown>;
+          };
+          const result = await _handler!(name, input);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ result }));
+        } catch (err) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: String(err) }));
+        }
+      });
+    });
+
+    _server.listen(0, '127.0.0.1', () => {
+      const addr = _server!.address() as { port: number };
+      _port = addr.port;
+      resolve();
+    });
+  });
+}

--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -5,14 +5,13 @@
  */
 
 import { spawn, ChildProcess } from 'child_process';
-import { createServer, Server } from 'http';
-import { randomUUID } from 'crypto';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import { BrowserWindow, shell } from 'electron';
 import { app } from 'electron';
 import { handleToolCall } from '../claude/tools';
+import { acquireBridge, type BridgeHandle } from './bridge-server';
 import { cliDir } from '../index';
 import {
   AgentBackend,
@@ -85,9 +84,7 @@ export class ClaudeBackend implements AgentBackend {
    * the UI — never a cumulative aggregate across sessions.
    */
   private sessionTokens = new Map<string, OuterClaudeSessionTokens>();
-  private bridgeServer: Server | null = null;
-  private bridgePort = 0;
-  private bridgeToken: string;
+  private bridge: BridgeHandle | null = null;
   private mainWindow: BrowserWindow | null = null;
   private logStream: fs.WriteStream | null = null;
   private timeoutMs: number;
@@ -100,7 +97,6 @@ export class ClaudeBackend implements AgentBackend {
     timeoutMs?: number,
     modelResolver?: (projectDir: string) => string
   ) {
-    this.bridgeToken = randomUUID();
     this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.modelResolver = modelResolver;
     this.initLogger();
@@ -196,48 +192,7 @@ export class ClaudeBackend implements AgentBackend {
   }
 
   async initialize(): Promise<void> {
-    await this.startBridgeServer();
-  }
-
-  private startBridgeServer(): Promise<void> {
-    return new Promise((resolve) => {
-      this.bridgeServer = createServer(async (req, res) => {
-        if (req.method !== 'POST' || req.url !== '/tool-call') {
-          res.writeHead(404);
-          res.end();
-          return;
-        }
-
-        const authToken = req.headers['x-auth-token'];
-        if (authToken !== this.bridgeToken) {
-          res.writeHead(403);
-          res.end();
-          return;
-        }
-
-        let body = '';
-        req.on('data', (chunk: Buffer) => {
-          body += chunk;
-        });
-        req.on('end', async () => {
-          try {
-            const { name, input } = JSON.parse(body);
-            const result = await handleToolCall(name, input);
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ result }));
-          } catch (err) {
-            res.writeHead(500, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: String(err) }));
-          }
-        });
-      });
-
-      this.bridgeServer.listen(0, '127.0.0.1', () => {
-        const addr = this.bridgeServer!.address() as { port: number };
-        this.bridgePort = addr.port;
-        resolve();
-      });
-    });
+    this.bridge = await acquireBridge(handleToolCall);
   }
 
   // --- Session management (AgentBackend interface) ---
@@ -1010,8 +965,8 @@ export class ClaudeBackend implements AgentBackend {
     const emptyPluginDir = this.ensureEmptyPluginCacheDir();
     const env: Record<string, string | undefined> = {
       ...getClaudeEnv(),
-      SANDSTORM_BRIDGE_URL: `http://127.0.0.1:${this.bridgePort}`,
-      SANDSTORM_BRIDGE_TOKEN: this.bridgeToken,
+      SANDSTORM_BRIDGE_URL: this.bridge?.url ?? '',
+      SANDSTORM_BRIDGE_TOKEN: this.bridge?.token ?? '',
       SANDSTORM_SKILLS_DIR: path.join(cliDir, 'skills'),
       CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
       CLAUDE_CODE_PLUGIN_CACHE_DIR: emptyPluginDir,
@@ -1240,7 +1195,8 @@ export class ClaudeBackend implements AgentBackend {
       }
     }
     this.sessions.clear();
-    this.bridgeServer?.close();
+    this.bridge?.release();
+    this.bridge = null;
     this.logStream?.end();
     this.logStream = null;
     // Close all raw-capture listeners (#299). Fire-and-forget — we don't

--- a/src/main/agent/index.ts
+++ b/src/main/agent/index.ts
@@ -1,3 +1,4 @@
 export type { AgentBackend, ChatMessage, AuthStatus, AgentSessionHistory, StackInfo, StackServiceInfo } from './types';
 export { ClaudeBackend } from './claude-backend';
+export { OpenCodeBackend } from './opencode-backend';
 export { BackendRouter } from './backend-router';

--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -1,0 +1,605 @@
+/**
+ * OpenCode implementation of AgentBackend.
+ *
+ * Manages an opencode serve process via @opencode-ai/sdk (pinned at 1.17.7),
+ * maps SSE events to the existing renderer IPC channels, and exposes the
+ * Sandstorm orchestration tools to OpenCode via the shared bridge shim.
+ *
+ * SDK types cited from @opencode-ai/sdk@1.17.7:
+ *   - Event (EventSubscribeResponses[200]) — types.gen.d.ts
+ *   - EventMessagePartUpdated, EventSessionIdle, EventSessionError — types.gen.d.ts
+ *   - StepFinishPart, TextPart, ToolPart — types.gen.d.ts
+ *   - OpencodeClient, createOpencodeClient — client.d.ts / sdk.gen.d.ts
+ *   - createOpencodeServer — server.d.ts
+ *   - SessionPromptAsyncData, SessionCreateData — types.gen.d.ts
+ */
+
+import path from 'path';
+import os from 'os';
+import { BrowserWindow } from 'electron';
+import { app } from 'electron';
+// @opencode-ai/sdk is ESM-only — static require() fails in the CJS bundle.
+// All runtime values are imported dynamically inside initialize() so that
+// Vite keeps them as real import() calls (same pattern as node-pty).
+// Only type-level imports are used here; they are erased by tsc at build time.
+import type {
+  OpencodeClient,
+  Event as OpenCodeEvent,
+  EventMessagePartUpdated,
+  EventSessionIdle,
+  EventSessionError,
+  StepFinishPart,
+  TextPart,
+  ToolPart,
+  Part,
+  Config as OpenCodeConfig,
+} from '@opencode-ai/sdk';
+import { handleToolCall } from '../claude/tools';
+import { acquireBridge, type BridgeHandle } from './bridge-server';
+import { generateOuterOpencodeConfig } from '../opencode-config';
+import {
+  type AgentBackend,
+  type ChatMessage,
+  type AuthStatus,
+  type AgentSessionHistory,
+  type OuterClaudeSessionTokens,
+  type StackInfo,
+  type EphemeralStreamEvent,
+  type EphemeralSessionHandle,
+  zeroSessionTokens,
+} from './types';
+import { appendEphemeralTiming, type EphemeralTimingRecord } from './ephemeral-timing';
+import { cliDir } from '../index';
+
+// ---------------------------------------------------------------------------
+// Internal session state
+// ---------------------------------------------------------------------------
+
+interface TabSession {
+  tabId: string;
+  openCodeSessionId: string;
+  /** In-flight session creation promise; guards against concurrent create() calls. */
+  creatingSession: Promise<string> | null;
+  messages: ChatMessage[];
+  processing: boolean;
+  fullResponse: string;
+  projectDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractEphemeralEvents(parts: Part[]): {
+  text: string;
+  events: EphemeralStreamEvent[];
+} {
+  let text = '';
+  const events: EphemeralStreamEvent[] = [];
+  for (const part of parts) {
+    if (part.type === 'text') {
+      const tp = part as TextPart;
+      if (tp.text) {
+        text += tp.text;
+        events.push({ kind: 'text', delta: tp.text });
+      }
+    } else if (part.type === 'tool') {
+      const tp = part as ToolPart;
+      const name = tp.tool;
+      const summary = `${name}(...)`;
+      events.push({ kind: 'tool_use', name, summary });
+    }
+  }
+  return { text, events };
+}
+
+// ---------------------------------------------------------------------------
+// OpenCodeBackend
+// ---------------------------------------------------------------------------
+
+export class OpenCodeBackend implements AgentBackend {
+  readonly name = 'OpenCode';
+
+  private client: OpencodeClient | null = null;
+  private serverClose: (() => void) | null = null;
+  private bridge: BridgeHandle | null = null;
+  private mainWindow: BrowserWindow | null = null;
+  private ephemeralTimingPath: string;
+
+  // tabId → session state
+  private tabSessions = new Map<string, TabSession>();
+  // openCodeSessionId → tabId (for persistent sessions)
+  private sessionToTab = new Map<string, string>();
+  // per-tab cumulative token totals
+  private sessionTokens = new Map<string, OuterClaudeSessionTokens>();
+
+  // SSE loop abort controller
+  private eventLoopAbort: AbortController | null = null;
+
+  constructor() {
+    this.ephemeralTimingPath = this.resolveEphemeralTimingPath();
+  }
+
+  private resolveEphemeralTimingPath(): string {
+    try {
+      const dir = typeof app !== 'undefined' && app.getPath ? app.getPath('userData') : os.tmpdir();
+      return path.join(dir, 'sandstorm-desktop-ephemeral-timing.jsonl');
+    } catch {
+      return path.join(os.tmpdir(), 'sandstorm-desktop-ephemeral-timing.jsonl');
+    }
+  }
+
+  // --- Lifecycle ---
+
+  async initialize(): Promise<void> {
+    // Acquire shared bridge (idempotent, ref-counted with ClaudeBackend)
+    this.bridge = await acquireBridge(handleToolCall);
+
+    // Dynamic imports: @opencode-ai/sdk is ESM-only and cannot be require()'d.
+    // Vite keeps import() calls as-is in CJS output (same as node-pty pattern),
+    // so these resolve correctly at runtime even though the bundle is CJS.
+    const { createOpencodeClient } = await import('@opencode-ai/sdk');
+    const { createOpencodeServer } = await import('@opencode-ai/sdk/server');
+
+    // Shim is compiled alongside this module in dist/main/
+    const shimPath = path.join(__dirname, 'orchestration-mcp-shim.cjs');
+
+    // Generate the outer config: registers the bridge shim as an MCP server so
+    // OpenCode can call create_stack, dispatch_task, etc. via standard MCP calls.
+    const outerConfig = generateOuterOpencodeConfig({
+      shimPath,
+      bridgeUrl: this.bridge.url,
+      bridgeToken: this.bridge.token,
+      instructionsPath: path.join(cliDir, 'SANDSTORM_OUTER.md'),
+    });
+
+    // Inject bridge credentials into process env so OpenCode agent bash skill
+    // scripts (curl "$SANDSTORM_BRIDGE_URL/tool-call") keep working unchanged.
+    process.env.SANDSTORM_BRIDGE_URL = this.bridge.url;
+    process.env.SANDSTORM_BRIDGE_TOKEN = this.bridge.token;
+
+    // Start OpenCode server, passing the outer config so the bridge shim MCP
+    // is registered and SANDSTORM_BRIDGE_URL/TOKEN flow into the shim env.
+    const sdkConfig: OpenCodeConfig = {
+      mcp: outerConfig.mcp as OpenCodeConfig['mcp'],
+    };
+    const server = await createOpencodeServer({ hostname: '127.0.0.1', config: sdkConfig });
+    this.serverClose = server.close;
+    this.client = createOpencodeClient({ baseUrl: server.url });
+
+    // Kick off the SSE event loop for persistent-session events
+    this.eventLoopAbort = new AbortController();
+    void this.startEventLoop(this.eventLoopAbort.signal);
+  }
+
+  destroy(): void {
+    this.eventLoopAbort?.abort();
+    this.eventLoopAbort = null;
+    this.serverClose?.();
+    this.serverClose = null;
+    this.client = null;
+    this.bridge?.release();
+    this.bridge = null;
+    this.tabSessions.clear();
+    this.sessionToTab.clear();
+    this.sessionTokens.clear();
+  }
+
+  setMainWindow(win: BrowserWindow | null): void {
+    this.mainWindow = win;
+  }
+
+  // --- SSE event loop (persistent sessions only) ---
+
+  private async startEventLoop(signal: AbortSignal): Promise<void> {
+    if (!this.client) return;
+    try {
+      const { stream } = await this.client.event.subscribe();
+      for await (const event of stream) {
+        if (signal.aborted) break;
+        this.dispatchEvent(event as OpenCodeEvent);
+      }
+    } catch {
+      // Stream closed — server may have shut down
+    }
+  }
+
+  private dispatchEvent(event: OpenCodeEvent): void {
+    switch (event.type) {
+      case 'message.part.updated':
+        this.handlePartUpdated(event as EventMessagePartUpdated);
+        break;
+      case 'session.idle':
+        this.handleSessionIdle(event as EventSessionIdle);
+        break;
+      case 'session.error':
+        this.handleSessionError(event as EventSessionError);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private handlePartUpdated(event: EventMessagePartUpdated): void {
+    const { part, delta } = event.properties;
+    const sessionId = part.sessionID;
+    const tabId = this.sessionToTab.get(sessionId);
+    if (!tabId) return;
+
+    const tabSession = this.tabSessions.get(tabId);
+    if (!tabSession) return;
+
+    if (part.type === 'text' && delta) {
+      tabSession.fullResponse += delta;
+      this.mainWindow?.webContents.send(`agent:output:${tabId}`, delta);
+    } else if (part.type === 'tool') {
+      const toolPart = part as ToolPart;
+      const summary = `\n[tool: ${toolPart.tool}]\n`;
+      tabSession.fullResponse += summary;
+      this.mainWindow?.webContents.send(`agent:output:${tabId}`, summary);
+    } else if (part.type === 'step-finish') {
+      this.accumulateTokens(tabId, part as StepFinishPart);
+    }
+  }
+
+  private handleSessionIdle(event: EventSessionIdle): void {
+    const sessionId = event.properties.sessionID;
+    const tabId = this.sessionToTab.get(sessionId);
+    if (!tabId) return;
+
+    const tabSession = this.tabSessions.get(tabId);
+    if (!tabSession) return;
+
+    if (tabSession.fullResponse) {
+      tabSession.messages.push({ role: 'assistant', content: tabSession.fullResponse });
+    }
+    tabSession.fullResponse = '';
+    tabSession.processing = false;
+    this.mainWindow?.webContents.send(`agent:done:${tabId}`);
+  }
+
+  private handleSessionError(event: EventSessionError): void {
+    const sessionId = event.properties.sessionID;
+    if (!sessionId) return;
+
+    const tabId = this.sessionToTab.get(sessionId);
+    if (!tabId) return;
+
+    const tabSession = this.tabSessions.get(tabId);
+    if (tabSession) tabSession.processing = false;
+
+    const errorMsg = this.formatSessionError(event);
+    this.mainWindow?.webContents.send(`agent:error:${tabId}`, errorMsg);
+  }
+
+  private formatSessionError(event: EventSessionError): string {
+    const err = event.properties.error;
+    if (!err) return 'OpenCode session error';
+    if ('message' in err && typeof (err as { message?: string }).message === 'string') {
+      return (err as { message: string }).message;
+    }
+    return JSON.stringify(err);
+  }
+
+  private accumulateTokens(tabId: string, stepPart: StepFinishPart): void {
+    const { tokens } = stepPart;
+    const prev = this.sessionTokens.get(tabId) ?? zeroSessionTokens();
+    const next: OuterClaudeSessionTokens = {
+      input_tokens: prev.input_tokens + tokens.input,
+      output_tokens: prev.output_tokens + tokens.output,
+      cache_creation_input_tokens: prev.cache_creation_input_tokens + tokens.cache.write,
+      cache_read_input_tokens: prev.cache_read_input_tokens + tokens.cache.read,
+    };
+    this.sessionTokens.set(tabId, next);
+    this.mainWindow?.webContents.send(`agent:token-usage:${tabId}`, next);
+  }
+
+  // --- Session management ---
+
+  sendMessage(tabId: string, message: string, projectDir?: string): void {
+    let tabSession = this.tabSessions.get(tabId);
+    if (!tabSession) {
+      tabSession = {
+        tabId,
+        openCodeSessionId: '',
+        creatingSession: null,
+        messages: [],
+        processing: false,
+        fullResponse: '',
+        projectDir,
+      };
+      this.tabSessions.set(tabId, tabSession);
+    }
+    if (projectDir) tabSession.projectDir = projectDir;
+
+    tabSession.messages.push({ role: 'user', content: message });
+
+    if (tabSession.processing) {
+      this.mainWindow?.webContents.send(`agent:queued:${tabId}`);
+    }
+
+    tabSession.processing = true;
+    this.mainWindow?.webContents.send(`agent:user-message:${tabId}`, message);
+
+    if (!this.client) {
+      tabSession.processing = false;
+      this.mainWindow?.webContents.send(`agent:error:${tabId}`, 'Backend not initialized');
+      return;
+    }
+    void this.sendMessageAsync(tabSession, message);
+  }
+
+  private async sendMessageAsync(tabSession: TabSession, message: string): Promise<void> {
+    if (!this.client) return;
+    const { tabId, projectDir } = tabSession;
+
+    try {
+      // Create session on first message, guarding against concurrent creation.
+      // If two sendMessage calls arrive before session.create() resolves, the
+      // second awaits the first's in-flight promise instead of launching a second.
+      if (!tabSession.openCodeSessionId) {
+        if (!tabSession.creatingSession) {
+          tabSession.creatingSession = this.client.session
+            .create({ query: projectDir ? { directory: projectDir } : undefined })
+            .then(({ data: session }) => {
+              if (!session) throw new Error('Failed to create OpenCode session');
+              tabSession.openCodeSessionId = session.id;
+              this.sessionToTab.set(session.id, tabId);
+              return session.id;
+            })
+            .finally(() => {
+              tabSession.creatingSession = null;
+            });
+        }
+        await tabSession.creatingSession;
+      }
+
+      tabSession.fullResponse = '';
+
+      // Send prompt; completion arrives via SSE events
+      await this.client.session.promptAsync({
+        path: { id: tabSession.openCodeSessionId },
+        query: projectDir ? { directory: projectDir } : undefined,
+        body: { parts: [{ type: 'text', text: message }] },
+      });
+    } catch (err) {
+      tabSession.processing = false;
+      const msg = err instanceof Error ? err.message : String(err);
+      this.mainWindow?.webContents.send(`agent:error:${tabId}`, msg);
+    }
+  }
+
+  getHistory(tabId: string): AgentSessionHistory {
+    const tabSession = this.tabSessions.get(tabId);
+    if (!tabSession) return { messages: [], processing: false };
+    return { messages: [...tabSession.messages], processing: tabSession.processing };
+  }
+
+  cancelSession(tabId: string): void {
+    const tabSession = this.tabSessions.get(tabId);
+    if (!tabSession || !this.client) return;
+    if (tabSession.openCodeSessionId && tabSession.processing) {
+      tabSession.processing = false;
+      this.mainWindow?.webContents.send(`agent:done:${tabId}`);
+      void this.client.session
+        .abort({ path: { id: tabSession.openCodeSessionId } })
+        .catch(() => {});
+    }
+  }
+
+  resetSession(tabId: string): void {
+    const tabSession = this.tabSessions.get(tabId);
+    if (tabSession?.openCodeSessionId) {
+      this.sessionToTab.delete(tabSession.openCodeSessionId);
+      void this.deleteOpenCodeSession(tabSession.openCodeSessionId);
+    }
+    this.tabSessions.delete(tabId);
+    this.sessionTokens.delete(tabId);
+    // Push zero tokens so the UI counter resets immediately
+    this.mainWindow?.webContents.send(`agent:token-usage:${tabId}`, zeroSessionTokens());
+  }
+
+  getSessionTokens(tabId: string): OuterClaudeSessionTokens {
+    return this.sessionTokens.get(tabId) ?? zeroSessionTokens();
+  }
+
+  private async deleteOpenCodeSession(sessionId: string): Promise<void> {
+    if (!this.client || !sessionId) return;
+    try {
+      await this.client.session.delete({ path: { id: sessionId } });
+    } catch {
+      // Best effort
+    }
+  }
+
+  // --- Ephemeral agents ---
+
+  getEphemeralTimingPath(): string {
+    return this.ephemeralTimingPath;
+  }
+
+  spawnEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs = 300_000,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+    attribution?: { ticketId?: string; stage?: string },
+    model?: string,
+  ): { promise: Promise<string>; cancel: () => void } {
+    if (!this.client) {
+      return { promise: Promise.resolve(''), cancel: () => {} };
+    }
+
+    const spawnedAt = Date.now();
+    let cancelled = false;
+    const abortCtrl = new AbortController();
+
+    const runEphemeral = async (): Promise<string> => {
+      const { data: session } = await this.client!.session.create({
+        query: { directory: projectDir },
+      });
+      if (!session) throw new Error('Failed to create ephemeral session');
+
+      try {
+        const { data: response } = await this.client!.session.prompt({
+          path: { id: session.id },
+          query: { directory: projectDir },
+          body: {
+            parts: [{ type: 'text', text: prompt }],
+            ...(model ? { model: { providerID: 'anthropic', modelID: model } } : {}),
+          },
+          signal: abortCtrl.signal,
+        });
+
+        const parts: Part[] = response?.parts ?? [];
+        const { text, events } = extractEphemeralEvents(parts);
+        if (onChunk) {
+          for (const ev of events) onChunk(ev);
+        }
+        return text;
+      } finally {
+        void this.deleteOpenCodeSession(session.id);
+      }
+    };
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    const cancelFn = (): void => {
+      cancelled = true;
+      abortCtrl.abort();
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    };
+
+    const withTimeout = (): Promise<string> =>
+      new Promise<string>((resolve, reject) => {
+        if (timeoutMs > 0) {
+          timeoutHandle = setTimeout(() => {
+            cancelFn();
+            reject(new Error(`Ephemeral agent timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }
+        runEphemeral()
+          .then((text) => {
+            if (timeoutHandle) clearTimeout(timeoutHandle);
+            if (cancelled) {
+              reject(new Error('Ephemeral agent cancelled'));
+              return;
+            }
+            const closedAt = Date.now();
+            const record: EphemeralTimingRecord = {
+              ts: new Date(closedAt).toISOString(),
+              spawnedAt,
+              firstChunkAt: null,
+              closedAt,
+              elapsedMs: closedAt - spawnedAt,
+              exitCode: 0,
+              promptChars: prompt.length,
+              turnCount: 1,
+              cancelled,
+              ...(attribution?.ticketId != null ? { ticketId: attribution.ticketId } : {}),
+              ...(attribution?.stage != null ? { stage: attribution.stage } : {}),
+            };
+            appendEphemeralTiming(this.ephemeralTimingPath, record);
+            resolve(text);
+          })
+          .catch((err) => {
+            if (timeoutHandle) clearTimeout(timeoutHandle);
+            reject(err instanceof Error ? err : new Error(String(err)));
+          });
+      });
+
+    return { promise: withTimeout(), cancel: cancelFn };
+  }
+
+  runEphemeralAgent(
+    prompt: string,
+    projectDir: string,
+    timeoutMs = 300_000,
+    attribution?: { ticketId?: string; stage?: string },
+    model?: string,
+  ): Promise<string> {
+    return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs, undefined, attribution, model)
+      .promise;
+  }
+
+  spawnEphemeralSession(
+    initialPrompt: string,
+    projectDir: string,
+    timeoutMs = 300_000,
+    onChunk?: (event: EphemeralStreamEvent) => void,
+  ): EphemeralSessionHandle {
+    if (!this.client) {
+      return {
+        initialResult: Promise.resolve(''),
+        sendFollowUp: () => Promise.resolve(''),
+        dispose: () => {},
+      };
+    }
+
+    let openCodeSessionId = '';
+    let isDisposed = false;
+    let initAbortCtrl = new AbortController();
+
+    const sendTurn = async (text: string, signal: AbortSignal): Promise<string> => {
+      if (isDisposed) throw new Error('Session disposed');
+      const { data: response } = await this.client!.session.prompt({
+        path: { id: openCodeSessionId },
+        query: { directory: projectDir },
+        body: { parts: [{ type: 'text', text }] },
+        signal,
+      });
+      const parts: Part[] = response?.parts ?? [];
+      const { text: resultText, events } = extractEphemeralEvents(parts);
+      if (onChunk) {
+        for (const ev of events) onChunk(ev);
+      }
+      return resultText;
+    };
+
+    const dispose = (): void => {
+      if (isDisposed) return;
+      isDisposed = true;
+      initAbortCtrl.abort();
+      if (openCodeSessionId) {
+        void this.deleteOpenCodeSession(openCodeSessionId);
+      }
+    };
+
+    const initialResult = (async (): Promise<string> => {
+      if (!this.client) throw new Error('OpenCodeBackend not initialized');
+      const { data: session } = await this.client.session.create({
+        query: { directory: projectDir },
+      });
+      if (!session) throw new Error('Failed to create ephemeral session');
+      if (isDisposed) {
+        void this.deleteOpenCodeSession(session.id);
+        throw new Error('Session disposed');
+      }
+      openCodeSessionId = session.id;
+      return sendTurn(initialPrompt, initAbortCtrl.signal);
+    })();
+
+    return {
+      initialResult,
+      sendFollowUp: (followUp: string) => {
+        const ctrl = new AbortController();
+        if (isDisposed) return Promise.reject(new Error('Session disposed'));
+        return sendTurn(followUp, ctrl.signal);
+      },
+      dispose,
+    };
+  }
+
+  // --- Auth ---
+
+  async getAuthStatus(): Promise<AuthStatus> {
+    return { loggedIn: false, expired: false };
+  }
+
+  async login(_mainWindow?: BrowserWindow): Promise<{ success: boolean; error?: string }> {
+    return { success: false, error: 'OpenCode auth not yet implemented (#479)' };
+  }
+
+  async syncCredentials(_stacks: StackInfo[]): Promise<void> {
+    // Full credential matrix deferred to #479
+  }
+}

--- a/src/main/agent/orchestration-mcp-shim.ts
+++ b/src/main/agent/orchestration-mcp-shim.ts
@@ -1,0 +1,368 @@
+/**
+ * Sandstorm Orchestration Bridge — stdio MCP shim.
+ *
+ * Spawned by OpenCodeBackend as a local MCP server. Reads SANDSTORM_BRIDGE_URL
+ * and SANDSTORM_BRIDGE_TOKEN from env, then proxies MCP tool/call requests to
+ * the in-process HTTP bridge.
+ *
+ * Protocol: newline-delimited JSON-RPC 2.0 on stdio (MCP stdio transport).
+ * Each message is a single line; notifications have no id and expect no reply.
+ */
+
+import * as http from 'http';
+import * as readline from 'readline';
+
+const BRIDGE_URL = process.env.SANDSTORM_BRIDGE_URL ?? '';
+const BRIDGE_TOKEN = process.env.SANDSTORM_BRIDGE_TOKEN ?? '';
+
+// ---------------------------------------------------------------------------
+// Static tool manifest — mirrors handleToolCall's switch cases.
+// Schemas are intentionally minimal: the LLM needs names/descriptions but the
+// bridge accepts any JSON object as input and validates server-side.
+// ---------------------------------------------------------------------------
+
+const TOOLS = [
+  {
+    name: 'create_stack',
+    description: 'Create a new Sandstorm agent stack',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        projectDir: { type: 'string' },
+        ticket: { type: 'string' },
+        branch: { type: 'string' },
+        description: { type: 'string' },
+        runtime: { type: 'string', enum: ['docker', 'podman'] },
+        task: { type: 'string' },
+        model: { type: 'string' },
+        gateApproved: { type: 'boolean' },
+        forceBypass: { type: 'boolean' },
+      },
+      required: ['name', 'projectDir'],
+    },
+  },
+  {
+    name: 'list_stacks',
+    description: 'List all active Sandstorm stacks',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'dispatch_task',
+    description: 'Dispatch a task to an existing stack',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        stackId: { type: 'string' },
+        prompt: { type: 'string' },
+        model: { type: 'string' },
+        gateApproved: { type: 'boolean' },
+        forceBypass: { type: 'boolean' },
+      },
+      required: ['stackId', 'prompt'],
+    },
+  },
+  {
+    name: 'get_diff',
+    description: 'Get the git diff for a stack',
+    inputSchema: {
+      type: 'object',
+      properties: { stackId: { type: 'string' } },
+      required: ['stackId'],
+    },
+  },
+  {
+    name: 'push_stack',
+    description: 'Push a stack\'s changes to git',
+    inputSchema: {
+      type: 'object',
+      properties: { stackId: { type: 'string' }, message: { type: 'string' } },
+      required: ['stackId'],
+    },
+  },
+  {
+    name: 'get_task_status',
+    description: 'Get the current task status for a stack',
+    inputSchema: {
+      type: 'object',
+      properties: { stackId: { type: 'string' } },
+      required: ['stackId'],
+    },
+  },
+  {
+    name: 'get_task_output',
+    description: 'Get the task output log for a stack',
+    inputSchema: {
+      type: 'object',
+      properties: { stackId: { type: 'string' }, lines: { type: 'number' } },
+      required: ['stackId'],
+    },
+  },
+  {
+    name: 'teardown_stack',
+    description: 'Tear down a Sandstorm stack',
+    inputSchema: {
+      type: 'object',
+      properties: { stackId: { type: 'string' } },
+      required: ['stackId'],
+    },
+  },
+  {
+    name: 'get_logs',
+    description: 'Get container logs for a stack',
+    inputSchema: {
+      type: 'object',
+      properties: { stackId: { type: 'string' }, service: { type: 'string' } },
+      required: ['stackId'],
+    },
+  },
+  {
+    name: 'set_pr',
+    description: 'Associate a pull request with a stack',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        stackId: { type: 'string' },
+        prUrl: { type: 'string' },
+        prNumber: { type: 'number' },
+      },
+      required: ['stackId', 'prUrl', 'prNumber'],
+    },
+  },
+  {
+    name: 'spec_check',
+    description: 'Run the spec quality gate check for a ticket',
+    inputSchema: {
+      type: 'object',
+      properties: { ticketId: { type: 'string' }, projectDir: { type: 'string' } },
+      required: ['ticketId', 'projectDir'],
+    },
+  },
+  {
+    name: 'spec_refine',
+    description: 'Refine a ticket spec with AI assistance',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: { type: 'string' },
+        projectDir: { type: 'string' },
+        userAnswers: { type: 'string' },
+      },
+      required: ['ticketId', 'projectDir'],
+    },
+  },
+  {
+    name: 'schedule_create',
+    description: 'Create a scheduled action',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectDir: { type: 'string' },
+        label: { type: 'string' },
+        cronExpression: { type: 'string' },
+        action: { type: 'object' },
+        enabled: { type: 'boolean' },
+      },
+      required: ['projectDir', 'cronExpression', 'action'],
+    },
+  },
+  {
+    name: 'schedule_list',
+    description: 'List scheduled actions for a project',
+    inputSchema: {
+      type: 'object',
+      properties: { projectDir: { type: 'string' } },
+      required: ['projectDir'],
+    },
+  },
+  {
+    name: 'schedule_update',
+    description: 'Update a scheduled action',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectDir: { type: 'string' },
+        id: { type: 'string' },
+        patch: { type: 'object' },
+      },
+      required: ['projectDir', 'id', 'patch'],
+    },
+  },
+  {
+    name: 'schedule_delete',
+    description: 'Delete a scheduled action',
+    inputSchema: {
+      type: 'object',
+      properties: { projectDir: { type: 'string' }, id: { type: 'string' } },
+      required: ['projectDir', 'id'],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Bridge proxy
+// ---------------------------------------------------------------------------
+
+// Export for unit testing (allows callers to inject bridgeUrl/bridgeToken)
+export function callBridge(
+  name: string,
+  input: Record<string, unknown>,
+  bridgeUrl: string = BRIDGE_URL,
+  bridgeToken: string = BRIDGE_TOKEN,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    if (!bridgeUrl) {
+      reject(new Error('SANDSTORM_BRIDGE_URL is not set'));
+      return;
+    }
+    const payload = JSON.stringify({ name, input });
+    const url = new URL('/tool-call', bridgeUrl);
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: Number(url.port),
+        path: '/tool-call',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+          'x-auth-token': bridgeToken,
+        },
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => { body += chunk; });
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(body) as { result?: unknown; error?: string };
+            if (parsed.error) reject(new Error(parsed.error));
+            else resolve(parsed.result);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// MCP JSON-RPC handler
+// ---------------------------------------------------------------------------
+
+interface JsonRpcMessage {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+type JsonRpcResponse = Record<string, unknown>;
+
+// Exported so unit tests can call handleMessage directly with a faked bridge.
+// bridgeUrl/bridgeToken default to the module-level env constants when omitted.
+export async function handleMessage(
+  msg: JsonRpcMessage,
+  bridgeUrl: string = BRIDGE_URL,
+  bridgeToken: string = BRIDGE_TOKEN,
+): Promise<JsonRpcResponse | null> {
+  const { id, method, params } = msg;
+  const isNotification = id === undefined || id === null;
+
+  switch (method) {
+    case 'initialize':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'sandstorm-bridge', version: '1.0.0' },
+        },
+      };
+
+    case 'notifications/initialized':
+    case 'initialized':
+      return null;
+
+    case 'ping':
+      if (isNotification) return null;
+      return { jsonrpc: '2.0', id, result: {} };
+
+    case 'tools/list':
+      return { jsonrpc: '2.0', id, result: { tools: TOOLS } };
+
+    case 'tools/call': {
+      const p = params as { name: string; arguments?: Record<string, unknown> } | undefined;
+      if (!p?.name) {
+        return {
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32602, message: 'Missing tool name' },
+        };
+      }
+      try {
+        const result = await callBridge(p.name, p.arguments ?? {}, bridgeUrl, bridgeToken);
+        return {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            isError: false,
+          },
+        };
+      } catch (err) {
+        return {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            content: [{ type: 'text', text: String(err) }],
+            isError: true,
+          },
+        };
+      }
+    }
+
+    default:
+      if (isNotification) return null;
+      return {
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32601, message: `Method not found: ${method}` },
+      };
+  }
+}
+
+// Export TOOLS manifest so tests can verify the tool list without spawning the shim
+export { TOOLS };
+
+// ---------------------------------------------------------------------------
+// Main loop — only runs when the shim is executed directly, not when imported
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+  rl.on('line', (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(trimmed) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+    void handleMessage(msg).then((response) => {
+      if (response) {
+        process.stdout.write(JSON.stringify(response) + '\n');
+      }
+    }).catch(() => {});
+  });
+
+  rl.on('close', () => {
+    process.exit(0);
+  });
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,7 @@ import { DockerRuntime } from './runtime/docker';
 import { PodmanRuntime } from './runtime/podman';
 import { ContainerRuntime } from './runtime/types';
 import { DockerConnectionManager } from './runtime/docker-connection';
-import { AgentBackend, ClaudeBackend, BackendRouter } from './agent';
+import { AgentBackend, ClaudeBackend, OpenCodeBackend, BackendRouter } from './agent';
 import { registerIpcHandlers } from './ipc';
 import { createTray } from './tray';
 import { SessionMonitor } from './control-plane/session-monitor';
@@ -179,7 +179,10 @@ async function initializeApp(): Promise<void> {
     return routing.model;
   };
   agentBackend = new BackendRouter(
-    { claude: () => new ClaudeBackend(undefined, modelResolver) },
+    {
+      claude: () => new ClaudeBackend(undefined, modelResolver),
+      opencode: () => new OpenCodeBackend(),
+    },
     (projectDir) => registry.getEffectiveBackend(projectDir, 'outer').backend,
   );
   await agentBackend.initialize();

--- a/src/main/opencode-config.ts
+++ b/src/main/opencode-config.ts
@@ -2,6 +2,17 @@ export interface OpencodeConfigInputs {
   // Placeholder for future per-task config: #477 adds model selection, #479 adds provider credentials
 }
 
+export interface OuterOpencodeConfigInputs {
+  /** Absolute path to the compiled orchestration-mcp-shim.cjs */
+  shimPath: string;
+  /** URL of the in-process bridge server, e.g. http://127.0.0.1:PORT */
+  bridgeUrl: string;
+  /** Auth token for the bridge */
+  bridgeToken: string;
+  /** Absolute path to SANDSTORM_OUTER.md (outer orchestrator system prompt) */
+  instructionsPath: string;
+}
+
 interface McpServer {
   type: 'local';
   command: string[];
@@ -18,6 +29,10 @@ export interface OpencodeConfig {
 
 export const STATIC_INPUTS: OpencodeConfigInputs = {};
 
+/**
+ * Generate the inner OpenCode config (for stack-internal agents).
+ * Chrome DevTools MCP only — no bridge shim.
+ */
 export function generateOpencodeConfig(_inputs: OpencodeConfigInputs): OpencodeConfig {
   return {
     model: 'anthropic/claude-sonnet-4-6',
@@ -50,6 +65,39 @@ export function generateOpencodeConfig(_inputs: OpencodeConfigInputs): OpencodeC
           PUPPETEER_EXECUTABLE_PATH: '/usr/bin/chromium',
         },
       },
+    },
+  };
+}
+
+/**
+ * Generate the outer OpenCode config (for the orchestrator agent).
+ * Includes the Sandstorm bridge shim as an MCP server so the orchestrator
+ * can call create_stack, dispatch_task, etc. via standard MCP tool calls.
+ *
+ * The McpServer shape is the committed interface: { type:'local'; command:string[];
+ * environment: Record<string,string> } — verified at src/main/opencode-config.ts:5-9.
+ */
+export function generateOuterOpencodeConfig(inputs: OuterOpencodeConfigInputs): OpencodeConfig {
+  const shimMcpServer: McpServer = {
+    type: 'local',
+    command: [process.execPath, inputs.shimPath],
+    environment: {
+      SANDSTORM_BRIDGE_URL: inputs.bridgeUrl,
+      SANDSTORM_BRIDGE_TOKEN: inputs.bridgeToken,
+    },
+  };
+
+  return {
+    model: 'anthropic/claude-sonnet-4-6',
+    provider: {
+      anthropic: {
+        apiKey: '{env:ANTHROPIC_API_KEY}',
+      },
+    },
+    permission: 'allow',
+    instructions: [inputs.instructionsPath],
+    mcp: {
+      'sandstorm-bridge': shimMcpServer,
     },
   };
 }

--- a/tests/unit/agent/backend-router.test.ts
+++ b/tests/unit/agent/backend-router.test.ts
@@ -69,6 +69,13 @@ describe('BackendRouter', () => {
     expect(opencodeFake.initializeMock).toHaveBeenCalledOnce();
   });
 
+  it('lazily-created backend gets initialize() called when router is already initialized', async () => {
+    await router.initialize();
+    // opencode was not instantiated during initialize() — first use creates it
+    router.sendMessage('tab-opencode', 'hi', '/opencode-project');
+    expect(opencodeFake.initializeMock).toHaveBeenCalledOnce();
+  });
+
   it('destroy() fans out to all instantiated backends', async () => {
     await router.initialize();
     router.sendMessage('tab-opencode', 'hi', '/opencode-project');

--- a/tests/unit/agent/opencode-backend.test.ts
+++ b/tests/unit/agent/opencode-backend.test.ts
@@ -1,0 +1,1082 @@
+/**
+ * Tests for OpenCodeBackend.
+ *
+ * Verifies:
+ *  - AgentBackend conformance suite (shared assertions)
+ *  - event→IPC channel mapping (agent:output, agent:done, agent:error)
+ *  - step-finish → OuterClaudeSessionTokens accumulation → agent:token-usage
+ *  - No agent:tool_use channel — tool events fold into agent:output
+ *  - Ephemeral prompt parsing (session.prompt response parts → text)
+ *  - Bridge singleton acquisition
+ *  - Shim tool/list + tools/call against a faked bridge
+ *
+ * All SDK/Electron/tool-call dependencies are mocked; no live provider.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { createConformanceSuite } from './agent-backend-conformance.test';
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be hoisted before any import that touches these modules.
+// Variables referenced inside vi.mock factories MUST use vi.hoisted() so they
+// are initialised before vitest hoists the vi.mock() calls to the top of the file.
+// ---------------------------------------------------------------------------
+
+// vi.hoisted returns values that are available inside vi.mock factories
+const {
+  mockBridgeRelease,
+  mockBridge,
+  mockSessionCreate,
+  mockSessionPromptAsync,
+  mockSessionPrompt,
+  mockSessionAbort,
+  mockSessionDelete,
+  mockEventSubscribe,
+  mockServerClose,
+} = vi.hoisted(() => {
+  const mockBridgeRelease = vi.fn();
+  const mockBridge = {
+    url: 'http://127.0.0.1:19999',
+    token: 'test-bridge-token',
+    release: mockBridgeRelease,
+  };
+  const mockSessionCreate = vi.fn().mockResolvedValue({
+    data: { id: 'oc-session-1', projectID: 'proj', directory: '/project', title: '' },
+  });
+  const mockSessionPromptAsync = vi.fn().mockResolvedValue({ data: undefined });
+  const mockSessionPrompt = vi.fn().mockResolvedValue({ data: { info: {}, parts: [] } });
+  const mockSessionAbort = vi.fn().mockResolvedValue({ data: true });
+  const mockSessionDelete = vi.fn().mockResolvedValue({ data: true });
+  const mockServerClose = vi.fn();
+
+  const mockEventSubscribe = vi.fn();
+
+  return {
+    mockBridgeRelease,
+    mockBridge,
+    mockSessionCreate,
+    mockSessionPromptAsync,
+    mockSessionPrompt,
+    mockSessionAbort,
+    mockSessionDelete,
+    mockEventSubscribe,
+    mockServerClose,
+  };
+});
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  BrowserWindow: class {},
+  shell: { openExternal: vi.fn() },
+}));
+
+vi.mock('../../../src/main/agent/bridge-server', () => ({
+  acquireBridge: vi.fn().mockResolvedValue(mockBridge),
+}));
+
+vi.mock('../../../src/main/claude/tools', () => ({
+  handleToolCall: vi.fn().mockResolvedValue({ success: true }),
+  validateProjectDir: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../../src/main/index', () => ({
+  stackManager: {},
+  agentBackend: {},
+  registry: {},
+  cliDir: '/tmp/sandstorm-cli',
+}));
+
+vi.mock('@opencode-ai/sdk', () => ({
+  createOpencodeClient: vi.fn(() => ({
+    session: {
+      create: mockSessionCreate,
+      promptAsync: mockSessionPromptAsync,
+      prompt: mockSessionPrompt,
+      abort: mockSessionAbort,
+      delete: mockSessionDelete,
+    },
+    event: { subscribe: mockEventSubscribe },
+  })),
+}));
+
+vi.mock('@opencode-ai/sdk/server', () => ({
+  createOpencodeServer: vi.fn().mockResolvedValue({
+    url: 'http://127.0.0.1:18765',
+    close: mockServerClose,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// SSE event emitter — tests call capturedEventEmitter to push synthetic events
+// ---------------------------------------------------------------------------
+
+type MockStreamEvent = { type: string; properties?: Record<string, unknown> };
+let capturedEventEmitter: ((event: MockStreamEvent) => void) | null = null;
+
+// Build a fresh mock stream and capture its emitter for use in tests.
+// Call this in beforeEach so each test gets a clean stream.
+function makeMockStream(): AsyncIterable<MockStreamEvent> {
+  let done = false;
+  const queue: MockStreamEvent[] = [];
+  let resolve: ((v: IteratorResult<MockStreamEvent>) => void) | null = null;
+
+  capturedEventEmitter = (event: MockStreamEvent) => {
+    if (resolve) {
+      const r = resolve;
+      resolve = null;
+      r({ value: event, done: false });
+    } else {
+      queue.push(event);
+    }
+  };
+
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<MockStreamEvent>> {
+          if (done)
+            return Promise.resolve({ value: undefined as unknown as MockStreamEvent, done: true });
+          if (queue.length > 0)
+            return Promise.resolve({ value: queue.shift()!, done: false });
+          return new Promise((r) => { resolve = r; });
+        },
+        return() {
+          done = true;
+          if (resolve)
+            resolve({ value: undefined as unknown as MockStreamEvent, done: true });
+          return Promise.resolve({ value: undefined as unknown as MockStreamEvent, done: true });
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Import the module under test after mocks are declared
+// ---------------------------------------------------------------------------
+
+import { createServer, type Server } from 'http';
+import { OpenCodeBackend } from '../../../src/main/agent/opencode-backend';
+import { acquireBridge } from '../../../src/main/agent/bridge-server';
+import { createOpencodeServer } from '@opencode-ai/sdk/server';
+import { createOpencodeClient } from '@opencode-ai/sdk';
+import { handleMessage, TOOLS } from '../../../src/main/agent/orchestration-mcp-shim';
+import { generateOuterOpencodeConfig } from '../../../src/main/opencode-config';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeInitializedBackend(): Promise<OpenCodeBackend> {
+  const backend = new OpenCodeBackend();
+  await backend.initialize();
+  return backend;
+}
+
+function makeIpcCapture(): { calls: Map<string, unknown[]>; send: (ch: string, ...data: unknown[]) => void } {
+  const calls = new Map<string, unknown[]>();
+  const send = (channel: string, ...data: unknown[]): void => {
+    if (!calls.has(channel)) calls.set(channel, []);
+    calls.get(channel)!.push(data.length === 1 ? data[0] : data);
+  };
+  return { calls, send };
+}
+
+// ---------------------------------------------------------------------------
+// Conformance suite — runs all shared AgentBackend contract assertions
+// ---------------------------------------------------------------------------
+
+createConformanceSuite('OpenCodeBackend', () => new OpenCodeBackend());
+
+// ---------------------------------------------------------------------------
+// Initialize / lifecycle tests
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend lifecycle', () => {
+  let backend: OpenCodeBackend;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    mockSessionCreate.mockResolvedValue({
+      data: { id: 'oc-session-1', projectID: 'proj', directory: '/project', title: '' },
+    });
+    mockSessionPromptAsync.mockResolvedValue({ data: undefined });
+    mockSessionPrompt.mockResolvedValue({ data: { info: {}, parts: [] } });
+  });
+
+  afterEach(() => {
+    backend?.destroy();
+  });
+
+  it('initialize() acquires shared bridge', async () => {
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    expect(acquireBridge).toHaveBeenCalledOnce();
+  });
+
+  it('initialize() starts opencode server with outer config and creates client', async () => {
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    expect(createOpencodeServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: '127.0.0.1',
+        config: expect.objectContaining({
+          mcp: expect.objectContaining({
+            'sandstorm-bridge': expect.objectContaining({
+              type: 'local',
+              environment: expect.objectContaining({
+                SANDSTORM_BRIDGE_URL: 'http://127.0.0.1:19999',
+                SANDSTORM_BRIDGE_TOKEN: 'test-bridge-token',
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(createOpencodeClient).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:18765' });
+  });
+
+  it('initialize() injects SANDSTORM_BRIDGE_URL and SANDSTORM_BRIDGE_TOKEN into process.env', async () => {
+    const prevUrl = process.env.SANDSTORM_BRIDGE_URL;
+    const prevToken = process.env.SANDSTORM_BRIDGE_TOKEN;
+    try {
+      backend = new OpenCodeBackend();
+      await backend.initialize();
+      expect(process.env.SANDSTORM_BRIDGE_URL).toBe('http://127.0.0.1:19999');
+      expect(process.env.SANDSTORM_BRIDGE_TOKEN).toBe('test-bridge-token');
+    } finally {
+      if (prevUrl === undefined) delete process.env.SANDSTORM_BRIDGE_URL;
+      else process.env.SANDSTORM_BRIDGE_URL = prevUrl;
+      if (prevToken === undefined) delete process.env.SANDSTORM_BRIDGE_TOKEN;
+      else process.env.SANDSTORM_BRIDGE_TOKEN = prevToken;
+    }
+  });
+
+  it('destroy() releases bridge and closes server', async () => {
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.destroy();
+    expect(mockBridgeRelease).toHaveBeenCalledOnce();
+    expect(mockServerClose).toHaveBeenCalledOnce();
+  });
+
+  it('destroy() before initialize() does not throw', () => {
+    backend = new OpenCodeBackend();
+    expect(() => backend.destroy()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistent session — sendMessage + IPC channel mapping
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend persistent sessions', () => {
+  let backend: OpenCodeBackend;
+  let ipc: ReturnType<typeof makeIpcCapture>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ipc = makeIpcCapture();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    mockSessionCreate.mockResolvedValue({
+      data: { id: 'oc-session-1', projectID: 'proj', directory: '/project', title: '' },
+    });
+    mockSessionPromptAsync.mockResolvedValue({ data: undefined });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.setMainWindow({ webContents: { send: ipc.send } } as unknown as import('electron').BrowserWindow);
+  });
+
+  afterEach(() => {
+    backend.destroy();
+  });
+
+  it('sendMessage emits agent:user-message and stores in history', () => {
+    backend.sendMessage('tab-1', 'Hello OpenCode', '/project');
+    expect(ipc.calls.get('agent:user-message:tab-1')).toContain('Hello OpenCode');
+    const history = backend.getHistory('tab-1');
+    expect(history.messages[0]).toMatchObject({ role: 'user', content: 'Hello OpenCode' });
+  });
+
+  it('sendMessage emits agent:queued when session is already processing', async () => {
+    backend.sendMessage('tab-1', 'first', '/project');
+    await new Promise((r) => setTimeout(r, 0)); // let first message start
+    ipc.calls.clear();
+    // Session is now processing — second message should emit agent:queued
+    backend.sendMessage('tab-1', 'second', '/project');
+    expect(ipc.calls.has('agent:queued:tab-1')).toBe(true);
+  });
+
+  it('sendMessage before initialize() emits agent:error and leaves processing false', async () => {
+    const uninit = new OpenCodeBackend();
+    uninit.setMainWindow({ webContents: { send: ipc.send } } as unknown as import('electron').BrowserWindow);
+    uninit.sendMessage('tab-x', 'hello', '/project');
+    expect(ipc.calls.has('agent:error:tab-x')).toBe(true);
+    expect(uninit.getHistory('tab-x').processing).toBe(false);
+  });
+
+  it('sendMessage creates a new OpenCode session on first message', async () => {
+    backend.sendMessage('tab-1', 'first message', '/project');
+    // Wait for the async session creation
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSessionCreate).toHaveBeenCalledWith({
+      query: { directory: '/project' },
+    });
+  });
+
+  it('sendMessage reuses existing session for same tab', async () => {
+    backend.sendMessage('tab-1', 'first', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+    backend.sendMessage('tab-1', 'second', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+    // Session created once
+    expect(mockSessionCreate).toHaveBeenCalledOnce();
+    // Prompt sent twice
+    expect(mockSessionPromptAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('concurrent sendMessage calls before session creation resolves create session once', async () => {
+    // Send two messages with no yield between them so both enter sendMessageAsync
+    // before session.create() resolves — the second must await the first's
+    // in-flight creatingSession promise rather than spawning a second create().
+    backend.sendMessage('tab-1', 'message 1', '/project');
+    backend.sendMessage('tab-1', 'message 2', '/project');
+
+    // Let all async operations settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSessionCreate).toHaveBeenCalledOnce();
+    expect(mockSessionPromptAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('sendMessage on separate tabs keeps sessions independent', async () => {
+    mockSessionCreate
+      .mockResolvedValueOnce({ data: { id: 'session-a' } })
+      .mockResolvedValueOnce({ data: { id: 'session-b' } });
+
+    backend.sendMessage('tab-a', 'msg a', '/project-a');
+    backend.sendMessage('tab-b', 'msg b', '/project-b');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(backend.getHistory('tab-a').messages[0].content).toBe('msg a');
+    expect(backend.getHistory('tab-b').messages[0].content).toBe('msg b');
+  });
+
+  it('SSE message.part.updated (text delta) emits agent:output channel', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0)); // session created
+
+    // Emit a text delta event
+    capturedEventEmitter?.({
+      type: 'message.part.updated',
+      properties: {
+        delta: 'Hello there',
+        part: { type: 'text', sessionID: 'oc-session-1', messageID: 'msg-1', id: 'p1' },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(ipc.calls.get('agent:output:tab-1')).toContain('Hello there');
+  });
+
+  it('SSE session.idle emits agent:done and marks processing false', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    capturedEventEmitter?.({
+      type: 'session.idle',
+      properties: { sessionID: 'oc-session-1' },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(ipc.calls.has('agent:done:tab-1')).toBe(true);
+    expect(backend.getHistory('tab-1').processing).toBe(false);
+  });
+
+  it('SSE session.error emits agent:error with message', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    capturedEventEmitter?.({
+      type: 'session.error',
+      properties: {
+        sessionID: 'oc-session-1',
+        error: { message: 'Provider rate limit' },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const errors = ipc.calls.get('agent:error:tab-1');
+    expect(errors).toBeDefined();
+    expect(errors![0]).toContain('Provider rate limit');
+  });
+
+  it('tool events fold into agent:output — no agent:tool_use channel', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    capturedEventEmitter?.({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          type: 'tool',
+          sessionID: 'oc-session-1',
+          messageID: 'msg-1',
+          id: 'p2',
+          callID: 'call-1',
+          tool: 'create_stack',
+          state: {},
+        },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // tool output goes to agent:output, NOT agent:tool_use
+    expect(ipc.calls.has('agent:output:tab-1')).toBe(true);
+    expect(ipc.calls.has('agent:tool_use:tab-1')).toBe(false);
+  });
+
+  it('step-finish tokens accumulate into OuterClaudeSessionTokens and emit agent:token-usage', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    capturedEventEmitter?.({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          type: 'step-finish',
+          sessionID: 'oc-session-1',
+          messageID: 'msg-1',
+          id: 'p3',
+          reason: 'end_turn',
+          cost: 0.001,
+          tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 10, write: 5 } },
+        },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const tokens = backend.getSessionTokens('tab-1');
+    expect(tokens.input_tokens).toBe(100);
+    expect(tokens.output_tokens).toBe(50);
+    expect(tokens.cache_read_input_tokens).toBe(10);
+    expect(tokens.cache_creation_input_tokens).toBe(5);
+
+    // agent:token-usage was emitted
+    expect(ipc.calls.has('agent:token-usage:tab-1')).toBe(true);
+    const usage = ipc.calls.get('agent:token-usage:tab-1')![0] as {
+      input_tokens: number;
+      output_tokens: number;
+    };
+    expect(usage.input_tokens).toBe(100);
+  });
+
+  it('step-finish tokens accumulate across multiple steps', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    const stepFinishPart = (input: number, output: number) => ({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          type: 'step-finish',
+          sessionID: 'oc-session-1',
+          messageID: 'msg-1',
+          id: 'px',
+          reason: 'end_turn',
+          cost: 0,
+          tokens: { input, output, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+      },
+    });
+
+    capturedEventEmitter?.(stepFinishPart(100, 50));
+    await new Promise((r) => setTimeout(r, 0));
+    capturedEventEmitter?.(stepFinishPart(200, 80));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const tokens = backend.getSessionTokens('tab-1');
+    expect(tokens.input_tokens).toBe(300);
+    expect(tokens.output_tokens).toBe(130);
+  });
+
+  it('cancelSession aborts the OpenCode session and emits agent:done', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    backend.cancelSession('tab-1');
+
+    expect(mockSessionAbort).toHaveBeenCalledWith({ path: { id: 'oc-session-1' } });
+    expect(ipc.calls.has('agent:done:tab-1')).toBe(true);
+    expect(backend.getHistory('tab-1').processing).toBe(false);
+  });
+
+  it('cancelSession on unknown tab does not throw', () => {
+    expect(() => backend.cancelSession('no-such-tab')).not.toThrow();
+  });
+
+  it('resetSession clears history and deletes the OpenCode session', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+
+    backend.resetSession('tab-1');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(backend.getHistory('tab-1').messages).toHaveLength(0);
+    expect(mockSessionDelete).toHaveBeenCalledWith({ path: { id: 'oc-session-1' } });
+  });
+
+  it('resetSession emits zero token-usage to the renderer', async () => {
+    backend.sendMessage('tab-1', 'hi', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+    ipc.calls.clear();
+
+    backend.resetSession('tab-1');
+
+    const tokenUpdates = ipc.calls.get('agent:token-usage:tab-1');
+    expect(tokenUpdates).toBeDefined();
+    const zeroed = tokenUpdates![0] as { input_tokens: number };
+    expect(zeroed.input_tokens).toBe(0);
+  });
+
+  it('getSessionTokens returns zero for unknown tab', () => {
+    const tokens = backend.getSessionTokens('no-tab');
+    expect(tokens.input_tokens).toBe(0);
+    expect(tokens.output_tokens).toBe(0);
+    expect(tokens.cache_creation_input_tokens).toBe(0);
+    expect(tokens.cache_read_input_tokens).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ephemeral agents
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend ephemeral agents', () => {
+  let backend: OpenCodeBackend;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    mockSessionCreate.mockResolvedValue({
+      data: { id: 'eph-session-1', projectID: 'proj', directory: '/project', title: '' },
+    });
+    mockSessionPrompt.mockResolvedValue({ data: { info: {}, parts: [] } });
+    mockSessionDelete.mockResolvedValue({ data: true });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.destroy();
+  });
+
+  it('runEphemeralAgent returns a string', async () => {
+    const result = await backend.runEphemeralAgent('test prompt', '/project');
+    expect(typeof result).toBe('string');
+  });
+
+  it('runEphemeralAgent extracts text from session.prompt response parts', async () => {
+    mockSessionPrompt.mockResolvedValueOnce({
+      data: {
+        info: {},
+        parts: [
+          { type: 'text', id: 'p1', sessionID: 'eph-1', messageID: 'm1', text: 'Hello ' },
+          { type: 'text', id: 'p2', sessionID: 'eph-1', messageID: 'm1', text: 'world' },
+        ],
+      },
+    });
+    const result = await backend.runEphemeralAgent('prompt', '/project');
+    expect(result).toBe('Hello world');
+  });
+
+  it('spawnEphemeralAgent emits text chunks via onChunk callback', async () => {
+    mockSessionPrompt.mockResolvedValueOnce({
+      data: {
+        info: {},
+        parts: [
+          { type: 'text', id: 'p1', sessionID: 'eph-1', messageID: 'm1', text: 'chunk 1' },
+          { type: 'text', id: 'p2', sessionID: 'eph-1', messageID: 'm1', text: 'chunk 2' },
+        ],
+      },
+    });
+    const chunks: import('../../../src/main/agent/types').EphemeralStreamEvent[] = [];
+    const { promise } = backend.spawnEphemeralAgent('prompt', '/project', 30000, (ev) => chunks.push(ev));
+    await promise;
+    expect(chunks.filter((c) => c.kind === 'text')).toHaveLength(2);
+    expect(chunks[0]).toMatchObject({ kind: 'text', delta: 'chunk 1' });
+  });
+
+  it('spawnEphemeralAgent emits tool_use chunks via onChunk', async () => {
+    mockSessionPrompt.mockResolvedValueOnce({
+      data: {
+        info: {},
+        parts: [
+          {
+            type: 'tool',
+            id: 'p3',
+            sessionID: 'eph-1',
+            messageID: 'm1',
+            callID: 'c1',
+            tool: 'create_stack',
+            state: {},
+          },
+        ],
+      },
+    });
+    const chunks: import('../../../src/main/agent/types').EphemeralStreamEvent[] = [];
+    const { promise } = backend.spawnEphemeralAgent('prompt', '/project', 30000, (ev) => chunks.push(ev));
+    await promise;
+    const toolEvent = chunks.find((c) => c.kind === 'tool_use');
+    expect(toolEvent).toMatchObject({ kind: 'tool_use', name: 'create_stack' });
+  });
+
+  it('spawnEphemeralAgent cancel() rejects the promise', async () => {
+    // Simulate a slow prompt that we cancel
+    let resolvePrompt: () => void = () => {};
+    mockSessionPrompt.mockImplementationOnce(
+      () => new Promise<{ data: { info: object; parts: object[] } }>((r) => { resolvePrompt = () => r({ data: { info: {}, parts: [] } }); }),
+    );
+    const { promise, cancel } = backend.spawnEphemeralAgent('prompt', '/project', 30000);
+    await new Promise((r) => setTimeout(r, 0)); // let session.create() run
+    cancel();
+    resolvePrompt(); // unblock the prompt
+    await expect(promise).rejects.toThrow();
+  });
+
+  it('spawnEphemeralAgent deletes the ephemeral session after completion', async () => {
+    await backend.runEphemeralAgent('prompt', '/project');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSessionDelete).toHaveBeenCalledWith({ path: { id: 'eph-session-1' } });
+  });
+
+  it('spawnEphemeralSession handle resolves initialResult', async () => {
+    mockSessionPrompt.mockResolvedValueOnce({
+      data: {
+        info: {},
+        parts: [{ type: 'text', id: 'p1', sessionID: 'eph-1', messageID: 'm1', text: 'initial result' }],
+      },
+    });
+    const handle = backend.spawnEphemeralSession('init prompt', '/project');
+    const result = await handle.initialResult;
+    expect(result).toBe('initial result');
+  });
+
+  it('spawnEphemeralSession sendFollowUp resolves', async () => {
+    mockSessionPrompt
+      .mockResolvedValueOnce({ data: { info: {}, parts: [{ type: 'text', id: 'p1', sessionID: 'eph-1', messageID: 'm1', text: 'init' }] } })
+      .mockResolvedValueOnce({ data: { info: {}, parts: [{ type: 'text', id: 'p2', sessionID: 'eph-1', messageID: 'm2', text: 'followup response' }] } });
+
+    const handle = backend.spawnEphemeralSession('init', '/project');
+    await handle.initialResult;
+    const followUp = await handle.sendFollowUp('follow-up prompt');
+    expect(followUp).toBe('followup response');
+  });
+
+  it('spawnEphemeralSession dispose deletes the session', async () => {
+    const handle = backend.spawnEphemeralSession('prompt', '/project');
+    await handle.initialResult;
+    handle.dispose();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSessionDelete).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bridge singleton sharing
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend bridge sharing', () => {
+  it('acquireBridge is called during initialize()', async () => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    const backend = new OpenCodeBackend();
+    await backend.initialize();
+    expect(acquireBridge).toHaveBeenCalledOnce();
+    backend.destroy();
+  });
+
+  it('bridge.release() is called during destroy()', async () => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    const backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.destroy();
+    expect(mockBridgeRelease).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shim: handleMessage + tools/call against a faked bridge
+// ---------------------------------------------------------------------------
+
+describe('orchestration-mcp-shim handleMessage', () => {
+  let fakeServer: Server;
+  let fakeUrl: string;
+  const fakeToken = 'shim-test-token-abc';
+
+  // Track what the fake bridge received
+  let lastReceivedBody: { name: string; input: Record<string, unknown> } | null = null;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      fakeServer = createServer((req, res) => {
+        if (req.method !== 'POST' || req.url !== '/tool-call') {
+          res.writeHead(404);
+          res.end();
+          return;
+        }
+        if (req.headers['x-auth-token'] !== fakeToken) {
+          res.writeHead(403);
+          res.end(JSON.stringify({ error: 'Forbidden' }));
+          return;
+        }
+        let body = '';
+        req.on('data', (chunk: Buffer) => { body += chunk; });
+        req.on('end', () => {
+          try {
+            lastReceivedBody = JSON.parse(body) as { name: string; input: Record<string, unknown> };
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ result: `bridge:${lastReceivedBody.name}` }));
+          } catch {
+            res.writeHead(400);
+            res.end(JSON.stringify({ error: 'bad json' }));
+          }
+        });
+      });
+      fakeServer.listen(0, '127.0.0.1', () => {
+        const addr = fakeServer.address() as { port: number };
+        fakeUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    fakeServer.close();
+  });
+
+  beforeEach(() => {
+    lastReceivedBody = null;
+  });
+
+  it('TOOLS is non-empty and contains sandstorm core tools', () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(names).toContain('create_stack');
+    expect(names).toContain('list_stacks');
+    expect(names).toContain('dispatch_task');
+    expect(names).toContain('get_diff');
+    expect(names).toContain('push_stack');
+    expect(names).toContain('get_task_status');
+    expect(names).toContain('get_task_output');
+    expect(names).toContain('teardown_stack');
+    expect(names).toContain('spec_check');
+    expect(names).toContain('schedule_create');
+    expect(names).toContain('schedule_list');
+    expect(names).toContain('schedule_update');
+    expect(names).toContain('schedule_delete');
+    expect(TOOLS.length).toBeGreaterThan(0);
+  });
+
+  it('tools/list returns all TOOLS entries', async () => {
+    const result = await handleMessage(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      fakeUrl,
+      fakeToken,
+    );
+    expect(result).toMatchObject({ jsonrpc: '2.0', id: 1 });
+    const tools = (result!.result as { tools: Array<{ name: string }> }).tools;
+    expect(tools.length).toBe(TOOLS.length);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('create_stack');
+    expect(names).toContain('list_stacks');
+  });
+
+  it('tools/call proxies to bridge and returns result', async () => {
+    const result = await handleMessage(
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'list_stacks', arguments: {} },
+      },
+      fakeUrl,
+      fakeToken,
+    );
+    expect(result).toMatchObject({ jsonrpc: '2.0', id: 2 });
+    const content = result!.result as { content: Array<{ type: string; text: string }>; isError: boolean };
+    expect(content.isError).toBe(false);
+    expect(content.content[0].text).toContain('list_stacks');
+    // The fake bridge received the correct tool name
+    expect(lastReceivedBody?.name).toBe('list_stacks');
+  });
+
+  it('tools/call passes arguments to the bridge', async () => {
+    const args = { stackId: 'stack-123', prompt: 'do something' };
+    await handleMessage(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'dispatch_task', arguments: args },
+      },
+      fakeUrl,
+      fakeToken,
+    );
+    expect(lastReceivedBody?.input).toMatchObject(args);
+  });
+
+  it('tools/call returns isError: true when bridge is unreachable', async () => {
+    const result = await handleMessage(
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'list_stacks', arguments: {} },
+      },
+      'http://127.0.0.1:1', // unreachable port
+      fakeToken,
+    );
+    expect(result).toMatchObject({ jsonrpc: '2.0', id: 4 });
+    const content = result!.result as { isError: boolean; content: Array<{ text: string }> };
+    expect(content.isError).toBe(true);
+    expect(typeof content.content[0].text).toBe('string');
+  });
+
+  it('tools/call returns error object when tool name is missing', async () => {
+    const result = await handleMessage(
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: {},
+      },
+      fakeUrl,
+      fakeToken,
+    );
+    expect(result).toMatchObject({
+      jsonrpc: '2.0',
+      id: 5,
+      error: expect.objectContaining({ code: -32602 }),
+    });
+  });
+
+  it('initialize returns MCP server capabilities', async () => {
+    const result = await handleMessage(
+      { jsonrpc: '2.0', id: 6, method: 'initialize' },
+      fakeUrl,
+      fakeToken,
+    );
+    expect(result).toMatchObject({
+      jsonrpc: '2.0',
+      id: 6,
+      result: expect.objectContaining({
+        capabilities: expect.objectContaining({ tools: {} }),
+        serverInfo: expect.objectContaining({ name: 'sandstorm-bridge' }),
+      }),
+    });
+  });
+
+  it('notifications/initialized returns null (no response for notifications)', async () => {
+    const result = await handleMessage(
+      { jsonrpc: '2.0', id: undefined, method: 'notifications/initialized' },
+      fakeUrl,
+      fakeToken,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateOuterOpencodeConfig
+// ---------------------------------------------------------------------------
+
+describe('generateOuterOpencodeConfig', () => {
+  it('includes sandstorm-bridge MCP entry with type local', () => {
+    const config = generateOuterOpencodeConfig({
+      shimPath: '/path/to/orchestration-mcp-shim.cjs',
+      bridgeUrl: 'http://127.0.0.1:12345',
+      bridgeToken: 'test-token',
+      instructionsPath: '/cli/SANDSTORM_OUTER.md',
+    });
+    expect(config.mcp['sandstorm-bridge']).toBeDefined();
+    expect(config.mcp['sandstorm-bridge'].type).toBe('local');
+  });
+
+  it('environment contains SANDSTORM_BRIDGE_URL and SANDSTORM_BRIDGE_TOKEN', () => {
+    const config = generateOuterOpencodeConfig({
+      shimPath: '/shim.cjs',
+      bridgeUrl: 'http://127.0.0.1:54321',
+      bridgeToken: 'secret-token',
+      instructionsPath: '/cli/SANDSTORM_OUTER.md',
+    });
+    const entry = config.mcp['sandstorm-bridge'];
+    expect(entry.environment.SANDSTORM_BRIDGE_URL).toBe('http://127.0.0.1:54321');
+    expect(entry.environment.SANDSTORM_BRIDGE_TOKEN).toBe('secret-token');
+  });
+
+  it('command includes the shimPath', () => {
+    const config = generateOuterOpencodeConfig({
+      shimPath: '/custom/path/shim.cjs',
+      bridgeUrl: 'http://127.0.0.1:0',
+      bridgeToken: 'tok',
+      instructionsPath: '/cli/SANDSTORM_OUTER.md',
+    });
+    expect(config.mcp['sandstorm-bridge'].command).toContain('/custom/path/shim.cjs');
+  });
+
+  it('command is a non-empty array starting with a node executable', () => {
+    const config = generateOuterOpencodeConfig({
+      shimPath: '/shim.cjs',
+      bridgeUrl: 'http://127.0.0.1:1',
+      bridgeToken: 'x',
+      instructionsPath: '/cli/SANDSTORM_OUTER.md',
+    });
+    const { command } = config.mcp['sandstorm-bridge'];
+    expect(Array.isArray(command)).toBe(true);
+    expect(command.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('instructions contains the instructionsPath', () => {
+    const config = generateOuterOpencodeConfig({
+      shimPath: '/shim.cjs',
+      bridgeUrl: 'http://127.0.0.1:1',
+      bridgeToken: 'x',
+      instructionsPath: '/cli/SANDSTORM_OUTER.md',
+    });
+    expect(config.instructions).toContain('/cli/SANDSTORM_OUTER.md');
+  });
+});
+
+describe('bridge-server: shared singleton', () => {
+  it('acquireBridge returns url and token', async () => {
+    // The real bridge-server is mocked; this confirms the mock shape is correct.
+    const bridge = await (acquireBridge as ReturnType<typeof vi.fn>)(() => Promise.resolve({}));
+    expect(bridge.url).toMatch(/^http:\/\//);
+    expect(typeof bridge.token).toBe('string');
+    expect(typeof bridge.release).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bridge-server real module — ref-counting, idempotent start, HTTP dispatch
+// ---------------------------------------------------------------------------
+
+describe('bridge-server: real module (unmocked)', () => {
+  it('acquireBridge starts server and returns valid url/token/release', async () => {
+    const { acquireBridge: realAcquireBridge } = await vi.importActual<
+      typeof import('../../../src/main/agent/bridge-server')
+    >('../../../src/main/agent/bridge-server');
+    const handler = vi.fn().mockResolvedValue({ ok: true });
+    const handle = await realAcquireBridge(handler);
+    try {
+      expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(handle.token).toBeTruthy();
+      expect(typeof handle.release).toBe('function');
+    } finally {
+      handle.release();
+    }
+  });
+
+  it('acquireBridge is idempotent — two callers get the same url and token', async () => {
+    const { acquireBridge: realAcquireBridge } = await vi.importActual<
+      typeof import('../../../src/main/agent/bridge-server')
+    >('../../../src/main/agent/bridge-server');
+    const handler = vi.fn().mockResolvedValue({});
+    const h1 = await realAcquireBridge(handler);
+    const h2 = await realAcquireBridge(handler);
+    try {
+      expect(h1.url).toBe(h2.url);
+      expect(h1.token).toBe(h2.token);
+    } finally {
+      h1.release();
+      h2.release();
+    }
+  });
+
+  it('POST /tool-call dispatches to handler and returns JSON result', async () => {
+    const { acquireBridge: realAcquireBridge } = await vi.importActual<
+      typeof import('../../../src/main/agent/bridge-server')
+    >('../../../src/main/agent/bridge-server');
+    const handler = vi.fn().mockResolvedValue({ stacks: ['s1', 's2'] });
+    const handle = await realAcquireBridge(handler);
+    try {
+      const resp = await fetch(`${handle.url}/tool-call`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-auth-token': handle.token },
+        body: JSON.stringify({ name: 'list_stacks', input: { projectDir: '/p' } }),
+      });
+      expect(resp.ok).toBe(true);
+      const json = (await resp.json()) as { result: unknown };
+      expect(json.result).toMatchObject({ stacks: ['s1', 's2'] });
+      expect(handler).toHaveBeenCalledWith('list_stacks', { projectDir: '/p' });
+    } finally {
+      handle.release();
+    }
+  });
+
+  it('ref-counting — server stays alive while any handle is held', async () => {
+    const { acquireBridge: realAcquireBridge } = await vi.importActual<
+      typeof import('../../../src/main/agent/bridge-server')
+    >('../../../src/main/agent/bridge-server');
+    const handler = vi.fn().mockResolvedValue({});
+    const h1 = await realAcquireBridge(handler);
+    const h2 = await realAcquireBridge(handler);
+    const { url, token } = h1;
+    h1.release(); // first release — h2 still holds a ref
+    // Server must still respond
+    const resp = await fetch(`${url}/tool-call`, {
+      method: 'POST',
+      headers: { 'x-auth-token': token },
+      body: JSON.stringify({ name: 'test', input: {} }),
+    });
+    expect(resp.status).toBeLessThan(600); // server responded (not a network error)
+    h2.release(); // last release — server shuts down
+  });
+
+  it('release() is idempotent — calling it twice does not throw', async () => {
+    const { acquireBridge: realAcquireBridge } = await vi.importActual<
+      typeof import('../../../src/main/agent/bridge-server')
+    >('../../../src/main/agent/bridge-server');
+    const handler = vi.fn().mockResolvedValue({});
+    const handle = await realAcquireBridge(handler);
+    handle.release();
+    expect(() => handle.release()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth (stub coverage)
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend auth', () => {
+  let backend: OpenCodeBackend;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+  });
+
+  afterEach(() => backend.destroy());
+
+  it('getAuthStatus returns a valid AuthStatus shape', async () => {
+    const status = await backend.getAuthStatus();
+    expect(typeof status.loggedIn).toBe('boolean');
+    expect(typeof status.expired).toBe('boolean');
+  });
+
+  it('login returns success: false with a reason (auth deferred to #479)', async () => {
+    const result = await backend.login();
+    expect(result.success).toBe(false);
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('syncCredentials resolves without error', async () => {
+    await expect(backend.syncCredentials([])).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an OpenCode agent backend alongside the existing Claude backend so projects can select OpenCode as their outer agent and still drive the Sandstorm orchestration tools.

- Introduces `OpenCodeBackend`, which manages an `opencode serve` process via `@opencode-ai/sdk` and maps its SSE events onto the existing renderer IPC channels. Because the SDK is ESM-only, all runtime values are loaded with dynamic `import()` inside `initialize()` while only `import type` is used at module scope — this keeps Vite from emitting a top-level `require()` that crashes the CJS main bundle (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
- Extracts the HTTP tool-call bridge out of `ClaudeBackend` into a shared, ref-counted `bridge-server` singleton (`acquireBridge`/`BridgeHandle`) so both backends share one server, token, and ephemeral timing file.
- Adds `orchestration-mcp-shim`, a stdio MCP server (built as a second electron-vite entry) that the OpenCode outer agent spawns to proxy MCP tool calls back into the in-process bridge. `generateOuterOpencodeConfig` wires the shim in as a local MCP server.
- `BackendRouter` registers the `opencode` backend, lazily initializes backends created after `initialize()` completes, and shares the claude ephemeral timing path.

## QA plan

1. Launch the desktop app and confirm the main window opens (regression check for the ESM `require()` crash).
2. Set a project's outer backend to OpenCode, send a message, and verify streamed responses render in the chat UI.
3. From the OpenCode agent, invoke a Sandstorm orchestration tool (e.g. create a stack) and confirm it executes via the bridge shim.
4. Switch a project back to the Claude backend and confirm it still works, exercising the shared bridge.

Closes #478