### PR TITLE
[627] fix: surface OpenCode models with needs-key gating

### DIFF
--- a/src/main/control-plane/routing.ts
+++ b/src/main/control-plane/routing.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 export type TouchpointId =
   | 'outer'
   | 'refine'
@@ -72,3 +74,41 @@ export const CLAUDE_MODELS: AvailableModel[] = [
   { backend: 'claude', model: 'haiku',  label: 'Haiku 4.5',  version: 'claude-haiku-4-5',  provider: 'anthropic', available: true },
   { backend: 'claude', model: 'auto',   label: 'Auto',       version: 'auto',              provider: 'anthropic', available: true },
 ];
+
+export const OPENCODE_MODELS: AvailableModel[] = [
+  {
+    backend: 'opencode',
+    model: 'anthropic/claude-sonnet-4-6',
+    label: 'Claude Sonnet 4.6 — Anthropic',
+    version: 'anthropic/claude-sonnet-4-6',
+    provider: 'anthropic',
+    needsKey: true,
+    available: false,
+  },
+  {
+    backend: 'opencode',
+    model: 'amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0',
+    label: 'Claude 3.5 Sonnet — Amazon Bedrock',
+    version: 'amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0',
+    provider: 'amazon-bedrock',
+    needsKey: true,
+    available: false,
+  },
+];
+
+export function getAvailableModels(
+  projectDir: string,
+  hasBackendSecret: (key: string, surface: 'inner' | 'outer') => boolean,
+): AvailableModel[] {
+  const projectKey = `project:${path.resolve(projectDir)}`;
+  const ocAvailable =
+    hasBackendSecret(projectKey, 'inner') ||
+    hasBackendSecret(projectKey, 'outer') ||
+    hasBackendSecret('global', 'inner') ||
+    hasBackendSecret('global', 'outer');
+
+  return [
+    ...CLAUDE_MODELS,
+    ...OPENCODE_MODELS.map((m) => ({ ...m, available: ocAvailable })),
+  ];
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -84,7 +84,7 @@ import { createTicketWithConfig, updateTicketWithConfig, fetchRawBodyWithConfig,
 import { withRetry } from './control-plane/retry-with-backoff';
 import type { TicketListError } from './control-plane/ticket-config';
 import type { ProjectTicketConfig } from './control-plane/registry';
-import { CLAUDE_MODELS } from './control-plane/routing';
+import { getAvailableModels } from './control-plane/routing';
 import type { RoutingAssignment, PresetId } from './control-plane/routing';
 import type { EphemeralStreamEvent } from './agent/types';
 import { handleToolCall, spawnSpecCheck, spawnSpecRefine } from './claude/tools';
@@ -1009,8 +1009,8 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     registry.applyPreset(projectDir, presetId);
   });
 
