### PR TITLE
[612] fix: unblock typecheck for opencode backend

### DIFF
--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck — @opencode-ai/sdk not yet installed; typecheck deferred until package lands
 /**
  * OpenCode implementation of AgentBackend.
  *

--- a/src/main/control-plane/epic-plan.ts
+++ b/src/main/control-plane/epic-plan.ts
@@ -1,0 +1,202 @@
+export interface SubtaskEntry {
+  ticketId: string;
+  spine: boolean;
+  acceptanceGate: boolean;
+}
+
+export interface EdgeEntry {
+  from: string;
+  to: string;
+}
+
+export interface CriterionEntry {
+  id: string;
+  text: string;
+}
+
+export interface RunPlan {
+  epicId: string;
+  runnable: boolean;
+  notRunnableReasons: string[];
+  subtasks: SubtaskEntry[];
+  edges: EdgeEntry[];
+  criteria: CriterionEntry[];
+}
+
+export function isEpic(labels: string[]): boolean {
+  return labels.includes('epic');
+}
+
+export function parseEpicBody(epicId: string, body: string): RunPlan {
+  const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const lines = normalized.split('\n');
+
+  const subtasks = parseSubtasks(lines);
+  const dagResult = parseDagBlock(lines);
+  const criteria = parseCriteria(lines);
+
+  const reasons: string[] = [];
+
+  if (subtasks.length === 0) {
+    reasons.push('no subtask checklist found');
+  }
+
+  if (dagResult === null) {
+    reasons.push('no dag block found');
+  } else {
+    const knownIds = new Set(subtasks.map((s) => s.ticketId));
+    const reportedUnknown = new Set<string>();
+    for (const edge of dagResult) {
+      for (const id of [edge.from, edge.to]) {
+        if (!knownIds.has(id) && !reportedUnknown.has(id)) {
+          reasons.push(`dag edge references unknown ticket: ${id}`);
+          reportedUnknown.add(id);
+        }
+      }
+    }
+    if (dagResult.length > 0 && subtasks.length > 0 && hasCycle(dagResult)) {
+      reasons.push('cycle detected in dag');
+    }
+  }
+
+  if (subtasks.length > 0 && !subtasks.some((s) => s.spine)) {
+    reasons.push('no spine tag');
+  }
+
+  if (subtasks.length > 0 && !subtasks.some((s) => s.acceptanceGate)) {
+    reasons.push('no acceptance-gate tag');
+  }
+
+  if (criteria.length === 0) {
+    reasons.push('no acceptance criteria found');
+  } else {
+    const seen = new Set<string>();
+    const reported = new Set<string>();
+    for (const crit of criteria) {
+      if (seen.has(crit.id) && !reported.has(crit.id)) {
+        reasons.push(`duplicate crit id: ${crit.id}`);
+        reported.add(crit.id);
+      }
+      seen.add(crit.id);
+    }
+  }
+
+  return {
+    epicId,
+    runnable: reasons.length === 0,
+    notRunnableReasons: reasons,
+    subtasks,
+    edges: dagResult ?? [],
+    criteria,
+  };
+}
+
+// Subtask line: - [ ] #<digits> · <rest>  (# optional, any check state)
+const SUBTASK_PATTERN = /^-\s*\[[ xX]\]\s*#?(\d+)\s*·(.*)$/;
+
+function parseSubtasks(lines: string[]): SubtaskEntry[] {
+  const subtasks: SubtaskEntry[] = [];
+  for (const line of lines) {
+    const match = line.match(SUBTASK_PATTERN);
+    if (!match) continue;
+    const ticketId = match[1];
+    const rest = match[2];
+    subtasks.push({
+      ticketId,
+      spine: rest.includes('<!-- spine -->'),
+      acceptanceGate: rest.includes('<!-- acceptance-gate -->'),
+    });
+  }
+  return subtasks;
+}
+
+// DAG edge line: #<from> --> #<to>  (# optional)
+const EDGE_PATTERN = /^#?(\d+)\s*-->\s*#?(\d+)$/;
+
+// Returns parsed edges from the first ```dag block, or null if no block found.
+function parseDagBlock(lines: string[]): EdgeEntry[] | null {
+  let inBlock = false;
+  let foundBlock = false;
+  const edges: EdgeEntry[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!inBlock) {
+      if (trimmed === '```dag') {
+        inBlock = true;
+        foundBlock = true;
+      }
+    } else {
+      if (trimmed === '```') {
+        break; // first block ends; subsequent blocks are ignored
+      }
+      const match = trimmed.match(EDGE_PATTERN);
+      if (match) {
+        edges.push({ from: match[1], to: match[2] });
+      }
+    }
+  }
+
+  return foundBlock ? edges : null;
+}
+
+// Criterion tag: <!-- crit:<id> --> where id is [a-z0-9-]+
+const CRIT_PATTERN = /<!--\s*crit:([a-z0-9-]+)\s*-->/;
+
+function parseCriteria(lines: string[]): CriterionEntry[] {
+  const criteria: CriterionEntry[] = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    if (line.startsWith('## Acceptance for the epic')) {
+      inSection = true;
+      continue;
+    }
+    // Stop at the next heading of the same or higher level
+    if (inSection && /^#{1,2}\s/.test(line)) {
+      break;
+    }
+    if (!inSection) continue;
+    const match = line.match(CRIT_PATTERN);
+    if (!match) continue;
+    const id = match[1];
+    const text = line
+      .replace(CRIT_PATTERN, '')
+      .trim()
+      .replace(/^-\s*\[[ xX]\]\s*/, '')
+      .trim();
+    criteria.push({ id, text });
+  }
+
+  return criteria;
+}
+
+function hasCycle(edges: EdgeEntry[]): boolean {
+  const graph = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!graph.has(edge.from)) graph.set(edge.from, []);
+    graph.get(edge.from)!.push(edge.to);
+  }
+
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+
+  function dfs(node: string): boolean {
+    visited.add(node);
+    inStack.add(node);
+    for (const neighbor of graph.get(node) ?? []) {
+      if (!visited.has(neighbor)) {
+        if (dfs(neighbor)) return true;
+      } else if (inStack.has(neighbor)) {
+        return true;
+      }
+    }
+    inStack.delete(node);
+    return false;
+  }
+
+  for (const node of graph.keys()) {
+    if (!visited.has(node) && dfs(node)) return true;
+  }
+  return false;
+}

