### PR TITLE
[638] fix: scope model secrets and routing per provider

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -11,6 +11,7 @@ import {
   type TouchpointId,
   type RoutingAssignment,
   type PresetId,
+  type AgentBackendKind,
 } from './routing';
 
 /** Per-ticket phase token totals from tasks columns (backfill when task_token_steps absent). */
@@ -767,6 +768,93 @@ export class Registry {
         );
       `);
       this.setSchemaVersion(26);
+    }
+
+    if (currentVersion < 27) {
+      // Per-touchpoint provider credential store (#638)
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS provider_secrets (
+          key      TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          value    TEXT NOT NULL,
+          PRIMARY KEY (key, provider)
+        );
+      `);
+
+      // Migrate backend_secrets + opencode_settings → provider_secrets.
+      // For each scope key and surface, read the bundle and the configured provider,
+      // then write to provider_secrets keyed by (key, provider).
+      // Conflict rule: if both surfaces resolve to the same provider with differing bundles,
+      // outer wins and a warning is logged.
+      const secretKeys = this.db.prepare(
+        'SELECT DISTINCT key FROM backend_secrets'
+      ).all() as Array<{ key: string }>;
+
+      for (const { key } of secretKeys) {
+        const staged: Record<string, Record<string, string>> = {};
+        for (const surface of ['inner', 'outer'] as const) {
+          const bundle = this.getBackendSecretBundle(key, surface);
+          if (!bundle) continue;
+          const ocRow = this.db.prepare(
+            'SELECT provider FROM opencode_settings WHERE key = ? AND surface = ?'
+          ).get(key, surface) as { provider: string | null } | undefined;
+          const provider = ocRow?.provider ?? 'anthropic';
+          if (staged[provider]) {
+            const existingStr = JSON.stringify(staged[provider]);
+            const newStr = JSON.stringify(bundle);
+            if (existingStr !== newStr && surface === 'outer') {
+              console.warn(
+                `[migration v27] Provider '${provider}' key '${key}': conflict — outer bundle wins over inner`
+              );
+              staged[provider] = bundle;
+            }
+          } else {
+            staged[provider] = bundle;
+          }
+        }
+        for (const [provider, bundle] of Object.entries(staged)) {
+          this.db.prepare(
+            'INSERT OR REPLACE INTO provider_secrets (key, provider, value) VALUES (?, ?, ?)'
+          ).run(key, provider, JSON.stringify(bundle));
+        }
+      }
+
+      // Update stored routing assignments to include provider.
+      // claude → 'anthropic'; opencode → check opencode_settings for the surface, fallback 'anthropic'.
+      const outerTouchpoints = new Set(['outer', 'refine', 'pr_description']);
+      const routingRows = this.db.prepare(
+        'SELECT key, assignments FROM model_routing'
+      ).all() as Array<{ key: string; assignments: string }>;
+
+      for (const row of routingRows) {
+        try {
+          const assignments = JSON.parse(row.assignments || '{}') as Record<
+            string,
+            { backend: string; model: string; provider?: string }
+          >;
+          let changed = false;
+          for (const [touchpoint, assignment] of Object.entries(assignments)) {
+            if (!assignment.provider) {
+              if (assignment.backend === 'claude') {
+                assignment.provider = 'anthropic';
+              } else {
+                const surface = outerTouchpoints.has(touchpoint) ? 'outer' : 'inner';
+                const ocRow = this.db.prepare(
+                  'SELECT provider FROM opencode_settings WHERE key = ? AND surface = ?'
+                ).get(row.key, surface) as { provider: string | null } | undefined;
+                assignment.provider = ocRow?.provider ?? 'anthropic';
+              }
+              changed = true;
+            }
+          }
+          if (changed) {
+            this.db.prepare('UPDATE model_routing SET assignments = ? WHERE key = ?')
+              .run(JSON.stringify(assignments), row.key);
+          }
+        } catch { /* skip malformed rows */ }
+      }
+
+      this.setSchemaVersion(27);
     }
   }
 