-  ipcMain.handle('modelRouting:getAvailableModels', (_event, _projectDir: string) => {
-    return CLAUDE_MODELS;
+  ipcMain.handle('modelRouting:getAvailableModels', (_event, projectDir: string) => {
+    return getAvailableModels(projectDir, (key, surface) => registry.hasBackendSecret(key, surface));
   });
 
   // --- Session Monitor ---

--- a/src/renderer/components/config/ModelsPane.tsx
+++ b/src/renderer/components/config/ModelsPane.tsx
@@ -319,8 +319,8 @@ function ModelsPaneBody({ ctx }: ModelsPaneBodyProps) {
                             value={`opencode:${m.model}`}
                             disabled={!m.available}
                             title={
-                              !m.available
-                                ? 'Enable the OpenCode backend — #472'
+                              m.needsKey && !m.available
+                                ? 'Needs API key — configure in Providers'
                                 : undefined
                             }
                           >

--- a/tests/unit/components/ModelsPane.test.tsx
+++ b/tests/unit/components/ModelsPane.test.tsx
@@ -26,6 +26,13 @@ const CC_MODELS_WITH_OC_DISABLED = [
   { backend: 'opencode', model: 'gpt-4o', label: 'GPT-4o', version: 'gpt-4o-2024-11', provider: 'openai', available: false },
 ];
 
+const OC_MODELS_REAL = [
+  { backend: 'opencode', model: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6 — Anthropic', version: 'anthropic/claude-sonnet-4-6', provider: 'anthropic', needsKey: true, available: true },
+  { backend: 'opencode', model: 'amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0', label: 'Claude 3.5 Sonnet — Amazon Bedrock', version: 'amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0', provider: 'amazon-bedrock', needsKey: true, available: false },
+];
+
+const CC_MODELS_WITH_OC_REAL = [...CC_MODELS, ...OC_MODELS_REAL];
+
 function makeRouting(overrides: Partial<ModelRoutingApi> = {}): ModelRoutingApi {
   return {
     getEffective: vi.fn().mockResolvedValue({
@@ -304,6 +311,77 @@ describe('ModelsPane', () => {
       expect(unknownOpt.disabled).toBe(true);
       expect(unknownOpt.textContent).toContain('unknown');
       expect(unknownOpt.textContent).toContain('unknown-model-xyz');
+    });
+
+    it('unavailable OC option shows needs-key hint (not #472)', async () => {
+      const routing = makeRouting({
+        getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS_WITH_OC_REAL),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      const select = screen.getByTestId('model-select-outer') as HTMLSelectElement;
+      const bedrockOption = Array.from(select.options).find(
+        (o) => o.value === 'opencode:amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0',
+      );
+      expect(bedrockOption).toBeDefined();
+      expect(bedrockOption!.disabled).toBe(true);
+      expect(bedrockOption!.title).toBe('Needs API key — configure in Providers');
+      expect(bedrockOption!.title).not.toContain('#472');
+    });
+
+    it('available OC option has no title attribute', async () => {
+      const routing = makeRouting({
+        getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS_WITH_OC_REAL),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      const select = screen.getByTestId('model-select-outer') as HTMLSelectElement;
+      const anthropicOption = Array.from(select.options).find(
+        (o) => o.value === 'opencode:anthropic/claude-sonnet-4-6',
+      );
+      expect(anthropicOption).toBeDefined();
+      expect(anthropicOption!.disabled).toBe(false);
+      expect(anthropicOption!.title).toBeFalsy();
+    });
+
+    it('the "#472" string does not appear anywhere in the rendered output', async () => {
+      const routing = makeRouting({
+        getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS_WITH_OC_REAL),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      expect(document.body.innerHTML).not.toContain('#472');
+    });
+
+    it('OC optgroup renders for each touchpoint when OC models supplied', async () => {
+      const routing = makeRouting({
+        getAvailableModels: vi.fn().mockResolvedValue(CC_MODELS_WITH_OC_REAL),
+      });
+      const ctx = makeCtx(routing);
+      await renderPane(ctx);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('customize-toggle'));
+      });
+
+      for (const touchpoint of ['outer', 'execution', 'review']) {
+        expect(screen.getByTestId(`optgroup-opencode-${touchpoint}`)).toBeDefined();
+      }
     });
   });
 

--- a/tests/unit/model-routing.test.ts
+++ b/tests/unit/model-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Registry } from '../../src/main/control-plane/registry';
-import { TOUCHPOINTS, PRESETS } from '../../src/main/control-plane/routing';
+import { TOUCHPOINTS, PRESETS, CLAUDE_MODELS, OPENCODE_MODELS, getAvailableModels } from '../../src/main/control-plane/routing';
 import type { TouchpointId, PresetId } from '../../src/main/control-plane/routing';
 import fs from 'fs';
 import path from 'path';
@@ -331,6 +331,142 @@ describe('Model Routing', () => {
         const result = registry.getEffectiveRoutingFor('/proj/x', t);
         expect(result.model).toBe('haiku');
       }
+    });
+  });
+
+  // ==========================================================================
+  // OPENCODE_MODELS catalog
+  // ==========================================================================
+  describe('OPENCODE_MODELS catalog', () => {
+    it('has exactly 2 entries', () => {
+      expect(OPENCODE_MODELS).toHaveLength(2);
+    });
+
+    it('all entries have backend:opencode', () => {
+      for (const m of OPENCODE_MODELS) {
+        expect(m.backend).toBe('opencode');
+      }
+    });
+
+    it('includes anthropic and amazon-bedrock providers (no ollama)', () => {
+      const providers = OPENCODE_MODELS.map((m) => m.provider);
+      expect(providers).toContain('anthropic');
+      expect(providers).toContain('amazon-bedrock');
+      expect(providers).not.toContain('ollama');
+    });
+
+    it('all entries have needsKey:true', () => {
+      for (const m of OPENCODE_MODELS) {
+        expect(m.needsKey).toBe(true);
+      }
+    });
+
+    it('model and version use provider-prefixed format', () => {
+      const anthropic = OPENCODE_MODELS.find((m) => m.provider === 'anthropic');
+      expect(anthropic?.model).toBe('anthropic/claude-sonnet-4-6');
+      expect(anthropic?.version).toBe('anthropic/claude-sonnet-4-6');
+
+      const bedrock = OPENCODE_MODELS.find((m) => m.provider === 'amazon-bedrock');
+      expect(bedrock?.model).toBe('amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0');
+      expect(bedrock?.version).toBe('amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0');
+    });
+  });
+
+  // ==========================================================================
+  // getAvailableModels availability logic
+  // ==========================================================================
+  describe('getAvailableModels', () => {
+    it('returns models from both backends', () => {
+      const models = getAvailableModels('/proj/test', () => false);
+      const backends = new Set(models.map((m) => m.backend));
+      expect(backends.has('claude')).toBe(true);
+      expect(backends.has('opencode')).toBe(true);
+    });
+
+    it('Claude entries are exactly 4 and all available:true', () => {
+      const models = getAvailableModels('/proj/test', () => false);
+      const cc = models.filter((m) => m.backend === 'claude');
+      expect(cc).toHaveLength(CLAUDE_MODELS.length);
+      expect(cc).toHaveLength(4);
+      for (const m of cc) {
+        expect(m.available).toBe(true);
+      }
+    });
+
+    it('OpenCode entries are exactly 2 with no ollama', () => {
+      const models = getAvailableModels('/proj/test', () => false);
+      const oc = models.filter((m) => m.backend === 'opencode');
+      expect(oc).toHaveLength(2);
+      expect(oc.map((m) => m.provider)).not.toContain('ollama');
+    });
+
+    it('OpenCode models unavailable when no secrets configured', () => {
+      const models = getAvailableModels('/proj/test', () => false);
+      const oc = models.filter((m) => m.backend === 'opencode');
+      for (const m of oc) {
+        expect(m.available).toBe(false);
+      }
+    });
+
+    it('OpenCode models available when project inner secret configured', () => {
+      const models = getAvailableModels('/proj/test', (key, surface) => {
+        return key === `project:${path.resolve('/proj/test')}` && surface === 'inner';
+      });
+      const oc = models.filter((m) => m.backend === 'opencode');
+      for (const m of oc) {
+        expect(m.available).toBe(true);
+      }
+    });
+
+    it('OpenCode models available when project outer secret configured', () => {
+      const models = getAvailableModels('/proj/test', (key, surface) => {
+        return key === `project:${path.resolve('/proj/test')}` && surface === 'outer';
+      });
+      const oc = models.filter((m) => m.backend === 'opencode');
+      for (const m of oc) {
+        expect(m.available).toBe(true);
+      }
+    });
+
+    it('OpenCode models available when global inner secret configured', () => {
+      const models = getAvailableModels('/proj/test', (key, surface) => {
+        return key === 'global' && surface === 'inner';
+      });
+      const oc = models.filter((m) => m.backend === 'opencode');
+      for (const m of oc) {
+        expect(m.available).toBe(true);
+      }
+    });
+
+    it('OpenCode models available when global outer secret configured', () => {
+      const models = getAvailableModels('/proj/test', (key, surface) => {
+        return key === 'global' && surface === 'outer';
+      });
+      const oc = models.filter((m) => m.backend === 'opencode');
+      for (const m of oc) {
+        expect(m.available).toBe(true);
+      }
+    });
+
+    it('uses path.resolve for the project key', () => {
+      const seenKeys: string[] = [];
+      getAvailableModels('/proj/test', (key) => {
+        seenKeys.push(key);
+        return false;
+      });
+      const projectKeys = seenKeys.filter((k) => k.startsWith('project:'));
+      expect(projectKeys.length).toBeGreaterThan(0);
+      for (const k of projectKeys) {
+        expect(k).toBe(`project:${path.resolve('/proj/test')}`);
+      }
+    });
+
+    it('does not mutate OPENCODE_MODELS constant', () => {
+      const originalAvailable = OPENCODE_MODELS.map((m) => m.available);
+      getAvailableModels('/proj/test', () => true);
+      OPENCODE_MODELS.forEach((m, i) => {
+        expect(m.available).toBe(originalAvailable[i]);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

The Models pane only listed the built-in Claude models and showed a stale, issue-referencing title (`Enable the OpenCode backend — #472`) on disabled entries. This change makes the OpenCode-routed models first-class citizens of the model catalog and replaces the developer-facing placeholder with an actionable hint.

A new `OPENCODE_MODELS` catalog (Anthropic `claude-sonnet-4-6` and Amazon Bedrock `claude-3-5-sonnet`) is unioned with the existing Claude catalog through a new `getAvailableModels(projectDir, hasBackendSecret)` helper. Availability is computed from the four secret surfaces (project inner/outer and global inner/outer), so a model becomes selectable as soon as a usable key exists for it. The IPC handler now feeds the project directory and backend-secret registry into that helper instead of returning the raw Claude list.

In the renderer, models that need a key but don't have one now show `Needs API key — configure in Providers`, pointing the user to where they can fix it rather than referencing an internal issue number.

## QA plan

1. Open the model selector with no provider API keys configured. Confirm the OpenCode models appear in their optgroup, are disabled, and hovering shows `Needs API key — configure in Providers` (no `#472` text anywhere).
2. Add an Anthropic API key in Providers, reopen the selector, and confirm the Anthropic OpenCode model becomes selectable with no hint.
3. Add a Bedrock credential and confirm the Amazon Bedrock model becomes selectable independently.
4. Verify available Claude models show no needs-key hint and remain selectable as before.

Closes #627