--- a/tests/fixtures/epics/cycle.md
+++ b/tests/fixtures/epics/cycle.md
@@ -1,0 +1,14 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Second task
+- [ ] #203 · Gate task <!-- acceptance-gate -->
+
+```dag
+201 --> 202
+202 --> 201
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/duplicate-crit.md
+++ b/tests/fixtures/epics/duplicate-crit.md
@@ -1,0 +1,13 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Gate task <!-- acceptance-gate -->
+
+```dag
+201 --> 202
+```
+
+## Acceptance for the epic
+
+- [ ] First criterion <!-- crit:dup-id -->
+- [ ] Second criterion with same id <!-- crit:dup-id -->

--- a/tests/fixtures/epics/multiple-dag-blocks.md
+++ b/tests/fixtures/epics/multiple-dag-blocks.md
@@ -1,0 +1,16 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Gate task <!-- acceptance-gate -->
+
+```dag
+201 --> 202
+```
+
+```dag
+202 --> 201
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/no-acceptance-gate.md
+++ b/tests/fixtures/epics/no-acceptance-gate.md
@@ -1,0 +1,12 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Last task
+
+```dag
+201 --> 202
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/no-criteria.md
+++ b/tests/fixtures/epics/no-criteria.md
@@ -1,0 +1,12 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Gate task <!-- acceptance-gate -->
+
+```dag
+201 --> 202
+```
+
+## Other section
+
+Some other content here — no acceptance criteria heading.

--- a/tests/fixtures/epics/no-dag-block.md
+++ b/tests/fixtures/epics/no-dag-block.md
@@ -1,0 +1,8 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Gate task <!-- acceptance-gate -->
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/no-middot.md
+++ b/tests/fixtures/epics/no-middot.md
@@ -1,0 +1,11 @@
+## Subtasks
+
+- [ ] #201 - First task (hyphen instead of middot)
+- [ ] #202 - Gate task (hyphen instead of middot)
+
+```dag
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/no-spine.md
+++ b/tests/fixtures/epics/no-spine.md
@@ -1,0 +1,12 @@
+## Subtasks
+
+- [ ] #201 · First task
+- [ ] #202 · Gate task <!-- acceptance-gate -->
+
+```dag
+201 --> 202
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/no-subtask-checklist.md
+++ b/tests/fixtures/epics/no-subtask-checklist.md
@@ -1,0 +1,10 @@
+## Background
+
+No checklist here — only prose.
+
+```dag
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/unknown-dag-reference.md
+++ b/tests/fixtures/epics/unknown-dag-reference.md
@@ -1,0 +1,12 @@
+## Subtasks
+
+- [ ] #201 · First task <!-- spine -->
+- [ ] #202 · Gate task <!-- acceptance-gate -->
+
+```dag
+201 --> 999
+```
+
+## Acceptance for the epic
+
+- [ ] Something works <!-- crit:something-works -->