@@ -1553,9 +1641,9 @@ export class Registry {
     const legacy = this.getLegacyEffectiveModels(projectDir);
     const outerTouchpoints: TouchpointId[] = ['outer', 'refine', 'pr_description'];
     if (outerTouchpoints.includes(touchpoint)) {
-      return { backend: 'claude', model: legacy.outer_model };
+      return { backend: 'claude', provider: 'anthropic', model: legacy.outer_model };
     }
-    return { backend: 'claude', model: legacy.inner_model };
+    return { backend: 'claude', provider: 'anthropic', model: legacy.inner_model };
   }
 
   getEffectiveRouting(projectDir: string): Record<TouchpointId, RoutingAssignment> {
@@ -1973,6 +2061,56 @@ export class Registry {
     }
     // Legacy single-field row: treat as { [name]: value }
     return row.name && row.value ? { [row.name]: row.value } : null;
+  }
+
+  // --- Provider Secrets ---
+
+  hasProviderSecret(key: string, provider: string): boolean {
+    const row = this.db.prepare(
+      'SELECT 1 FROM provider_secrets WHERE key = ? AND provider = ?'
+    ).get(key, provider);
+    return row != null;
+  }
+
+  getProviderSecretBundle(key: string, provider: string): Record<string, string> | null {
+    const row = this.db.prepare(
+      'SELECT value FROM provider_secrets WHERE key = ? AND provider = ?'
+    ).get(key, provider) as { value: string } | undefined;
+    if (!row) return null;
+    try {
+      return JSON.parse(row.value) as Record<string, string>;
+    } catch {
+      return null;
+    }
+  }
+
+  setProviderSecretBundle(key: string, provider: string, bundle: Record<string, string>): void {
+    this.db.prepare(
+      'INSERT OR REPLACE INTO provider_secrets (key, provider, value) VALUES (?, ?, ?)'
+    ).run(key, provider, JSON.stringify(bundle));
+  }
+
+  removeProviderSecret(key: string, provider: string): void {
+    this.db.prepare(
+      'DELETE FROM provider_secrets WHERE key = ? AND provider = ?'
+    ).run(key, provider);
+  }
+
+  getEffectiveTouchpointDescriptor(
+    projectDir: string,
+    touchpoint: TouchpointId,
+  ): { backend: AgentBackendKind; provider: string; model: string; credentials: Record<string, string> | null } {
+    const assignment = this.getEffectiveRoutingFor(projectDir, touchpoint);
+    const projectKey = `project:${path.resolve(projectDir)}`;
+    const credentials =
+      this.getProviderSecretBundle(projectKey, assignment.provider) ??
+      this.getProviderSecretBundle('global', assignment.provider);
+    return {
+      backend: assignment.backend,
+      provider: assignment.provider,
+      model: assignment.model,
+      credentials,
+    };
   }
 
   // --- Session Monitor Settings ---

--- a/src/main/control-plane/routing.ts
+++ b/src/main/control-plane/routing.ts
@@ -23,6 +23,7 @@ export type AgentBackendKind = 'claude' | 'opencode';
 
 export interface RoutingAssignment {
   backend: AgentBackendKind;
+  provider: string;
   model: string;
 }
 
