### PR TITLE
[537] feat: add automation and ticketing config panes

### DIFF
--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -856,6 +856,25 @@ export class Registry {
 
       this.setSchemaVersion(27);
     }
+
+    if (currentVersion < 28) {
+      // Add level and merge_strategy columns to project_dark_factory.
+      // Backfill runs once inside the level-column guard (idempotent: never re-runs after columns exist).
+      let levelColumnAdded = false;
+      try {
+        this.db.exec("ALTER TABLE project_dark_factory ADD COLUMN level TEXT NOT NULL DEFAULT 'manual'");
+        levelColumnAdded = true;
+      } catch { /* Column already exists */ }
+      if (levelColumnAdded) {
+        this.db.exec(
+          "UPDATE project_dark_factory SET level = CASE WHEN enabled = 1 THEN 'dark_factory' ELSE 'manual' END"
+        );
+      }
+      try {
+        this.db.exec("ALTER TABLE project_dark_factory ADD COLUMN merge_strategy TEXT NOT NULL DEFAULT 'squash'");
+      } catch { /* Column already exists */ }
+      this.setSchemaVersion(28);
+    }
   }
 
   // --- Projects ---
@@ -1716,15 +1735,43 @@ export class Registry {
 
   getDarkFactoryEnabled(projectDir: string): boolean {
     const key = `project:${path.resolve(projectDir)}`;
-    const row = this.db.prepare('SELECT enabled FROM project_dark_factory WHERE key = ?').get(key) as { enabled: number } | undefined;
-    return row ? row.enabled === 1 : false;
+    const row = this.db.prepare('SELECT level FROM project_dark_factory WHERE key = ?').get(key) as { level: string } | undefined;
+    return row ? row.level === 'dark_factory' : false;
   }
 
   setDarkFactoryEnabled(projectDir: string, enabled: boolean): void {
     const key = `project:${path.resolve(projectDir)}`;
+    if (enabled) {
+      this.db.prepare(
+        `INSERT INTO project_dark_factory (key, enabled, level, merge_strategy) VALUES (?, 1, 'dark_factory', 'squash')
+         ON CONFLICT(key) DO UPDATE SET enabled = 1, level = 'dark_factory'`
+      ).run(key);
+    } else {
+      const current = this.db.prepare('SELECT level FROM project_dark_factory WHERE key = ?').get(key) as { level: string } | undefined;
+      if (!current) {
+        this.db.prepare(
+          `INSERT INTO project_dark_factory (key, enabled, level, merge_strategy) VALUES (?, 0, 'manual', 'squash')`
+        ).run(key);
+      } else if (current.level === 'dark_factory') {
+        this.db.prepare(`UPDATE project_dark_factory SET enabled = 0, level = 'manual' WHERE key = ?`).run(key);
+      }
+      // If level is 'assisted', leave it unchanged — getDarkFactoryEnabled already returns false for non-dark_factory levels
+    }
+  }
+
+  getDarkFactoryConfig(projectDir: string): { level: string; merge_strategy: string } {
+    const key = `project:${path.resolve(projectDir)}`;
+    const row = this.db.prepare('SELECT level, merge_strategy FROM project_dark_factory WHERE key = ?').get(key) as { level: string; merge_strategy: string } | undefined;
+    return row ? { level: row.level, merge_strategy: row.merge_strategy } : { level: 'manual', merge_strategy: 'squash' };
+  }
+
+  setDarkFactoryConfig(projectDir: string, config: { level: string; merge_strategy: string }): void {
+    const key = `project:${path.resolve(projectDir)}`;
+    const enabled = config.level === 'dark_factory' ? 1 : 0;
     this.db.prepare(
-      'INSERT OR REPLACE INTO project_dark_factory (key, enabled) VALUES (?, ?)'
-    ).run(key, enabled ? 1 : 0);
+      `INSERT INTO project_dark_factory (key, enabled, level, merge_strategy) VALUES (?, ?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET enabled = excluded.enabled, level = excluded.level, merge_strategy = excluded.merge_strategy`
+    ).run(key, enabled, config.level, config.merge_strategy);
   }
 
   // --- Ticket Board ---

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1787,6 +1787,14 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
+  ipcMain.handle('darkFactory:getConfig', (_event, projectDir: string) => {
+    return registry.getDarkFactoryConfig(projectDir);
+  });
+
+  ipcMain.handle('darkFactory:setConfig', (_event, projectDir: string, config: { level: string; merge_strategy: string }) => {
+    registry.setDarkFactoryConfig(projectDir, config);
+  });
+
   ipcMain.handle('pr:autoResolve', async (_event, ticketId: string, projectDir: string) => {
     return stackManager.autoResolveConflicts(ticketId, projectDir);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -282,6 +282,8 @@ export interface SandstormAPI {
   darkFactory: {
     getEnabled: (projectDir: string) => Promise<boolean>;
     setEnabled: (projectDir: string, enabled: boolean) => Promise<void>;
+    getConfig: (projectDir: string) => Promise<{ level: string; merge_strategy: string }>;
+    setConfig: (projectDir: string, config: { level: string; merge_strategy: string }) => Promise<void>;
   };
   telemetry: {
     summary: (range: { since: string; until: string }) => Promise<unknown>;
@@ -530,6 +532,8 @@ const api: SandstormAPI = {
   darkFactory: {
     getEnabled: (projectDir) => ipcRenderer.invoke('darkFactory:getEnabled', projectDir),
     setEnabled: (projectDir, enabled) => ipcRenderer.invoke('darkFactory:setEnabled', projectDir, enabled),
+    getConfig: (projectDir) => ipcRenderer.invoke('darkFactory:getConfig', projectDir),
+    setConfig: (projectDir, config) => ipcRenderer.invoke('darkFactory:setConfig', projectDir, config),
   },
   telemetry: {
     summary: (range) => ipcRenderer.invoke('stats:telemetry:summary', range),

--- a/src/renderer/components/config/AutomationPane.tsx
+++ b/src/renderer/components/config/AutomationPane.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { ConfigPane, ConfigPaneContext } from './types';
+
+export type AutomationLevel = 'manual' | 'assisted' | 'dark_factory';
+export type MergeStrategy = 'squash' | 'merge' | 'rebase';
+
+interface LevelMeta {
+  id: AutomationLevel;
+  title: string;
+  description: string;
+  subtext?: string;
+  chips: string[];
+  youMerge?: boolean;
+}
+
+export const AUTOMATION_LEVELS: LevelMeta[] = [
+  {
+    id: 'manual',
+    title: 'Manual',
+    description: 'You drive everything.',
+    subtext: 'you spin stacks · you open PRs',
+    chips: [],
+  },
+  {
+    id: 'assisted',
+    title: 'Assisted',
+    description: 'Auto-spins a stack and implements on spec_ready; you review & merge the PR.',
+    chips: ['✓ spin stack', '✓ implement', '✓ open PR'],
+    youMerge: true,
+  },
+  {
+    id: 'dark_factory',
+    title: 'Dark Factory',
+    description: 'Hands-off. Fully automated from spec_ready through merge. No human in the loop.',
+    chips: ['✓ spin stack', '✓ implement', '✓ open PR', '✓ auto-merge'],
+  },
+];
+
+export const MERGE_STRATEGIES: { id: MergeStrategy; label: string }[] = [
+  { id: 'squash', label: 'Squash' },
+  { id: 'merge', label: 'Merge' },
+  { id: 'rebase', label: 'Rebase' },
+];
+
+interface AutomationConfig {
+  level: AutomationLevel;
+  merge_strategy: MergeStrategy;
+}
+
+function AutomationPaneBody({ ctx }: { ctx: ConfigPaneContext }) {
+  const { projectDir, darkFactory, onDirtyChange, registerSave } = ctx;
+
+  const [baseline, setBaseline] = useState<AutomationConfig>({ level: 'manual', merge_strategy: 'squash' });
+  const [buffered, setBuffered] = useState<AutomationConfig>({ level: 'manual', merge_strategy: 'squash' });
+
+  const bufferedRef = useRef(buffered);
+  bufferedRef.current = buffered;
+
+  useEffect(() => {
+    let cancelled = false;
+    darkFactory.getConfig(projectDir).then((cfg) => {
+      if (cancelled) return;
+      const config: AutomationConfig = {
+        level: (cfg.level as AutomationLevel) || 'manual',
+        merge_strategy: (cfg.merge_strategy as MergeStrategy) || 'squash',
+      };
+      setBaseline(config);
+      setBuffered(config);
+    });
+    return () => { cancelled = true; };
+  }, [projectDir]);
+
+  useEffect(() => {
+    const isDirty = JSON.stringify(buffered) !== JSON.stringify(baseline);
+    onDirtyChange(isDirty);
+  }, [buffered, baseline]);
+
+  useEffect(() => {
+    registerSave(async () => {
+      const current = bufferedRef.current;
+      await darkFactory.setConfig(projectDir, current);
+      setBaseline(current);
+      onDirtyChange(false);
+    });
+  }, [projectDir]);
+
+  return (
+    <div data-testid="automation-pane" className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium text-sandstorm-fg mb-1">Automation Level</h3>
+        <p className="text-xs text-sandstorm-muted mb-3">
+          Selecting Assisted or Dark Factory stores your preference but does not yet change pipeline behavior.
+        </p>
+        <div className="space-y-2">
+          {AUTOMATION_LEVELS.map((lvl) => (
+            <button
+              key={lvl.id}
+              data-testid={`level-card-${lvl.id}`}
+              className={`w-full text-left p-3 rounded border transition-colors ${
+                buffered.level === lvl.id
+                  ? 'border-sandstorm-accent bg-sandstorm-accent/10'
+                  : 'border-sandstorm-border bg-sandstorm-surface hover:border-sandstorm-muted'
+              }`}
+              onClick={() => setBuffered((b) => ({ ...b, level: lvl.id }))}
+            >
+              <div className="font-medium text-sm text-sandstorm-fg">{lvl.title}</div>
+              <div className="text-xs text-sandstorm-muted mt-0.5">{lvl.description}</div>
+              {lvl.subtext && (
+                <div className="text-xs text-sandstorm-muted/70 mt-0.5">{lvl.subtext}</div>
+              )}
+              {(lvl.chips.length > 0 || lvl.youMerge) && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {lvl.chips.map((chip) => (
+                    <span
+                      key={chip}
+                      className="text-xs px-1.5 py-0.5 rounded bg-sandstorm-accent/20 text-sandstorm-accent"
+                    >
+                      {chip}
+                    </span>
+                  ))}
+                  {lvl.youMerge && (
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-sandstorm-surface-2 text-sandstorm-muted">
+                      you merge
+                    </span>
+                  )}
+                </div>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-sandstorm-fg mb-1">Merge Strategy</h3>
+        <div className="flex rounded border border-sandstorm-border overflow-hidden">
+          {MERGE_STRATEGIES.map((s) => (
+            <button
+              key={s.id}
+              data-testid={`merge-strategy-${s.id}`}
+              className={`flex-1 py-1.5 text-sm transition-colors ${
+                buffered.merge_strategy === s.id
+                  ? 'bg-sandstorm-accent text-white'
+                  : 'bg-sandstorm-surface text-sandstorm-muted hover:bg-sandstorm-surface-2'
+              }`}
+              onClick={() => setBuffered((b) => ({ ...b, merge_strategy: s.id }))}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function buildAutomationPane(ctx: ConfigPaneContext): ConfigPane {
+  return {
+    id: 'automation',
+    label: 'Automation',
+    icon: <span className="text-sm">⚡</span>,
+    render: () => <AutomationPaneBody ctx={ctx} />,
+  };
+}

--- a/src/renderer/components/config/TicketingPane.tsx
+++ b/src/renderer/components/config/TicketingPane.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { ConfigPane, ConfigPaneContext, ProjectTicketConfig, TicketProvider } from './types';
+
+interface TicketingPaneBodyProps {
+  ctx: ConfigPaneContext;
+}
+
+const EMPTY_CONFIG: ProjectTicketConfig = {
+  provider: 'github',
+  jira_url: null,
+  jira_username: null,
+  jira_api_token: null,
+  jira_project_key: null,
+  jira_issue_type: null,
+  ticket_prefix: null,
+};
+
+function jiraFieldsMissing(config: ProjectTicketConfig): boolean {
+  if (config.provider !== 'jira') return false;
+  return !config.jira_url || !config.jira_username || !config.jira_api_token || !config.jira_project_key;
+}
+
+function TicketingPaneBody({ ctx }: TicketingPaneBodyProps) {
+  const { projectDir, ticketing, onDirtyChange, registerSave } = ctx;
+
+  const [baseline, setBaseline] = useState<ProjectTicketConfig>(EMPTY_CONFIG);
+  const [buffered, setBuffered] = useState<ProjectTicketConfig>(EMPTY_CONFIG);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const bufferedRef = useRef(buffered);
+  bufferedRef.current = buffered;
+
+  useEffect(() => {
+    let cancelled = false;
+    ticketing.get(projectDir).then((cfg) => {
+      if (cancelled) return;
+      const config = cfg ?? EMPTY_CONFIG;
+      setBaseline(config);
+      setBuffered(config);
+    });
+    return () => { cancelled = true; };
+  }, [projectDir]);
+
+  useEffect(() => {
+    const isDirty = JSON.stringify(buffered) !== JSON.stringify(baseline);
+    onDirtyChange(isDirty);
+  }, [buffered, baseline]);
+
+  useEffect(() => {
+    registerSave(async () => {
+      const current = bufferedRef.current;
+      if (jiraFieldsMissing(current)) {
+        setSaveError('Jira requires URL, username, API token, and project key.');
+        return;
+      }
+      setSaveError(null);
+      await ticketing.set(projectDir, current);
+      setBaseline(current);
+      onDirtyChange(false);
+    });
+  }, [projectDir]);
+
+  const setProvider = (provider: TicketProvider) => {
+    setSaveError(null);
+    setBuffered((b) => ({ ...b, provider }));
+  };
+
+  const setField = (field: keyof ProjectTicketConfig, value: string) => {
+    setBuffered((b) => ({ ...b, [field]: value || null }));
+  };
+
+  return (
+    <div data-testid="ticketing-pane" className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium text-sandstorm-fg mb-3">Provider</h3>
+        <div className="flex gap-3">
+          {(['github', 'jira'] as TicketProvider[]).map((p) => (
+            <button
+              key={p}
+              data-testid={`provider-tile-${p}`}
+              className={`flex-1 py-3 px-4 rounded border text-sm font-medium transition-colors ${
+                buffered.provider === p
+                  ? 'border-sandstorm-accent bg-sandstorm-accent/10 text-sandstorm-accent'
+                  : 'border-sandstorm-border bg-sandstorm-surface text-sandstorm-muted hover:border-sandstorm-muted'
+              }`}
+              onClick={() => setProvider(p)}
+            >
+              {p === 'github' ? 'GitHub' : 'Jira'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {buffered.provider === 'jira' && (
+        <div className="space-y-3" data-testid="jira-fields">
+          <div>
+            <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+              Jira URL <span className="text-red-400">*</span>
+            </label>
+            <input
+              data-testid="jira-url"
+              type="url"
+              className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+              value={buffered.jira_url ?? ''}
+              onChange={(e) => setField('jira_url', e.target.value)}
+              placeholder="https://yourteam.atlassian.net"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+              Username (email) <span className="text-red-400">*</span>
+            </label>
+            <input
+              data-testid="jira-username"
+              type="email"
+              className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+              value={buffered.jira_username ?? ''}
+              onChange={(e) => setField('jira_username', e.target.value)}
+              placeholder="you@example.com"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+              API Token <span className="text-red-400">*</span>
+            </label>
+            <input
+              data-testid="jira-api-token"
+              type="password"
+              className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+              value={buffered.jira_api_token ?? ''}
+              onChange={(e) => setField('jira_api_token', e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+              Project Key <span className="text-red-400">*</span>
+            </label>
+            <input
+              data-testid="jira-project-key"
+              type="text"
+              className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+              value={buffered.jira_project_key ?? ''}
+              onChange={(e) => setField('jira_project_key', e.target.value)}
+              placeholder="PROJ"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+              Issue Type
+            </label>
+            <input
+              data-testid="jira-issue-type"
+              type="text"
+              className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+              value={buffered.jira_issue_type ?? ''}
+              onChange={(e) => setField('jira_issue_type', e.target.value)}
+              placeholder="Story"
+            />
+          </div>
+        </div>
+      )}
+
+      <div>
+        <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+          Ticket Prefix
+        </label>
+        <input
+          data-testid="ticket-prefix"
+          type="text"
+          className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+          value={buffered.ticket_prefix ?? ''}
+          onChange={(e) => setField('ticket_prefix', e.target.value)}
+          placeholder="e.g. PROJ"
+        />
+      </div>
+
+      {saveError && (
+        <p data-testid="ticketing-save-error" className="text-xs text-red-400">
+          {saveError}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function buildTicketingPane(ctx: ConfigPaneContext): ConfigPane {
+  return {
+    id: 'ticketing',
+    label: 'Ticketing',
+    icon: <span className="text-sm">🎫</span>,
+    render: () => <TicketingPaneBody ctx={ctx} />,
+  };
+}

--- a/src/renderer/components/config/panes.tsx
+++ b/src/renderer/components/config/panes.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { ConfigPane, ConfigPaneContext } from './types';
 import { buildModelsPane } from './ModelsPane';
+import { buildAutomationPane } from './AutomationPane';
+import { buildTicketingPane } from './TicketingPane';
 
 export async function buildConfigPanes(ctx: ConfigPaneContext): Promise<ConfigPane[]> {
   return [
@@ -11,17 +13,7 @@ export async function buildConfigPanes(ctx: ConfigPaneContext): Promise<ConfigPa
       icon: <span className="text-sm">🔌</span>,
       render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
     },
-    {
-      id: 'automation',
-      label: 'Automation',
-      icon: <span className="text-sm">⚡</span>,
-      render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-    },
-    {
-      id: 'ticketing',
-      label: 'Ticketing',
-      icon: <span className="text-sm">🎫</span>,
-      render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-    },
+    buildAutomationPane(ctx),
+    buildTicketingPane(ctx),
   ];
 }

--- a/src/renderer/components/config/types.ts
+++ b/src/renderer/components/config/types.ts
@@ -20,9 +20,37 @@ export interface ModelRoutingApi {
   getAvailableModels: (projectDir: string) => Promise<Array<{ backend: string; model: string; label: string; version: string; provider: string; needsKey?: boolean; available: boolean }>>;
 }
 
+export interface DarkFactoryApi {
+  getConfig: (projectDir: string) => Promise<{ level: string; merge_strategy: string }>;
+  setConfig: (projectDir: string, config: { level: string; merge_strategy: string }) => Promise<void>;
+}
+
+export type TicketProvider = 'github' | 'jira';
+
+export interface ProjectTicketConfig {
+  provider: TicketProvider;
+  jira_url?: string | null;
+  jira_username?: string | null;
+  jira_api_token?: string | null;
+  jira_project_key?: string | null;
+  jira_issue_type?: string | null;
+  ticket_prefix?: string | null;
+  filter_mode?: 'assisted' | 'advanced' | null;
+  filter_ownership?: 'created' | 'assigned' | null;
+  filter_open_only?: boolean | null;
+  filter_query?: string | null;
+}
+
+export interface TicketingApi {
+  get: (projectDir: string) => Promise<ProjectTicketConfig | null>;
+  set: (projectDir: string, config: ProjectTicketConfig) => Promise<void>;
+}
+
 export interface ConfigPaneContext {
   projectDir: string;
   routing: ModelRoutingApi;
+  darkFactory: DarkFactoryApi;
+  ticketing: TicketingApi;
   onDirtyChange: (dirty: boolean) => void;
   registerSave: (save: () => Promise<void>) => void;
 }

--- a/tests/unit/components/AutomationPane.test.tsx
+++ b/tests/unit/components/AutomationPane.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor, cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
+import { buildAutomationPane, AUTOMATION_LEVELS, MERGE_STRATEGIES } from '../../../src/renderer/components/config/AutomationPane';
+import type { ConfigPaneContext } from '../../../src/renderer/components/config/types';
+
+function makeCtx(overrides: Partial<ConfigPaneContext['darkFactory']> = {}): ConfigPaneContext {
+  return {
+    projectDir: '/test/project',
+    routing: {
+      getEffective: vi.fn().mockResolvedValue({}),
+      getProject: vi.fn().mockResolvedValue(null),
+      setProject: vi.fn().mockResolvedValue(undefined),
+      removeProject: vi.fn().mockResolvedValue(undefined),
+      getGlobal: vi.fn().mockResolvedValue({ assignments: {}, preset: null }),
+      setGlobal: vi.fn().mockResolvedValue(undefined),
+      applyPreset: vi.fn().mockResolvedValue(undefined),
+      getAvailableModels: vi.fn().mockResolvedValue([]),
+    },
+    darkFactory: {
+      getConfig: vi.fn().mockResolvedValue({ level: 'manual', merge_strategy: 'squash' }),
+      setConfig: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    },
+    ticketing: {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onDirtyChange: vi.fn(),
+    registerSave: vi.fn(),
+  };
+}
+
+describe('AutomationPane', () => {
+  it('renders the automation-pane testid', async () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => expect(screen.getByTestId('automation-pane')).toBeDefined());
+  });
+
+  it('pane has id automation and label Automation', () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    expect(pane.id).toBe('automation');
+    expect(pane.label).toBe('Automation');
+  });
+
+  it('renders all three level cards', async () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      for (const lvl of AUTOMATION_LEVELS) {
+        expect(screen.getByTestId(`level-card-${lvl.id}`)).toBeDefined();
+      }
+    });
+  });
+
+  it('renders all three merge strategy buttons', async () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      for (const s of MERGE_STRATEGIES) {
+        expect(screen.getByTestId(`merge-strategy-${s.id}`)).toBeDefined();
+      }
+    });
+  });
+
+  it('loads level from getConfig and highlights the correct card', async () => {
+    const ctx = makeCtx({
+      getConfig: vi.fn().mockResolvedValue({ level: 'assisted', merge_strategy: 'squash' }),
+    });
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      const card = screen.getByTestId('level-card-assisted');
+      expect(card.className).toContain('border-sandstorm-accent');
+    });
+  });
+
+  it('clicking a level card calls onDirtyChange and updates the selection', async () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('level-card-dark_factory'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('level-card-dark_factory'));
+    });
+    expect(ctx.onDirtyChange).toHaveBeenCalledWith(true);
+  });
+
+  it('clicking a merge strategy button updates the selection', async () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('merge-strategy-rebase'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('merge-strategy-rebase'));
+    });
+    expect(ctx.onDirtyChange).toHaveBeenCalledWith(true);
+  });
+
+  it('save handler calls setConfig with the current level and merge_strategy', async () => {
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    const registerSave = vi.fn();
+    const ctx = makeCtx({ setConfig });
+    ctx.registerSave = registerSave;
+
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('level-card-assisted'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('level-card-assisted'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('merge-strategy-rebase'));
+    });
+
+    const savedFn = registerSave.mock.calls[registerSave.mock.calls.length - 1][0];
+    await act(async () => { await savedFn(); });
+
+    expect(setConfig).toHaveBeenCalledWith('/test/project', { level: 'assisted', merge_strategy: 'rebase' });
+  });
+
+  it('getConfig returning dark_factory level maps to getDarkFactoryEnabled=true equivalent', async () => {
+    const ctx = makeCtx({
+      getConfig: vi.fn().mockResolvedValue({ level: 'dark_factory', merge_strategy: 'merge' }),
+    });
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      const card = screen.getByTestId('level-card-dark_factory');
+      expect(card.className).toContain('border-sandstorm-accent');
+    });
+  });
+
+  it('chip labels match the AUTOMATION_LEVELS constant', async () => {
+    const ctx = makeCtx();
+    const pane = buildAutomationPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('automation-pane'));
+    // Assisted chips
+    expect(screen.getAllByText('✓ spin stack').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('✓ implement').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('✓ open PR').length).toBeGreaterThan(0);
+    // Dark factory extra chip
+    expect(screen.getAllByText('✓ auto-merge').length).toBeGreaterThan(0);
+  });
+
+  it('reloads config when projectDir changes', async () => {
+    const getConfig = vi.fn()
+      .mockResolvedValueOnce({ level: 'manual', merge_strategy: 'squash' })
+      .mockResolvedValueOnce({ level: 'dark_factory', merge_strategy: 'merge' });
+    const ctx = makeCtx({ getConfig });
+    const pane = buildAutomationPane(ctx);
+    const { rerender } = render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('automation-pane'));
+
+    const ctx2 = { ...ctx, projectDir: '/other/project' };
+    const pane2 = buildAutomationPane(ctx2);
+    rerender(<>{pane2.render()}</>);
+    await waitFor(() => expect(getConfig).toHaveBeenCalledTimes(2));
+  });
+});

--- a/tests/unit/components/ProjectConfigModal.test.tsx
+++ b/tests/unit/components/ProjectConfigModal.test.tsx
@@ -174,6 +174,14 @@ describe('buildConfigPanes registry', () => {
         applyPreset: vi.fn().mockResolvedValue(undefined),
         getAvailableModels: vi.fn().mockResolvedValue([]),
       },
+      darkFactory: {
+        getConfig: vi.fn().mockResolvedValue({ level: 'manual', merge_strategy: 'squash' }),
+        setConfig: vi.fn().mockResolvedValue(undefined),
+      },
+      ticketing: {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
       onDirtyChange: vi.fn(),
       registerSave: vi.fn(),
     };

--- a/tests/unit/components/TicketingPane.test.tsx
+++ b/tests/unit/components/TicketingPane.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor, cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
+import { buildTicketingPane } from '../../../src/renderer/components/config/TicketingPane';
+import type { ConfigPaneContext, ProjectTicketConfig } from '../../../src/renderer/components/config/types';
+
+function makeCtx(initialConfig: ProjectTicketConfig | null = null): ConfigPaneContext {
+  return {
+    projectDir: '/test/project',
+    routing: {
+      getEffective: vi.fn().mockResolvedValue({}),
+      getProject: vi.fn().mockResolvedValue(null),
+      setProject: vi.fn().mockResolvedValue(undefined),
+      removeProject: vi.fn().mockResolvedValue(undefined),
+      getGlobal: vi.fn().mockResolvedValue({ assignments: {}, preset: null }),
+      setGlobal: vi.fn().mockResolvedValue(undefined),
+      applyPreset: vi.fn().mockResolvedValue(undefined),
+      getAvailableModels: vi.fn().mockResolvedValue([]),
+    },
+    darkFactory: {
+      getConfig: vi.fn().mockResolvedValue({ level: 'manual', merge_strategy: 'squash' }),
+      setConfig: vi.fn().mockResolvedValue(undefined),
+    },
+    ticketing: {
+      get: vi.fn().mockResolvedValue(initialConfig),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    onDirtyChange: vi.fn(),
+    registerSave: vi.fn(),
+  };
+}
+
+describe('TicketingPane', () => {
+  it('renders the ticketing-pane testid', async () => {
+    const ctx = makeCtx();
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => expect(screen.getByTestId('ticketing-pane')).toBeDefined());
+  });
+
+  it('pane has id ticketing and label Ticketing', () => {
+    const ctx = makeCtx();
+    const pane = buildTicketingPane(ctx);
+    expect(pane.id).toBe('ticketing');
+    expect(pane.label).toBe('Ticketing');
+  });
+
+  it('renders both provider tiles', async () => {
+    const ctx = makeCtx();
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-tile-github')).toBeDefined();
+      expect(screen.getByTestId('provider-tile-jira')).toBeDefined();
+    });
+  });
+
+  it('defaults to github provider when no config exists', async () => {
+    const ctx = makeCtx(null);
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      const githubTile = screen.getByTestId('provider-tile-github');
+      expect(githubTile.className).toContain('border-sandstorm-accent');
+    });
+  });
+
+  it('does not render jira fields when provider is github', async () => {
+    const ctx = makeCtx(null);
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('ticketing-pane'));
+    expect(screen.queryByTestId('jira-fields')).toBeNull();
+  });
+
+  it('shows jira fields when jira tile is selected', async () => {
+    const ctx = makeCtx(null);
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-tile-jira'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-tile-jira'));
+    });
+    expect(screen.getByTestId('jira-fields')).toBeDefined();
+    expect(screen.getByTestId('jira-url')).toBeDefined();
+    expect(screen.getByTestId('jira-username')).toBeDefined();
+    expect(screen.getByTestId('jira-api-token')).toBeDefined();
+    expect(screen.getByTestId('jira-project-key')).toBeDefined();
+  });
+
+  it('loads jira provider from existing config and shows jira fields', async () => {
+    const ctx = makeCtx({
+      provider: 'jira',
+      jira_url: 'https://test.atlassian.net',
+      jira_username: 'user@test.com',
+      jira_api_token: 'token123',
+      jira_project_key: 'TEST',
+    });
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      expect(screen.getByTestId('jira-fields')).toBeDefined();
+      const urlInput = screen.getByTestId('jira-url') as HTMLInputElement;
+      expect(urlInput.value).toBe('https://test.atlassian.net');
+    });
+  });
+
+  it('blocks save with Jira provider when required fields are missing', async () => {
+    const set = vi.fn();
+    const registerSave = vi.fn();
+    const ctx = makeCtx(null);
+    ctx.ticketing.set = set;
+    ctx.registerSave = registerSave;
+
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-tile-jira'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-tile-jira'));
+    });
+
+    const savedFn = registerSave.mock.calls[registerSave.mock.calls.length - 1][0];
+    await act(async () => { await savedFn(); });
+
+    expect(set).not.toHaveBeenCalled();
+    expect(screen.getByTestId('ticketing-save-error')).toBeDefined();
+  });
+
+  it('save calls ticketing.set with the correct shape for github', async () => {
+    const set = vi.fn().mockResolvedValue(undefined);
+    const registerSave = vi.fn();
+    const ctx = makeCtx(null);
+    ctx.ticketing.set = set;
+    ctx.registerSave = registerSave;
+
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('ticket-prefix'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('ticket-prefix'), { target: { value: 'GH' } });
+    });
+
+    const savedFn = registerSave.mock.calls[registerSave.mock.calls.length - 1][0];
+    await act(async () => { await savedFn(); });
+
+    expect(set).toHaveBeenCalledWith(
+      '/test/project',
+      expect.objectContaining({ provider: 'github', ticket_prefix: 'GH' })
+    );
+  });
+
+  it('save calls ticketing.set with jira config when all required fields are filled', async () => {
+    const set = vi.fn().mockResolvedValue(undefined);
+    const registerSave = vi.fn();
+    const ctx = makeCtx(null);
+    ctx.ticketing.set = set;
+    ctx.registerSave = registerSave;
+
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-tile-jira'));
+
+    await act(async () => { fireEvent.click(screen.getByTestId('provider-tile-jira')); });
+    await act(async () => { fireEvent.change(screen.getByTestId('jira-url'), { target: { value: 'https://team.atlassian.net' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('jira-username'), { target: { value: 'me@team.com' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('jira-api-token'), { target: { value: 'secret' } }); });
+    await act(async () => { fireEvent.change(screen.getByTestId('jira-project-key'), { target: { value: 'TEAM' } }); });
+
+    const savedFn = registerSave.mock.calls[registerSave.mock.calls.length - 1][0];
+    await act(async () => { await savedFn(); });
+
+    expect(set).toHaveBeenCalledWith(
+      '/test/project',
+      expect.objectContaining({
+        provider: 'jira',
+        jira_url: 'https://team.atlassian.net',
+        jira_username: 'me@team.com',
+        jira_api_token: 'secret',
+        jira_project_key: 'TEAM',
+      })
+    );
+  });
+
+  it('switching provider clears the save error', async () => {
+    const registerSave = vi.fn();
+    const ctx = makeCtx(null);
+    ctx.registerSave = registerSave;
+
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-tile-jira'));
+    await act(async () => { fireEvent.click(screen.getByTestId('provider-tile-jira')); });
+
+    const savedFn = registerSave.mock.calls[registerSave.mock.calls.length - 1][0];
+    await act(async () => { await savedFn(); });
+    expect(screen.getByTestId('ticketing-save-error')).toBeDefined();
+
+    await act(async () => { fireEvent.click(screen.getByTestId('provider-tile-github')); });
+    expect(screen.queryByTestId('ticketing-save-error')).toBeNull();
+  });
+
+  it('selecting a provider marks the form dirty', async () => {
+    const ctx = makeCtx(null);
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-tile-jira'));
+    await act(async () => { fireEvent.click(screen.getByTestId('provider-tile-jira')); });
+    expect(ctx.onDirtyChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders ticket-prefix input', async () => {
+    const ctx = makeCtx({ provider: 'github', ticket_prefix: 'PROJ' });
+    const pane = buildTicketingPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      const input = screen.getByTestId('ticket-prefix') as HTMLInputElement;
+      expect(input.value).toBe('PROJ');
+    });
+  });
+});

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -76,6 +76,8 @@ const {
     deleteBoardTicket: vi.fn(),
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
     setDarkFactoryEnabled: vi.fn(),
+    getDarkFactoryConfig: vi.fn().mockReturnValue({ level: 'manual', merge_strategy: 'squash' }),
+    setDarkFactoryConfig: vi.fn(),
     getDb: vi.fn().mockReturnValue({}),
     getStepWeightsByTicket: vi.fn().mockReturnValue([]),
     getTaskPhaseTokensByTicket: vi.fn().mockReturnValue([]),
@@ -2022,6 +2024,33 @@ describe('IPC Handlers', () => {
     });
   });
 
