### PR TITLE
[479] fix: support multi-field OpenCode provider credentials

### DIFF
--- a/docs/opencode-architecture.html
+++ b/docs/opencode-architecture.html
@@ -896,18 +896,100 @@ as container ENV VARS, never baked into the image.
       Ollama — the two most-requested "we can't use Claude Code" cases — are first-class.
     </p>
 
+    <h3>5.1 Credential matrix (first-class providers)</h3>
+
+    <p>
+      The source of truth for which fields each provider needs lives in
+      <code>src/shared/opencode-providers.ts</code> (<code>PROVIDER_METADATA</code>). The UI renders
+      exactly those fields; the config generator reads the same object. This keeps provider knowledge
+      in one place.
+    </p>
+
     <table class="smell-table">
       <thead>
-        <tr><th>Provider</th><th>How model is named</th><th>Credential delivery (container env / config)</th></tr>
+        <tr><th>Provider</th><th>Config key</th><th>Required fields</th><th>Optional fields</th><th>Env passthrough</th></tr>
       </thead>
       <tbody>
-        <tr><td><strong>Anthropic</strong></td><td><code>anthropic/claude-…</code></td><td>OAuth (existing sync) or <code>ANTHROPIC_API_KEY</code></td></tr>
-        <tr><td><strong>OpenAI</strong></td><td><code>openai/gpt-…</code></td><td><code>OPENAI_API_KEY</code></td></tr>
-        <tr><td><strong>Amazon Bedrock</strong></td><td><code>amazon-bedrock/…</code></td><td>AWS chain: <code>AWS_BEARER_TOKEN_BEDROCK</code> or <code>AWS_PROFILE</code> / access keys + <code>region</code></td></tr>
-        <tr><td><strong>Local Ollama</strong></td><td>custom provider, OpenAI-compatible</td><td>base URL <code>http://host:11434/v1</code> — no key</td></tr>
-        <tr><td><strong>OpenRouter / others</strong></td><td><code>openrouter/…</code></td><td>provider <code>apiKey</code> via <code>{env:VAR}</code></td></tr>
+        <tr>
+          <td><strong>Anthropic</strong></td>
+          <td><code>anthropic</code></td>
+          <td><code>apiKey</code></td>
+          <td>—</td>
+          <td><code>ANTHROPIC_API_KEY</code></td>
+        </tr>
+        <tr>
+          <td><strong>Amazon Bedrock</strong></td>
+          <td><code>amazon-bedrock</code></td>
+          <td><code>region</code></td>
+          <td><code>bearerToken</code> <em>or</em> <code>accessKeyId</code> + <code>secretAccessKey</code>; <code>profile</code></td>
+          <td><code>AWS_BEARER_TOKEN_BEDROCK</code>, <code>AWS_ACCESS_KEY_ID</code>, <code>AWS_SECRET_ACCESS_KEY</code>, <code>AWS_REGION</code>, <code>AWS_PROFILE</code></td>
+        </tr>
+        <tr>
+          <td><strong>Ollama</strong></td>
+          <td><code>openai</code> (OpenAI-compatible)</td>
+          <td><code>baseUrl</code></td>
+          <td>—</td>
+          <td>none — config-only</td>
+        </tr>
+        <tr>
+          <td><strong>Other</strong></td>
+          <td>provider ID as-is</td>
+          <td><code>apiKey</code></td>
+          <td>—</td>
+          <td><code>{PROVIDER}_API_KEY</code></td>
+        </tr>
       </tbody>
     </table>
+
+    <p>
+      <strong>Bedrock bearer token precedence.</strong> When both <code>bearerToken</code> and
+      <code>accessKeyId</code>/<code>secretAccessKey</code> are present, the bearer token wins and the
+      access keys are omitted from the generated config. The <code>options</code> block is always nested
+      under the <code>amazon-bedrock</code> provider key.
+    </p>
+
+    <h3>5.2 Config injection flow</h3>
+
+    <p>
+      Credentials are stored as a JSON bundle (name = <code>__bundle__</code>) in the
+      <code>backend_secrets</code> table (schema v25). The
+      <code>OPENCODE_CONFIG</code> env var points to
+      <code>/tmp/sandstorm-opencode.json</code>, which is generated at container startup by
+      <code>opencode-config.js</code> (bundled inside the Docker image). When credentials are configured,
+      <code>syncCredentials</code> overwrites this file with a config that embeds the actual values.
+    </p>
+
+    <p>
+      <strong><code>{env:VAR}</code> fallback.</strong> When no credential bundle is stored,
+      <code>generateOpencodeConfig</code> emits <code>{env:ANTHROPIC_API_KEY}</code> (and equivalent
+      for other providers). OpenCode resolves these placeholders from the container environment at
+      runtime. The compose generator passes all relevant AWS and Anthropic env vars through from the
+      host so ambient credentials (e.g. an IAM instance role or a shell-exported key) work without
+      any UI input.
+    </p>
+
+    <h3>5.3 Clean-auth precedence guard</h3>
+
+    <div class="callout smell">
+      <strong>Credential precedence trap.</strong> A stored OpenCode <code>~/.local/share/opencode/auth.json</code>
+      OAuth token silently overrides keys injected via config — a known upstream behavior. This means
+      a user who previously ran <code>opencode auth</code> inside a container would have their stored
+      OAuth token take precedence over the provider configured in Sandstorm.
+    </div>
+
+    <p>
+      <code>OpenCodeBackend.syncCredentials</code> is called whenever running stacks need credential
+      updates. For each running stack that has a <code>claude</code> service container, it:
+    </p>
+    <ol>
+      <li>Deletes <code>~/.local/share/opencode/auth.json</code> inside the container via <code>docker exec</code>, removing any cached OAuth token.</li>
+      <li>Generates a fresh <code>opencode.json</code> config with the active provider and credential bundle embedded as literal values.</li>
+      <li>Writes the config to <code>/tmp/sandstorm-opencode.json</code> inside the container via <code>docker exec -i … bash -c 'cat &gt; /tmp/sandstorm-opencode.json'</code>.</li>
+    </ol>
+    <p>
+      Result: the configured credentials always take effect deterministically regardless of any prior
+      interactive auth state in the container.
+    </p>
 
     <p>
       <strong>Autonomy.</strong> Inside the sandboxed container we want zero permission prompts, exactly
@@ -916,13 +998,6 @@ as container ENV VARS, never baked into the image.
       <code>"permission": "allow"</code> in the generated config. We use the config form so it also
       covers the server-driven outer path.
     </p>
-
-    <div class="callout smell">
-      <strong>Credential precedence trap.</strong> A stored OpenCode <code>auth.json</code> OAuth token
-      can silently override keys injected via config (known upstream issue). In-container we start from
-      a clean <code>auth.json</code> and inject via env vars so the active credential is deterministic
-      and matches what the user configured in the modal.
-    </div>
 
     <!-- ============================================================= §6 -->
     <h2><span class="num">§ 6</span> Telemetry — stays on the rails</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sandstorm",
       "version": "0.1.0",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.7",
+        "@opencode-ai/sdk": "^1.17.7",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "better-sqlite3": "^12.8.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "1.17.7",
+    "@opencode-ai/sdk": "^1.17.7",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "better-sqlite3": "^12.8.0",

--- a/sandstorm-cli/docker/opencode-config.js
+++ b/sandstorm-cli/docker/opencode-config.js
@@ -25,15 +25,56 @@ __export(opencode_config_exports, {
   generateOuterOpencodeConfig: () => generateOuterOpencodeConfig
 });
 module.exports = __toCommonJS(opencode_config_exports);
