### PR TITLE
[620] fix: reconcile app node_modules before verify on lock drift

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -460,6 +460,74 @@ is_infra_error_only() {
   return 1  # Unknown failure — treat as real
 }
 
+# Pure comparison: returns 0 (install needed) when hashes differ, 1 (skip) when they match.
+needs_node_modules_reconcile() {
+  local current_hash="$1"
+  local stored_hash="$2"
+  if [ "$current_hash" = "$stored_hash" ]; then
+    return 1  # hashes match — skip install
+  fi
+  return 0    # hashes differ — install needed
+}
+
+# Reconcile the app container's node_modules against the committed package-lock.json.
+# Detects drift via lockfile hash; reconciles only when node_modules is a Docker named
+# volume (not a host bind mount). Serializes concurrent runs with flock on the volume.
+# Returns: 0 = up-to-date or skipped, 2 = infrastructure error (halt)
+reconcile_app_node_modules() {
+  local verify_log="$1"
+
+  # No lockfile — not an npm project or lockfile missing, skip
+  if [ ! -f /app/package-lock.json ]; then
+    return 0
+  fi
+
+  # Read mountinfo from app container; skip if app service is unreachable
+  local mountinfo
+  mountinfo=$(sandstorm-exec app cat /proc/self/mountinfo 2>/dev/null) || return 0
+
+  # Extract the mount source for /app/node_modules from mountinfo
+  # mountinfo format: mountid parentid major:minor root mountpoint mountopts [opts] - fstype source superopts
+  local nm_source
+  nm_source=$(echo "$mountinfo" | awk '$5 == "/app/node_modules" { for(i=1;i<=NF;i++) if($i=="-") { print $(i+2); break } }')
+
+  # Reconcile only when node_modules is a Docker named volume (source under /var/lib/docker/volumes/)
+  # Bind-mounted node_modules (host paths) are skipped to avoid mutating the user's working tree
+  if [ -z "$nm_source" ] || ! echo "$nm_source" | grep -q '^/var/lib/docker/volumes/'; then
+    log_loop "node_modules reconcile: not a named volume (source: ${nm_source:-absent}), skipping"
+    return 0
+  fi
+
+  # Hash the committed lockfile; compare to the marker stored in the named volume
+  local current_hash
+  current_hash=$(sha256sum /app/package-lock.json | awk '{print $1}')
+
+  local stored_hash
+  stored_hash=$(sandstorm-exec app cat /app/node_modules/.sandstorm-lock-hash 2>/dev/null || true)
+
+  # Idempotency: skip install when node_modules are already up to date
+  if ! needs_node_modules_reconcile "$current_hash" "$stored_hash"; then
+    log_loop "node_modules reconcile: up-to-date (hash match), skipping npm ci"
+    return 0
+  fi
+
+  log_loop "node_modules reconcile: drift detected — running npm ci in app container..."
+
+  # Run npm ci in the app container; flock on the named volume file serializes concurrent stacks
+  if ! sandstorm-exec app bash -c "flock /app/node_modules/.sandstorm-reconcile-lock npm ci" >> "$verify_log" 2>&1; then
+    log_loop "node_modules reconcile: npm ci failed — infrastructure error, halting"
+    echo "VERIFY_FAIL"
+    tail -n 50 "$verify_log"
+    return 2
+  fi
+
+  # Persist the new hash into the named volume so the next run is a no-op
+  sandstorm-exec app bash -c "echo '$current_hash' > /app/node_modules/.sandstorm-lock-hash" 2>/dev/null || true
+
+  log_loop "node_modules reconcile: npm ci complete, marker updated"
+  return 0
+}
+
 # Run verification using the project's .sandstorm/verify.sh script.
 # Returns: 0 = all pass (or no verify.sh), 1 = failure (retryable), 2 = infrastructure error (halt)
 run_verify() {
@@ -474,6 +542,13 @@ run_verify() {
   fi
 
   log_loop "Running verification suite (.sandstorm/verify.sh)..."
+
+  # Reconcile app container node_modules before verify to fix stale image-baked deps
+  reconcile_app_node_modules "$verify_log"
+  local reconcile_result=$?
+  if [ $reconcile_result -ne 0 ]; then
+    return $reconcile_result
+  fi
 
   # Run the project's verify script, redirect all output to log only
   (cd /app && bash "$verify_script" 2>&1) >> "$verify_log"

--- a/tests/unit/task-runner-node-modules-reconcile.test.ts
+++ b/tests/unit/task-runner-node-modules-reconcile.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const taskRunnerPath = resolve(__dirname, '../../sandstorm-cli/docker/task-runner.sh')
+const taskRunner = readFileSync(taskRunnerPath, 'utf-8')
+
+describe('task-runner.sh node_modules reconcile', () => {
+  // ── needs_node_modules_reconcile — pure comparison function ──────────
+
+  describe('needs_node_modules_reconcile function', () => {
+    it('defines needs_node_modules_reconcile()', () => {
+      expect(taskRunner).toContain('needs_node_modules_reconcile()')
+    })
+
+    it('accepts current_hash and stored_hash arguments', () => {
+      const fn = taskRunner.indexOf('needs_node_modules_reconcile()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('local current_hash="$1"')
+      expect(body).toContain('local stored_hash="$2"')
+    })
+
+    it('returns 1 (skip) when hashes match — idempotency', () => {
+      const fn = taskRunner.indexOf('needs_node_modules_reconcile()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('"$current_hash" = "$stored_hash"')
+      expect(body).toContain('return 1')
+    })
+
+    it('returns 0 (install needed) when hashes differ', () => {
+      const fn = taskRunner.indexOf('needs_node_modules_reconcile()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('return 0')
+    })
+
+    it('is defined before reconcile_app_node_modules (used by it)', () => {
+      const pureIdx = taskRunner.indexOf('needs_node_modules_reconcile()')
+      const reconcileIdx = taskRunner.indexOf('reconcile_app_node_modules()')
+      expect(pureIdx).toBeGreaterThan(-1)
+      expect(reconcileIdx).toBeGreaterThan(-1)
+      expect(pureIdx).toBeLessThan(reconcileIdx)
+    })
+  })
+
+  // ── reconcile_app_node_modules — main reconcile function ─────────────
+
+  describe('reconcile_app_node_modules function', () => {
+    it('defines reconcile_app_node_modules()', () => {
+      expect(taskRunner).toContain('reconcile_app_node_modules()')
+    })
+
+    it('accepts verify_log as its first argument', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('local verify_log="$1"')
+    })
+
+    it('skips when /app/package-lock.json does not exist', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('! -f /app/package-lock.json')
+      expect(body).toContain('return 0')
+    })
+
+    it('reads /proc/self/mountinfo from the app container via sandstorm-exec', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('sandstorm-exec app cat /proc/self/mountinfo')
+    })
+
+    it('uses awk to extract the mount source for /app/node_modules', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('/app/node_modules')
+      expect(body).toContain('awk')
+    })
+
+    it('parses the source field after the - separator in mountinfo', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      // The awk extracts the source (2nd field after '-') from the mountinfo line
+      expect(body).toContain('$5 == "/app/node_modules"')
+      expect(body).toContain('if($i=="-")')
+    })
+  })
+
+  // ── Volume-vs-bind gate ───────────────────────────────────────────────
+
+  describe('volume-vs-bind gate', () => {
+    it('checks that nm_source starts with /var/lib/docker/volumes/', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('/var/lib/docker/volumes/')
+      expect(body).toContain('grep -q')
+    })
+
+    it('skips when nm_source is empty (no /app/node_modules mount entry)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('-z "$nm_source"')
+    })
+
+    it('skips when nm_source does not start with /var/lib/docker/volumes/ (bind mount)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      // The gate condition skips when NOT matching the named-volume prefix
+      expect(body).toContain('^/var/lib/docker/volumes/')
+    })
+
+    it('logs a skip message when not a named volume', () => {
+      expect(taskRunner).toContain('not a named volume')
+      expect(taskRunner).toContain('skipping')
+    })
+  })
+
+  // ── Hash-based drift detection ────────────────────────────────────────
+
+  describe('hash-based drift detection', () => {
+    it('hashes /app/package-lock.json with sha256sum', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('sha256sum /app/package-lock.json')
+    })
+
+    it('reads the stored hash from the app container named volume marker', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('sandstorm-exec app cat /app/node_modules/.sandstorm-lock-hash')
+    })
+
+    it('calls needs_node_modules_reconcile to compare hashes', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('needs_node_modules_reconcile "$current_hash" "$stored_hash"')
+    })
+
+    it('skips npm ci and logs when hashes match (idempotency)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('up-to-date (hash match), skipping npm ci')
+    })
+  })
+
+  // ── npm ci invocation and serialization ──────────────────────────────
+
+  describe('npm ci invocation', () => {
+    it('runs npm ci in the app container via sandstorm-exec', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('sandstorm-exec app')
+      expect(body).toContain('npm ci')
+    })
+
+    it('serializes npm ci with flock on the named volume lock file', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('flock /app/node_modules/.sandstorm-reconcile-lock')
+    })
+
+    it('appends npm ci output to verify_log', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('>> "$verify_log"')
+    })
+
+    it('writes new hash marker to the named volume after successful npm ci', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      expect(body).toContain('.sandstorm-lock-hash')
+      // The hash write comes after npm ci succeeds
+      const npmCiIdx = body.indexOf('flock /app/node_modules/.sandstorm-reconcile-lock npm ci')
+      const hashWriteIdx = body.indexOf('.sandstorm-lock-hash', npmCiIdx + 1)
+      expect(hashWriteIdx).toBeGreaterThan(npmCiIdx)
+    })
+  })
+
+  // ── Reconcile failure handling ────────────────────────────────────────
+
+  describe('reconcile failure handling', () => {
+    it('returns 2 (infrastructure error) when npm ci fails', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      // The failure path returns 2
+      const failurePathIdx = body.indexOf('npm ci failed')
+      const return2Idx = body.indexOf('return 2', failurePathIdx)
+      expect(failurePathIdx).toBeGreaterThan(-1)
+      expect(return2Idx).toBeGreaterThan(failurePathIdx)
+    })
+
+    it('echoes VERIFY_FAIL before returning 2 on npm ci failure', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      const failurePathIdx = body.indexOf('npm ci failed')
+      const verifyFailIdx = body.indexOf('VERIFY_FAIL', failurePathIdx)
+      const return2Idx = body.indexOf('return 2', failurePathIdx)
+      expect(verifyFailIdx).toBeGreaterThan(-1)
+      expect(verifyFailIdx).toBeLessThan(return2Idx)
+    })
+
+    it('tails the verify log before returning 2 (consistent with existing infra-error path)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      const failurePathIdx = body.indexOf('npm ci failed')
+      const tailIdx = body.indexOf('tail -n 50 "$verify_log"', failurePathIdx)
+      const return2Idx = body.indexOf('return 2', failurePathIdx)
+      expect(tailIdx).toBeGreaterThan(failurePathIdx)
+      expect(tailIdx).toBeLessThan(return2Idx)
+    })
+
+    it('npm ci failure short-circuits before continuing (does not return 0)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      const failurePathIdx = body.indexOf('npm ci failed')
+      // After the failure path there should be no 'return 0' before 'return 2'
+      const return2Idx = body.indexOf('return 2', failurePathIdx)
+      const return0InFailure = body.indexOf('return 0', failurePathIdx)
+      // Either no return 0 between failure and return 2, or return 0 is elsewhere
+      expect(return2Idx).toBeGreaterThan(failurePathIdx)
+      if (return0InFailure !== -1) {
+        expect(return0InFailure).toBeGreaterThan(return2Idx)
+      }
+    })
+  })
+
+  // ── Ordering: reconcile runs before verify script ─────────────────────
+
+  describe('ordering in run_verify', () => {
+    it('reconcile_app_node_modules is called within run_verify', () => {
+      const runVerifyStart = taskRunner.indexOf('run_verify()')
+      const reconcileCall = taskRunner.indexOf('reconcile_app_node_modules "$verify_log"', runVerifyStart)
+      expect(reconcileCall).toBeGreaterThan(runVerifyStart)
+    })
+
+    it('reconcile call appears before bash "$verify_script" in run_verify', () => {
+      const runVerifyStart = taskRunner.indexOf('run_verify()')
+      const reconcileCall = taskRunner.indexOf('reconcile_app_node_modules "$verify_log"', runVerifyStart)
+      const verifyScriptInvocation = taskRunner.indexOf('bash "$verify_script"', runVerifyStart)
+      expect(reconcileCall).toBeGreaterThan(-1)
+      expect(verifyScriptInvocation).toBeGreaterThan(-1)
+      expect(reconcileCall).toBeLessThan(verifyScriptInvocation)
+    })
+
+    it('reconcile failure short-circuits run_verify before the project verify script runs', () => {
+      const runVerifyStart = taskRunner.indexOf('run_verify()')
+      const reconcileBlock = taskRunner.indexOf('reconcile_app_node_modules "$verify_log"', runVerifyStart)
+      const returnOnFailure = taskRunner.indexOf('return $reconcile_result', reconcileBlock)
+      const verifyScriptInvocation = taskRunner.indexOf('bash "$verify_script"', runVerifyStart)
+      expect(returnOnFailure).toBeGreaterThan(reconcileBlock)
+      expect(returnOnFailure).toBeLessThan(verifyScriptInvocation)
+    })
+
+    it('reconcile_app_node_modules is defined before run_verify', () => {
+      const reconcileFnDef = taskRunner.indexOf('reconcile_app_node_modules()')
+      const runVerifyDef = taskRunner.indexOf('run_verify()')
+      expect(reconcileFnDef).toBeGreaterThan(-1)
+      expect(runVerifyDef).toBeGreaterThan(-1)
+      expect(reconcileFnDef).toBeLessThan(runVerifyDef)
+    })
+  })
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles missing app service gracefully (sandstorm-exec failure → skip)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      // The mountinfo read uses || return 0 to skip gracefully when app service unreachable
+      expect(body).toContain('|| return 0')
+    })
+
+    it('handles missing stored hash gracefully (first run or cleared volume)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      // The stored hash read uses || true so an empty string triggers install on first run
+      expect(body).toContain('|| true')
+    })
+
+    it('hash marker write failure does not halt the reconcile (|| true)', () => {
+      const fn = taskRunner.indexOf('reconcile_app_node_modules()')
+      const fnEnd = taskRunner.indexOf('\n}', fn + 10)
+      const body = taskRunner.substring(fn, fnEnd)
+      const hashWriteIdx = body.lastIndexOf('.sandstorm-lock-hash')
+      const trueAfterWrite = body.indexOf('|| true', hashWriteIdx)
+      expect(trueAfterWrite).toBeGreaterThan(hashWriteIdx)
+    })
+  })
+})

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -435,7 +435,7 @@ describe('task-runner.sh dual-loop workflow', () => {
     it('does not use `local` in the outer/inner while loops', () => {
       // Find all `local ` usages and verify they are inside function bodies.
       // Functions in the script: log_loop, run_claude, run_opencode, run_agent, check_for_diff, run_review, run_verify, check_for_stop_and_ask
-      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance']
+      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance', 'needs_node_modules_reconcile', 'reconcile_app_node_modules']
 
       // Collect the line ranges of all function bodies
       const functionRanges: Array<{ start: number; end: number }> = []


### PR DESCRIPTION
## Summary

When a project's `package-lock.json` changes but the app container's `node_modules` named volume is stale, `verify.sh` runs against out-of-date dependencies and produces misleading failures. This change adds a reconcile step to the task runner that detects lockfile drift and reinstalls dependencies before verification runs.

Two functions are added to `task-runner.sh`:

- `needs_node_modules_reconcile` — pure comparison of the current vs. stored lockfile hash, so the install is idempotent and only runs on actual drift.
- `reconcile_app_node_modules` — reads the app container's mounts via `/proc/self/mountinfo`, gates strictly on the `node_modules` mount being a Docker named volume (under `/var/lib/docker/volumes/`, never a bind mount), hashes `package-lock.json` against the `.sandstorm-lock-hash` marker, and on drift runs a `flock`-serialized `npm ci`. It returns 2 on failure and tails the log so the cause is visible.

`run_verify()` now invokes the reconcile step before the project's `verify.sh`, so verification always runs against dependencies matching the current lockfile.

## QA plan

1. Start a stack and let a task run `verify.sh` once to populate the `node_modules` volume and `.sandstorm-lock-hash` marker.
2. Change `package-lock.json` (add or bump a dependency) and dispatch another task; confirm the runner detects drift, runs `npm ci` once, and `verify.sh` then runs against the updated dependencies.
3. Re-run a task without touching the lockfile and confirm the reconcile step is skipped (no redundant `npm ci`).
4. Confirm that when `node_modules` is a bind mount rather than a named volume, the reconcile step is skipped entirely.
5. Force `npm ci` to fail and confirm the runner returns non-zero and surfaces the tail of the install log.

Closes #620