### PR TITLE
[621] fix: skip agent on environmental verify failures out of task sco

### DIFF
--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -573,6 +573,55 @@ run_verify() {
   return 1
 }
 
+# _get_task_changed_files
+# Emits the set of files changed or added by the current task (one per line,
+# sorted). Extracted as a standalone function so smoke tests can shadow it.
+_get_task_changed_files() {
+  (cd /app && {
+    git diff --name-only HEAD 2>/dev/null
+    git ls-files --others --exclude-standard 2>/dev/null
+  }) | sort -u
+}
+
+# classify_verify_failure_scope <verify_log>
+# Returns 0 (environmental) when EVERY failing file parsed from TypeScript error
+# lines in <verify_log> is outside the current task's changed-file set.
+# Returns 1 (not environmental) when:
+#   - no TypeScript error paths are parseable (e.g. test-runner failures, infra)
+#   - at least one failing file is in the changed set (agent's own change)
+#   - mixed scope: some failing files in-scope, some out-of-scope
+classify_verify_failure_scope() {
+  local verify_log="${1:-/tmp/claude-verify.log}"
+
+  # Parse TypeScript error lines: path(line,col): error TSxxxx
+  local failing_files
+  failing_files=$(grep -E '\([0-9]+,[0-9]+\): error TS[0-9]+' "$verify_log" 2>/dev/null \
+    | sed -E 's/\([0-9]+,[0-9]+\): error TS[^(].*$//' \
+    | sed 's/[[:space:]]*$//' \
+    | sort -u || true)
+
+  # No parseable paths → cannot classify as environmental; fall through
+  if [ -z "$failing_files" ]; then
+    return 1
+  fi
+
+  # Build changed-file set
+  local changed_files
+  changed_files=$(_get_task_changed_files)
+
+  # If any failing file is in the changed set → NOT environmental
+  while IFS= read -r failing_file; do
+    local normalized
+    normalized=$(echo "$failing_file" | sed 's|^\./||')
+    if echo "$changed_files" | grep -qxF "$normalized"; then
+      return 1
+    fi
+  done <<< "$failing_files"
+
+  # All failing files are outside the changed set → environmental
+  return 0
+}
+
 # ─── Main Loop ──────────────────────────────────────────────────────────────
 
 echo "Waiting for tasks..."
@@ -1000,6 +1049,19 @@ while true; do
 
         # Capture first notable error line for diagnostics (best-effort)
         VERIFY_FAIL_FINGERPRINT=$(grep -m1 -E 'Error|error|FAIL|fail|not found|command not found' /tmp/claude-verify.log 2>/dev/null | head -c 200 || true)
+
+        # If all failing files are outside the task's changed-file set, this is
+        # a pre-existing/environmental failure — classify and halt immediately
+        # rather than retrying or feeding it to the agent (which would cause an
+        # unhelpful STOP_AND_ASK with no questions).
+        if classify_verify_failure_scope /tmp/claude-verify.log; then
+          log_loop "All verify-failing files are outside this task's changed-file set — treating as environmental"
+          log_loop "Failure fingerprint: ${VERIFY_FAIL_FINGERPRINT}"
+          printf 'VERIFY_FAIL_FINGERPRINT: %s\n' "${VERIFY_FAIL_FINGERPRINT}" > /tmp/claude-verify-environmental.txt
+          VERIFY_BLOCKED_ENVIRONMENTAL=1
+          TASK_FAILED=1
+          break
+        fi
 
         if [ $TOTAL_VERIFY_RETRIES -ge $MAX_VERIFY_RETRIES ]; then
           if [ $META_REVIEW_FIRED_VERIFY -eq 0 ]; then