+  describe('darkFactory:getConfig', () => {
+    it('returns the config object from registry', async () => {
+      mockRegistry.getDarkFactoryConfig.mockReturnValue({ level: 'assisted', merge_strategy: 'squash' });
+      const result = await invokeHandler('darkFactory:getConfig', '/proj');
+      expect(result).toEqual({ level: 'assisted', merge_strategy: 'squash' });
+      expect(mockRegistry.getDarkFactoryConfig).toHaveBeenCalledWith('/proj');
+    });
+
+    it('returns manual/squash defaults for a new project', async () => {
+      mockRegistry.getDarkFactoryConfig.mockReturnValue({ level: 'manual', merge_strategy: 'squash' });
+      const result = await invokeHandler('darkFactory:getConfig', '/new-proj');
+      expect(result).toEqual({ level: 'manual', merge_strategy: 'squash' });
+    });
+  });
+
+  describe('darkFactory:setConfig', () => {
+    it('calls setDarkFactoryConfig on registry with the given config', async () => {
+      await invokeHandler('darkFactory:setConfig', '/proj', { level: 'dark_factory', merge_strategy: 'squash' });
+      expect(mockRegistry.setDarkFactoryConfig).toHaveBeenCalledWith('/proj', { level: 'dark_factory', merge_strategy: 'squash' });
+    });
+
+    it('persists assisted + rebase config', async () => {
+      await invokeHandler('darkFactory:setConfig', '/proj', { level: 'assisted', merge_strategy: 'rebase' });
+      expect(mockRegistry.setDarkFactoryConfig).toHaveBeenCalledWith('/proj', { level: 'assisted', merge_strategy: 'rebase' });
+    });
+  });
+
   // =========================================================================
   // PR Auto-Resolve
   // =========================================================================