@@ -30,31 +31,31 @@ export type PresetId = 'max_quality' | 'balanced' | 'budget';
 
 export const PRESETS: Record<PresetId, Record<TouchpointId, RoutingAssignment>> = {
   balanced: {
-    outer:          { backend: 'claude', model: 'opus' },
-    refine:         { backend: 'claude', model: 'sonnet' },
-    execution:      { backend: 'claude', model: 'sonnet' },
-    review:         { backend: 'claude', model: 'opus' },
-    meta_review:    { backend: 'claude', model: 'opus' },
-    merge_conflict: { backend: 'claude', model: 'sonnet' },
-    pr_description: { backend: 'claude', model: 'haiku' },
+    outer:          { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    refine:         { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    execution:      { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    review:         { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    meta_review:    { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    merge_conflict: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    pr_description: { backend: 'claude', provider: 'anthropic', model: 'haiku' },
   },
   max_quality: {
-    outer:          { backend: 'claude', model: 'opus' },
-    refine:         { backend: 'claude', model: 'opus' },
-    execution:      { backend: 'claude', model: 'opus' },
-    review:         { backend: 'claude', model: 'opus' },
-    meta_review:    { backend: 'claude', model: 'opus' },
-    merge_conflict: { backend: 'claude', model: 'opus' },
-    pr_description: { backend: 'claude', model: 'sonnet' },
+    outer:          { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    refine:         { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    execution:      { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    review:         { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    meta_review:    { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    merge_conflict: { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    pr_description: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
   },
   budget: {
-    outer:          { backend: 'claude', model: 'sonnet' },
-    refine:         { backend: 'claude', model: 'haiku' },
-    execution:      { backend: 'claude', model: 'haiku' },
-    review:         { backend: 'claude', model: 'sonnet' },
-    meta_review:    { backend: 'claude', model: 'sonnet' },
-    merge_conflict: { backend: 'claude', model: 'haiku' },
-    pr_description: { backend: 'claude', model: 'haiku' },
+    outer:          { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    refine:         { backend: 'claude', provider: 'anthropic', model: 'haiku' },
+    execution:      { backend: 'claude', provider: 'anthropic', model: 'haiku' },
+    review:         { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    meta_review:    { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    merge_conflict: { backend: 'claude', provider: 'anthropic', model: 'haiku' },
+    pr_description: { backend: 'claude', provider: 'anthropic', model: 'haiku' },
   },
 };
 
@@ -98,17 +99,14 @@ export const OPENCODE_MODELS: AvailableModel[] = [
 
 export function getAvailableModels(
   projectDir: string,
-  hasBackendSecret: (key: string, surface: 'inner' | 'outer') => boolean,
+  hasProviderSecret: (key: string, provider: string) => boolean,
 ): AvailableModel[] {
   const projectKey = `project:${path.resolve(projectDir)}`;
-  const ocAvailable =
-    hasBackendSecret(projectKey, 'inner') ||
-    hasBackendSecret(projectKey, 'outer') ||
-    hasBackendSecret('global', 'inner') ||
-    hasBackendSecret('global', 'outer');
-
   return [
     ...CLAUDE_MODELS,
-    ...OPENCODE_MODELS.map((m) => ({ ...m, available: ocAvailable })),
+    ...OPENCODE_MODELS.map((m) => ({
+      ...m,
+      available: hasProviderSecret(projectKey, m.provider) || hasProviderSecret('global', m.provider),
+    })),
   ];
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1010,7 +1010,39 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle('modelRouting:getAvailableModels', (_event, projectDir: string) => {
-    return getAvailableModels(projectDir, (key, surface) => registry.hasBackendSecret(key, surface));
+    return getAvailableModels(projectDir, (key, provider) => registry.hasProviderSecret(key, provider));
+  });
+
+  // --- Provider Secrets ---
+
+  ipcMain.handle('providerSecrets:status', (_event, scope: string, provider: string) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    return { set: registry.hasProviderSecret(key, provider) };
+  });
+
+  ipcMain.handle('providerSecrets:get', (_event, scope: string, provider: string) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    return registry.getProviderSecretBundle(key, provider);
+  });
+
+  ipcMain.handle('providerSecrets:getBundle', (_event, scope: string, provider: string) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    return registry.getProviderSecretBundle(key, provider);
+  });
+
+  ipcMain.handle('providerSecrets:set', (_event, scope: string, provider: string, bundle: Record<string, string>) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    registry.setProviderSecretBundle(key, provider, bundle);
+  });
+
+  ipcMain.handle('providerSecrets:setBundle', (_event, scope: string, provider: string, bundle: Record<string, string>) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    registry.setProviderSecretBundle(key, provider, bundle);
+  });
+
+  ipcMain.handle('providerSecrets:remove', (_event, scope: string, provider: string) => {
+    const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
+    registry.removeProviderSecret(key, provider);
   });
 
   // --- Session Monitor ---

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -158,13 +158,21 @@ export interface SandstormAPI {
     setSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer', bundle: Record<string, string>) => Promise<void>;
     getSecretBundle: (scope: 'global' | string, surface: 'inner' | 'outer') => Promise<Record<string, string> | null>;
   };
+  providerSecrets: {
+    get: (scope: 'global' | string, provider: string) => Promise<Record<string, string> | null>;
+    set: (scope: 'global' | string, provider: string, bundle: Record<string, string>) => Promise<void>;
+    remove: (scope: 'global' | string, provider: string) => Promise<void>;
+    status: (scope: 'global' | string, provider: string) => Promise<{ set: boolean }>;
+    getBundle: (scope: 'global' | string, provider: string) => Promise<Record<string, string> | null>;
+    setBundle: (scope: 'global' | string, provider: string, bundle: Record<string, string>) => Promise<void>;
+  };
   modelRouting: {
-    getEffective: (projectDir: string) => Promise<Record<string, { backend: string; model: string }>>;
-    getProject: (projectDir: string) => Promise<{ assignments: Record<string, { backend: string; model: string }>; preset: string | null } | null>;
-    setProject: (projectDir: string, config: { assignments?: Record<string, { backend: string; model: string }>; preset?: string | null }) => Promise<void>;
+    getEffective: (projectDir: string) => Promise<Record<string, { backend: string; provider: string; model: string }>>;
+    getProject: (projectDir: string) => Promise<{ assignments: Record<string, { backend: string; provider: string; model: string }>; preset: string | null } | null>;
+    setProject: (projectDir: string, config: { assignments?: Record<string, { backend: string; provider: string; model: string }>; preset?: string | null }) => Promise<void>;
     removeProject: (projectDir: string) => Promise<void>;
-    getGlobal: () => Promise<{ assignments: Record<string, { backend: string; model: string }>; preset: string | null }>;
-    setGlobal: (config: { assignments?: Record<string, { backend: string; model: string }>; preset?: string | null }) => Promise<void>;
+    getGlobal: () => Promise<{ assignments: Record<string, { backend: string; provider: string; model: string }>; preset: string | null }>;
+    setGlobal: (config: { assignments?: Record<string, { backend: string; provider: string; model: string }>; preset?: string | null }) => Promise<void>;
     applyPreset: (projectDir: string, presetId: string) => Promise<void>;
     getAvailableModels: (projectDir: string) => Promise<Array<{ backend: string; model: string; label: string; version: string; provider: string; needsKey?: boolean; available: boolean }>>;
   };
@@ -414,6 +422,14 @@ const api: SandstormAPI = {
     secretStatus: (scope, surface) => ipcRenderer.invoke('backendSettings:secretStatus', scope, surface),
     setSecretBundle: (scope, surface, bundle) => ipcRenderer.invoke('backendSettings:setSecretBundle', scope, surface, bundle),
     getSecretBundle: (scope, surface) => ipcRenderer.invoke('backendSettings:getSecretBundle', scope, surface),
+  },
+  providerSecrets: {
+    get: (scope, provider) => ipcRenderer.invoke('providerSecrets:get', scope, provider),
+    set: (scope, provider, bundle) => ipcRenderer.invoke('providerSecrets:set', scope, provider, bundle),
+    remove: (scope, provider) => ipcRenderer.invoke('providerSecrets:remove', scope, provider),
+    status: (scope, provider) => ipcRenderer.invoke('providerSecrets:status', scope, provider),
+    getBundle: (scope, provider) => ipcRenderer.invoke('providerSecrets:getBundle', scope, provider),
+    setBundle: (scope, provider, bundle) => ipcRenderer.invoke('providerSecrets:setBundle', scope, provider, bundle),
   },
   modelRouting: {
     getEffective: (projectDir) => ipcRenderer.invoke('modelRouting:getEffective', projectDir),

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -86,8 +86,12 @@ const {
     getEffectiveBackend: vi.fn().mockReturnValue({ backend: 'claude' }),
     setBackendSecret: vi.fn(),
     hasBackendSecret: vi.fn().mockReturnValue(false),
+    hasProviderSecret: vi.fn().mockReturnValue(false),
+    getProviderSecretBundle: vi.fn().mockReturnValue(null),
+    setProviderSecretBundle: vi.fn(),
+    removeProviderSecret: vi.fn(),
     getEffectiveRouting: vi.fn().mockReturnValue({}),
-    getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'haiku' }),
+    getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'haiku' }),
     getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
     getProjectRouting: vi.fn().mockReturnValue(null),
     setProjectRouting: vi.fn(),
@@ -2660,6 +2664,12 @@ describe('IPC Handlers', () => {
       'modelRouting:setGlobal',
       'modelRouting:applyPreset',
       'modelRouting:getAvailableModels',
+      'providerSecrets:status',
+      'providerSecrets:get',
+      'providerSecrets:getBundle',
+      'providerSecrets:set',
+      'providerSecrets:setBundle',
+      'providerSecrets:remove',
       'runtime:available',
       'session:getState',
       'session:getSettings',
@@ -2943,6 +2953,103 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('backendSettings:secretStatus', 'global', 'inner') as Record<string, unknown>;
       expect(Object.keys(result)).toEqual(['set']);
       expect(result['set']).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // providerSecrets handlers
+  // =========================================================================
+  describe('providerSecrets handlers', () => {
+    describe('providerSecrets:status', () => {
+      it('returns { set: false } when no provider secret stored (global scope)', async () => {
+        mockRegistry.hasProviderSecret.mockReturnValueOnce(false);
+        const result = await invokeHandler('providerSecrets:status', 'global', 'anthropic');
+        expect(mockRegistry.hasProviderSecret).toHaveBeenCalledWith('global', 'anthropic');
+        expect(result).toEqual({ set: false });
+      });
+
+      it('returns { set: true } when provider secret exists', async () => {
+        mockRegistry.hasProviderSecret.mockReturnValueOnce(true);
+        const result = await invokeHandler('providerSecrets:status', 'global', 'anthropic');
+        expect(result).toEqual({ set: true });
+      });
+
+      it('derives key="project:<resolved>" for project scope', async () => {
+        const projectDir = '/some/project';
+        const pathMod = require('path');
+        const expectedKey = `project:${pathMod.resolve(projectDir)}`;
+        mockRegistry.hasProviderSecret.mockReturnValueOnce(true);
+        const result = await invokeHandler('providerSecrets:status', projectDir, 'amazon-bedrock');
+        expect(mockRegistry.hasProviderSecret).toHaveBeenCalledWith(expectedKey, 'amazon-bedrock');
+        expect(result).toEqual({ set: true });
+      });
+    });
+
+    describe('providerSecrets:getBundle', () => {
+      it('returns null when no bundle stored', async () => {
+        mockRegistry.getProviderSecretBundle.mockReturnValueOnce(null);
+        const result = await invokeHandler('providerSecrets:getBundle', 'global', 'anthropic');
+        expect(mockRegistry.getProviderSecretBundle).toHaveBeenCalledWith('global', 'anthropic');
+        expect(result).toBeNull();
+      });
+
+      it('returns bundle when stored', async () => {
+        const bundle = { api_key: 'sk-test' };
+        mockRegistry.getProviderSecretBundle.mockReturnValueOnce(bundle);
+        const result = await invokeHandler('providerSecrets:getBundle', 'global', 'anthropic');
+        expect(result).toEqual(bundle);
+      });
+    });
+
+    describe('providerSecrets:get', () => {
+      it('is an alias for getBundle — returns the bundle', async () => {
+        const bundle = { api_key: 'sk-alias' };
+        mockRegistry.getProviderSecretBundle.mockReturnValueOnce(bundle);
+        const result = await invokeHandler('providerSecrets:get', 'global', 'anthropic');
+        expect(result).toEqual(bundle);
+      });
+    });
+
+    describe('providerSecrets:setBundle', () => {
+      it('calls registry.setProviderSecretBundle with key and provider (global scope)', async () => {
+        const bundle = { api_key: 'sk-new' };
+        const result = await invokeHandler('providerSecrets:setBundle', 'global', 'anthropic', bundle);
+        expect(mockRegistry.setProviderSecretBundle).toHaveBeenCalledWith('global', 'anthropic', bundle);
+        expect(result).toBeUndefined();
+      });
+
+      it('derives key="project:<resolved>" for project scope', async () => {
+        const projectDir = '/my/proj';
+        const pathMod = require('path');
+        const expectedKey = `project:${pathMod.resolve(projectDir)}`;
+        const bundle = { aws_key: 'bedrock-key' };
+        await invokeHandler('providerSecrets:setBundle', projectDir, 'amazon-bedrock', bundle);
+        expect(mockRegistry.setProviderSecretBundle).toHaveBeenCalledWith(expectedKey, 'amazon-bedrock', bundle);
+      });
+    });
+
+    describe('providerSecrets:set', () => {
+      it('is an alias for setBundle — calls registry.setProviderSecretBundle', async () => {
+        const bundle = { api_key: 'sk-set' };
+        await invokeHandler('providerSecrets:set', 'global', 'anthropic', bundle);
+        expect(mockRegistry.setProviderSecretBundle).toHaveBeenCalledWith('global', 'anthropic', bundle);
+      });
+    });
+
+    describe('providerSecrets:remove', () => {
+      it('calls registry.removeProviderSecret with key and provider', async () => {
+        const result = await invokeHandler('providerSecrets:remove', 'global', 'anthropic');
+        expect(mockRegistry.removeProviderSecret).toHaveBeenCalledWith('global', 'anthropic');
+        expect(result).toBeUndefined();
+      });
+
+      it('derives key="project:<resolved>" for project scope', async () => {
+        const projectDir = '/my/proj';
+        const pathMod = require('path');
+        const expectedKey = `project:${pathMod.resolve(projectDir)}`;
+        await invokeHandler('providerSecrets:remove', projectDir, 'anthropic');
+        expect(mockRegistry.removeProviderSecret).toHaveBeenCalledWith(expectedKey, 'anthropic');
+      });
     });
   });
 

--- a/tests/unit/model-routing.test.ts
+++ b/tests/unit/model-routing.test.ts
@@ -128,13 +128,13 @@ describe('Model Routing', () => {
     it('layer 5: legacy fallback from model_settings for outer touchpoints', () => {
       registry.setGlobalModelSettings({ outer_model: 'haiku' });
       const result = registry.getEffectiveRoutingFor('/proj/no-routing', 'outer');
-      expect(result).toEqual({ backend: 'claude', model: 'haiku' });
+      expect(result).toEqual({ backend: 'claude', provider: 'anthropic', model: 'haiku' });
     });
 
     it('layer 5: legacy fallback from model_settings for inner touchpoints', () => {
       registry.setGlobalModelSettings({ inner_model: 'opus' });
       const result = registry.getEffectiveRoutingFor('/proj/no-routing', 'execution');
-      expect(result).toEqual({ backend: 'claude', model: 'opus' });
+      expect(result).toEqual({ backend: 'claude', provider: 'anthropic', model: 'opus' });
     });
 
     it('partial project assignment: unassigned touchpoints fall through to global', () => {
@@ -408,40 +408,41 @@ describe('Model Routing', () => {
       }
     });
 
-    it('OpenCode models available when project inner secret configured', () => {
-      const models = getAvailableModels('/proj/test', (key, surface) => {
-        return key === `project:${path.resolve('/proj/test')}` && surface === 'inner';
+    it('OpenCode anthropic model available when project has anthropic provider secret', () => {
+      const projectKey = `project:${path.resolve('/proj/test')}`;
+      const models = getAvailableModels('/proj/test', (key, provider) => {
+        return key === projectKey && provider === 'anthropic';
       });
       const oc = models.filter((m) => m.backend === 'opencode');
-      for (const m of oc) {
-        expect(m.available).toBe(true);
-      }
+      const anthropicModel = oc.find((m) => m.provider === 'anthropic');
+      const bedrockModel = oc.find((m) => m.provider === 'amazon-bedrock');
+      expect(anthropicModel?.available).toBe(true);
+      expect(bedrockModel?.available).toBe(false);
     });
 
-    it('OpenCode models available when project outer secret configured', () => {
-      const models = getAvailableModels('/proj/test', (key, surface) => {
-        return key === `project:${path.resolve('/proj/test')}` && surface === 'outer';
+    it('OpenCode amazon-bedrock model available when project has amazon-bedrock provider secret', () => {
+      const projectKey = `project:${path.resolve('/proj/test')}`;
+      const models = getAvailableModels('/proj/test', (key, provider) => {
+        return key === projectKey && provider === 'amazon-bedrock';
       });
       const oc = models.filter((m) => m.backend === 'opencode');
-      for (const m of oc) {
-        expect(m.available).toBe(true);
-      }
+      const anthropicModel = oc.find((m) => m.provider === 'anthropic');
+      const bedrockModel = oc.find((m) => m.provider === 'amazon-bedrock');
+      expect(anthropicModel?.available).toBe(false);
+      expect(bedrockModel?.available).toBe(true);
     });
 
-    it('OpenCode models available when global inner secret configured', () => {
-      const models = getAvailableModels('/proj/test', (key, surface) => {
-        return key === 'global' && surface === 'inner';
+    it('OpenCode models available when global provider secret configured', () => {
+      const models = getAvailableModels('/proj/test', (key, provider) => {
+        return key === 'global' && provider === 'anthropic';
       });
       const oc = models.filter((m) => m.backend === 'opencode');
-      for (const m of oc) {
-        expect(m.available).toBe(true);
-      }
+      const anthropicModel = oc.find((m) => m.provider === 'anthropic');
+      expect(anthropicModel?.available).toBe(true);
     });
 
-    it('OpenCode models available when global outer secret configured', () => {
-      const models = getAvailableModels('/proj/test', (key, surface) => {
-        return key === 'global' && surface === 'outer';
-      });
+    it('all OpenCode models available when all provider secrets configured', () => {
+      const models = getAvailableModels('/proj/test', () => true);
       const oc = models.filter((m) => m.backend === 'opencode');
       for (const m of oc) {
         expect(m.available).toBe(true);
@@ -467,6 +468,58 @@ describe('Model Routing', () => {
       OPENCODE_MODELS.forEach((m, i) => {
         expect(m.available).toBe(originalAvailable[i]);
       });
+    });
+  });
+
+  // ==========================================================================
+  // getEffectiveTouchpointDescriptor
+  // ==========================================================================
+  describe('getEffectiveTouchpointDescriptor', () => {
+    it('returns backend, provider, model, and credentials for a claude touchpoint', () => {
+      const desc = registry.getEffectiveTouchpointDescriptor('/proj/test', 'execution');
+      expect(desc.backend).toBe('claude');
+      expect(desc.provider).toBe('anthropic');
+      expect(typeof desc.model).toBe('string');
+      expect(desc.credentials).toBeNull(); // no secrets stored yet
+    });
+
+    it('returns credentials:null when no provider secret stored', () => {
+      const desc = registry.getEffectiveTouchpointDescriptor('/proj/test', 'outer');
+      expect(desc.credentials).toBeNull();
+    });
+
+    it('returns project-level credentials when stored', () => {
+      const projectKey = `project:${path.resolve('/proj/creds')}`;
+      registry.setProviderSecretBundle(projectKey, 'anthropic', { api_key: 'proj-sk-123' });
+      const desc = registry.getEffectiveTouchpointDescriptor('/proj/creds', 'execution');
+      expect(desc.credentials).toEqual({ api_key: 'proj-sk-123' });
+    });
+
+    it('falls back to global credentials when no project-level secret', () => {
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'global-sk-456' });
+      const desc = registry.getEffectiveTouchpointDescriptor('/proj/no-creds', 'execution');
+      expect(desc.credentials).toEqual({ api_key: 'global-sk-456' });
+    });
+
+    it('project credentials take precedence over global', () => {
+      const projectKey = `project:${path.resolve('/proj/precedence')}`;
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'global-sk' });
+      registry.setProviderSecretBundle(projectKey, 'anthropic', { api_key: 'project-sk' });
+      const desc = registry.getEffectiveTouchpointDescriptor('/proj/precedence', 'execution');
+      expect(desc.credentials).toEqual({ api_key: 'project-sk' });
+    });
+
+    it('all touchpoints resolve to a descriptor with required fields', () => {
+      for (const touchpoint of TOUCHPOINTS) {
+        const desc = registry.getEffectiveTouchpointDescriptor('/proj/all', touchpoint);
+        expect(desc).toHaveProperty('backend');
+        expect(desc).toHaveProperty('provider');
+        expect(desc).toHaveProperty('model');
+        expect(desc).toHaveProperty('credentials');
+        expect(typeof desc.backend).toBe('string');
+        expect(typeof desc.provider).toBe('string');
+        expect(typeof desc.model).toBe('string');
+      }
     });
   });
 });

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1688,4 +1688,198 @@ describe('Registry', () => {
     });
   });
 
+  // ==========================================================================
+  // provider_secrets CRUD
+  // ==========================================================================
+  describe('provider_secrets CRUD', () => {
+    it('hasProviderSecret returns false when nothing stored', () => {
+      expect(registry.hasProviderSecret('global', 'anthropic')).toBe(false);
+    });
+
+    it('setProviderSecretBundle / getProviderSecretBundle round-trip', () => {
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'sk-test' });
+      expect(registry.hasProviderSecret('global', 'anthropic')).toBe(true);
+      expect(registry.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'sk-test' });
+    });
+
+    it('getProviderSecretBundle returns null when key not found', () => {
+      expect(registry.getProviderSecretBundle('global', 'no-such-provider')).toBeNull();
+    });
+
+    it('setProviderSecretBundle overwrites existing bundle (upsert)', () => {
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'sk-old' });
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'sk-new' });
+      expect(registry.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'sk-new' });
+    });
+
+    it('removeProviderSecret deletes the entry', () => {
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'sk-test' });
+      registry.removeProviderSecret('global', 'anthropic');
+      expect(registry.hasProviderSecret('global', 'anthropic')).toBe(false);
+      expect(registry.getProviderSecretBundle('global', 'anthropic')).toBeNull();
+    });
+
+    it('removeProviderSecret on non-existent key is a no-op', () => {
+      expect(() => registry.removeProviderSecret('global', 'ghost')).not.toThrow();
+    });
+
+    it('provider secrets are scoped by (key, provider) independently', () => {
+      const projectKey = `project:${path.resolve('/proj/x')}`;
+      registry.setProviderSecretBundle('global', 'anthropic', { api_key: 'global-sk' });
+      registry.setProviderSecretBundle(projectKey, 'anthropic', { api_key: 'project-sk' });
+      registry.setProviderSecretBundle('global', 'amazon-bedrock', { aws_key: 'bedrock-key' });
+      expect(registry.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'global-sk' });
+      expect(registry.getProviderSecretBundle(projectKey, 'anthropic')).toEqual({ api_key: 'project-sk' });
+      expect(registry.getProviderSecretBundle('global', 'amazon-bedrock')).toEqual({ aws_key: 'bedrock-key' });
+    });
+
+    it('stores multi-field bundles correctly', () => {
+      const bundle = { access_key: 'AKIA123', secret_key: 'abc456', region: 'us-east-1' };
+      registry.setProviderSecretBundle('global', 'amazon-bedrock', bundle);
+      expect(registry.getProviderSecretBundle('global', 'amazon-bedrock')).toEqual(bundle);
+    });
+  });
+
+  // ==========================================================================
+  // migration v27 — provider_secrets table and credential migration (#638)
+  // ==========================================================================
+  describe('migration v27 — provider_secrets (#638)', () => {
+    it('creates provider_secrets table with correct columns', () => {
+      const db = registry.getDb();
+      const cols = (db.prepare('PRAGMA table_info(provider_secrets)').all() as { name: string }[]).map(r => r.name);
+      expect(cols).toContain('key');
+      expect(cols).toContain('provider');
+      expect(cols).toContain('value');
+    });
+
+    it('migrates inner bundle to provider_secrets using opencode_settings provider', async () => {
+      const tmpPath = path.join(os.tmpdir(), `reg-v27-inner-${Date.now()}.db`);
+      try {
+        // Simulate a pre-v27 DB by opening it fresh (all migrations run), resetting
+        // schema_version to 26, dropping provider_secrets, adding test data, then re-opening.
+        const r1 = await Registry.create(tmpPath);
+        const db1 = r1.getDb();
+        db1.exec('DROP TABLE IF EXISTS provider_secrets');
+        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-inner' }));
+        db1.prepare("INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'inner', 'anthropic', NULL)").run();
+        r1.close();
+
+        const r2 = await Registry.create(tmpPath);
+        expect(r2.hasProviderSecret('global', 'anthropic')).toBe(true);
+        expect(r2.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'sk-inner' });
+        r2.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(tmpPath + suffix); } catch { /* ok */ }
+        }
+      }
+    });
+
+    it('migrates a legacy single-field backend_secrets row as a bundle', async () => {
+      const tmpPath = path.join(os.tmpdir(), `reg-v27-legacy-${Date.now()}.db`);
+      try {
+        const r1 = await Registry.create(tmpPath);
+        const db1 = r1.getDb();
+        db1.exec('DROP TABLE IF EXISTS provider_secrets');
+        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        // Legacy single-field row (written by old setBackendSecret)
+        db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', 'api_key', 'sk-legacy')").run();
+        db1.prepare("INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'inner', 'anthropic', NULL)").run();
+        r1.close();
+
+        const r2 = await Registry.create(tmpPath);
+        expect(r2.hasProviderSecret('global', 'anthropic')).toBe(true);
+        // Legacy single-field becomes { api_key: 'sk-legacy' }
+        expect(r2.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'sk-legacy' });
+        r2.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(tmpPath + suffix); } catch { /* ok */ }
+        }
+      }
+    });
+
+    it('outer bundle wins when both surfaces map to same provider with conflicting bundles', async () => {
+      const tmpPath = path.join(os.tmpdir(), `reg-v27-conflict-${Date.now()}.db`);
+      try {
+        const r1 = await Registry.create(tmpPath);
+        const db1 = r1.getDb();
+        db1.exec('DROP TABLE IF EXISTS provider_secrets');
+        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        // Both surfaces → anthropic provider, but different bundles
+        db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-inner' }));
+        db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'outer', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-outer' }));
+        db1.prepare("INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'inner', 'anthropic', NULL)").run();
+        db1.prepare("INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'outer', 'anthropic', NULL)").run();
+        r1.close();
+
+        const r2 = await Registry.create(tmpPath);
+        // Outer wins
+        expect(r2.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'sk-outer' });
+        r2.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(tmpPath + suffix); } catch { /* ok */ }
+        }
+      }
+    });
+
+    it('migration is idempotent — running v27 twice does not error or duplicate', async () => {
+      const tmpPath = path.join(os.tmpdir(), `reg-v27-idem-${Date.now()}.db`);
+      try {
+        const r1 = await Registry.create(tmpPath);
+        r1.close();
+        // Second open re-runs migrate() but v27 guard fires only if version < 27
+        const r2 = await Registry.create(tmpPath);
+        // provider_secrets table still exists and is functional
+        r2.setProviderSecretBundle('global', 'anthropic', { api_key: 'sk' });
+        expect(r2.hasProviderSecret('global', 'anthropic')).toBe(true);
+        r2.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(tmpPath + suffix); } catch { /* ok */ }
+        }
+      }
+    });
+
+    it('null surface provider falls back to anthropic during migration', async () => {
+      const tmpPath = path.join(os.tmpdir(), `reg-v27-nullprovider-${Date.now()}.db`);
+      try {
+        const r1 = await Registry.create(tmpPath);
+        const db1 = r1.getDb();
+        db1.exec('DROP TABLE IF EXISTS provider_secrets');
+        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        // backend_secrets with no corresponding opencode_settings row → provider = null → falls back to anthropic
+        db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-fallback' }));
+        // No opencode_settings row → provider resolves to null → 'anthropic'
+        r1.close();
+
+        const r2 = await Registry.create(tmpPath);
+        expect(r2.hasProviderSecret('global', 'anthropic')).toBe(true);
+        expect(r2.getProviderSecretBundle('global', 'anthropic')).toEqual({ api_key: 'sk-fallback' });
+        r2.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(tmpPath + suffix); } catch { /* ok */ }
+        }
+      }
+    });
+
+    it('v27 guard: migration does not re-run after schema version is 27', async () => {
+      const tmpPath = path.join(os.tmpdir(), `reg-v27-guard-${Date.now()}.db`);
+      try {
+        const r1 = await Registry.create(tmpPath);
+        const db1 = r1.getDb();
+        const versionRow = db1.prepare('SELECT MAX(version) as v FROM schema_version').get() as { v: number };
+        expect(versionRow.v).toBeGreaterThanOrEqual(27);
+        r1.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(tmpPath + suffix); } catch { /* ok */ }
+        }
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

Reworks credential storage and model routing so secrets are tracked per provider rather than per backend surface. Claude models are always offered, while OpenCode models become available only when a secret exists for their specific provider.

A schema v27 migration introduces a `provider_secrets(key, provider, value)` table and folds the legacy `backend_secrets` and `opencode_settings` data into it (outer-wins on conflict), and rewrites stored routing assignments to carry a `provider` field. Routing presets and the legacy fallback now default to `anthropic`.

The registry gains provider-secret CRUD plus a `getEffectiveTouchpointDescriptor` helper that resolves backend, provider, model, and credentials with project-to-global fallback. New `providerSecrets:*` IPC handlers and matching preload bindings expose this to the renderer, and `modelRouting:getAvailableModels` now keys availability off `hasProviderSecret`.

## QA plan

1. Launch the app against an existing DB containing `backend_secrets`/`opencode_settings` and confirm the v27 migration runs cleanly and prior credentials still work.
2. In model routing, verify Claude models are always selectable.
3. With no OpenCode provider secret set, confirm that provider's models are hidden; add the secret and confirm they appear.
4. Set a project-level routing override and confirm it takes precedence over the global assignment; clear it and confirm fallback to global.
5. Add, update, and remove a provider secret via the settings UI and confirm availability updates accordingly.

Closes #638