### PR TITLE
[622] fix: clarifying-questions ask flow and verify-blocked controls

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -197,10 +197,20 @@ interface CliResult {
   exitCode: number;
 }
 
+export const ASK_CLARIFYING_QUESTIONS_PROMPT =
+  'You previously stopped for human input but produced no questions. ' +
+  'Step 1: Write the specific clarifying questions you need answered to ' +
+  '/tmp/claude-stop-questions.json as a JSON array of objects, each with string fields "id" and "question". ' +
+  'Step 2 (required): After writing that file, re-engage the STOP_AND_ASK halt — ' +
+  'emit a line STOP_AND_ASK: <one-sentence reason> on its own line and stop immediately ' +
+  'without making any further changes. This re-sets the task to needs_human via the harness ' +
+  'so your questions are surfaced to the human. Do not continue the work.';
+
 export class StackManager {
   private onStackUpdate?: () => void;
   private appVersion: string;
   private portProxy?: PortProxy;
+  private askClarifyingInFlight = new Set<string>();
 
   constructor(
     private registry: Registry,
@@ -916,8 +926,8 @@ export class StackManager {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
-    if (stack.status !== 'needs_human' && stack.status !== 'failed') {
-      throw new SandstormError(ErrorCode.INVALID_INPUT, `Stack "${stackId}" is not in a resumable state (needs_human or failed)`);
+    if (stack.status !== 'needs_human' && stack.status !== 'failed' && stack.status !== 'verify_blocked_environmental') {
+      throw new SandstormError(ErrorCode.INVALID_INPUT, `Stack "${stackId}" is not in a resumable state (needs_human, failed, or verify_blocked_environmental)`);
     }
 
     const task = this.registry.getMostRecentTask(stackId);
@@ -968,6 +978,77 @@ export class StackManager {
         this.notifyUpdate();
       }
       throw err;
+    }
+  }
+
+  /**
+   * Resume a needs_human stack to generate clarifying questions.
+   * Resumes the in-container agent with a fixed prompt instructing it to write
+   * /tmp/claude-stop-questions.json and emit STOP_AND_ASK so the harness re-populates
+   * needs_human_questions. If no session_id, falls back to fresh dispatch.
+   * Idempotent: no-op while a resume is already in flight for this stack.
+   */
+  async askClarifyingQuestions(stackId: string): Promise<void> {
+    // In-flight check first — status may have been changed to 'building' by the first call
+    if (this.askClarifyingInFlight.has(stackId)) {
+      return;
+    }
+
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    if (stack.status !== 'needs_human') {
+      throw new SandstormError(ErrorCode.INVALID_INPUT, `Stack "${stackId}" is not in needs_human state`);
+    }
+
+    this.askClarifyingInFlight.add(stackId);
+
+    const task = this.registry.getMostRecentTask(stackId);
+    if (!task) {
+      this.askClarifyingInFlight.delete(stackId);
+      throw new SandstormError(ErrorCode.INTERNAL_ERROR, `No task found for stack "${stackId}"`);
+    }
+
+    this.registry.updateStackStatus(stackId, 'building');
+    this.notifyUpdate();
+    try {
+      await this.ensureStackContainersRunning(stack, stackId);
+    } catch (err) {
+      this.askClarifyingInFlight.delete(stackId);
+      this.registry.updateStackStatus(stackId, 'needs_human');
+      this.notifyUpdate();
+      throw err;
+    }
+
+    try {
+      if (task.session_id) {
+        // Case A: resume in-container session with fixed prompt to trigger STOP_AND_ASK
+        this.registry.reopenTaskForResume(task.id);
+        await this.dispatchContinuation(stack, stackId, { ...task, status: 'running' }, ASK_CLARIFYING_QUESTIONS_PROMPT);
+      } else {
+        // Case B: no session_id — re-dispatch fresh with original prompt
+        // The fixed clarifying-questions prompt does not apply; the original prompt is re-run.
+        this.registry.interruptTask(task.id);
+        try {
+          await this.dispatchTask(stackId, task.prompt, task.model ?? undefined, {
+            skipTicketFetch: true,
+          });
+        } catch (err) {
+          this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+          this.registry.updateStackStatus(stackId, 'needs_human');
+          this.notifyUpdate();
+          throw err;
+        }
+      }
+    } catch (err) {
+      if (task.session_id) {
+        this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+        this.registry.updateStackStatus(stackId, 'needs_human');
+        this.notifyUpdate();
+      }
+      throw err;
+    } finally {
+      this.askClarifyingInFlight.delete(stackId);
     }
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1083,6 +1083,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     await stackManager.resumeNeedsHumanStack(stackId, answers);
   });
 
+  ipcMain.handle('stacks:askClarifyingQuestions', async (_event, stackId: string) => {
+    await stackManager.askClarifyingQuestions(stackId);
+  });
+
   ipcMain.handle('stacks:recheckCompleted', async (_event, stackId: string) => {
     return stackManager.recheckCompletedStack(stackId);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,6 +74,7 @@ export interface SandstormAPI {
     cleanupStale: (workspacePaths: string[]) => Promise<unknown[]>;
     getNeedsHumanQuestions: (stackId: string) => Promise<string | null>;
     resumeNeedsHuman: (stackId: string, answers: string) => Promise<void>;
+    askClarifyingQuestions: (stackId: string) => Promise<void>;
     selfHealContinue: (stackId: string) => Promise<void>;
     restartWithFindings: (stackId: string, updatedTicketBody: string) => Promise<{ newStackId: string }>;
     recheckCompleted: (stackId: string) => Promise<{
@@ -319,6 +320,8 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('stacks:getNeedsHumanQuestions', stackId),
     resumeNeedsHuman: (stackId: string, answers: string) =>
       ipcRenderer.invoke('stacks:resumeNeedsHuman', stackId, answers),
+    askClarifyingQuestions: (stackId: string) =>
+      ipcRenderer.invoke('stacks:askClarifyingQuestions', stackId),
     selfHealContinue: (stackId: string) =>
       ipcRenderer.invoke('stacks:selfHealContinue', stackId),
     restartWithFindings: (stackId: string, updatedTicketBody: string) =>

--- a/src/renderer/components/AnswerQuestionsModal.tsx
+++ b/src/renderer/components/AnswerQuestionsModal.tsx
@@ -15,9 +15,18 @@ export function AnswerQuestionsModal({ stackId, onClose, onResumed }: AnswerQues
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [asking, setAsking] = useState(false);
+  const [hasAsked, setHasAsked] = useState(false);
+  // Bumped to re-trigger the fetch effect after askClarifyingQuestions resolves
+  const [fetchKey, setFetchKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
+    setQuestions(null);
+    setFallbackMessage(null);
+    setAnswers([]);
+
     window.sandstorm.stacks.getNeedsHumanQuestions(stackId)
       .then((raw) => {
         if (cancelled) return;
@@ -46,8 +55,9 @@ export function AnswerQuestionsModal({ stackId, onClose, onResumed }: AnswerQues
         setFallbackMessage(`Could not load questions: ${err instanceof Error ? err.message : String(err)}`);
         setLoading(false);
       });
+
     return () => { cancelled = true; };
-  }, [stackId]);
+  }, [stackId, fetchKey]);
 
   const handleSubmit = useCallback(async () => {
     if (!questions) return;
@@ -62,6 +72,19 @@ export function AnswerQuestionsModal({ stackId, onClose, onResumed }: AnswerQues
       setSubmitting(false);
     }
   }, [stackId, questions, answers, onResumed]);
+
+  const handleAskClarifyingQuestions = useCallback(async () => {
+    setAsking(true);
+    try {
+      await window.sandstorm.stacks.askClarifyingQuestions(stackId);
+      setHasAsked(true);
+      setFetchKey((k) => k + 1);
+    } catch {
+      // Swallow — refetch will show the updated state
+    } finally {
+      setAsking(false);
+    }
+  }, [stackId]);
 
   return (
     <div
@@ -113,6 +136,32 @@ export function AnswerQuestionsModal({ stackId, onClose, onResumed }: AnswerQues
               <div className="text-xs text-sandstorm-muted bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2.5 whitespace-pre-wrap font-mono">
                 {fallbackMessage}
               </div>
+              {hasAsked ? (
+                <div
+                  className="text-xs text-sandstorm-muted bg-sandstorm-bg border border-sandstorm-border rounded-lg px-3 py-2.5"
+                  data-testid="answer-modal-terminal-no-questions"
+                >
+                  The agent did not produce questions. You can close this dialog and re-dispatch the stack manually.
+                </div>
+              ) : (
+                <button
+                  onClick={handleAskClarifyingQuestions}
+                  disabled={asking}
+                  className="w-full px-4 py-2 bg-sandstorm-surface border border-sandstorm-border text-sandstorm-text-secondary text-xs font-medium rounded-lg hover:bg-sandstorm-surface-hover hover:text-sandstorm-text transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                  data-testid="answer-modal-ask-clarifying"
+                >
+                  {asking ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" className="animate-spin">
+                        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" strokeDasharray="48" strokeDashoffset="32"/>
+                      </svg>
+                      Asking…
+                    </span>
+                  ) : (
+                    'Ask for clarifying questions'
+                  )}
+                </button>
+              )}
             </div>
           )}
 

--- a/src/renderer/components/StackDetail.tsx
+++ b/src/renderer/components/StackDetail.tsx
@@ -330,9 +330,10 @@ export function StackDetail({
 
       {/* Two-column layout: workflow progress (left) + tabs (right) */}
       <div className="flex-1 overflow-hidden flex">
-        {/* Left column: workflow progress panel — always visible */}
+        {/* Left column: workflow progress panel + verify output — always visible */}
         <div className="w-[35%] min-w-[260px] max-w-[380px] border-r border-sandstorm-border flex flex-col overflow-hidden shrink-0">
           <WorkflowProgressPanel progress={effectiveWorkflowProgress} />
+          <VerifyOutputPanel tasks={tasks} />
         </div>
 
         {/* Right column: tabs + content */}
@@ -582,6 +583,46 @@ function TaskHistoryCard({ task }: { task: Task }) {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function VerifyOutputPanel({ tasks }: { tasks: Task[] }) {
+  const mostRecent = tasks
+    .slice()
+    .reverse()
+    .find((t) => t.verify_outputs != null);
+
+  if (!mostRecent?.verify_outputs) return null;
+
+  let outputs: string[] = [];
+  try {
+    const parsed = JSON.parse(mostRecent.verify_outputs) as unknown;
+    if (Array.isArray(parsed)) {
+      outputs = (parsed as unknown[]).filter((x): x is string => typeof x === 'string');
+    }
+  } catch {
+    outputs = [mostRecent.verify_outputs];
+  }
+
+  if (outputs.length === 0) return null;
+
+  return (
+    <div className="border-t border-sandstorm-border p-3 shrink-0 overflow-hidden" data-testid="verify-output-panel">
+      <div className="text-[10px] font-semibold uppercase tracking-wider text-sandstorm-muted mb-2">
+        Verify Output
+      </div>
+      <div className="space-y-1.5 max-h-40 overflow-y-auto">
+        {outputs.map((output, i) => (
+          <pre
+            key={i}
+            className="text-[10px] text-sandstorm-text-secondary bg-sandstorm-bg border border-sandstorm-border rounded px-2 py-1.5 whitespace-pre-wrap break-words font-mono overflow-auto"
+            data-testid={`verify-output-item-${i}`}
+          >
+            {output}
+          </pre>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -17,6 +17,7 @@ const STATUS_COLORS: Record<string, string> = {
   pr_created: 'bg-violet-400',
   rate_limited: 'bg-orange-400 animate-pulse',
   session_paused: 'bg-orange-400',
+  verify_blocked_environmental: 'bg-orange-400',
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -32,6 +33,7 @@ const STATUS_LABELS: Record<string, string> = {
   pr_created: 'PR Open',
   rate_limited: 'Limited',
   session_paused: 'Halted',
+  verify_blocked_environmental: 'Verify Blocked',
 };
 
 const POPOVER_OPEN_DELAY_MS = 150;
@@ -53,6 +55,7 @@ export function StackTableRow({
   const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
+  const [continuing, setContinuing] = useState(false);
   const rowRef = useRef<HTMLTableRowElement>(null);
   const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -150,6 +153,19 @@ export function StackTableRow({
   const handleAnswer = (e: React.MouseEvent) => {
     e.stopPropagation();
     setShowAnswerModal(true);
+  };
+
+  const handleContinueVerifyBlocked = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setContinuing(true);
+    try {
+      await window.sandstorm.stacks.resumeNeedsHuman(stack.id, '');
+      await refreshStacks();
+    } catch (err) {
+      alert(`Failed to continue: ${err}`);
+    } finally {
+      setContinuing(false);
+    }
   };
 
   const handleAnswerResumed = async () => {
@@ -275,6 +291,17 @@ export function StackTableRow({
                 title="Answer the agent's questions and resume"
               >
                 Answer
+              </button>
+            )}
+            {stack.status === 'verify_blocked_environmental' && (
+              <button
+                onClick={handleContinueVerifyBlocked}
+                disabled={continuing}
+                className="text-[10px] font-medium px-2 py-0.5 rounded bg-orange-500/10 text-orange-400 border border-orange-500/30 hover:bg-orange-500/20 transition-colors disabled:opacity-40"
+                data-testid={`row-continue-verify-blocked-${stack.id}`}
+                title="Continue past environmental verify block"
+              >
+                {continuing ? '…' : 'Continue'}
               </button>
             )}
             {makePrEligible(stack) && (

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -721,6 +721,7 @@ declare global {
         cleanupStale: (workspacePaths: string[]) => Promise<CleanupResult[]>;
         getNeedsHumanQuestions: (stackId: string) => Promise<string | null>;
         resumeNeedsHuman: (stackId: string, answers: string) => Promise<void>;
+        askClarifyingQuestions: (stackId: string) => Promise<void>;
         selfHealContinue: (stackId: string) => Promise<void>;
         restartWithFindings: (stackId: string, updatedTicketBody: string) => Promise<{ newStackId: string }>;
         recheckCompleted: (stackId: string) => Promise<{

--- a/tests/unit/components/AnswerQuestionsModal.test.tsx
+++ b/tests/unit/components/AnswerQuestionsModal.test.tsx
@@ -126,4 +126,91 @@ describe('AnswerQuestionsModal', () => {
     });
     expect(screen.getByTestId('answer-modal-error').textContent).toContain('Network failure');
   });
+
+  it('renders "Ask for clarifying questions" button in fallback when no questions', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(null);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+    expect(screen.getByTestId('answer-modal-fallback')).toBeDefined();
+    expect(screen.getByTestId('answer-modal-ask-clarifying')).toBeDefined();
+    expect(screen.queryByTestId('answer-modal-submit')).toBeNull();
+  });
+
+  it('calls askClarifyingQuestions and refetches when button is clicked', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(null);
+    (window.sandstorm.stacks.askClarifyingQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(undefined);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+
+    await act(async () => {
+      screen.getByTestId('answer-modal-ask-clarifying').click();
+    });
+
+    expect(window.sandstorm.stacks.askClarifyingQuestions).toHaveBeenCalledWith('test-stack');
+    expect(window.sandstorm.stacks.getNeedsHumanQuestions).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows terminal message when ask returns still no questions', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(null);
+    (window.sandstorm.stacks.askClarifyingQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(undefined);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+
+    await act(async () => {
+      screen.getByTestId('answer-modal-ask-clarifying').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('answer-modal-terminal-no-questions')).toBeDefined();
+    });
+    expect(screen.queryByTestId('answer-modal-ask-clarifying')).toBeNull();
+  });
+
+  it('shows questions when ask clarifying questions populates them', async () => {
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(QUESTIONS_JSON);
+    (window.sandstorm.stacks.askClarifyingQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(undefined);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+
+    await act(async () => {
+      screen.getByTestId('answer-modal-ask-clarifying').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('How should we handle it?')).toBeDefined();
+    });
+    expect(screen.queryByTestId('answer-modal-terminal-no-questions')).toBeNull();
+  });
+
+  it('disables "Ask for clarifying questions" button while in flight', async () => {
+    let resolveAsk!: () => void;
+    const askPromise = new Promise<void>((resolve) => { resolveAsk = resolve; });
+    (window.sandstorm.stacks.getNeedsHumanQuestions as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(null);
+    (window.sandstorm.stacks.askClarifyingQuestions as ReturnType<typeof vi.fn>)
+      .mockReturnValue(askPromise);
+    renderModal();
+    await waitFor(() => expect(screen.queryByTestId('answer-modal-loading')).toBeNull());
+
+    act(() => {
+      screen.getByTestId('answer-modal-ask-clarifying').click();
+    });
+
+    // Button should be disabled during in-flight
+    await waitFor(() => {
+      const btn = screen.getByTestId('answer-modal-ask-clarifying') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    // Resolve the ask
+    await act(async () => { resolveAsk(); });
+  });
 });

--- a/tests/unit/components/StackDetail.test.tsx
+++ b/tests/unit/components/StackDetail.test.tsx
@@ -609,4 +609,61 @@ describe('StackDetail', () => {
       expect(detail.textContent).toContain('Total');
     });
   });
+
+  it('renders verify output panel when most recent task has verify_outputs', async () => {
+    api.tasks.list.mockResolvedValue([
+      {
+        id: 1,
+        stack_id: 'detail-stack',
+        prompt: 'Run tests',
+        model: null,
+        status: 'needs_human',
+        exit_code: null,
+        verify_outputs: JSON.stringify(['tsc: Cannot find module ./Foo', 'Test suite failed']),
+        started_at: new Date().toISOString(),
+        finished_at: null,
+      },
+    ]);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('verify-output-panel')).toBeDefined();
+      expect(screen.getByTestId('verify-output-item-0')).toBeDefined();
+      expect(screen.getByTestId('verify-output-item-1')).toBeDefined();
+    });
+    expect(screen.getByTestId('verify-output-item-0').textContent).toContain('Cannot find module');
+    expect(screen.getByTestId('verify-output-item-1').textContent).toContain('Test suite failed');
+  });
+
+  it('does not render verify output panel when task has null verify_outputs', async () => {
+    api.tasks.list.mockResolvedValue([
+      {
+        id: 1,
+        stack_id: 'detail-stack',
+        prompt: 'Clean task',
+        model: null,
+        status: 'completed',
+        exit_code: 0,
+        verify_outputs: null,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+      },
+    ]);
+
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+
+    await waitFor(() => {
+      // tasks loaded
+      expect(api.tasks.list).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('verify-output-panel')).toBeNull();
+  });
+
+  it('does not render verify output panel when no tasks are loaded', async () => {
+    api.tasks.list.mockResolvedValue([]);
+    render(<StackDetail stackId="detail-stack" onBack={onBack} />);
+    await waitFor(() => expect(api.tasks.list).toHaveBeenCalled());
+    expect(screen.queryByTestId('verify-output-panel')).toBeNull();
+  });
 });

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -473,3 +473,37 @@ describe('StackTableRow popover suppression on actions hover (#316)', () => {
     expect(screen.queryByTestId('stack-row-popover-foo')).toBeNull();
   });
 });
+
+describe('StackTableRow verify_blocked_environmental', () => {
+  beforeEach(() => {
+    mockSandstormApi();
+    useAppStore.setState({ stacks: [], selectedStackId: null, stackMetrics: {} });
+  });
+
+  it('renders "Verify Blocked" status label', () => {
+    renderRow(makeStack({ status: 'verify_blocked_environmental' }));
+    expect(screen.getByText('Verify Blocked')).toBeDefined();
+  });
+
+  it('renders Continue button for verify_blocked_environmental', () => {
+    renderRow(makeStack({ status: 'verify_blocked_environmental' }));
+    expect(screen.getByTestId('row-continue-verify-blocked-test-stack')).toBeDefined();
+  });
+
+  it('calls resumeNeedsHuman with empty answers when Continue is clicked', async () => {
+    (window.sandstorm.stacks.resumeNeedsHuman as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(undefined);
+    renderRow(makeStack({ status: 'verify_blocked_environmental' }));
+
+    await act(async () => {
+      screen.getByTestId('row-continue-verify-blocked-test-stack').click();
+    });
+
+    expect(window.sandstorm.stacks.resumeNeedsHuman).toHaveBeenCalledWith('test-stack', '');
+  });
+
+  it('does not render Continue button for other statuses', () => {
+    renderRow(makeStack({ status: 'needs_human' }));
+    expect(screen.queryByTestId('row-continue-verify-blocked-test-stack')).toBeNull();
+  });
+});

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -35,6 +35,7 @@ export function mockSandstormApi() {
       cleanupStale: vi.fn().mockResolvedValue([]),
       getNeedsHumanQuestions: vi.fn().mockResolvedValue(null),
       resumeNeedsHuman: vi.fn().mockResolvedValue(undefined),
+      askClarifyingQuestions: vi.fn().mockResolvedValue(undefined),
       selfHealContinue: vi.fn().mockResolvedValue(undefined),
       restartWithFindings: vi.fn().mockResolvedValue({ newStackId: 'feat/123-fix-r2' }),
     },

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -2709,6 +2709,7 @@ describe('IPC Handlers', () => {
       'darkFactory:setEnabled',
       'stacks:getNeedsHumanQuestions',
       'stacks:resumeNeedsHuman',
+      'stacks:askClarifyingQuestions',
       'stacks:selfHealContinue',
       'stacks:restartWithFindings',
       'stacks:recheckCompleted',

--- a/tests/unit/main/control-plane/stack-manager-ask-clarifying.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-ask-clarifying.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for StackManager.askClarifyingQuestions (D2, ticket #622)
+ * and the relaxed gate in resumeNeedsHumanStack (D3, ticket #622).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import {
+  StackManager,
+  ASK_CLARIFYING_QUESTIONS_PROMPT,
+} from '../../../../src/main/control-plane/stack-manager';
+import { Registry } from '../../../../src/main/control-plane/registry';
+import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
+import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
+import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `sm-clarify-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function createMockRuntime(): ContainerRuntime {
+  return {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([
+      {
+        id: 'cid-claude',
+        name: 'sandstorm-proj-s1-claude-1',
+        image: 'sandstorm-claude',
+        status: 'running' as const,
+        state: 'running',
+        ports: [],
+        labels: {},
+        created: new Date().toISOString(),
+      },
+    ]),
+    inspect: vi.fn().mockResolvedValue({}),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
+    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+describe('ASK_CLARIFYING_QUESTIONS_PROMPT', () => {
+  it('includes instruction to emit STOP_AND_ASK after writing the questions file', () => {
+    expect(ASK_CLARIFYING_QUESTIONS_PROMPT).toContain('STOP_AND_ASK:');
+  });
+
+  it('includes the questions file path', () => {
+    expect(ASK_CLARIFYING_QUESTIONS_PROMPT).toContain('/tmp/claude-stop-questions.json');
+  });
+});
+
+describe('StackManager.askClarifyingQuestions', () => {
+  let registry: Registry;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    const portAllocator = new PortAllocator(registry, [40100, 40199]);
+    const taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+
+    registry.createStack({
+      id: 's1',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'needs_human',
+      runtime: 'docker',
+    });
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  it('throws when stack not found', async () => {
+    await expect(manager.askClarifyingQuestions('no-such-stack')).rejects.toThrow();
+  });
+
+  it('throws when stack is not needs_human', async () => {
+    registry.updateStackStatus('s1', 'running');
+    await expect(manager.askClarifyingQuestions('s1')).rejects.toThrow('not in needs_human state');
+  });
+
+  it('throws when no task found', async () => {
+    await expect(manager.askClarifyingQuestions('s1')).rejects.toThrow();
+  });
+
+  it('calls dispatchContinuation with ASK_CLARIFYING_QUESTIONS_PROMPT when session_id is present', async () => {
+    const task = registry.createTask('s1', 'Do the thing', 'sonnet');
+    registry.setTaskSessionId(task.id, 'sess-abc');
+    registry.completeTaskNeedsHuman(task.id, 'No questions produced', null);
+    registry.updateStackStatus('s1', 'needs_human');
+
+    vi.spyOn(manager as unknown as { ensureStackContainersRunning: () => Promise<void> }, 'ensureStackContainersRunning')
+      .mockResolvedValue(undefined);
+    const dispatchSpy = vi.spyOn(manager as unknown as { dispatchContinuation: () => Promise<void> }, 'dispatchContinuation')
+      .mockResolvedValue(undefined);
+
+    await manager.askClarifyingQuestions('s1');
+
+    expect(dispatchSpy).toHaveBeenCalledOnce();
+    const callArgs = dispatchSpy.mock.calls[0];
+    // Fourth arg is the continuation prompt
+    expect(callArgs[3]).toBe(ASK_CLARIFYING_QUESTIONS_PROMPT);
+  });
+
+  it('calls dispatchTask with original prompt when no session_id is present (Case B)', async () => {
+    const task = registry.createTask('s1', 'Do the thing', 'sonnet');
+    // No setTaskSessionId — task has no session_id
+    registry.completeTaskNeedsHuman(task.id, 'No questions', null);
+    registry.updateStackStatus('s1', 'needs_human');
+
+    vi.spyOn(manager as unknown as { ensureStackContainersRunning: () => Promise<void> }, 'ensureStackContainersRunning')
+      .mockResolvedValue(undefined);
+    const dispatchSpy = vi.spyOn(manager as unknown as { dispatchTask: () => Promise<void> }, 'dispatchTask')
+      .mockResolvedValue(undefined);
+
+    await manager.askClarifyingQuestions('s1');
+
+    expect(dispatchSpy).toHaveBeenCalledOnce();
+    const callArgs = dispatchSpy.mock.calls[0];
+    expect(callArgs[0]).toBe('s1');
+    expect(callArgs[1]).toBe('Do the thing');
+    expect(callArgs[3]).toMatchObject({ skipTicketFetch: true });
+  });
+
+  it('rolls back stack to needs_human when dispatchTask throws in Case B', async () => {
+    const task = registry.createTask('s1', 'Do the thing', 'sonnet');
+    // No setTaskSessionId — task has no session_id
+    registry.completeTaskNeedsHuman(task.id, 'No questions', null);
+    registry.updateStackStatus('s1', 'needs_human');
+
+    vi.spyOn(manager as unknown as { ensureStackContainersRunning: () => Promise<void> }, 'ensureStackContainersRunning')
+      .mockResolvedValue(undefined);
+    vi.spyOn(manager as unknown as { dispatchTask: () => Promise<void> }, 'dispatchTask')
+      .mockRejectedValue(new Error('dispatch failed'));
+
+    await expect(manager.askClarifyingQuestions('s1')).rejects.toThrow('dispatch failed');
+
+    const stack = registry.getStack('s1');
+    expect(stack?.status).toBe('needs_human');
+  });
+
+  it('is a no-op when already in flight (idempotency guard)', async () => {
+    const task = registry.createTask('s1', 'Do the thing', 'sonnet');
+    registry.setTaskSessionId(task.id, 'sess-abc');
+    registry.completeTaskNeedsHuman(task.id, 'No questions', null);
+    registry.updateStackStatus('s1', 'needs_human');
+
+    vi.spyOn(manager as unknown as { ensureStackContainersRunning: () => Promise<void> }, 'ensureStackContainersRunning')
+      .mockResolvedValue(undefined);
+
+    let resolve1!: () => void;
+    const dispatchSpy = vi.spyOn(manager as unknown as { dispatchContinuation: () => Promise<void> }, 'dispatchContinuation')
+      .mockImplementation(() => new Promise<void>((res) => { resolve1 = res; }));
+
+    // First call — in flight
+    const p1 = manager.askClarifyingQuestions('s1');
+    // Second call while first is in flight — should be no-op
+    const p2 = manager.askClarifyingQuestions('s1');
+
+    // p2 resolves immediately (no-op)
+    await p2;
+    // dispatch should only have been called once (by p1 only)
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+
+    resolve1();
+    await p1;
+  });
+});
+
+describe('StackManager.resumeNeedsHumanStack gate relaxation', () => {
+  let registry: Registry;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    const portAllocator = new PortAllocator(registry, [40100, 40199]);
+    const taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+
+    registry.createStack({
+      id: 's1',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: 'verify_blocked_environmental',
+      runtime: 'docker',
+    });
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+    vi.restoreAllMocks();
+  });
+
+  it('accepts verify_blocked_environmental status without throwing the gate error', async () => {
+    const task = registry.createTask('s1', 'Do the thing', 'sonnet');
+    registry.setTaskSessionId(task.id, 'sess-abc');
+    // Mark task as needs_human so we have a task to resume
+    registry.completeTaskNeedsHuman(task.id, 'env blocked', null);
+    registry.updateStackStatus('s1', 'verify_blocked_environmental');
+
+    // Mock out container/dispatch so it doesn't actually spawn
+    vi.spyOn(manager as unknown as { ensureStackContainersRunning: () => Promise<void> }, 'ensureStackContainersRunning')
+      .mockResolvedValue(undefined);
+    vi.spyOn(manager as unknown as { dispatchContinuation: () => Promise<void> }, 'dispatchContinuation')
+      .mockResolvedValue(undefined);
+
+    // Should not throw "not in a resumable state" error
+    await expect(manager.resumeNeedsHumanStack('s1', '')).resolves.toBeUndefined();
+  });
+
+  it('still rejects truly invalid statuses', async () => {
+    registry.updateStackStatus('s1', 'running');
+    const task = registry.createTask('s1', 'task', undefined);
+    registry.completeTaskNeedsHuman(task.id, 'reason', null);
+    registry.updateStackStatus('s1', 'running');
+
+    await expect(manager.resumeNeedsHumanStack('s1', '')).rejects.toThrow('not in a resumable state');
+  });
+});


### PR DESCRIPTION
## Summary

When a stack stops at `needs_human` but the agent produced no clarifying questions, the answer dialog previously had nothing to offer. This adds an **Ask for clarifying questions** action that resumes the in-container session with a fixed prompt instructing the agent to write `/tmp/claude-stop-questions.json` and re-emit `STOP_AND_ASK`, so the harness re-populates `needs_human_questions` and they surface to the human. The flow is idempotent (no-op while a resume is already in flight) and rolls the stack status back to `needs_human` if the resume dispatch fails. When the task has no `session_id`, it falls back to a fresh re-dispatch of the original prompt.

The answer modal now re-fetches questions after the ask resolves (with a stale-closure fix so each effect run owns its own `cancelled` flag), and shows a terminal message when the agent still yields nothing.

This also wires up the `verify_blocked_environmental` status end to end: it is now a resumable state, gets its own color and "Verify Blocked" label in the stack table, and exposes a **Continue** button to resume past the environmental block. A **Verify Output** panel in the stack detail view renders the most recent task's `verify_outputs`.

New plumbing: `stacks:askClarifyingQuestions` IPC handler, preload binding, and store typing.

## QA plan

1. Dispatch a task and force a `needs_human` stop with no questions produced.
2. Open the answer dialog; confirm the **Ask for clarifying questions** button appears. Click it and verify the button shows an "Asking…" spinner, then the dialog re-fetches and displays the agent's questions.
3. If the agent still produces nothing, confirm the terminal "did not produce questions" message is shown instead of the button.
4. Click the button twice quickly and confirm only one resume runs (in-flight guard).
5. Simulate a resume-dispatch failure and confirm the stack returns to `needs_human` rather than getting stuck in `building`.
6. Drive a stack into `verify_blocked_environmental`; confirm the table row shows the orange "Verify Blocked" badge and a **Continue** button, and that clicking it resumes the stack and refreshes the list.
7. Open a stack detail view for a task with verify outputs and confirm the **Verify Output** panel renders them in the left column.

Closes #622