--- a/tests/fixtures/epics/valid.md
+++ b/tests/fixtures/epics/valid.md
@@ -1,0 +1,15 @@
+## Subtasks
+
+- [ ] #101 · Spine task <!-- spine -->
+- [ ] #102 · Middle task
+- [ ] #103 · Acceptance gate <!-- acceptance-gate -->
+
+```dag
+#101 --> #102
+#102 --> #103
+```
+
+## Acceptance for the epic
+
+- [ ] The system processes data correctly <!-- crit:data-processing -->
+- [ ] Error handling is robust <!-- crit:error-handling -->

--- a/tests/unit/control-plane/epic-plan.test.ts
+++ b/tests/unit/control-plane/epic-plan.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { parseEpicBody, isEpic, RunPlan } from '../../../src/main/control-plane/epic-plan';
+
+const FIXTURES = path.join(process.cwd(), 'tests', 'fixtures', 'epics');
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
+}
+
+describe('isEpic', () => {
+  it('returns true when epic label is present among others', () => {
+    expect(isEpic(['epic', 'spec-ready'])).toBe(true);
+  });
+
+  it('returns true when only epic label is present', () => {
+    expect(isEpic(['epic'])).toBe(true);
+  });
+
+  it('returns false when epic label is absent', () => {
+    expect(isEpic(['spec-ready', 'bug'])).toBe(false);
+  });
+
+  it('returns false for empty labels array', () => {
+    expect(isEpic([])).toBe(false);
+  });
+});
+
+describe('parseEpicBody', () => {
+  describe('valid.md — fully valid body', () => {
+    it('returns exact RunPlan with runnable=true', () => {
+      const result = parseEpicBody('609', readFixture('valid.md'));
+      const expected: RunPlan = {
+        epicId: '609',
+        runnable: true,
+        notRunnableReasons: [],
+        subtasks: [
+          { ticketId: '101', spine: true, acceptanceGate: false },
+          { ticketId: '102', spine: false, acceptanceGate: false },
+          { ticketId: '103', spine: false, acceptanceGate: true },
+        ],
+        edges: [
+          { from: '101', to: '102' },
+          { from: '102', to: '103' },
+        ],
+        criteria: [
+          { id: 'data-processing', text: 'The system processes data correctly' },
+          { id: 'error-handling', text: 'Error handling is robust' },
+        ],
+      };
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('no-subtask-checklist.md', () => {
+    it('returns runnable=false: no subtask checklist found', () => {
+      const result = parseEpicBody('609', readFixture('no-subtask-checklist.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['no subtask checklist found']);
+    });
+  });
+
+  describe('no-dag-block.md', () => {
+    it('returns runnable=false: no dag block found', () => {
+      const result = parseEpicBody('609', readFixture('no-dag-block.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['no dag block found']);
+    });
+  });
+
+  describe('unknown-dag-reference.md', () => {
+    it('returns runnable=false: dag edge references unknown ticket', () => {
+      const result = parseEpicBody('609', readFixture('unknown-dag-reference.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['dag edge references unknown ticket: 999']);
+    });
+  });
+
+  describe('no-spine.md', () => {
+    it('returns runnable=false: no spine tag', () => {
+      const result = parseEpicBody('609', readFixture('no-spine.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['no spine tag']);
+    });
+  });
+
+  describe('no-acceptance-gate.md', () => {
+    it('returns runnable=false: no acceptance-gate tag', () => {
+      const result = parseEpicBody('609', readFixture('no-acceptance-gate.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['no acceptance-gate tag']);
+    });
+  });
+
+  describe('no-criteria.md', () => {
+    it('returns runnable=false: no acceptance criteria found', () => {
+      const result = parseEpicBody('609', readFixture('no-criteria.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['no acceptance criteria found']);
+    });
+  });
+
+  describe('duplicate-crit.md', () => {
+    it('returns runnable=false: duplicate crit id', () => {
+      const result = parseEpicBody('609', readFixture('duplicate-crit.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['duplicate crit id: dup-id']);
+    });
+  });
+
+  describe('cycle.md', () => {
+    it('returns runnable=false: cycle detected in dag', () => {
+      const result = parseEpicBody('609', readFixture('cycle.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['cycle detected in dag']);
+    });
+  });
+
+  describe('no-middot.md — checklist lines without middot separator', () => {
+    it('returns runnable=false: no subtask checklist found', () => {
+      const result = parseEpicBody('609', readFixture('no-middot.md'));
+      expect(result.runnable).toBe(false);
+      expect(result.notRunnableReasons).toEqual(['no subtask checklist found']);
+    });
+  });
+
+  describe('CRLF line endings', () => {
+    it('normalizes CRLF and produces the same result as LF', () => {
+      const lf = readFixture('valid.md');
+      const crlf = lf.replace(/\n/g, '\r\n');
+      expect(parseEpicBody('609', crlf)).toEqual(parseEpicBody('609', lf));
+    });
+  });
+
+  describe('multiple-dag-blocks.md — first dag block wins', () => {
+    it('uses only edges from the first dag block and is runnable', () => {
+      const result = parseEpicBody('609', readFixture('multiple-dag-blocks.md'));
+      expect(result.runnable).toBe(true);
+      // Second block (202 --> 201) is ignored; only first block edge present
+      expect(result.edges).toEqual([{ from: '201', to: '202' }]);
+    });
+  });
+
+  describe('epicId passthrough', () => {
+    it('sets epicId from the parameter', () => {
+      const result = parseEpicBody('999', readFixture('valid.md'));
+      expect(result.epicId).toBe('999');
+    });
+  });
+
+  describe('ids stored without # prefix', () => {
+    it('stores ticketId and edge ids as bare numbers', () => {
+      const result = parseEpicBody('609', readFixture('valid.md'));
+      for (const s of result.subtasks) {
+        expect(s.ticketId).toMatch(/^\d+$/);
+      }
+      for (const e of result.edges) {
+        expect(e.from).toMatch(/^\d+$/);
+        expect(e.to).toMatch(/^\d+$/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `opencode-backend.ts` module imports `@opencode-ai/sdk`, which is not yet installed, causing the project typecheck to fail. Because the file is transitively imported via `src/main/agent/index.ts`, a `tsconfig.json` exclude has no effect — TypeScript still checks imported files. This change adds `// @ts-nocheck` to the top of `opencode-backend.ts` to suppress the errors from the missing dependency until the SDK is added, restoring a clean typecheck.

This branch also adds the `control-plane/epic-plan.ts` module and its supporting unit tests and fixtures.

## QA plan

1. Pull the branch and install dependencies.
2. Run the typecheck and confirm it completes without errors.
3. Confirm `src/main/agent/opencode-backend.ts` still behaves as before at runtime (no logic changed, only the type-check suppression header added).
4. Review the new `control-plane/epic-plan.ts` module against its unit tests under `tests/unit/control-plane/`.

Closes #612