### PR TITLE
[630] fix: route outer provider/model through opencode backend

### DIFF
--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -95,8 +95,45 @@ function extractEphemeralEvents(parts: Part[]): {
 }
 
 // ---------------------------------------------------------------------------
+// Provider routing helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the { providerID, modelID } pair needed by the SDK session body from
+ * an EffectiveBackend.
+ *
+ * Split rules (mirrors the stored combined-model-string format):
+ *   - model contains '/': split on first '/' → providerID = left, modelID = right
+ *   - model set but no '/': providerID = effective.provider ?? 'anthropic', modelID = whole string
+ *   - model unset: return null → caller omits the `model` field from the body
+ */
+function splitModel(effective: { provider?: string; model?: string }): { providerID: string; modelID: string } | null {
+  if (!effective.model) return null;
+  const slashIdx = effective.model.indexOf('/');
+  if (slashIdx !== -1) {
+    return {
+      providerID: effective.model.slice(0, slashIdx),
+      modelID: effective.model.slice(slashIdx + 1),
+    };
+  }
+  return {
+    providerID: effective.provider ?? 'anthropic',
+    modelID: effective.model,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // OpenCodeBackend
 // ---------------------------------------------------------------------------
+
+// Minimal interface for the registry methods this class needs. Avoids a
+// static import of the full registry module (which would create a circular
+// dependency at load time — same reason syncCredentials uses a dynamic import).
+interface RegistryRef {
+  getGlobalBackendSettings(): { outer_provider: string | null; outer_model: string | null };
+  getBackendSecretBundle(key: string, surface: 'inner' | 'outer'): Record<string, string> | null;
+  getEffectiveBackend(projectDir: string, surface: 'inner' | 'outer'): { backend: string; provider?: string; model?: string };
+}
 
 export class OpenCodeBackend implements AgentBackend {
   readonly name = 'OpenCode';
@@ -106,6 +143,9 @@ export class OpenCodeBackend implements AgentBackend {
   private bridge: BridgeHandle | null = null;
   private mainWindow: BrowserWindow | null = null;
   private ephemeralTimingPath: string;
+  // Cached registry reference — populated once in initialize() to avoid
+  // repeated dynamic imports (and concurrent-import races) in the hot path.
+  private registryRef: RegistryRef | null = null;
 
   // tabId → session state
   private tabSessions = new Map<string, TabSession>();
@@ -142,6 +182,18 @@ export class OpenCodeBackend implements AgentBackend {
     const { createOpencodeClient } = await import('@opencode-ai/sdk');
     const { createOpencodeServer } = await import('@opencode-ai/sdk/server');
 
+    // Resolve global outer provider/model/bundle from registry.
+    // initialize() runs at app startup before any project is selected, so we use
+    // global settings. Dynamic import avoids a circular dependency at load time
+    // (mirrors the syncCredentials pattern for the inner surface). Cache the
+    // reference so hot-path methods (sendMessageAsync etc.) don't re-import.
+    const { registry } = await import('../index');
+    this.registryRef = registry as RegistryRef;
+    const globalSettings = registry.getGlobalBackendSettings();
+    const providerId = globalSettings.outer_provider ?? undefined;
+    const bundle = registry.getBackendSecretBundle('global', 'outer') ?? undefined;
+    const model = globalSettings.outer_model ?? undefined;
+
     // Shim is compiled alongside this module in dist/main/
     const shimPath = path.join(__dirname, 'orchestration-mcp-shim.cjs');
 
@@ -152,6 +204,9 @@ export class OpenCodeBackend implements AgentBackend {
       bridgeUrl: this.bridge.url,
       bridgeToken: this.bridge.token,
       instructionsPath: path.join(cliDir, 'SANDSTORM_OUTER.md'),
+      providerId,
+      bundle,
+      model,
     });
 
     // Inject bridge credentials into process env so OpenCode agent bash skill
@@ -159,10 +214,17 @@ export class OpenCodeBackend implements AgentBackend {
     process.env.SANDSTORM_BRIDGE_URL = this.bridge.url;
     process.env.SANDSTORM_BRIDGE_TOKEN = this.bridge.token;
 
-    // Start OpenCode server, passing the outer config so the bridge shim MCP
-    // is registered and SANDSTORM_BRIDGE_URL/TOKEN flow into the shim env.
+    // Forward full config (mcp + provider) so non-Anthropic provider credentials
+    // and baseURL reach the opencode serve process.
+    // NOTE: the outer opencode serve is a single app-wide process whose provider
+    // credentials come from global settings. A project that overrides outer_provider
+    // to a provider whose credentials exist only at project scope (not global) will
+    // route per-session to that provider but the server config may lack its credentials,
+    // surfacing an auth error via agent:error. Full per-project outer credential
+    // isolation is a follow-up task.
     const sdkConfig: OpenCodeConfig = {
       mcp: outerConfig.mcp as OpenCodeConfig['mcp'],
+      provider: outerConfig.provider as OpenCodeConfig['provider'],
     };
     const server = await createOpencodeServer({ hostname: '127.0.0.1', config: sdkConfig });
     this.serverClose = server.close;
@@ -181,6 +243,7 @@ export class OpenCodeBackend implements AgentBackend {
     this.client = null;
     this.bridge?.release();
     this.bridge = null;
+    this.registryRef = null;
     this.tabSessions.clear();
     this.sessionToTab.clear();
     this.sessionTokens.clear();
@@ -357,11 +420,19 @@ export class OpenCodeBackend implements AgentBackend {
 
       tabSession.fullResponse = '';
 
+      // Resolve per-session model routing from the project's effective backend config.
+      const modelParts = (projectDir && this.registryRef)
+        ? splitModel(this.registryRef.getEffectiveBackend(projectDir, 'outer'))
+        : null;
+
       // Send prompt; completion arrives via SSE events
       await this.client.session.promptAsync({
         path: { id: tabSession.openCodeSessionId },
         query: projectDir ? { directory: projectDir } : undefined,
-        body: { parts: [{ type: 'text', text: message }] },
+        body: {
+          parts: [{ type: 'text', text: message }],
+          ...(modelParts ? { model: modelParts } : {}),
+        },
       });
     } catch (err) {
       tabSession.processing = false;
@@ -442,12 +513,17 @@ export class OpenCodeBackend implements AgentBackend {
       if (!session) throw new Error('Failed to create ephemeral session');
 
       try {
+        // Resolve per-session model routing from the project's effective backend config.
+        const modelParts = this.registryRef
+          ? splitModel(this.registryRef.getEffectiveBackend(projectDir, 'outer'))
+          : null;
+
         const { data: response } = await this.client!.session.prompt({
           path: { id: session.id },
           query: { directory: projectDir },
           body: {
             parts: [{ type: 'text', text: prompt }],
-            ...(model ? { model: { providerID: 'anthropic', modelID: model } } : {}),
+            ...(modelParts ? { model: modelParts } : {}),
           },
           signal: abortCtrl.signal,
         });
@@ -540,13 +616,18 @@ export class OpenCodeBackend implements AgentBackend {
     let openCodeSessionId = '';
     let isDisposed = false;
     let initAbortCtrl = new AbortController();
+    // Resolved once in initialResult and reused for all subsequent sendTurn calls.
+    let resolvedModelParts: { providerID: string; modelID: string } | null = null;
 
     const sendTurn = async (text: string, signal: AbortSignal): Promise<string> => {
       if (isDisposed) throw new Error('Session disposed');
       const { data: response } = await this.client!.session.prompt({
         path: { id: openCodeSessionId },
         query: { directory: projectDir },
-        body: { parts: [{ type: 'text', text }] },
+        body: {
+          parts: [{ type: 'text', text }],
+          ...(resolvedModelParts ? { model: resolvedModelParts } : {}),
+        },
         signal,
       });
       const parts: Part[] = response?.parts ?? [];
@@ -568,6 +649,12 @@ export class OpenCodeBackend implements AgentBackend {
 
     const initialResult = (async (): Promise<string> => {
       if (!this.client) throw new Error('OpenCodeBackend not initialized');
+
+      // Resolve model once for the session lifetime from effective backend config.
+      resolvedModelParts = this.registryRef
+        ? splitModel(this.registryRef.getEffectiveBackend(projectDir, 'outer'))
+        : null;
+
       const { data: session } = await this.client.session.create({
         query: { directory: projectDir },
       });

--- a/tests/unit/agent/opencode-backend.test.ts
+++ b/tests/unit/agent/opencode-backend.test.ts
@@ -33,6 +33,9 @@ const {
   mockSessionDelete,
   mockEventSubscribe,
   mockServerClose,
+  mockGetGlobalBackendSettings,
+  mockGetBackendSecretBundle,
+  mockGetEffectiveBackend,
 } = vi.hoisted(() => {
   const mockBridgeRelease = vi.fn();
   const mockBridge = {
@@ -48,8 +51,22 @@ const {
   const mockSessionAbort = vi.fn().mockResolvedValue({ data: true });
   const mockSessionDelete = vi.fn().mockResolvedValue({ data: true });
   const mockServerClose = vi.fn();
-
   const mockEventSubscribe = vi.fn();
+
+  const mockGetGlobalBackendSettings = vi.fn().mockReturnValue({
+    inner_backend: 'opencode',
+    inner_provider: 'anthropic',
+    inner_model: null,
+    outer_backend: 'claude',
+    outer_provider: null,
+    outer_model: null,
+  });
+  const mockGetBackendSecretBundle = vi.fn().mockReturnValue(null);
+  const mockGetEffectiveBackend = vi.fn().mockReturnValue({
+    backend: 'opencode',
+    provider: undefined,
+    model: undefined,
+  });
 
   return {
     mockBridgeRelease,
@@ -61,6 +78,9 @@ const {
     mockSessionDelete,
     mockEventSubscribe,
     mockServerClose,
+    mockGetGlobalBackendSettings,
+    mockGetBackendSecretBundle,
+    mockGetEffectiveBackend,
   };
 });
 
@@ -83,15 +103,9 @@ vi.mock('../../../src/main/index', () => ({
   stackManager: {},
   agentBackend: {},
   registry: {
-    getGlobalBackendSettings: vi.fn().mockReturnValue({
-      inner_backend: 'opencode',
-      inner_provider: 'anthropic',
-      inner_model: null,
-      outer_backend: 'claude',
-      outer_provider: null,
-      outer_model: null,
-    }),
-    getBackendSecretBundle: vi.fn().mockReturnValue(null),
+    getGlobalBackendSettings: mockGetGlobalBackendSettings,
+    getBackendSecretBundle: mockGetBackendSecretBundle,
+    getEffectiveBackend: mockGetEffectiveBackend,
   },
   cliDir: '/tmp/sandstorm-cli',
 }));
@@ -1088,5 +1102,314 @@ describe('OpenCodeBackend auth', () => {
 
   it('syncCredentials resolves without error', async () => {
     await expect(backend.syncCredentials([])).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider routing — splitModel + all three session entry points
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend provider routing', () => {
+  let backend: OpenCodeBackend;
+
+  const defaultGlobalSettings = {
+    inner_backend: 'opencode',
+    inner_provider: 'anthropic',
+    inner_model: null,
+    outer_backend: 'opencode',
+    outer_provider: null,
+    outer_model: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    mockSessionCreate.mockResolvedValue({
+      data: { id: 'oc-session-1', projectID: 'proj', directory: '/project', title: '' },
+    });
+    mockSessionPromptAsync.mockResolvedValue({ data: undefined });
+    mockSessionPrompt.mockResolvedValue({ data: { info: {}, parts: [] } });
+    // Reset registry mocks to safe defaults each test
+    mockGetGlobalBackendSettings.mockReturnValue({ ...defaultGlobalSettings });
+    mockGetBackendSecretBundle.mockReturnValue(null);
+    mockGetEffectiveBackend.mockReturnValue({ backend: 'opencode' });
+  });
+
+  afterEach(() => {
+    backend?.destroy();
+  });
+
+  // --- initialize() server config ---
+
+  it('initialize() forwards provider block from global outer settings to createOpencodeServer', async () => {
+    mockGetGlobalBackendSettings.mockReturnValue({
+      ...defaultGlobalSettings,
+      outer_provider: 'amazon-bedrock',
+      outer_model: 'amazon-bedrock/anthropic.claude-3-5-sonnet',
+    });
+    mockGetBackendSecretBundle.mockReturnValue({ region: 'us-east-1' });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+
+    expect(createOpencodeServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          provider: expect.objectContaining({
+            'amazon-bedrock': expect.any(Object),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('initialize() with null outer_provider defaults to anthropic provider in sdkConfig', async () => {
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+
+    expect(createOpencodeServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          provider: expect.objectContaining({
+            anthropic: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('initialize() passes bundle to generateOuterOpencodeConfig (ollama provider has baseURL)', async () => {
+    mockGetGlobalBackendSettings.mockReturnValue({
+      ...defaultGlobalSettings,
+      outer_provider: 'ollama',
+      outer_model: 'ollama/llama3',
+    });
+    mockGetBackendSecretBundle.mockReturnValue({ baseUrl: 'http://localhost:11434' });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+
+    // ollama maps to providerKey 'openai' with a baseURL field
+    const call = (createOpencodeServer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const providerBlock = call?.config?.provider as Record<string, unknown>;
+    // The 'openai' key is used for ollama (custom OpenAI-compatible endpoint)
+    expect(providerBlock).toBeDefined();
+    expect(Object.keys(providerBlock).length).toBeGreaterThan(0);
+  });
+
+  it('idempotent: two initialize() calls with same global settings yield equal provider+mcp config', async () => {
+    mockGetGlobalBackendSettings.mockReturnValue({
+      ...defaultGlobalSettings,
+      outer_provider: 'amazon-bedrock',
+      outer_model: 'amazon-bedrock/some-model',
+    });
+
+    const b1 = new OpenCodeBackend();
+    await b1.initialize();
+    const call1 = (createOpencodeServer as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    b1.destroy();
+
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    mockGetGlobalBackendSettings.mockReturnValue({
+      ...defaultGlobalSettings,
+      outer_provider: 'amazon-bedrock',
+      outer_model: 'amazon-bedrock/some-model',
+    });
+    mockGetBackendSecretBundle.mockReturnValue(null);
+    mockGetEffectiveBackend.mockReturnValue({ backend: 'opencode' });
+
+    const b2 = new OpenCodeBackend();
+    await b2.initialize();
+    const call2 = (createOpencodeServer as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    b2.destroy();
+
+    expect(call1?.config?.provider).toEqual(call2?.config?.provider);
+    expect(call1?.config?.mcp).toEqual(call2?.config?.mcp);
+  });
+
+  // --- sendMessage / promptAsync (entry point :361) ---
+
+  it('sendMessage routes to provider/model from getEffectiveBackend (combined form with /)', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      provider: 'amazon-bedrock',
+      model: 'amazon-bedrock/some-model',
+    });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.sendMessage('tab-1', 'hello', '/project');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSessionPromptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          model: { providerID: 'amazon-bedrock', modelID: 'some-model' },
+        }),
+      }),
+    );
+  });
+
+  it('sendMessage omits model field when effective.model is unset', async () => {
+    mockGetEffectiveBackend.mockReturnValue({ backend: 'opencode' });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.sendMessage('tab-1', 'hello', '/project');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const callArg = mockSessionPromptAsync.mock.calls[0]?.[0];
+    expect(callArg?.body?.model).toBeUndefined();
+  });
+
+  it('sendMessage routes no-slash model using provider as providerID', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      provider: 'openai',
+      model: 'gpt-4o',
+    });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.sendMessage('tab-1', 'hello', '/project');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSessionPromptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          model: { providerID: 'openai', modelID: 'gpt-4o' },
+        }),
+      }),
+    );
+  });
+
+  it('sendMessage no-slash model falls back to anthropic when provider unset', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      model: 'claude-opus-4',
+    });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    backend.sendMessage('tab-1', 'hello', '/project');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockSessionPromptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          model: { providerID: 'anthropic', modelID: 'claude-opus-4' },
+        }),
+      }),
+    );
+  });
+
+  // --- spawnEphemeralAgent / session.prompt (entry point :450) ---
+
+  it('spawnEphemeralAgent routes to provider/model from getEffectiveBackend (combined form)', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      provider: 'amazon-bedrock',
+      model: 'amazon-bedrock/some-model',
+    });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    await backend.runEphemeralAgent('prompt', '/project');
+
+    expect(mockSessionPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          model: { providerID: 'amazon-bedrock', modelID: 'some-model' },
+        }),
+      }),
+    );
+  });
+
+  it('spawnEphemeralAgent does not hardcode anthropic as providerID', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      provider: 'openai',
+      model: 'openai/gpt-4o',
+    });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    await backend.runEphemeralAgent('prompt', '/project');
+
+    const callArg = mockSessionPrompt.mock.calls[0]?.[0];
+    expect(callArg?.body?.model?.providerID).toBe('openai');
+    expect(callArg?.body?.model?.providerID).not.toBe('anthropic');
+  });
+
+  it('spawnEphemeralAgent omits model field when effective.model is unset', async () => {
+    mockGetEffectiveBackend.mockReturnValue({ backend: 'opencode' });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    await backend.runEphemeralAgent('prompt', '/project');
+
+    const callArg = mockSessionPrompt.mock.calls[0]?.[0];
+    expect(callArg?.body?.model).toBeUndefined();
+  });
+
+  // --- spawnEphemeralSession / sendTurn (entry point :546) ---
+
+  it('spawnEphemeralSession routes initial turn to provider/model from getEffectiveBackend', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      provider: 'amazon-bedrock',
+      model: 'amazon-bedrock/some-model',
+    });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    const handle = backend.spawnEphemeralSession('init prompt', '/project');
+    await handle.initialResult;
+    handle.dispose();
+
+    expect(mockSessionPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          model: { providerID: 'amazon-bedrock', modelID: 'some-model' },
+        }),
+      }),
+    );
+  });
+
+  it('spawnEphemeralSession follow-up turns also carry the resolved model', async () => {
+    mockGetEffectiveBackend.mockReturnValue({
+      backend: 'opencode',
+      provider: 'amazon-bedrock',
+      model: 'amazon-bedrock/some-model',
+    });
+    mockSessionPrompt
+      .mockResolvedValueOnce({ data: { info: {}, parts: [{ type: 'text', id: 'p1', sessionID: 'oc-session-1', messageID: 'm1', text: 'init' }] } })
+      .mockResolvedValueOnce({ data: { info: {}, parts: [{ type: 'text', id: 'p2', sessionID: 'oc-session-1', messageID: 'm2', text: 'followup' }] } });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    const handle = backend.spawnEphemeralSession('init', '/project');
+    await handle.initialResult;
+    await handle.sendFollowUp('follow-up');
+    handle.dispose();
+
+    expect(mockSessionPrompt).toHaveBeenCalledTimes(2);
+    for (const call of mockSessionPrompt.mock.calls) {
+      expect(call[0].body.model).toEqual({ providerID: 'amazon-bedrock', modelID: 'some-model' });
+    }
+  });
+
+  it('spawnEphemeralSession omits model field when effective.model is unset', async () => {
+    mockGetEffectiveBackend.mockReturnValue({ backend: 'opencode' });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+    const handle = backend.spawnEphemeralSession('init', '/project');
+    await handle.initialResult;
+    handle.dispose();
+
+    const callArg = mockSessionPrompt.mock.calls[0]?.[0];
+    expect(callArg?.body?.model).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The OpenCode backend hardcoded `anthropic` as the provider and never forwarded the configured outer provider/model to the OpenCode server or to session requests. This routes the effective backend through every entry point so non-Anthropic providers and explicit model selections are honored.

Key changes in `src/main/agent/opencode-backend.ts`:

- Added a `splitModel()` helper that converts an `EffectiveBackend` into `{ providerID, modelID }`: it splits combined `provider/model` strings on the first `/`, falls back to `effective.provider ?? 'anthropic'` for bare model strings, and returns `null` (so the `model` field is omitted) when the model is unset.
- Cached a `registryRef` once in `initialize()` to avoid repeated dynamic imports and concurrent-import races in the hot path.
- `initialize()` now reads the global `outer_provider`/`outer_model`/secret bundle and forwards the full generated config (`mcp` **and** `provider`) to `createOpencodeServer()`; previously only `mcp` was passed.
- `sendMessageAsync()`, `spawnEphemeralAgent()`, and `spawnEphemeralSession()`/`sendTurn` now resolve the effective backend via the registry and use `splitModel()` to set the request model, replacing the hardcoded `providerID: 'anthropic'`. Ephemeral sessions resolve the model parts once at creation and reuse them across turns.

Test coverage in `tests/unit/agent/opencode-backend.test.ts` adds a `provider routing` suite (16 tests) covering server config forwarding, idempotency, all three session entry points with combined-form models, no-slash fallback, unset-model omission, and an assertion that no Anthropic provider is hardcoded.

## QA plan

1. Configure a non-Anthropic outer provider/model (combined `provider/model` form) in backend settings.
2. Start a stack and dispatch a task; confirm the OpenCode server and the resulting session/prompt requests use the configured provider and model rather than `anthropic`.
3. Set only a bare model with a separate provider and confirm the provider falls back correctly.
4. Unset the outer model and confirm requests omit the `model` field (provider default is used) without errors.
5. Exercise an ephemeral agent run and confirm it routes through the configured provider.

Closes #630