@@ -2717,6 +2746,8 @@ describe('IPC Handlers', () => {
       'projectTicketConfig:set',
       'darkFactory:getEnabled',
       'darkFactory:setEnabled',
+      'darkFactory:getConfig',
+      'darkFactory:setConfig',
       'stacks:getNeedsHumanQuestions',
       'stacks:resumeNeedsHuman',
       'stacks:askClarifyingQuestions',

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1415,6 +1415,99 @@ describe('Registry', () => {
       // Prevent afterEach double-close — reopen so afterEach can close it
       registry = await Registry.create(dbPath);
     });
+
+    // --- getDarkFactoryConfig / setDarkFactoryConfig ---
+
+    it('getDarkFactoryConfig returns manual/squash defaults for an unknown project', () => {
+      const cfg = registry.getDarkFactoryConfig('/no/row');
+      expect(cfg).toEqual({ level: 'manual', merge_strategy: 'squash' });
+    });
+
+    it('setDarkFactoryConfig persists level and merge_strategy', () => {
+      registry.setDarkFactoryConfig('/proj', { level: 'assisted', merge_strategy: 'rebase' });
+      expect(registry.getDarkFactoryConfig('/proj')).toEqual({ level: 'assisted', merge_strategy: 'rebase' });
+    });
+
+    it('setDarkFactoryConfig with dark_factory level makes getDarkFactoryEnabled return true', () => {
+      registry.setDarkFactoryConfig('/proj', { level: 'dark_factory', merge_strategy: 'squash' });
+      expect(registry.getDarkFactoryEnabled('/proj')).toBe(true);
+    });
+
+    it('setDarkFactoryConfig with assisted level makes getDarkFactoryEnabled return false', () => {
+      registry.setDarkFactoryConfig('/proj', { level: 'assisted', merge_strategy: 'squash' });
+      expect(registry.getDarkFactoryEnabled('/proj')).toBe(false);
+    });
+
+    it('setDarkFactoryConfig is idempotent — running twice with same payload yields same row', () => {
+      registry.setDarkFactoryConfig('/proj', { level: 'dark_factory', merge_strategy: 'merge' });
+      registry.setDarkFactoryConfig('/proj', { level: 'dark_factory', merge_strategy: 'merge' });
+      expect(registry.getDarkFactoryConfig('/proj')).toEqual({ level: 'dark_factory', merge_strategy: 'merge' });
+    });
+
+    it('setDarkFactoryEnabled(false) on an assisted project leaves level unchanged', () => {
+      registry.setDarkFactoryConfig('/proj', { level: 'assisted', merge_strategy: 'squash' });
+      registry.setDarkFactoryEnabled('/proj', false);
+      expect(registry.getDarkFactoryConfig('/proj')).toEqual({ level: 'assisted', merge_strategy: 'squash' });
+      expect(registry.getDarkFactoryEnabled('/proj')).toBe(false);
+    });
+
+    it('setDarkFactoryEnabled(false) on a dark_factory project flips level to manual', () => {
+      registry.setDarkFactoryConfig('/proj', { level: 'dark_factory', merge_strategy: 'squash' });
+      registry.setDarkFactoryEnabled('/proj', false);
+      expect(registry.getDarkFactoryEnabled('/proj')).toBe(false);
+      expect(registry.getDarkFactoryConfig('/proj').level).toBe('manual');
+    });
+
+    it('setDarkFactoryEnabled(true) sets level to dark_factory', () => {
+      registry.setDarkFactoryEnabled('/proj', true);
+      expect(registry.getDarkFactoryEnabled('/proj')).toBe(true);
+      expect(registry.getDarkFactoryConfig('/proj').level).toBe('dark_factory');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Migration v28: project_dark_factory level + merge_strategy columns
+  // ---------------------------------------------------------------------------
+  describe('migration v28 — dark factory level + merge_strategy', () => {
+    it('backfills enabled=1 rows to level=dark_factory', async () => {
+      // Seed a DB at v17 (before level column) with an enabled=1 row
+      const Database = (await import('better-sqlite3')).default;
+      const migrationDbPath = makeTempDb();
+      try {
+        const rawDb = new Database(migrationDbPath);
+        rawDb.pragma('journal_mode = WAL');
+        rawDb.pragma('foreign_keys = ON');
+        rawDb.exec(`
+          CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')));
+          INSERT INTO schema_version (version) VALUES (17);
+          CREATE TABLE IF NOT EXISTS project_dark_factory (key TEXT PRIMARY KEY, enabled INTEGER NOT NULL DEFAULT 0);
+          INSERT INTO project_dark_factory (key, enabled) VALUES ('project:/enabled', 1);
+          INSERT INTO project_dark_factory (key, enabled) VALUES ('project:/disabled', 0);
+        `);
+        rawDb.close();
+
+        const migratedRegistry = await Registry.create(migrationDbPath);
+        expect(migratedRegistry.getDarkFactoryConfig('/enabled')).toEqual(
+          expect.objectContaining({ level: 'dark_factory' })
+        );
+        expect(migratedRegistry.getDarkFactoryConfig('/disabled')).toEqual(
+          expect.objectContaining({ level: 'manual' })
+        );
+        expect(migratedRegistry.getDarkFactoryEnabled('/enabled')).toBe(true);
+        expect(migratedRegistry.getDarkFactoryEnabled('/disabled')).toBe(false);
+        migratedRegistry.close();
+      } finally {
+        for (const suffix of ['', '-wal', '-shm']) {
+          try { fs.unlinkSync(migrationDbPath + suffix); } catch { /* ignore */ }
+        }
+      }
+    });
+
+    it('migration is idempotent — running v28 twice yields correct state', async () => {
+      // Registry.create runs the full migration chain each time; opening an already-migrated DB should be safe
+      const cfg = registry.getDarkFactoryConfig('/any/project');
+      expect(cfg).toEqual({ level: 'manual', merge_strategy: 'squash' });
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -1760,7 +1853,7 @@ describe('Registry', () => {
         const r1 = await Registry.create(tmpPath);
         const db1 = r1.getDb();
         db1.exec('DROP TABLE IF EXISTS provider_secrets');
-        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        db1.exec("DELETE FROM schema_version WHERE version >= 27");
         db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-inner' }));
         db1.prepare("INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'inner', 'anthropic', NULL)").run();
         r1.close();
@@ -1782,7 +1875,7 @@ describe('Registry', () => {
         const r1 = await Registry.create(tmpPath);
         const db1 = r1.getDb();
         db1.exec('DROP TABLE IF EXISTS provider_secrets');
-        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        db1.exec("DELETE FROM schema_version WHERE version >= 27");
         // Legacy single-field row (written by old setBackendSecret)
         db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', 'api_key', 'sk-legacy')").run();
         db1.prepare("INSERT OR REPLACE INTO opencode_settings (key, surface, provider, model) VALUES ('global', 'inner', 'anthropic', NULL)").run();
@@ -1806,7 +1899,7 @@ describe('Registry', () => {
         const r1 = await Registry.create(tmpPath);
         const db1 = r1.getDb();
         db1.exec('DROP TABLE IF EXISTS provider_secrets');
-        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        db1.exec("DELETE FROM schema_version WHERE version >= 27");
         // Both surfaces → anthropic provider, but different bundles
         db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-inner' }));
         db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'outer', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-outer' }));
@@ -1849,7 +1942,7 @@ describe('Registry', () => {
         const r1 = await Registry.create(tmpPath);
         const db1 = r1.getDb();
         db1.exec('DROP TABLE IF EXISTS provider_secrets');
-        db1.exec("DELETE FROM schema_version WHERE version = 27");
+        db1.exec("DELETE FROM schema_version WHERE version >= 27");
         // backend_secrets with no corresponding opencode_settings row → provider = null → falls back to anthropic
         db1.prepare("INSERT OR REPLACE INTO backend_secrets (key, surface, name, value) VALUES ('global', 'inner', '__bundle__', ?)").run(JSON.stringify({ api_key: 'sk-fallback' }));
         // No opencode_settings row → provider resolves to null → 'anthropic'


### PR DESCRIPTION
## Summary

Replaces the "Coming soon" placeholders in the project config modal with two functional panes:

- **Automation pane** lets users pick an automation level (Manual / Assisted / Dark Factory) via level cards with stage chips, plus a merge-strategy segmented control. Selections read and write through the new `darkFactory` config API.
- **Ticketing pane** lets users choose a provider (GitHub / Jira), fill provider-specific fields (conditional Jira fields), and set a ticket prefix. Required-field validation blocks saves until the config is complete.

Backing these, the dark-factory project config is migrated from a single `enabled` flag to a richer model. Schema migration v28 adds `level` and `merge_strategy` columns to `project_dark_factory` and backfills `level` from the existing `enabled` value one time. `getDarkFactoryEnabled`/`setDarkFactoryEnabled` are rederived from `level` so legacy callers keep working (setting `enabled(false)` is a no-op while the level is `assisted`), and new `getDarkFactoryConfig`/`setDarkFactoryConfig` methods are surfaced through IPC (`darkFactory:getConfig`/`setConfig`) and the preload bridge.

## QA plan

1. Open a project's config modal and go to the Automation tab.
2. Switch between Manual, Assisted, and Dark Factory level cards; confirm stage chips update and the merge-strategy control is selectable. Save and reopen to confirm the choice persists.
3. Go to the Ticketing tab. Select GitHub, then Jira; confirm Jira-specific fields appear only for Jira.
4. Clear a required field and confirm the save is blocked; fill it back in and confirm the save succeeds and persists across reopen.
5. With an existing project that previously had dark factory enabled/disabled, confirm the automation level reflects the prior `enabled` state after the v28 migration backfill.

Closes #537