-var STATIC_INPUTS = {};
-function generateOpencodeConfig(_inputs) {
-  return {
-    model: "anthropic/claude-sonnet-4-6",
-    provider: {
-      anthropic: {
-        // Concrete var name finalized in #479; {env:…} placeholder keeps auth clean
-        apiKey: "{env:ANTHROPIC_API_KEY}"
+
+// src/shared/opencode-providers.ts
+function buildProviderEntry(providerId, bundle) {
+  switch (providerId) {
+    case "anthropic":
+      return {
+        providerKey: "anthropic",
+        config: bundle.apiKey ? { apiKey: bundle.apiKey } : { apiKey: "{env:ANTHROPIC_API_KEY}" }
+      };
+    case "amazon-bedrock": {
+      const options = {};
+      if (bundle.region) options.region = bundle.region;
+      if (bundle.bearerToken) {
+        options.bearerToken = bundle.bearerToken;
+      } else {
+        if (bundle.accessKeyId) options.accessKeyId = bundle.accessKeyId;
+        if (bundle.secretAccessKey) options.secretAccessKey = bundle.secretAccessKey;
+        if (bundle.profile) options.profile = bundle.profile;
       }
+      return {
+        providerKey: "amazon-bedrock",
+        config: Object.keys(options).length > 0 ? { options } : {}
+      };
+    }
+    case "ollama":
+      return {
+        providerKey: "openai",
+        config: {
+          apiKey: "ollama",
+          ...bundle.baseUrl ? { baseURL: bundle.baseUrl } : {}
+        }
+      };
+    default:
+      return {
+        providerKey: providerId,
+        config: bundle.apiKey ? { apiKey: bundle.apiKey } : { apiKey: `{env:${providerId.toUpperCase().replace(/-/g, "_")}_API_KEY}` }
+      };
+  }
+}
+
+// src/main/opencode-config.ts
+var STATIC_INPUTS = {};
+function generateOpencodeConfig(inputs = {}) {
+  const providerId = inputs.providerId ?? "anthropic";
+  const bundle = inputs.bundle ?? {};
+  const { providerKey, config: providerConfig } = buildProviderEntry(providerId, bundle);
+  return {
+    model: inputs.model ?? "anthropic/claude-sonnet-4-6",
+    provider: {
+      [providerKey]: providerConfig
     },
     permission: "allow",
     instructions: ["/home/claude/.claude/CLAUDE.md"],
@@ -70,12 +111,13 @@ function generateOuterOpencodeConfig(inputs) {
       SANDSTORM_BRIDGE_TOKEN: inputs.bridgeToken
     }
   };
+  const providerId = inputs.providerId ?? "anthropic";
+  const bundle = inputs.bundle ?? {};
+  const { providerKey, config: providerConfig } = buildProviderEntry(providerId, bundle);
   return {
-    model: "anthropic/claude-sonnet-4-6",
+    model: inputs.model ?? "anthropic/claude-sonnet-4-6",
     provider: {
-      anthropic: {
-        apiKey: "{env:ANTHROPIC_API_KEY}"
-      }
+      [providerKey]: providerConfig
     },
     permission: "allow",
     instructions: [inputs.instructionsPath],

--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -16,6 +16,7 @@
 
 import path from 'path';
 import os from 'os';
+import { spawn } from 'child_process';
 import { BrowserWindow } from 'electron';
 import { app } from 'electron';
 // @opencode-ai/sdk is ESM-only — static require() fails in the CJS bundle.
@@ -494,6 +495,7 @@ export class OpenCodeBackend implements AgentBackend {
               exitCode: 0,
               promptChars: prompt.length,
               turnCount: 1,
+              tokens: 0,
               cancelled,
               ...(attribution?.ticketId != null ? { ticketId: attribution.ticketId } : {}),
               ...(attribution?.stage != null ? { stage: attribution.stage } : {}),
@@ -599,7 +601,56 @@ export class OpenCodeBackend implements AgentBackend {
     return { success: false, error: 'OpenCode auth not yet implemented (#479)' };
   }
 
-  async syncCredentials(_stacks: StackInfo[]): Promise<void> {
-    // Full credential matrix deferred to #479
+  async syncCredentials(stacks: StackInfo[]): Promise<void> {
+    // Dynamic import to avoid a circular dependency at load time.
+    const { registry } = await import('../index');
+
+    const globalSettings = registry.getGlobalBackendSettings();
+    const providerId = globalSettings.inner_provider ?? 'anthropic';
+    const bundle = registry.getBackendSecretBundle('global', 'inner') ?? {};
+
+    for (const stack of stacks) {
+      if (stack.status !== 'running' && stack.status !== 'up') continue;
+      const claudeService = stack.services?.find((s) => s.name === 'claude');
+      if (!claudeService?.containerId) continue;
+
+      try {
+        // 1. Clean auth.json so env-based credentials always take precedence.
+        //    Prevents an OAuth token cached in auth.json from overriding the
+        //    configured env credentials (the OAuth-overrides-config trap).
+        await this.execInContainer(claudeService.containerId, [
+          'bash', '-c',
+          'rm -f ~/.local/share/opencode/auth.json && mkdir -p ~/.local/share/opencode',
+        ]);
+
+        // 2. Write the generated OpenCode config with actual credential values
+        //    directly to the config file the task runner reads.
+        const { generateOpencodeConfig } = await import('../opencode-config');
+        const config = generateOpencodeConfig({ providerId, bundle, model: globalSettings.inner_model ?? undefined });
+        const configJson = JSON.stringify(config, null, 2);
+
+        const writeProc = spawn('docker', [
+          'exec', '-i', '-u', 'claude', claudeService.containerId,
+          'bash', '-c', 'cat > /tmp/sandstorm-opencode.json',
+        ], { stdio: ['pipe', 'ignore', 'ignore'] });
+        writeProc.on('error', () => {});
+        writeProc.stdin.write(configJson);
+        writeProc.stdin.end();
+        await new Promise<void>((resolve) => writeProc.on('close', () => resolve()));
+      } catch {
+        // Best effort per container
+      }
+    }
+  }
+
+  private execInContainer(containerId: string, cmd: string[]): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const proc = spawn('docker', ['exec', '-u', 'claude', containerId, ...cmd], {
+        stdio: ['pipe', 'ignore', 'ignore'],
+      });
+      proc.stdin.end();
+      proc.on('close', () => resolve());
+      proc.on('error', () => resolve());
+    });
   }
 }

--- a/src/main/compose-generator.ts
+++ b/src/main/compose-generator.ts
@@ -253,6 +253,16 @@ export function generateComposeYaml(analysis: ComposeAnalysis): string {
   lines.push('      - SANDSTORM_PROJECT');
   lines.push('      - SANDSTORM_STACK_ID');
   lines.push('      - OPENCODE_CONFIG');
+  // Provider credential passthrough — inherited from host process.env when set.
+  // The stack launcher populates these from the configured backend_secrets bundle
+  // before calling docker compose up. OpenCode resolves {env:…} placeholders in
+  // the generated config against the container's environment at runtime.
+  lines.push('      - ANTHROPIC_API_KEY');
+  lines.push('      - AWS_BEARER_TOKEN_BEDROCK');
+  lines.push('      - AWS_ACCESS_KEY_ID');
+  lines.push('      - AWS_SECRET_ACCESS_KEY');
+  lines.push('      - AWS_REGION');
+  lines.push('      - AWS_PROFILE');
   lines.push('    volumes:');
   lines.push('      - ${SANDSTORM_WORKSPACE}:/app');
   lines.push('      - ${SANDSTORM_CONTEXT}:/sandstorm-context:ro');

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -705,6 +705,14 @@ export class Registry {
       try { this.db.exec('ALTER TABLE project_ticket_config ADD COLUMN filter_query TEXT'); } catch { /* exists */ }
       this.setSchemaVersion(24);
     }
+
+    if (currentVersion < 25) {
+      // Provider credential matrix (#479): backend_secrets.value now stores a JSON bundle when
+      // name = '__bundle__'. Existing single-field rows (name='api_key', value='sk-…') remain
+      // readable — getBackendSecretBundle treats them as { [name]: value } for backward compat.
+      // No DDL change: columns are unchanged, only value semantics widen.
+      this.setSchemaVersion(25);
+    }
   }
 
   // --- Projects ---
@@ -1878,6 +1886,38 @@ export class Registry {
       'SELECT value FROM backend_secrets WHERE key = ? AND surface = ?'
     ).get(key, surface) as { value: string } | undefined;
     return row?.value ?? null;
+  }
+
+  /**
+   * Store a multi-field credential bundle for a provider.
+   * Serialises the bundle as JSON in the value column with name='__bundle__'.
+   * Supersedes single-field setBackendSecret for multi-field providers (Bedrock, Ollama).
+   */
+  setBackendSecretBundle(key: string, surface: 'inner' | 'outer', bundle: Record<string, string>): void {
+    this.db.prepare(
+      'INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES (?, ?, ?, ?)'
+    ).run(key, surface, '__bundle__', JSON.stringify(bundle));
+  }
+
+  /**
+   * Read the credential bundle for a provider.
+   * Handles both v25 JSON bundles (name='__bundle__') and legacy single-field rows
+   * (written by setBackendSecret) — legacy rows are returned as { [name]: value }.
+   */
+  getBackendSecretBundle(key: string, surface: 'inner' | 'outer'): Record<string, string> | null {
+    const row = this.db.prepare(
+      'SELECT name, value FROM backend_secrets WHERE key = ? AND surface = ?'
+    ).get(key, surface) as { name: string; value: string } | undefined;
+    if (!row) return null;
+    if (row.name === '__bundle__') {
+      try {
+        return JSON.parse(row.value) as Record<string, string>;
+      } catch {
+        return null;
+      }
+    }
+    // Legacy single-field row: treat as { [name]: value }
+    return row.name && row.value ? { [row.name]: row.value } : null;
   }
 
   // --- Session Monitor Settings ---

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -969,6 +969,16 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return { set: registry.hasBackendSecret(key, surface) };
   });
 
+  ipcMain.handle('backendSettings:setSecretBundle', (_event, scope: string, surface: 'inner' | 'outer', bundle: Record<string, string>) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    registry.setBackendSecretBundle(key, surface, bundle);
+  });
+
+  ipcMain.handle('backendSettings:getSecretBundle', (_event, scope: string, surface: 'inner' | 'outer') => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    return registry.getBackendSecretBundle(key, surface);
+  });
+
   // --- Model Routing ---
 
   ipcMain.handle('modelRouting:getEffective', (_event, projectDir: string) => {

--- a/src/main/opencode-config.ts
+++ b/src/main/opencode-config.ts
@@ -1,5 +1,22 @@
+import { buildProviderEntry } from '../shared/opencode-providers';
+
 export interface OpencodeConfigInputs {
-  // Placeholder for future per-task config: #477 adds model selection, #479 adds provider credentials
+  /**
+   * OpenCode provider ID (e.g. 'anthropic', 'amazon-bedrock', 'ollama').
+   * Defaults to 'anthropic' when omitted.
+   */
+  providerId?: string;
+  /**
+   * Credential bundle for the selected provider (field key → value).
+   * When omitted, env-var placeholders are used (container startup path).
+   */
+  bundle?: Record<string, string>;
+  /**
+   * Override model string, e.g. 'anthropic/claude-sonnet-4-6' or
+   * 'amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0'.
+   * Defaults to 'anthropic/claude-sonnet-4-6'.
+   */
+  model?: string;
 }
 
 export interface OuterOpencodeConfigInputs {
@@ -11,6 +28,12 @@ export interface OuterOpencodeConfigInputs {
   bridgeToken: string;
   /** Absolute path to SANDSTORM_OUTER.md (outer orchestrator system prompt) */
   instructionsPath: string;
+  /** Provider ID for the outer agent (defaults to 'anthropic') */
+  providerId?: string;
+  /** Credential bundle for the outer agent's provider */
+  bundle?: Record<string, string>;
+  /** Override model for the outer agent */
+  model?: string;
 }
 
 interface McpServer {
@@ -21,7 +44,13 @@ interface McpServer {
 
 export interface OpencodeConfig {
   model: string;
-  provider: Record<string, { apiKey: string }>;
+  provider: Record<string, {
+    apiKey?: string;
+    baseURL?: string;
+    region?: string;
+    options?: Record<string, unknown>;
+    [key: string]: unknown;
+  }>;
   permission: string;
   instructions: string[];
   mcp: Record<string, McpServer>;
@@ -32,15 +61,20 @@ export const STATIC_INPUTS: OpencodeConfigInputs = {};
 /**
  * Generate the inner OpenCode config (for stack-internal agents).
  * Chrome DevTools MCP only — no bridge shim.
+ *
+ * When bundle is provided, actual credential values are embedded directly.
+ * When bundle is absent, {env:…} placeholders are used — the container
+ * entrypoint passes the vars via compose env passthrough.
  */
-export function generateOpencodeConfig(_inputs: OpencodeConfigInputs): OpencodeConfig {
+export function generateOpencodeConfig(inputs: OpencodeConfigInputs = {}): OpencodeConfig {
+  const providerId = inputs.providerId ?? 'anthropic';
+  const bundle = inputs.bundle ?? {};
+  const { providerKey, config: providerConfig } = buildProviderEntry(providerId, bundle);
+
   return {
-    model: 'anthropic/claude-sonnet-4-6',
+    model: inputs.model ?? 'anthropic/claude-sonnet-4-6',
     provider: {
-      anthropic: {
-        // Concrete var name finalized in #479; {env:…} placeholder keeps auth clean
-        apiKey: '{env:ANTHROPIC_API_KEY}',
-      },
+      [providerKey]: providerConfig,
     },
     permission: 'allow',
     instructions: ['/home/claude/.claude/CLAUDE.md'],
@@ -87,12 +121,14 @@ export function generateOuterOpencodeConfig(inputs: OuterOpencodeConfigInputs): 
     },
   };
 
+  const providerId = inputs.providerId ?? 'anthropic';
+  const bundle = inputs.bundle ?? {};
+  const { providerKey, config: providerConfig } = buildProviderEntry(providerId, bundle);
+
   return {
-    model: 'anthropic/claude-sonnet-4-6',
+    model: inputs.model ?? 'anthropic/claude-sonnet-4-6',
     provider: {
-      anthropic: {
-        apiKey: '{env:ANTHROPIC_API_KEY}',
-      },
+      [providerKey]: providerConfig,
     },
     permission: 'allow',
     instructions: [inputs.instructionsPath],

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -154,6 +154,8 @@ export interface SandstormAPI {
     getEffective: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
     setSecret: (scope: 'global' | string, surface: 'inner' | 'outer', name: string, value: string) => Promise<void>;
     secretStatus: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
+    setSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer', bundle: Record<string, string>) => Promise<void>;
+    getSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<Record<string, string> | null>;
   };
   modelRouting: {
     getEffective: (projectDir: string) => Promise<Record<string, { backend: string; model: string }>>;
@@ -407,6 +409,8 @@ const api: SandstormAPI = {
     getEffective: (projectDir, surface) => ipcRenderer.invoke('backendSettings:getEffective', projectDir, surface),
     setSecret: (scope, surface, name, value) => ipcRenderer.invoke('backendSettings:setSecret', scope, surface, name, value),
     secretStatus: (scope, surface) => ipcRenderer.invoke('backendSettings:secretStatus', scope, surface),
+    setSecretBundle: (scope, surface, bundle) => ipcRenderer.invoke('backendSettings:setSecretBundle', scope, surface, bundle),
+    getSecretBundle: (scope, surface) => ipcRenderer.invoke('backendSettings:getSecretBundle', scope, surface),
   },
   modelRouting: {
     getEffective: (projectDir) => ipcRenderer.invoke('modelRouting:getEffective', projectDir),

--- a/src/renderer/components/ModelSettings.tsx
+++ b/src/renderer/components/ModelSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAppStore, ModelSettings as ModelSettingsType, ProjectTicketConfig } from '../store';
+import { PROVIDER_METADATA, getProviderMeta } from '../../shared/opencode-providers';
 
 type Tab = 'global' | 'project' | 'ticketing';
 
@@ -33,14 +34,6 @@ const PROJECT_BACKEND_OPTIONS = [
   { id: 'global', label: 'Use Global Default' },
   { id: 'claude', label: 'Claude Code' },
   { id: 'opencode', label: 'OpenCode' },
-] as const;
-
-const OPENCODE_PROVIDERS = [
-  { id: 'anthropic', label: 'Anthropic' },
-  { id: 'openai', label: 'OpenAI' },
-  { id: 'amazon-bedrock', label: 'Amazon Bedrock' },
-  { id: 'ollama', label: 'Ollama' },
-  { id: 'openrouter', label: 'OpenRouter' },
 ] as const;
 
 function ModelButton({
@@ -82,8 +75,8 @@ function BackendSelector({
   onProviderChange,
   model,
   onModelChange,
-  credInput,
-  onCredInputChange,
+  credBundle,
+  onCredBundleChange,
   credSet,
   testId,
 }: {
@@ -94,12 +87,14 @@ function BackendSelector({
   onProviderChange: (v: string) => void;
   model: string;
   onModelChange: (v: string) => void;
-  credInput: string;
-  onCredInputChange: (v: string) => void;
+  credBundle: Record<string, string>;
+  onCredBundleChange: (bundle: Record<string, string>) => void;
   credSet: boolean;
   testId: string;
 }) {
   const options = scope === 'global' ? GLOBAL_BACKEND_OPTIONS : PROJECT_BACKEND_OPTIONS;
+  const providerMeta = getProviderMeta(provider);
+
   return (
     <div className="space-y-2">
       <div className="flex gap-2 flex-wrap">
@@ -125,11 +120,11 @@ function BackendSelector({
             <label className="block text-[10px] font-medium text-sandstorm-text-secondary mb-1">Provider</label>
             <select
               value={provider}
-              onChange={(e) => { onProviderChange(e.target.value); }}
+              onChange={(e) => { onProviderChange(e.target.value); onCredBundleChange({}); }}
               className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
               data-testid={`${testId}-provider`}
             >
-              {OPENCODE_PROVIDERS.map((p) => (
+              {PROVIDER_METADATA.map((p) => (
                 <option key={p.id} value={p.id}>{p.label}</option>
               ))}
             </select>
@@ -140,27 +135,48 @@ function BackendSelector({
               type="text"
               value={model}
               onChange={(e) => { onModelChange(e.target.value); }}
-              placeholder="e.g. claude-sonnet-4-5"
+              placeholder="e.g. anthropic/claude-sonnet-4-6"
               className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
               data-testid={`${testId}-model`}
             />
           </div>
-          <div>
-            <label className="block text-[10px] font-medium text-sandstorm-text-secondary mb-1">
-              API Credential
+          <div className="space-y-1.5" data-testid={`${testId}-cred-fields`}>
+            <label className="block text-[10px] font-medium text-sandstorm-text-secondary">
+              Credentials
               <span className="ml-2 font-normal text-sandstorm-muted" data-testid={`${testId}-cred-status`}>
                 {credSet ? '(Set)' : '(Not set)'}
               </span>
             </label>
-            <input
-              type="password"
-              value={credInput}
-              onChange={(e) => { onCredInputChange(e.target.value); }}
-              placeholder={credSet ? 'Enter new value to update' : 'Enter API key'}
-              className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
-              data-testid={`${testId}-cred-input`}
-              autoComplete="new-password"
-            />
+            {providerMeta ? (
+              providerMeta.fields.map((field) => (
+                <div key={field.key}>
+                  <label className="block text-[10px] text-sandstorm-muted mb-0.5">
+                    {field.label}{field.required ? ' *' : ''}
+                  </label>
+                  <input
+                    type={field.type === 'password' ? 'password' : 'text'}
+                    value={credBundle[field.key] ?? ''}
+                    onChange={(e) => {
+                      onCredBundleChange({ ...credBundle, [field.key]: e.target.value });
+                    }}
+                    placeholder={credSet ? 'Enter new value to update' : (field.placeholder ?? '')}
+                    className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
+                    data-testid={`${testId}-cred-${field.key}`}
+                    autoComplete="new-password"
+                  />
+                </div>
+              ))
+            ) : (
+              <input
+                type="password"
+                value={credBundle['apiKey'] ?? ''}
+                onChange={(e) => { onCredBundleChange({ ...credBundle, apiKey: e.target.value }); }}
+                placeholder={credSet ? 'Enter new value to update' : 'Enter API key'}
+                className="w-full bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-1.5 text-xs text-sandstorm-text focus:outline-none focus:ring-1 focus:ring-sandstorm-accent"
+                data-testid={`${testId}-cred-input`}
+                autoComplete="new-password"
+              />
+            )}
           </div>
         </div>
       )}
@@ -189,6 +205,8 @@ export function ModelSettingsModal() {
     getEffectiveBackend,
     setBackendSecret,
     getBackendSecretStatus,
+    setBackendSecretBundle,
+    getBackendSecretBundle,
   } = useAppStore();
 
   const project = activeProject();
@@ -203,12 +221,12 @@ export function ModelSettingsModal() {
   const [globalInnerBackend, setGlobalInnerBackend] = useState<string>(globalBackendSettings.inner_backend ?? 'claude');
   const [globalInnerProvider, setGlobalInnerProvider] = useState<string>(globalBackendSettings.inner_provider ?? 'anthropic');
   const [globalInnerModel, setGlobalInnerModel] = useState<string>(globalBackendSettings.inner_model ?? '');
-  const [globalInnerCredInput, setGlobalInnerCredInput] = useState('');
+  const [globalInnerCredBundle, setGlobalInnerCredBundle] = useState<Record<string, string>>({});
   const [globalInnerCredSet, setGlobalInnerCredSet] = useState(false);
   const [globalOuterBackend, setGlobalOuterBackend] = useState<string>(globalBackendSettings.outer_backend ?? 'claude');
   const [globalOuterProvider, setGlobalOuterProvider] = useState<string>(globalBackendSettings.outer_provider ?? 'anthropic');
   const [globalOuterModel, setGlobalOuterModel] = useState<string>(globalBackendSettings.outer_model ?? '');
-  const [globalOuterCredInput, setGlobalOuterCredInput] = useState('');
+  const [globalOuterCredBundle, setGlobalOuterCredBundle] = useState<Record<string, string>>({});
   const [globalOuterCredSet, setGlobalOuterCredSet] = useState(false);
   const [globalBackendLoaded, setGlobalBackendLoaded] = useState(false);
 
@@ -222,12 +240,12 @@ export function ModelSettingsModal() {
   const [projectInnerBackend, setProjectInnerBackend] = useState<string>('global');
   const [projectInnerProvider, setProjectInnerProvider] = useState<string>('anthropic');
   const [projectInnerModel, setProjectInnerModel] = useState<string>('');
-  const [projectInnerCredInput, setProjectInnerCredInput] = useState('');
+  const [projectInnerCredBundle, setProjectInnerCredBundle] = useState<Record<string, string>>({});
   const [projectInnerCredSet, setProjectInnerCredSet] = useState(false);
   const [projectOuterBackend, setProjectOuterBackend] = useState<string>('global');
   const [projectOuterProvider, setProjectOuterProvider] = useState<string>('anthropic');
   const [projectOuterModel, setProjectOuterModel] = useState<string>('');
-  const [projectOuterCredInput, setProjectOuterCredInput] = useState('');
+  const [projectOuterCredBundle, setProjectOuterCredBundle] = useState<Record<string, string>>({});
   const [projectOuterCredSet, setProjectOuterCredSet] = useState(false);
   const [projectBackendLoaded, setProjectBackendLoaded] = useState(false);
 
@@ -290,6 +308,9 @@ export function ModelSettingsModal() {
     ]);
     setGlobalInnerCredSet(innerStatus.set);
     setGlobalOuterCredSet(outerStatus.set);
+    // Reset bundle inputs so stale values don't persist across reopens
+    setGlobalInnerCredBundle({});
+    setGlobalOuterCredBundle({});
     setGlobalBackendLoaded(true);
   }, [refreshGlobalBackendSettings, getBackendSecretStatus]);
 
@@ -339,6 +360,8 @@ export function ModelSettingsModal() {
     ]);
     setProjectInnerCredSet(innerStatus.set);
     setProjectOuterCredSet(outerStatus.set);
+    setProjectInnerCredBundle({});
+    setProjectOuterCredBundle({});
     setProjectBackendLoaded(true);
   }, [project, getProjectBackendSettings, getBackendSecretStatus]);
 
@@ -404,14 +427,14 @@ export function ModelSettingsModal() {
         outer_provider: globalOuterBackend === 'opencode' ? (globalOuterProvider || null) : null,
         outer_model: globalOuterBackend === 'opencode' ? (globalOuterModel || null) : null,
       });
-      if (globalInnerBackend === 'opencode' && globalInnerCredInput) {
-        await setBackendSecret('global', 'inner', globalInnerCredInput);
-        setGlobalInnerCredInput('');
+      if (globalInnerBackend === 'opencode' && Object.values(globalInnerCredBundle).some(Boolean)) {
+        await setBackendSecretBundle('global', 'inner', globalInnerCredBundle);
+        setGlobalInnerCredBundle({});
         setGlobalInnerCredSet(true);
       }
-      if (globalOuterBackend === 'opencode' && globalOuterCredInput) {
-        await setBackendSecret('global', 'outer', globalOuterCredInput);
-        setGlobalOuterCredInput('');
+      if (globalOuterBackend === 'opencode' && Object.values(globalOuterCredBundle).some(Boolean)) {
+        await setBackendSecretBundle('global', 'outer', globalOuterCredBundle);
+        setGlobalOuterCredBundle({});
         setGlobalOuterCredSet(true);
       }
       setGlobalDirty(false);
@@ -440,14 +463,14 @@ export function ModelSettingsModal() {
         outer_provider: projectOuterBackend === 'opencode' ? (projectOuterProvider || null) : null,
         outer_model: projectOuterBackend === 'opencode' ? (projectOuterModel || null) : null,
       });
-      if (projectInnerBackend === 'opencode' && projectInnerCredInput) {
-        await setBackendSecret(project.directory, 'inner', projectInnerCredInput);
-        setProjectInnerCredInput('');
+      if (projectInnerBackend === 'opencode' && Object.values(projectInnerCredBundle).some(Boolean)) {
+        await setBackendSecretBundle(project.directory, 'inner', projectInnerCredBundle);
+        setProjectInnerCredBundle({});
         setProjectInnerCredSet(true);
       }
-      if (projectOuterBackend === 'opencode' && projectOuterCredInput) {
-        await setBackendSecret(project.directory, 'outer', projectOuterCredInput);
-        setProjectOuterCredInput('');
+      if (projectOuterBackend === 'opencode' && Object.values(projectOuterCredBundle).some(Boolean)) {
+        await setBackendSecretBundle(project.directory, 'outer', projectOuterCredBundle);
+        setProjectOuterCredBundle({});
         setProjectOuterCredSet(true);
       }
       await loadEffectiveBackend();
@@ -606,8 +629,8 @@ export function ModelSettingsModal() {
                   onProviderChange={(v) => { setGlobalInnerProvider(v); setGlobalDirty(true); }}
                   model={globalInnerModel}
                   onModelChange={(v) => { setGlobalInnerModel(v); setGlobalDirty(true); }}
-                  credInput={globalInnerCredInput}
-                  onCredInputChange={(v) => { setGlobalInnerCredInput(v); setGlobalDirty(true); }}
+                  credBundle={globalInnerCredBundle}
+                  onCredBundleChange={(b) => { setGlobalInnerCredBundle(b); setGlobalDirty(true); }}
                   credSet={globalInnerCredSet}
                   testId="global-inner-backend"
                 />
@@ -652,8 +675,8 @@ export function ModelSettingsModal() {
                   onProviderChange={(v) => { setGlobalOuterProvider(v); setGlobalDirty(true); }}
                   model={globalOuterModel}
                   onModelChange={(v) => { setGlobalOuterModel(v); setGlobalDirty(true); }}
-                  credInput={globalOuterCredInput}
-                  onCredInputChange={(v) => { setGlobalOuterCredInput(v); setGlobalDirty(true); }}
+                  credBundle={globalOuterCredBundle}
+                  onCredBundleChange={(b) => { setGlobalOuterCredBundle(b); setGlobalDirty(true); }}
                   credSet={globalOuterCredSet}
                   testId="global-outer-backend"
                 />
@@ -702,8 +725,8 @@ export function ModelSettingsModal() {
                   onProviderChange={(v) => { setProjectInnerProvider(v); setProjectDirty(true); }}
                   model={projectInnerModel}
                   onModelChange={(v) => { setProjectInnerModel(v); setProjectDirty(true); }}
-                  credInput={projectInnerCredInput}
-                  onCredInputChange={(v) => { setProjectInnerCredInput(v); setProjectDirty(true); }}
+                  credBundle={projectInnerCredBundle}
+                  onCredBundleChange={(b) => { setProjectInnerCredBundle(b); setProjectDirty(true); }}
                   credSet={projectInnerCredSet}
                   testId="project-inner-backend"
                 />
@@ -748,8 +771,8 @@ export function ModelSettingsModal() {
                   onProviderChange={(v) => { setProjectOuterProvider(v); setProjectDirty(true); }}
                   model={projectOuterModel}
                   onModelChange={(v) => { setProjectOuterModel(v); setProjectDirty(true); }}
-                  credInput={projectOuterCredInput}
-                  onCredInputChange={(v) => { setProjectOuterCredInput(v); setProjectDirty(true); }}
+                  credBundle={projectOuterCredBundle}
+                  onCredBundleChange={(b) => { setProjectOuterCredBundle(b); setProjectDirty(true); }}
                   credSet={projectOuterCredSet}
                   testId="project-outer-backend"
                 />

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -491,6 +491,8 @@ interface AppState {
   getEffectiveBackend: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
   setBackendSecret: (scope: 'global' | string, surface: 'inner' | 'outer', value: string) => Promise<void>;
   getBackendSecretStatus: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
+  setBackendSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer', bundle: Record<string, string>) => Promise<void>;
+  getBackendSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<Record<string, string> | null>;
 
   // Project ticket config
   getProjectTicketConfig: (projectDir: string) => Promise<ProjectTicketConfig | null>;
@@ -794,6 +796,8 @@ declare global {
         getEffective: (projectDir: string, surface: 'inner' | 'outer') => Promise<{ backend: 'claude' | 'opencode'; provider?: string; model?: string }>;
         setSecret: (scope: 'global' | string, surface: 'inner' | 'outer', name: string, value: string) => Promise<void>;
         secretStatus: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<{ set: boolean }>;
+        setSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer', bundle: Record<string, string>) => Promise<void>;
+        getSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<Record<string, string> | null>;
       };
       projectTicketConfig: {
         get: (projectDir: string) => Promise<ProjectTicketConfig | null>;
@@ -1129,6 +1133,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   getBackendSecretStatus: async (scope, surface) => {
     return window.sandstorm.backendSettings.secretStatus(scope, surface);
+  },
+
+  setBackendSecretBundle: async (scope, surface, bundle) => {
+    await window.sandstorm.backendSettings.setSecretBundle(scope, surface, bundle);
+  },
+
+  getBackendSecretBundle: async (scope, surface) => {
+    return window.sandstorm.backendSettings.getSecretBundle(scope, surface);
   },
 
   // Project ticket config

--- a/src/shared/opencode-providers.ts
+++ b/src/shared/opencode-providers.ts
@@ -1,0 +1,153 @@
+/**
+ * Provider→required-fields metadata for OpenCode providers.
+ * Single owner: this file. Consumers (config modal, syncCredentials, config generator) import from here.
+ */
+
+export interface ProviderField {
+  /** Key in the credential bundle stored in backend_secrets */
+  key: string;
+  label: string;
+  type: 'password' | 'text' | 'url';
+  required: boolean;
+  /** Corresponding env var name for compose passthrough (undefined = config-only, no env var) */
+  envVar?: string;
+  placeholder?: string;
+}
+
+export interface ProviderMeta {
+  id: string;
+  label: string;
+  fields: ProviderField[];
+}
+
+export const PROVIDER_METADATA: readonly ProviderMeta[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    fields: [
+      {
+        key: 'apiKey',
+        label: 'API Key',
+        type: 'password',
+        required: true,
+        envVar: 'ANTHROPIC_API_KEY',
+        placeholder: 'sk-ant-...',
+      },
+    ],
+  },
+  {
+    id: 'amazon-bedrock',
+    label: 'Amazon Bedrock',
+    fields: [
+      {
+        key: 'region',
+        label: 'AWS Region',
+        type: 'text',
+        required: true,
+        envVar: 'AWS_REGION',
+        placeholder: 'us-east-1',
+      },
+      {
+        key: 'accessKeyId',
+        label: 'Access Key ID',
+        type: 'text',
+        required: false,
+        envVar: 'AWS_ACCESS_KEY_ID',
+        placeholder: 'AKIA...',
+      },
+      {
+        key: 'secretAccessKey',
+        label: 'Secret Access Key',
+        type: 'password',
+        required: false,
+        envVar: 'AWS_SECRET_ACCESS_KEY',
+      },
+      {
+        key: 'bearerToken',
+        label: 'Bearer Token (alternative to access keys)',
+        type: 'password',
+        required: false,
+        envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+      },
+      {
+        key: 'profile',
+        label: 'AWS Profile (alternative to access keys)',
+        type: 'text',
+        required: false,
+        envVar: 'AWS_PROFILE',
+      },
+    ],
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama',
+    fields: [
+      {
+        key: 'baseUrl',
+        label: 'Base URL',
+        type: 'url',
+        required: true,
+        placeholder: 'http://host:11434/v1',
+      },
+    ],
+  },
+] as const;
+
+export function getProviderMeta(id: string): ProviderMeta | undefined {
+  return PROVIDER_METADATA.find((p) => p.id === id);
+}
+
+/**
+ * Returns { providerKey, config } where providerKey is the key used in the OpenCode
+ * config's provider map, and config is the value object for that provider.
+ *
+ * Bedrock uses 'amazon-bedrock', Ollama uses 'openai' (custom OpenAI-compatible endpoint).
+ * Falls back to `{env:…}` placeholders when no bundle fields are present (container startup path).
+ */
+export function buildProviderEntry(
+  providerId: string,
+  bundle: Record<string, string>,
+): { providerKey: string; config: Record<string, unknown> } {
+  switch (providerId) {
+    case 'anthropic':
+      return {
+        providerKey: 'anthropic',
+        config: bundle.apiKey
+          ? { apiKey: bundle.apiKey }
+          : { apiKey: '{env:ANTHROPIC_API_KEY}' },
+      };
+
+    case 'amazon-bedrock': {
+      const options: Record<string, string> = {};
+      if (bundle.region) options.region = bundle.region;
+      if (bundle.bearerToken) {
+        options.bearerToken = bundle.bearerToken;
+      } else {
+        if (bundle.accessKeyId) options.accessKeyId = bundle.accessKeyId;
+        if (bundle.secretAccessKey) options.secretAccessKey = bundle.secretAccessKey;
+        if (bundle.profile) options.profile = bundle.profile;
+      }
+      return {
+        providerKey: 'amazon-bedrock',
+        config: Object.keys(options).length > 0 ? { options } : {},
+      };
+    }
+
+    case 'ollama':
+      return {
+        providerKey: 'openai',
+        config: {
+          apiKey: 'ollama',
+          ...(bundle.baseUrl ? { baseURL: bundle.baseUrl } : {}),
+        },
+      };
+
+    default:
+      return {
+        providerKey: providerId,
+        config: bundle.apiKey
+          ? { apiKey: bundle.apiKey }
+          : { apiKey: `{env:${providerId.toUpperCase().replace(/-/g, '_')}_API_KEY}` },
+      };
+  }
+}

--- a/tests/unit/agent/opencode-backend.test.ts
+++ b/tests/unit/agent/opencode-backend.test.ts
@@ -82,7 +82,17 @@ vi.mock('../../../src/main/claude/tools', () => ({
 vi.mock('../../../src/main/index', () => ({
   stackManager: {},
   agentBackend: {},
-  registry: {},
+  registry: {
+    getGlobalBackendSettings: vi.fn().mockReturnValue({
+      inner_backend: 'opencode',
+      inner_provider: 'anthropic',
+      inner_model: null,
+      outer_backend: 'claude',
+      outer_provider: null,
+      outer_model: null,
+    }),
+    getBackendSecretBundle: vi.fn().mockReturnValue(null),
+  },
   cliDir: '/tmp/sandstorm-cli',
 }));
 

--- a/tests/unit/backend-settings-v25.test.ts
+++ b/tests/unit/backend-settings-v25.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Registry } from '../../src/main/control-plane/registry';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+function makeTempDb(): string {
+  return path.join(os.tmpdir(), `sandstorm-v25-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+describe('Registry v25 — backend_secrets bundle read/write', () => {
+  let registry: Registry;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  describe('schema version', () => {
+    it('migrates to at least version 25 on fresh database', () => {
+      // Registry constructor applies all migrations including v25.
+      // If no error thrown and bundle methods exist, migration ran successfully.
+      expect(typeof registry.setBackendSecretBundle).toBe('function');
+      expect(typeof registry.getBackendSecretBundle).toBe('function');
+    });
+  });
+
+  describe('setBackendSecretBundle / getBackendSecretBundle', () => {
+    it('round-trip: store and retrieve a multi-field bundle', () => {
+      registry.setBackendSecretBundle('global', 'inner', {
+        region: 'us-east-1',
+        accessKeyId: 'AKIATEST',
+        secretAccessKey: 'secret123',
+      });
+      const bundle = registry.getBackendSecretBundle('global', 'inner');
+      expect(bundle).toEqual({
+        region: 'us-east-1',
+        accessKeyId: 'AKIATEST',
+        secretAccessKey: 'secret123',
+      });
+    });
+
+    it('hasBackendSecret returns true after setBackendSecretBundle', () => {
+      registry.setBackendSecretBundle('global', 'inner', { apiKey: 'sk-ant-test' });
+      expect(registry.hasBackendSecret('global', 'inner')).toBe(true);
+    });
+
+    it('returns null when no bundle is stored', () => {
+      expect(registry.getBackendSecretBundle('global', 'inner')).toBeNull();
+    });
+
+    it('different key/surface pairs are independent', () => {
+      registry.setBackendSecretBundle('global', 'inner', { apiKey: 'inner-key' });
+      expect(registry.getBackendSecretBundle('global', 'outer')).toBeNull();
+    });
+
+    it('overwrites previous bundle', () => {
+      registry.setBackendSecretBundle('global', 'inner', { apiKey: 'old-key' });
+      registry.setBackendSecretBundle('global', 'inner', { apiKey: 'new-key' });
+      const bundle = registry.getBackendSecretBundle('global', 'inner');
+      expect(bundle?.apiKey).toBe('new-key');
+    });
+
+    it('project-scoped bundle is independent of global', () => {
+      const projectKey = `project:${path.resolve('/proj/a')}`;
+      registry.setBackendSecretBundle(projectKey, 'inner', { apiKey: 'proj-key' });
+      expect(registry.getBackendSecretBundle('global', 'inner')).toBeNull();
+      expect(registry.getBackendSecretBundle(projectKey, 'inner')?.apiKey).toBe('proj-key');
+    });
+
+    it('stores anthropic bundle with apiKey only', () => {
+      registry.setBackendSecretBundle('global', 'outer', { apiKey: 'sk-ant-outer' });
+      const bundle = registry.getBackendSecretBundle('global', 'outer');
+      expect(bundle?.apiKey).toBe('sk-ant-outer');
+    });
+
+    it('stores bedrock bundle with all credential fields', () => {
+      registry.setBackendSecretBundle('global', 'inner', {
+        region: 'eu-west-1',
+        bearerToken: 'bt-secret',
+      });
+      const bundle = registry.getBackendSecretBundle('global', 'inner');
+      expect(bundle?.region).toBe('eu-west-1');
+      expect(bundle?.bearerToken).toBe('bt-secret');
+    });
+
+    it('stores ollama bundle with baseUrl', () => {
+      registry.setBackendSecretBundle('global', 'inner', {
+        baseUrl: 'http://host:11434/v1',
+      });
+      const bundle = registry.getBackendSecretBundle('global', 'inner');
+      expect(bundle?.baseUrl).toBe('http://host:11434/v1');
+    });
+  });
+
+  describe('backward compatibility — legacy single-field rows', () => {
+    it('getBackendSecretBundle reads legacy name+value row as { [name]: value }', () => {
+      // Write a legacy row (pre-v25 format: name='api_key', value='sk-legacy')
+      registry.setBackendSecret('global', 'inner', 'api_key', 'sk-legacy');
+      const bundle = registry.getBackendSecretBundle('global', 'inner');
+      expect(bundle).toEqual({ api_key: 'sk-legacy' });
+    });
+
+    it('hasBackendSecret works for legacy rows', () => {
+      registry.setBackendSecret('global', 'inner', 'api_key', 'sk-legacy');
+      expect(registry.hasBackendSecret('global', 'inner')).toBe(true);
+    });
+
+    it('setBackendSecretBundle overwrites a legacy row', () => {
+      registry.setBackendSecret('global', 'inner', 'api_key', 'sk-legacy');
+      registry.setBackendSecretBundle('global', 'inner', { apiKey: 'sk-new' });
+      const bundle = registry.getBackendSecretBundle('global', 'inner');
+      expect(bundle?.apiKey).toBe('sk-new');
+      // Legacy field is gone
+      expect(bundle?.api_key).toBeUndefined();
+    });
+  });
+
+  describe('migration idempotency', () => {
+    it('opening the same database twice does not throw', async () => {
+      registry.close();
+      const registry2 = await Registry.create(dbPath);
+      expect(registry2).toBeDefined();
+      registry2.close();
+      // Reopen to satisfy afterEach
+      registry = await Registry.create(dbPath);
+    });
+  });
+});

--- a/tests/unit/components/BackendSelector-provider-fields.test.tsx
+++ b/tests/unit/components/BackendSelector-provider-fields.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ModelSettingsModal } from '../../../src/renderer/components/ModelSettings';
+import { useAppStore } from '../../../src/renderer/store';
+import { mockSandstormApi } from './setup';
+
+describe('BackendSelector — per-provider credential fields', () => {
+  const OPENCODE_GLOBAL_SETTINGS = {
+    inner_backend: 'opencode',
+    outer_backend: 'claude',
+    inner_provider: 'anthropic',
+    inner_model: null,
+    outer_provider: null,
+    outer_model: null,
+  };
+
+  beforeEach(() => {
+    const api = mockSandstormApi();
+    // Override default mock so component doesn't overwrite store with 'claude'
+    (api.backendSettings.getGlobal as ReturnType<typeof vi.fn>).mockResolvedValue(OPENCODE_GLOBAL_SETTINGS);
+    useAppStore.setState({
+      projects: [],
+      activeProjectId: null,
+      showModelSettings: true,
+      globalModelSettings: { inner_model: 'sonnet', outer_model: 'opus' },
+      globalBackendSettings: OPENCODE_GLOBAL_SETTINGS,
+    });
+  });
+
+  it('shows opencode fields when OpenCode backend is selected', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
+    });
+    const openCodeFields = screen.getByTestId('global-inner-backend-opencode-fields');
+    expect(openCodeFields).toBeDefined();
+  });
+
+  it('renders provider selector from PROVIDER_METADATA (anthropic, amazon-bedrock, ollama)', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-provider')).toBeDefined();
+    });
+    const select = screen.getByTestId('global-inner-backend-provider') as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain('anthropic');
+    expect(options).toContain('amazon-bedrock');
+    expect(options).toContain('ollama');
+  });
+
+  it('renders apiKey field for anthropic provider', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      // anthropic has one field: apiKey
+      expect(screen.getByTestId('global-inner-backend-cred-apiKey')).toBeDefined();
+    });
+    const input = screen.getByTestId('global-inner-backend-cred-apiKey') as HTMLInputElement;
+    expect(input.type).toBe('password');
+  });
+
+  it('switching to amazon-bedrock shows region and credential fields', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-provider')).toBeDefined();
+    });
+    // Switch provider to amazon-bedrock
+    fireEvent.change(screen.getByTestId('global-inner-backend-provider'), {
+      target: { value: 'amazon-bedrock' },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-cred-region')).toBeDefined();
+    });
+    expect(screen.getByTestId('global-inner-backend-cred-accessKeyId')).toBeDefined();
+    expect(screen.getByTestId('global-inner-backend-cred-secretAccessKey')).toBeDefined();
+    expect(screen.getByTestId('global-inner-backend-cred-bearerToken')).toBeDefined();
+    expect(screen.getByTestId('global-inner-backend-cred-profile')).toBeDefined();
+  });
+
+  it('switching to ollama shows baseUrl field', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-provider')).toBeDefined();
+    });
+    fireEvent.change(screen.getByTestId('global-inner-backend-provider'), {
+      target: { value: 'ollama' },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-cred-baseUrl')).toBeDefined();
+    });
+    const input = screen.getByTestId('global-inner-backend-cred-baseUrl') as HTMLInputElement;
+    expect(input.type).toBe('text');
+  });
+
+  it('switching provider clears the credential bundle', async () => {
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-cred-apiKey')).toBeDefined();
+    });
+    // Type an API key
+    fireEvent.change(screen.getByTestId('global-inner-backend-cred-apiKey'), {
+      target: { value: 'sk-test' },
+    });
+    // Switch provider
+    fireEvent.change(screen.getByTestId('global-inner-backend-provider'), {
+      target: { value: 'ollama' },
+    });
+    await waitFor(() => {
+      const baseUrl = screen.getByTestId('global-inner-backend-cred-baseUrl') as HTMLInputElement;
+      // Bundle was cleared on provider switch — baseUrl starts empty
+      expect(baseUrl.value).toBe('');
+    });
+  });
+
+  it('hides credential fields when Claude Code backend is selected', async () => {
+    // Reset mock to default (claude) to override beforeEach's opencode mock
+    mockSandstormApi();
+    useAppStore.setState({
+      globalBackendSettings: {
+        inner_backend: 'claude',
+        outer_backend: 'claude',
+        inner_provider: null,
+        inner_model: null,
+        outer_provider: null,
+        outer_model: null,
+      },
+    });
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      expect(screen.getByTestId('global-inner-backend-claude')).toBeDefined();
+    });
+    // OpenCode fields not rendered
+    expect(screen.queryByTestId('global-inner-backend-opencode-fields')).toBeNull();
+  });
+
+  it('shows (Set) cred status when credSet is true', async () => {
+    // Mock secretStatus to return set: true, keep getGlobal returning opencode settings
+    const api = mockSandstormApi();
+    (api.backendSettings.getGlobal as ReturnType<typeof vi.fn>).mockResolvedValue(OPENCODE_GLOBAL_SETTINGS);
+    (api.backendSettings.secretStatus as ReturnType<typeof vi.fn>).mockResolvedValue({ set: true });
+    render(<ModelSettingsModal />);
+    await waitFor(() => {
+      const status = screen.getByTestId('global-inner-backend-cred-status');
+      expect(status.textContent).toContain('(Set)');
+    });
+  });
+});

--- a/tests/unit/components/ModelSettings.test.tsx
+++ b/tests/unit/components/ModelSettings.test.tsx
@@ -158,7 +158,8 @@ describe('ModelSettingsModal', () => {
       await waitFor(() => {
         expect(screen.getByTestId('global-inner-backend-provider')).toBeDefined();
         expect(screen.getByTestId('global-inner-backend-model')).toBeDefined();
-        expect(screen.getByTestId('global-inner-backend-cred-input')).toBeDefined();
+        // anthropic (default) uses apiKey field
+        expect(screen.getByTestId('global-inner-backend-cred-apiKey')).toBeDefined();
       });
     });
 
@@ -171,7 +172,7 @@ describe('ModelSettingsModal', () => {
       fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
       await waitFor(() => {
         expect(screen.getByTestId('global-inner-backend-cred-status').textContent).toContain('Set');
-        const credInput = screen.getByTestId('global-inner-backend-cred-input') as HTMLInputElement;
+        const credInput = screen.getByTestId('global-inner-backend-cred-apiKey') as HTMLInputElement;
         expect(credInput.value).toBe('');
       });
     });
@@ -202,23 +203,23 @@ describe('ModelSettingsModal', () => {
       });
     });
 
-    it('calls setSecret with scope=global when credential is entered', async () => {
+    it('calls setSecretBundle with scope=global when credential is entered', async () => {
       render(<ModelSettingsModal />);
       await waitFor(() => {
         expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
       });
       fireEvent.click(screen.getByTestId('global-inner-backend-opencode'));
       await waitFor(() => {
-        expect(screen.getByTestId('global-inner-backend-cred-input')).toBeDefined();
+        expect(screen.getByTestId('global-inner-backend-cred-apiKey')).toBeDefined();
       });
-      fireEvent.change(screen.getByTestId('global-inner-backend-cred-input'), { target: { value: 'sk-test-key' } });
+      fireEvent.change(screen.getByTestId('global-inner-backend-cred-apiKey'), { target: { value: 'sk-test-key' } });
       fireEvent.click(screen.getByTestId('model-settings-save'));
       await waitFor(() => {
-        expect(api.backendSettings.setSecret).toHaveBeenCalledWith('global', 'inner', 'api_key', 'sk-test-key');
+        expect(api.backendSettings.setSecretBundle).toHaveBeenCalledWith('global', 'inner', expect.objectContaining({ apiKey: 'sk-test-key' }));
       });
     });
 
-    it('does not call setSecret when credential input is empty', async () => {
+    it('does not call setSecretBundle when credential input is empty', async () => {
       render(<ModelSettingsModal />);
       await waitFor(() => {
         expect(screen.getByTestId('global-inner-backend-opencode')).toBeDefined();
@@ -229,7 +230,7 @@ describe('ModelSettingsModal', () => {
       await waitFor(() => {
         expect(api.backendSettings.setGlobal).toHaveBeenCalled();
       });
-      expect(api.backendSettings.setSecret).not.toHaveBeenCalled();
+      expect(api.backendSettings.setSecretBundle).not.toHaveBeenCalled();
     });
 
     it('provider change does not clear credential status', async () => {
@@ -246,7 +247,7 @@ describe('ModelSettingsModal', () => {
       fireEvent.change(screen.getByTestId('global-inner-backend-provider'), { target: { value: 'openai' } });
       // Status should still be Set
       expect(screen.getByTestId('global-inner-backend-cred-status').textContent).toContain('Set');
-      expect(api.backendSettings.setSecret).not.toHaveBeenCalled();
+      expect(api.backendSettings.setSecretBundle).not.toHaveBeenCalled();
     });
   });
 
@@ -562,19 +563,19 @@ describe('ModelSettingsModal', () => {
         });
       });
 
-      it('calls setSecret with scope=projectDir when credential is entered for project', async () => {
+      it('calls setSecretBundle with scope=projectDir when credential is entered for project', async () => {
         render(<ModelSettingsModal />);
         await waitFor(() => {
           expect(screen.getByTestId('project-inner-backend-opencode')).toBeDefined();
         });
         fireEvent.click(screen.getByTestId('project-inner-backend-opencode'));
         await waitFor(() => {
-          expect(screen.getByTestId('project-inner-backend-cred-input')).toBeDefined();
+          expect(screen.getByTestId('project-inner-backend-cred-apiKey')).toBeDefined();
         });
-        fireEvent.change(screen.getByTestId('project-inner-backend-cred-input'), { target: { value: 'sk-proj-key' } });
+        fireEvent.change(screen.getByTestId('project-inner-backend-cred-apiKey'), { target: { value: 'sk-proj-key' } });
         fireEvent.click(screen.getByTestId('model-settings-save'));
         await waitFor(() => {
-          expect(api.backendSettings.setSecret).toHaveBeenCalledWith('/myapp', 'inner', 'api_key', 'sk-proj-key');
+          expect(api.backendSettings.setSecretBundle).toHaveBeenCalledWith('/myapp', 'inner', expect.objectContaining({ apiKey: 'sk-proj-key' }));
         });
       });
 
@@ -627,12 +628,12 @@ describe('ModelSettingsModal', () => {
         fireEvent.change(screen.getByTestId('project-inner-backend-provider'), { target: { value: 'openai' } });
         // Status unchanged
         expect(screen.getByTestId('project-inner-backend-cred-status').textContent).toContain('Set');
-        // Save — should not call setSecret (no new cred value entered)
+        // Save — should not call setSecretBundle (no new cred value entered)
         fireEvent.click(screen.getByTestId('model-settings-save'));
         await waitFor(() => {
           expect(api.backendSettings.setProject).toHaveBeenCalled();
         });
-        expect(api.backendSettings.setSecret).not.toHaveBeenCalled();
+        expect(api.backendSettings.setSecretBundle).not.toHaveBeenCalled();
       });
     });
 

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -121,6 +121,8 @@ export function mockSandstormApi() {
       getEffective: vi.fn().mockResolvedValue({ backend: 'claude' }),
       setSecret: vi.fn().mockResolvedValue(undefined),
       secretStatus: vi.fn().mockResolvedValue({ set: false }),
+      setSecretBundle: vi.fn().mockResolvedValue(undefined),
+      getSecretBundle: vi.fn().mockResolvedValue(null),
     },
     projectTicketConfig: {
       get: vi.fn().mockResolvedValue(null),

--- a/tests/unit/compose-generator.test.ts
+++ b/tests/unit/compose-generator.test.ts
@@ -266,6 +266,13 @@ describe('compose-generator', () => {
       expect(yaml).not.toContain(':/home/claude/.claude ');
       // OpenCode config env passthrough (additive; Claude stacks unchanged beyond this line)
       expect(yaml).toContain('      - OPENCODE_CONFIG');
+      // Provider credential env passthrough
+      expect(yaml).toContain('      - ANTHROPIC_API_KEY');
+      expect(yaml).toContain('      - AWS_BEARER_TOKEN_BEDROCK');
+      expect(yaml).toContain('      - AWS_ACCESS_KEY_ID');
+      expect(yaml).toContain('      - AWS_SECRET_ACCESS_KEY');
+      expect(yaml).toContain('      - AWS_REGION');
+      expect(yaml).toContain('      - AWS_PROFILE');
     });
 
     it('includes network overrides when named networks exist', () => {

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -2650,6 +2650,8 @@ describe('IPC Handlers', () => {
       'backendSettings:getEffective',
       'backendSettings:setSecret',
       'backendSettings:secretStatus',
+      'backendSettings:setSecretBundle',
+      'backendSettings:getSecretBundle',
       'modelRouting:getEffective',
       'modelRouting:getProject',
       'modelRouting:setProject',

--- a/tests/unit/main/opencode-syncCredentials.test.ts
+++ b/tests/unit/main/opencode-syncCredentials.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenCodeBackend } from '../../../src/main/agent/opencode-backend';
+import type { StackInfo } from '../../../src/main/agent/types';
+
+// Mock child_process.spawn so we don't need Docker
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn().mockImplementation(() => {
+      const proc = {
+        stdin: { write: vi.fn(), end: vi.fn() },
+        on: vi.fn().mockImplementation((event: string, cb: () => void) => {
+          if (event === 'close' || event === 'error') cb();
+          return proc;
+        }),
+      };
+      return proc;
+    }),
+  };
+});
+
+// Mock the '../index' import to return a fake registry
+vi.mock('../../../src/main/index', () => ({
+  registry: {
+    getGlobalBackendSettings: vi.fn().mockReturnValue({
+      inner_backend: 'opencode',
+      inner_provider: 'anthropic',
+      inner_model: null,
+      outer_backend: 'claude',
+      outer_provider: null,
+      outer_model: null,
+    }),
+    getBackendSecretBundle: vi.fn().mockReturnValue({ apiKey: 'sk-test-bedrock' }),
+  },
+  cliDir: '/fake/cli',
+}));
+
+// Mock opencode-config so we don't need the full runtime
+vi.mock('../../../src/main/opencode-config', () => ({
+  generateOpencodeConfig: vi.fn().mockReturnValue({
+    model: 'anthropic/claude-sonnet-4-6',
+    provider: { anthropic: { apiKey: 'sk-test-bedrock' } },
+    permission: 'allow',
+    instructions: ['/home/claude/.claude/CLAUDE.md'],
+    mcp: {},
+  }),
+}));
+
+describe('OpenCodeBackend.syncCredentials', () => {
+  let backend: OpenCodeBackend;
+
+  beforeEach(() => {
+    backend = new OpenCodeBackend();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips stacks that are not running or up', async () => {
+    const { spawn } = await import('child_process');
+    const stacks: StackInfo[] = [
+      { status: 'building', services: [{ name: 'claude', status: 'starting', containerId: 'cid1' }] },
+      { status: 'stopped', services: [{ name: 'claude', status: 'exited', containerId: 'cid2' }] },
+    ];
+    await backend.syncCredentials(stacks);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('skips stacks with no claude service', async () => {
+    const { spawn } = await import('child_process');
+    const stacks: StackInfo[] = [
+      { status: 'running', services: [{ name: 'app', status: 'running', containerId: 'cid1' }] },
+    ];
+    await backend.syncCredentials(stacks);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('calls docker exec to clean auth.json for running stacks', async () => {
+    const { spawn } = await import('child_process');
+    const stacks: StackInfo[] = [
+      { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'abc123' }] },
+    ];
+    await backend.syncCredentials(stacks);
+
+    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
+    // Should have been called at least once for auth.json cleanup
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+
+    // First call should be the auth.json cleanup
+    const [cmd, args] = calls[0];
+    expect(cmd).toBe('docker');
+    expect(args).toContain('exec');
+    expect(args).toContain('abc123');
+    const scriptArg = args.find((a: string) => a.includes('auth.json'));
+    expect(scriptArg).toBeDefined();
+    expect(scriptArg).toContain('rm -f');
+  });
+
+  it('writes generated config to /tmp/sandstorm-opencode.json', async () => {
+    const { spawn } = await import('child_process');
+    const stacks: StackInfo[] = [
+      { status: 'up', services: [{ name: 'claude', status: 'running', containerId: 'def456' }] },
+    ];
+    await backend.syncCredentials(stacks);
+
+    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
+    // Second docker exec should write the config file
+    const configWriteCall = calls.find(([, args]: [string, string[]]) =>
+      args.some((a: string) => a.includes('sandstorm-opencode.json')),
+    );
+    expect(configWriteCall).toBeDefined();
+    const [, args] = configWriteCall;
+    expect(args).toContain('exec');
+    expect(args).toContain('def456');
+  });
+
+  it('proceeds with empty bundle when no credentials are stored', async () => {
+    const { registry } = await import('../../../src/main/index');
+    (registry.getBackendSecretBundle as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
+
+    const stacks: StackInfo[] = [
+      { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'ghi789' }] },
+    ];
+    // Should not throw
+    await expect(backend.syncCredentials(stacks)).resolves.toBeUndefined();
+  });
+
+  it('selects non-Anthropic active credential when provider is bedrock', async () => {
+    const { registry } = await import('../../../src/main/index');
+    (registry.getGlobalBackendSettings as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      inner_backend: 'opencode',
+      inner_provider: 'amazon-bedrock',
+      inner_model: null,
+    });
+    (registry.getBackendSecretBundle as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      region: 'us-east-1',
+      bearerToken: 'bt-bedrock-active',
+    });
+
+    const { generateOpencodeConfig } = await import('../../../src/main/opencode-config');
+    const stacks: StackInfo[] = [
+      { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'jkl012' }] },
+    ];
+    await backend.syncCredentials(stacks);
+
+    // Asserts that the active non-Anthropic credential was used in config generation
+    expect(generateOpencodeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'amazon-bedrock',
+        bundle: expect.objectContaining({ bearerToken: 'bt-bedrock-active' }),
+      }),
+    );
+  });
+});

--- a/tests/unit/opencode-config-providers.test.ts
+++ b/tests/unit/opencode-config-providers.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { generateOpencodeConfig, generateOuterOpencodeConfig } from '../../src/main/opencode-config';
+
+describe('generateOpencodeConfig — provider credential mapping', () => {
+  it('anthropic with apiKey bundle embeds the actual key', () => {
+    const config = generateOpencodeConfig({
+      providerId: 'anthropic',
+      bundle: { apiKey: 'sk-ant-test-123' },
+    });
+    expect(config.provider['anthropic']?.apiKey).toBe('sk-ant-test-123');
+    expect(config.provider['anthropic']?.apiKey).not.toMatch(/^\{env:/);
+  });
+
+  it('anthropic with no bundle uses env placeholder', () => {
+    const config = generateOpencodeConfig({ providerId: 'anthropic', bundle: {} });
+    expect(config.provider['anthropic']?.apiKey).toBe('{env:ANTHROPIC_API_KEY}');
+  });
+
+  it('amazon-bedrock with access keys produces options block', () => {
+    const config = generateOpencodeConfig({
+      providerId: 'amazon-bedrock',
+      bundle: { region: 'us-east-1', accessKeyId: 'AKID', secretAccessKey: 'SAK' },
+    });
+    expect(config.provider['amazon-bedrock']).toBeDefined();
+    const opts = config.provider['amazon-bedrock']?.options as Record<string, string>;
+    expect(opts.region).toBe('us-east-1');
+    expect(opts.accessKeyId).toBe('AKID');
+    expect(opts.secretAccessKey).toBe('SAK');
+  });
+
+  it('amazon-bedrock bearer token takes precedence over access keys', () => {
+    const config = generateOpencodeConfig({
+      providerId: 'amazon-bedrock',
+      bundle: {
+        region: 'us-west-2',
+        accessKeyId: 'AKID',
+        secretAccessKey: 'SAK',
+        bearerToken: 'bt-real',
+      },
+    });
+    const opts = config.provider['amazon-bedrock']?.options as Record<string, string>;
+    expect(opts.bearerToken).toBe('bt-real');
+    expect(opts.accessKeyId).toBeUndefined();
+    expect(opts.secretAccessKey).toBeUndefined();
+  });
+
+  it('ollama maps to provider key "openai" with baseURL', () => {
+    const config = generateOpencodeConfig({
+      providerId: 'ollama',
+      bundle: { baseUrl: 'http://myhost:11434/v1' },
+      model: 'openai/llama3',
+    });
+    expect(config.provider['openai']).toBeDefined();
+    expect(config.provider['openai']?.apiKey).toBe('ollama');
+    expect(config.provider['openai']?.baseURL).toBe('http://myhost:11434/v1');
+    expect(config.model).toBe('openai/llama3');
+    expect(config.provider['anthropic']).toBeUndefined();
+  });
+
+  it('custom model override is respected', () => {
+    const config = generateOpencodeConfig({
+      model: 'amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0',
+      providerId: 'amazon-bedrock',
+      bundle: { region: 'eu-west-1' },
+    });
+    expect(config.model).toBe('amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0');
+  });
+
+  it('default model is anthropic/claude-sonnet-4-6 when unspecified', () => {
+    const config = generateOpencodeConfig({});
+    expect(config.model).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('clean-auth: no embedded OAuth credentials for any provider', () => {
+    const configs = [
+      generateOpencodeConfig({ providerId: 'anthropic', bundle: { apiKey: 'sk-test' } }),
+      generateOpencodeConfig({ providerId: 'amazon-bedrock', bundle: { region: 'us-east-1', bearerToken: 'bt' } }),
+      generateOpencodeConfig({ providerId: 'ollama', bundle: { baseUrl: 'http://host:11434/v1' } }),
+    ];
+    for (const config of configs) {
+      const json = JSON.stringify(config);
+      expect(json).not.toContain('refresh_token');
+      expect(json).not.toContain('access_token');
+      expect(json).not.toContain('oauth_token');
+    }
+  });
+
+  it('non-Anthropic provider is selected when specified (mocked-transport: config env selects active credential)', () => {
+    // This is the "mocked-transport" assertion from Q3: given a non-Anthropic bundle,
+    // the generated config references the active credential — not the Anthropic placeholder.
+    const bedrockConfig = generateOpencodeConfig({
+      providerId: 'amazon-bedrock',
+      bundle: { region: 'us-east-1', bearerToken: 'bt-active' },
+    });
+    // Active credential is embedded; no Anthropic env placeholder present
+    expect(JSON.stringify(bedrockConfig)).not.toContain('{env:ANTHROPIC_API_KEY}');
+    expect(JSON.stringify(bedrockConfig)).toContain('bt-active');
+    expect(bedrockConfig.provider['anthropic']).toBeUndefined();
+    expect(bedrockConfig.provider['amazon-bedrock']).toBeDefined();
+  });
+});
+
+describe('generateOuterOpencodeConfig — provider support', () => {
+  const baseInputs = {
+    shimPath: '/dist/main/orchestration-mcp-shim.cjs',
+    bridgeUrl: 'http://127.0.0.1:9999',
+    bridgeToken: 'tok-test',
+    instructionsPath: '/home/user/.sandstorm/SANDSTORM_OUTER.md',
+  };
+
+  it('anthropic outer config uses env placeholder when no bundle', () => {
+    const config = generateOuterOpencodeConfig({ ...baseInputs });
+    expect(config.provider['anthropic']?.apiKey).toBe('{env:ANTHROPIC_API_KEY}');
+  });
+
+  it('outer bedrock config embeds credentials from bundle', () => {
+    const config = generateOuterOpencodeConfig({
+      ...baseInputs,
+      providerId: 'amazon-bedrock',
+      bundle: { region: 'us-east-1', accessKeyId: 'AKID', secretAccessKey: 'SAK' },
+    });
+    const opts = config.provider['amazon-bedrock']?.options as Record<string, string>;
+    expect(opts.region).toBe('us-east-1');
+    expect(opts.accessKeyId).toBe('AKID');
+  });
+
+  it('outer ollama config maps to openai provider', () => {
+    const config = generateOuterOpencodeConfig({
+      ...baseInputs,
+      providerId: 'ollama',
+      bundle: { baseUrl: 'http://host:11434/v1' },
+    });
+    expect(config.provider['openai']?.baseURL).toBe('http://host:11434/v1');
+  });
+});

--- a/tests/unit/opencode-providers.test.ts
+++ b/tests/unit/opencode-providers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROVIDER_METADATA,
+  getProviderMeta,
+  buildProviderEntry,
+} from '../../src/shared/opencode-providers';
+
+describe('PROVIDER_METADATA', () => {
+  it('includes anthropic, amazon-bedrock, and ollama', () => {
+    const ids = PROVIDER_METADATA.map((p) => p.id);
+    expect(ids).toContain('anthropic');
+    expect(ids).toContain('amazon-bedrock');
+    expect(ids).toContain('ollama');
+  });
+
+  it('anthropic has a required apiKey field with env var ANTHROPIC_API_KEY', () => {
+    const meta = getProviderMeta('anthropic')!;
+    expect(meta).toBeDefined();
+    const apiKey = meta.fields.find((f) => f.key === 'apiKey')!;
+    expect(apiKey).toBeDefined();
+    expect(apiKey.required).toBe(true);
+    expect(apiKey.envVar).toBe('ANTHROPIC_API_KEY');
+    expect(apiKey.type).toBe('password');
+  });
+
+  it('amazon-bedrock has region as required and access keys as optional', () => {
+    const meta = getProviderMeta('amazon-bedrock')!;
+    const region = meta.fields.find((f) => f.key === 'region')!;
+    const accessKeyId = meta.fields.find((f) => f.key === 'accessKeyId')!;
+    const secretAccessKey = meta.fields.find((f) => f.key === 'secretAccessKey')!;
+    const bearerToken = meta.fields.find((f) => f.key === 'bearerToken')!;
+    const profile = meta.fields.find((f) => f.key === 'profile')!;
+
+    expect(region.required).toBe(true);
+    expect(region.envVar).toBe('AWS_REGION');
+
+    expect(accessKeyId.required).toBe(false);
+    expect(accessKeyId.envVar).toBe('AWS_ACCESS_KEY_ID');
+
+    expect(secretAccessKey.required).toBe(false);
+    expect(secretAccessKey.envVar).toBe('AWS_SECRET_ACCESS_KEY');
+
+    expect(bearerToken.required).toBe(false);
+    expect(bearerToken.envVar).toBe('AWS_BEARER_TOKEN_BEDROCK');
+
+    expect(profile.required).toBe(false);
+    expect(profile.envVar).toBe('AWS_PROFILE');
+  });
+
+  it('ollama has a required baseUrl field with no env var (config-only)', () => {
+    const meta = getProviderMeta('ollama')!;
+    const baseUrl = meta.fields.find((f) => f.key === 'baseUrl')!;
+    expect(baseUrl.required).toBe(true);
+    expect(baseUrl.type).toBe('url');
+    expect(baseUrl.envVar).toBeUndefined();
+  });
+
+  it('getProviderMeta returns undefined for unknown provider', () => {
+    expect(getProviderMeta('unknown-provider')).toBeUndefined();
+  });
+});
+
+describe('buildProviderEntry', () => {
+  describe('anthropic', () => {
+    it('embeds actual apiKey when bundle provides it', () => {
+      const { providerKey, config } = buildProviderEntry('anthropic', { apiKey: 'sk-ant-real' });
+      expect(providerKey).toBe('anthropic');
+      expect(config.apiKey).toBe('sk-ant-real');
+    });
+
+    it('falls back to {env:ANTHROPIC_API_KEY} when bundle is empty', () => {
+      const { providerKey, config } = buildProviderEntry('anthropic', {});
+      expect(providerKey).toBe('anthropic');
+      expect(config.apiKey).toBe('{env:ANTHROPIC_API_KEY}');
+    });
+  });
+
+  describe('amazon-bedrock', () => {
+    it('maps access keys + region into options', () => {
+      const { providerKey, config } = buildProviderEntry('amazon-bedrock', {
+        region: 'us-east-1',
+        accessKeyId: 'AKIATEST',
+        secretAccessKey: 'secret123',
+      });
+      expect(providerKey).toBe('amazon-bedrock');
+      const opts = config.options as Record<string, string>;
+      expect(opts.region).toBe('us-east-1');
+      expect(opts.accessKeyId).toBe('AKIATEST');
+      expect(opts.secretAccessKey).toBe('secret123');
+      expect(opts.bearerToken).toBeUndefined();
+    });
+
+    it('uses bearerToken when provided (takes precedence over access keys)', () => {
+      const { providerKey, config } = buildProviderEntry('amazon-bedrock', {
+        region: 'us-west-2',
+        accessKeyId: 'AKIATEST',
+        secretAccessKey: 'secret123',
+        bearerToken: 'bearer-tok',
+      });
+      expect(providerKey).toBe('amazon-bedrock');
+      const opts = config.options as Record<string, string>;
+      expect(opts.bearerToken).toBe('bearer-tok');
+      expect(opts.accessKeyId).toBeUndefined();
+      expect(opts.secretAccessKey).toBeUndefined();
+    });
+
+    it('uses AWS profile when provided', () => {
+      const { providerKey, config } = buildProviderEntry('amazon-bedrock', {
+        region: 'eu-west-1',
+        profile: 'my-profile',
+      });
+      expect(providerKey).toBe('amazon-bedrock');
+      const opts = config.options as Record<string, string>;
+      expect(opts.profile).toBe('my-profile');
+      expect(opts.region).toBe('eu-west-1');
+    });
+  });
+
+  describe('ollama', () => {
+    it('uses openai as providerKey (OpenAI-compatible endpoint)', () => {
+      const { providerKey, config } = buildProviderEntry('ollama', {
+        baseUrl: 'http://host:11434/v1',
+      });
+      expect(providerKey).toBe('openai');
+      expect(config.apiKey).toBe('ollama');
+      expect(config.baseURL).toBe('http://host:11434/v1');
+    });
+
+    it('omits baseURL when not provided', () => {
+      const { providerKey, config } = buildProviderEntry('ollama', {});
+      expect(providerKey).toBe('openai');
+      expect(config.apiKey).toBe('ollama');
+      expect(config.baseURL).toBeUndefined();
+    });
+  });
+
+  describe('unknown provider', () => {
+    it('falls back to {env:PROVIDER_API_KEY} placeholder when no apiKey in bundle', () => {
+      const { providerKey, config } = buildProviderEntry('my-custom', {});
+      expect(providerKey).toBe('my-custom');
+      expect(config.apiKey).toBe('{env:MY_CUSTOM_API_KEY}');
+    });
+
+    it('uses provided apiKey from bundle', () => {
+      const { config } = buildProviderEntry('my-custom', { apiKey: 'sk-custom' });
+      expect(config.apiKey).toBe('sk-custom');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

OpenCode backends previously only accepted a single API key, which left providers that need more than one credential field (Amazon Bedrock with region + access keys / bearer token / profile, and similar) unconfigurable. This change introduces a per-provider field matrix and threads it through every layer that touches backend credentials.

- Adds `src/shared/opencode-providers.ts` as the single source of truth mapping each provider to its required credential fields and the env var each one maps to for compose passthrough.
- Stores credentials as a JSON bundle in `backend_secrets` (schema v25) via new `setBackendSecretBundle` / `getBackendSecretBundle` helpers. Legacy single-field rows remain readable, so existing configs keep working with no migration step.
- Renders the correct fields per selected provider in the model/backend settings UI, driven by the shared metadata rather than hardcoded inputs.
- Syncs the bundle into the generated OpenCode config (`{env:...}` placeholders) and passes the provider env vars (`ANTHROPIC_API_KEY`, `AWS_*`) through to the stack container in the generated compose file.

## QA plan

1. Open model/backend settings and select an OpenCode backend with the Anthropic provider; confirm a single API Key field appears and saving persists it.
2. Switch the provider to Amazon Bedrock; confirm the field set changes to region (required) plus access key / secret / bearer token / profile, and that required-field validation behaves correctly.
3. Save a Bedrock credential bundle, spin up a stack, and verify the generated compose passes the `AWS_*` env vars through and the OpenCode config resolves the provider credentials.
4. Confirm an existing stack configured before this change (single API key) still launches and authenticates without re-entering credentials.

Closes #479