--- a/tests/unit/task-runner-environmental-scope.sh
+++ b/tests/unit/task-runner-environmental-scope.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+# Regression smoke test: verify-failure scope classification
+#
+# Verifies that classify_verify_failure_scope (sourced from task-runner.sh)
+# correctly detects when ALL failing TypeScript files are outside the task's
+# changed-file set and returns 0 (environmental). Also verifies the four
+# documented non-environmental cases: in-scope failure, mixed scope, no
+# parseable paths, and empty changed-file set.
+#
+# Exit codes: 0 = PASS, 1 = FAIL
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_RUNNER="$(realpath "$SCRIPT_DIR/../../sandstorm-cli/docker/task-runner.sh")"
+
+if [ ! -f "$TASK_RUNNER" ]; then
+  echo "SKIP: task-runner.sh not found at $TASK_RUNNER" >&2
+  exit 0
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ---------------------------------------------------------------------------
+# Source helper functions from task-runner.sh (stop before the main loop).
+# Override /tmp paths to tmpdir equivalents so the tests are isolated.
+# ---------------------------------------------------------------------------
+FUNC_SOURCE=$(sed -n '1,/^# ─── Main Loop/p' "$TASK_RUNNER" | head -n -1)
+
+# Patch /tmp/ references used by helper functions to point at our tmpdir
+FUNC_SOURCE="${FUNC_SOURCE//\/tmp\//$tmpdir/}"
+
+eval "$FUNC_SOURCE"
+
+# ---------------------------------------------------------------------------
+# Shadow _get_task_changed_files so we control the changed-file set.
+# MOCK_CHANGED_FILES is set per test case (newline-separated paths).
+# ---------------------------------------------------------------------------
+MOCK_CHANGED_FILES=""
+
+_get_task_changed_files() {
+  printf '%s\n' "$MOCK_CHANGED_FILES" | grep -v '^$' || true
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a verify log with TypeScript errors for given file paths
+# ---------------------------------------------------------------------------
+make_tsc_log() {
+  local logfile="$1"
+  shift
+  : > "$logfile"
+  for f in "$@"; do
+    echo "${f}(10,5): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'." >> "$logfile"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Helper: assert environmental classification
+# ---------------------------------------------------------------------------
+FAIL=0
+
+assert_environmental() {
+  local label="$1"
+  local verify_log="$2"
+  local expect_env="$3"   # "yes" or "no"
+
+  local result
+  if classify_verify_failure_scope "$verify_log"; then
+    result="yes"
+  else
+    result="no"
+  fi
+
+  if [ "$result" != "$expect_env" ]; then
+    echo "FAIL [$label]: expected environmental=$expect_env, got $result" >&2
+    FAIL=1
+  else
+    echo "PASS [$label]"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: all failing files outside changed set → environmental
+# ---------------------------------------------------------------------------
+LOG1="$tmpdir/verify-case1.log"
+make_tsc_log "$LOG1" \
+  "src/unrelated/foo.ts" \
+  "src/unrelated/bar.ts"
+
+MOCK_CHANGED_FILES="src/main/my-change.ts"
+assert_environmental "out-of-scope only → environmental" "$LOG1" "yes"
+
+# ---------------------------------------------------------------------------
+# Case 2: failing file matches a changed file → NOT environmental
+# ---------------------------------------------------------------------------
+LOG2="$tmpdir/verify-case2.log"
+make_tsc_log "$LOG2" "src/main/my-change.ts"
+
+MOCK_CHANGED_FILES="src/main/my-change.ts"
+assert_environmental "in-scope failure → not environmental" "$LOG2" "no"
+
+# ---------------------------------------------------------------------------
+# Case 3: mixed scope (one in-scope, one out-of-scope) → NOT environmental
+# ---------------------------------------------------------------------------
+LOG3="$tmpdir/verify-case3.log"
+make_tsc_log "$LOG3" \
+  "src/main/my-change.ts" \
+  "src/unrelated/other.ts"
+
+MOCK_CHANGED_FILES="src/main/my-change.ts"
+assert_environmental "mixed scope → not environmental" "$LOG3" "no"
+
+# ---------------------------------------------------------------------------
+# Case 4: no parseable TypeScript error paths → NOT environmental
+# ---------------------------------------------------------------------------
+LOG4="$tmpdir/verify-case4.log"
+cat > "$LOG4" << 'EOF'
+FAIL tests/unit/some.test.ts
+  ● some test › should work
+
+    expect(received).toBe(expected)
+
+    Expected: true
+    Received: false
+
+Tests: 1 failed, 5 passed
+EOF
+
+MOCK_CHANGED_FILES="src/main/my-change.ts"
+assert_environmental "no parseable paths → not environmental" "$LOG4" "no"
+
+# ---------------------------------------------------------------------------
+# Case 5: empty verify log → NOT environmental
+# ---------------------------------------------------------------------------
+LOG5="$tmpdir/verify-case5.log"
+: > "$LOG5"
+
+MOCK_CHANGED_FILES="src/main/my-change.ts"
+assert_environmental "empty log → not environmental" "$LOG5" "no"
+
+# ---------------------------------------------------------------------------
+# Case 6: out-of-scope with ./  prefix in tsc output → environmental
+# ---------------------------------------------------------------------------
+LOG6="$tmpdir/verify-case6.log"
+make_tsc_log "$LOG6" "./src/unrelated/baz.ts"
+
+MOCK_CHANGED_FILES="src/main/my-change.ts"
+assert_environmental "dotslash prefix stripped → environmental" "$LOG6" "yes"
+
+# ---------------------------------------------------------------------------
+# Case 7: empty changed-file set, parseable failure → environmental
+# (no agent changes; any failure must be pre-existing)
+# ---------------------------------------------------------------------------
+LOG7="$tmpdir/verify-case7.log"
+make_tsc_log "$LOG7" "src/unrelated/foo.ts"
+
+MOCK_CHANGED_FILES=""
+assert_environmental "no changed files → environmental" "$LOG7" "yes"
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+if [ $FAIL -eq 0 ]; then
+  echo ""
+  echo "All cases PASSED"
+  exit 0
+else
+  exit 1
+fi

--- a/tests/unit/task-runner-environmental-scope.test.ts
+++ b/tests/unit/task-runner-environmental-scope.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+import { spawnSync } from 'child_process'
+
+const taskRunnerPath = resolve(__dirname, '../../sandstorm-cli/docker/task-runner.sh')
+const taskRunner = readFileSync(taskRunnerPath, 'utf-8')
+
+describe('task-runner.sh environmental verify scope classification', () => {
+  // ── Helper functions ────────────────────────────────────────────────────
+
+  describe('helper functions', () => {
+    it('defines _get_task_changed_files', () => {
+      expect(taskRunner).toContain('_get_task_changed_files()')
+    })
+
+    it('defines classify_verify_failure_scope', () => {
+      expect(taskRunner).toContain('classify_verify_failure_scope()')
+    })
+
+    it('classify_verify_failure_scope uses _get_task_changed_files', () => {
+      expect(taskRunner).toContain('changed_files=$(_get_task_changed_files)')
+    })
+
+    it('parses TypeScript error lines of the form path(line,col): error TSxxxx', () => {
+      expect(taskRunner).toContain('error TS[0-9]+')
+    })
+
+    it('returns 1 when no parseable paths are found', () => {
+      expect(taskRunner).toContain('No parseable paths')
+    })
+
+    it('returns 0 when all failing files are outside changed set', () => {
+      expect(taskRunner).toContain('All failing files are outside the changed set')
+    })
+  })
+
+  // ── Integration into verify-fail path ───────────────────────────────────
+
+  describe('verify-fail path integration', () => {
+    it('calls classify_verify_failure_scope after a verify failure', () => {
+      expect(taskRunner).toContain('classify_verify_failure_scope /tmp/claude-verify.log')
+    })
+
+    it('sets VERIFY_BLOCKED_ENVIRONMENTAL=1 when scope check fires', () => {
+      const classifyIdx = taskRunner.indexOf('classify_verify_failure_scope /tmp/claude-verify.log')
+      expect(classifyIdx).toBeGreaterThan(-1)
+
+      const blockAfter = taskRunner.slice(classifyIdx, classifyIdx + 500)
+      expect(blockAfter).toContain('VERIFY_BLOCKED_ENVIRONMENTAL=1')
+    })
+
+    it('does NOT set TASK_NEEDS_HUMAN when environmental check fires', () => {
+      // Find the classify_verify_failure_scope block and confirm TASK_NEEDS_HUMAN=1
+      // does not appear in the consequent branch.
+      const classifyIdx = taskRunner.indexOf('classify_verify_failure_scope /tmp/claude-verify.log')
+      expect(classifyIdx).toBeGreaterThan(-1)
+
+      // Extract until the next 'fi' that closes the if block
+      const blockAfter = taskRunner.slice(classifyIdx, classifyIdx + 500)
+      const fiIdx = blockAfter.indexOf('\n        fi\n')
+      expect(fiIdx).toBeGreaterThan(-1)
+
+      const consequentBlock = blockAfter.slice(0, fiIdx)
+      expect(consequentBlock).not.toContain('TASK_NEEDS_HUMAN=1')
+    })
+
+    it('logs an "outside this task\'s changed-file set" message for environmental failures', () => {
+      expect(taskRunner).toContain("outside this task's changed-file set")
+    })
+
+    it('environmental check runs before feeding verify failure to execution agent', () => {
+      const classifyIdx = taskRunner.indexOf('classify_verify_failure_scope /tmp/claude-verify.log')
+      const feedIdx = taskRunner.indexOf('Sending verify failure to execution agent')
+      expect(classifyIdx).toBeGreaterThan(-1)
+      expect(feedIdx).toBeGreaterThan(-1)
+      expect(classifyIdx).toBeLessThan(feedIdx)
+    })
+
+    it('environmental check runs before STOP_AND_ASK check in verify path', () => {
+      const classifyIdx = taskRunner.indexOf('classify_verify_failure_scope /tmp/claude-verify.log')
+      const stopAskIdx = taskRunner.indexOf(
+        'STOP_AND_ASK detected after verify failure',
+      )
+      expect(classifyIdx).toBeGreaterThan(-1)
+      expect(stopAskIdx).toBeGreaterThan(-1)
+      expect(classifyIdx).toBeLessThan(stopAskIdx)
+    })
+  })
+
+  // ── Smoke test (bash) ────────────────────────────────────────────────────
+
+  describe('smoke test', () => {
+    it('runs task-runner-environmental-scope.sh and all cases pass', () => {
+      const smokeScript = resolve(__dirname, 'task-runner-environmental-scope.sh')
+      expect(existsSync(smokeScript)).toBe(true)
+
+      const result = spawnSync('bash', [smokeScript], {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      })
+      if (result.stdout) process.stdout.write(result.stdout)
+      if (result.stderr) process.stderr.write(result.stderr)
+      expect(result.status).toBe(0)
+    })
+  })
+})

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -435,7 +435,7 @@ describe('task-runner.sh dual-loop workflow', () => {
     it('does not use `local` in the outer/inner while loops', () => {
       // Find all `local ` usages and verify they are inside function bodies.
       // Functions in the script: log_loop, run_claude, run_opencode, run_agent, check_for_diff, run_review, run_verify, check_for_stop_and_ask
-      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance', 'needs_node_modules_reconcile', 'reconcile_app_node_modules']
+      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance', 'needs_node_modules_reconcile', 'reconcile_app_node_modules', '_get_task_changed_files', 'classify_verify_failure_scope']
 
       // Collect the line ranges of all function bodies
       const functionRanges: Array<{ start: number; end: number }> = []


### PR DESCRIPTION
## Summary

When a task's verify step failed only because of TypeScript errors in files the task never touched, the runner still fed the failure to the execution agent. With nothing in scope to fix, the agent would emit a no-questions STOP_AND_ASK, stalling the task on a problem it could not solve.

This change classifies verify failures by scope before routing them to the agent. It parses the TypeScript error lines from the verify log and compares the failing files against the task's changed-file set (`git diff --name-only HEAD` plus untracked files). If every failing file is outside that set, the failure is treated as environmental: the runner sets `VERIFY_BLOCKED_ENVIRONMENTAL=1` and breaks out of the loop rather than handing the agent an unsolvable prompt. The check runs after the failure fingerprint is captured but before the agent is invoked.

Classification falls through to the existing agent path whenever no parseable error paths are found (test-runner failures, infra errors), so only clearly out-of-scope TypeScript failures are short-circuited. Mixed in-scope/out-of-scope failures still go to the agent.

## QA plan

1. Run a task whose verify step fails only on TypeScript errors in files the task did not modify; confirm the runner stops with the environmental block instead of invoking the agent and producing a STOP_AND_ASK.
2. Run a task whose verify failure includes at least one in-scope file; confirm the failure is still routed to the execution agent as before.
3. Run a task whose verify failure is a test-runner or infra error with no parseable TypeScript paths; confirm it falls through to the agent path unchanged.
4. Exercise the bash smoke test directly (`tests/unit/task-runner-environmental-scope.sh`) and confirm all 7 cases pass, including dotslash-prefix normalization and the no-changed-files scenario.

Closes #621