### PR TITLE
[536] fix: add providers config pane for credentials

### DIFF
--- a/src/renderer/components/config/ProvidersPane.tsx
+++ b/src/renderer/components/config/ProvidersPane.tsx
@@ -1,0 +1,232 @@
+import React, { useState, useEffect } from 'react';
+import { PROVIDER_METADATA, ProviderMeta } from '../../../shared/opencode-providers';
+import { ConfigPane, ConfigPaneContext } from './types';
+
+interface ProvidersPaneBodyProps {
+  ctx: ConfigPaneContext;
+}
+
+function ProvidersPaneBody({ ctx }: ProvidersPaneBodyProps) {
+  const { projectDir, providerSecrets, routing } = ctx;
+
+  const [statuses, setStatuses] = useState<Record<string, boolean>>({});
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [removeWarnings, setRemoveWarnings] = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadStatuses() {
+      const results: Record<string, boolean> = {};
+      await Promise.all(
+        PROVIDER_METADATA.map(async (provider) => {
+          const s = await providerSecrets.status(projectDir, provider.id);
+          results[provider.id] = s.set;
+        })
+      );
+      if (!cancelled) setStatuses(results);
+    }
+    loadStatuses();
+    return () => { cancelled = true; };
+  }, [projectDir]);
+
+  const handleToggleExpand = (providerId: string) => {
+    setRemoveWarnings((w) => { const next = { ...w }; delete next[providerId]; return next; });
+    if (expanded === providerId) {
+      setExpanded(null);
+      setFormValues({});
+      setErrors((e) => { const next = { ...e }; delete next[providerId]; return next; });
+    } else {
+      setExpanded(providerId);
+      setFormValues({});
+      setErrors((e) => { const next = { ...e }; delete next[providerId]; return next; });
+    }
+  };
+
+  const handleSave = async (provider: ProviderMeta) => {
+    const missingLabels = provider.fields
+      .filter((f) => f.required && !formValues[f.key]?.trim())
+      .map((f) => f.label);
+
+    if (missingLabels.length > 0) {
+      setErrors((e) => ({ ...e, [provider.id]: `Required: ${missingLabels.join(', ')}` }));
+      return;
+    }
+
+    const bundle: Record<string, string> = {};
+    for (const field of provider.fields) {
+      if (formValues[field.key]?.trim()) {
+        bundle[field.key] = formValues[field.key].trim();
+      }
+    }
+
+    setSaving(provider.id);
+    try {
+      await providerSecrets.setBundle(projectDir, provider.id, bundle);
+      setStatuses((s) => ({ ...s, [provider.id]: true }));
+      setExpanded(null);
+      setFormValues({});
+      setErrors((e) => { const next = { ...e }; delete next[provider.id]; return next; });
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleRemove = async (provider: ProviderMeta) => {
+    setRemoving(provider.id);
+    try {
+      const effective = await routing.getEffective(projectDir);
+      const affectedTouchpoints = Object.keys(effective).filter(
+        (tp) => effective[tp].provider === provider.id
+      );
+      if (affectedTouchpoints.length > 0) {
+        setRemoveWarnings((w) => ({ ...w, [provider.id]: affectedTouchpoints }));
+      }
+      await providerSecrets.remove(projectDir, provider.id);
+      setStatuses((s) => ({ ...s, [provider.id]: false }));
+      if (expanded === provider.id) {
+        setExpanded(null);
+        setFormValues({});
+      }
+    } finally {
+      setRemoving(null);
+    }
+  };
+
+  const statusesLoaded = Object.keys(statuses).length === PROVIDER_METADATA.length;
+  const noneConfigured = statusesLoaded && PROVIDER_METADATA.every((p) => !statuses[p.id]);
+
+  return (
+    <div data-testid="providers-pane" className="space-y-3">
+      {PROVIDER_METADATA.length === 0 ? (
+        <p className="text-xs text-sandstorm-muted">No providers available.</p>
+      ) : (
+        <>
+          {noneConfigured && (
+            <p data-testid="providers-empty-prompt" className="text-xs text-sandstorm-muted mb-3">
+              No providers are configured yet. Add credentials for at least one provider to enable model routing.
+            </p>
+          )}
+          {PROVIDER_METADATA.map((provider) => {
+            const isSet = statuses[provider.id] ?? false;
+            const isExpanded = expanded === provider.id;
+            const isSaving = saving === provider.id;
+            const isRemoving = removing === provider.id;
+            const error = errors[provider.id];
+
+            return (
+              <div
+                key={provider.id}
+                data-testid={`provider-card-${provider.id}`}
+                className="border border-sandstorm-border rounded-lg overflow-hidden"
+              >
+                <div className="flex items-center justify-between px-4 py-3 bg-sandstorm-surface">
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium text-sandstorm-fg">{provider.label}</span>
+                    <span
+                      data-testid={`provider-status-${provider.id}`}
+                      className={`text-xs px-2 py-0.5 rounded-full ${
+                        isSet
+                          ? 'bg-green-500/20 text-green-400'
+                          : 'bg-sandstorm-surface-2 text-sandstorm-muted'
+                      }`}
+                    >
+                      {isSet ? 'Configured' : 'Not configured'}
+                    </span>
+                  </div>
+                  <button
+                    data-testid={`provider-expand-${provider.id}`}
+                    className="text-xs text-sandstorm-muted hover:text-sandstorm-fg transition-colors px-2 py-1 rounded"
+                    onClick={() => handleToggleExpand(provider.id)}
+                  >
+                    {isExpanded ? 'Cancel' : isSet ? 'Edit' : 'Configure'}
+                  </button>
+                </div>
+
+                {removeWarnings[provider.id] && removeWarnings[provider.id].length > 0 && (
+                  <p
+                    data-testid={`provider-remove-warning-${provider.id}`}
+                    className="px-4 py-2 text-xs text-yellow-400 border-t border-sandstorm-border"
+                  >
+                    Removed: touchpoints {removeWarnings[provider.id].join(', ')} will need a key.
+                  </p>
+                )}
+
+                {isExpanded && (
+                  <div
+                    data-testid={`provider-form-${provider.id}`}
+                    className="px-4 py-3 border-t border-sandstorm-border bg-sandstorm-surface-2 space-y-3"
+                  >
+                    {isSet && (
+                      <p className="text-xs text-sandstorm-muted">
+                        Credentials are already set. Enter new values to update them.
+                      </p>
+                    )}
+                    {provider.fields.map((field) => (
+                      <div key={field.key}>
+                        <label className="block text-xs font-medium text-sandstorm-muted mb-1">
+                          {field.label}
+                          {field.required && <span className="text-red-400 ml-1">*</span>}
+                        </label>
+                        <input
+                          data-testid={`provider-field-${provider.id}-${field.key}`}
+                          type={field.type === 'password' ? 'password' : field.type === 'url' ? 'url' : 'text'}
+                          className="w-full px-2 py-1.5 text-sm rounded border border-sandstorm-border bg-sandstorm-surface text-sandstorm-fg"
+                          value={formValues[field.key] ?? ''}
+                          onChange={(e) =>
+                            setFormValues((v) => ({ ...v, [field.key]: e.target.value }))
+                          }
+                          placeholder={field.placeholder ?? ''}
+                          autoComplete="off"
+                        />
+                      </div>
+                    ))}
+
+                    {error && (
+                      <p data-testid={`provider-error-${provider.id}`} className="text-xs text-red-400">
+                        {error}
+                      </p>
+                    )}
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        data-testid={`provider-save-${provider.id}`}
+                        className="px-3 py-1.5 text-xs font-medium rounded bg-sandstorm-accent text-white hover:bg-sandstorm-accent/90 transition-colors disabled:opacity-50"
+                        onClick={() => handleSave(provider)}
+                        disabled={isSaving}
+                      >
+                        {isSaving ? 'Saving…' : 'Save'}
+                      </button>
+                      {isSet && (
+                        <button
+                          data-testid={`provider-remove-${provider.id}`}
+                          className="px-3 py-1.5 text-xs font-medium rounded border border-sandstorm-border text-sandstorm-muted hover:text-red-400 hover:border-red-400/50 transition-colors disabled:opacity-50"
+                          onClick={() => handleRemove(provider)}
+                          disabled={isRemoving}
+                        >
+                          {isRemoving ? 'Removing…' : 'Remove'}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function buildProvidersPane(ctx: ConfigPaneContext): ConfigPane {
+  return {
+    id: 'providers',
+    label: 'Providers',
+    icon: <span className="text-sm">🔌</span>,
+    render: () => <ProvidersPaneBody ctx={ctx} />,
+  };
+}

--- a/src/renderer/components/config/panes.tsx
+++ b/src/renderer/components/config/panes.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import { ConfigPane, ConfigPaneContext } from './types';
 import { buildModelsPane } from './ModelsPane';
+import { buildProvidersPane } from './ProvidersPane';
 import { buildAutomationPane } from './AutomationPane';
 import { buildTicketingPane } from './TicketingPane';
 
 export async function buildConfigPanes(ctx: ConfigPaneContext): Promise<ConfigPane[]> {
   return [
     await buildModelsPane(ctx),
-    {
-      id: 'providers',
-      label: 'Providers',
-      icon: <span className="text-sm">🔌</span>,
-      render: () => <div className="text-sandstorm-muted text-sm">Coming soon</div>,
-    },
+    buildProvidersPane(ctx),
     buildAutomationPane(ctx),
     buildTicketingPane(ctx),
   ];

--- a/src/renderer/components/config/types.ts
+++ b/src/renderer/components/config/types.ts
@@ -9,13 +9,19 @@ export interface ConfigPane {
   render: () => ReactNode;
 }
 
+export interface ProviderSecretsApi {
+  status: (scope: string, provider: string) => Promise<{ set: boolean }>;
+  setBundle: (scope: string, provider: string, bundle: Record<string, string>) => Promise<void>;
+  remove: (scope: string, provider: string) => Promise<void>;
+}
+
 export interface ModelRoutingApi {
-  getEffective: (projectDir: string) => Promise<Record<string, { backend: string; model: string }>>;
-  getProject: (projectDir: string) => Promise<{ assignments: Record<string, { backend: string; model: string }>; preset: string | null } | null>;
-  setProject: (projectDir: string, config: { assignments?: Record<string, { backend: string; model: string }>; preset?: string | null }) => Promise<void>;
+  getEffective: (projectDir: string) => Promise<Record<string, { backend: string; provider: string; model: string }>>;
+  getProject: (projectDir: string) => Promise<{ assignments: Record<string, { backend: string; provider: string; model: string }>; preset: string | null } | null>;
+  setProject: (projectDir: string, config: { assignments?: Record<string, { backend: string; provider: string; model: string }>; preset?: string | null }) => Promise<void>;
   removeProject: (projectDir: string) => Promise<void>;
-  getGlobal: () => Promise<{ assignments: Record<string, { backend: string; model: string }>; preset: string | null }>;
-  setGlobal: (config: { assignments?: Record<string, { backend: string; model: string }>; preset?: string | null }) => Promise<void>;
+  getGlobal: () => Promise<{ assignments: Record<string, { backend: string; provider: string; model: string }>; preset: string | null }>;
+  setGlobal: (config: { assignments?: Record<string, { backend: string; provider: string; model: string }>; preset?: string | null }) => Promise<void>;
   applyPreset: (projectDir: string, presetId: string) => Promise<void>;
   getAvailableModels: (projectDir: string) => Promise<Array<{ backend: string; model: string; label: string; version: string; provider: string; needsKey?: boolean; available: boolean }>>;
 }
@@ -51,6 +57,7 @@ export interface ConfigPaneContext {
   routing: ModelRoutingApi;
   darkFactory: DarkFactoryApi;
   ticketing: TicketingApi;
+  providerSecrets: ProviderSecretsApi;
   onDirtyChange: (dirty: boolean) => void;
   registerSave: (save: () => Promise<void>) => void;
 }

--- a/tests/unit/components/ProjectConfigModal.test.tsx
+++ b/tests/unit/components/ProjectConfigModal.test.tsx
@@ -182,6 +182,11 @@ describe('buildConfigPanes registry', () => {
         get: vi.fn().mockResolvedValue(null),
         set: vi.fn().mockResolvedValue(undefined),
       },
+      providerSecrets: {
+        status: vi.fn().mockResolvedValue({ set: false }),
+        setBundle: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(undefined),
+      },
       onDirtyChange: vi.fn(),
       registerSave: vi.fn(),
     };

--- a/tests/unit/components/ProvidersPane.test.tsx
+++ b/tests/unit/components/ProvidersPane.test.tsx
@@ -1,0 +1,457 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor, cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
+
+import { buildProvidersPane } from '../../../src/renderer/components/config/ProvidersPane';
+import { PROVIDER_METADATA } from '../../../src/shared/opencode-providers';
+import type { ConfigPaneContext, ProviderSecretsApi } from '../../../src/renderer/components/config/types';
+
+function makeProviderSecrets(overrides: Partial<ProviderSecretsApi> = {}): ProviderSecretsApi {
+  return {
+    status: vi.fn().mockResolvedValue({ set: false }),
+    setBundle: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeCtx(providerSecretsOverrides: Partial<ProviderSecretsApi> = {}): ConfigPaneContext {
+  return {
+    projectDir: '/test/project',
+    routing: {
+      getEffective: vi.fn().mockResolvedValue({}),
+      getProject: vi.fn().mockResolvedValue(null),
+      setProject: vi.fn().mockResolvedValue(undefined),
+      removeProject: vi.fn().mockResolvedValue(undefined),
+      getGlobal: vi.fn().mockResolvedValue({ assignments: {}, preset: null }),
+      setGlobal: vi.fn().mockResolvedValue(undefined),
+      applyPreset: vi.fn().mockResolvedValue(undefined),
+      getAvailableModels: vi.fn().mockResolvedValue([]),
+    },
+    darkFactory: {
+      getConfig: vi.fn().mockResolvedValue({ level: 'manual', merge_strategy: 'squash' }),
+      setConfig: vi.fn().mockResolvedValue(undefined),
+    },
+    ticketing: {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    providerSecrets: makeProviderSecrets(providerSecretsOverrides),
+    onDirtyChange: vi.fn(),
+    registerSave: vi.fn(),
+  };
+}
+
+describe('ProvidersPane', () => {
+  it('renders the providers-pane testid', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => expect(screen.getByTestId('providers-pane')).toBeDefined());
+  });
+
+  it('pane has id providers and label Providers', () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    expect(pane.id).toBe('providers');
+    expect(pane.label).toBe('Providers');
+  });
+
+  it('renders a card for each provider in PROVIDER_METADATA', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      for (const provider of PROVIDER_METADATA) {
+        expect(screen.getByTestId(`provider-card-${provider.id}`)).toBeDefined();
+      }
+    });
+  });
+
+  it('shows "Not configured" status for all providers when none are set', async () => {
+    const ctx = makeCtx({ status: vi.fn().mockResolvedValue({ set: false }) });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      for (const provider of PROVIDER_METADATA) {
+        const statusEl = screen.getByTestId(`provider-status-${provider.id}`);
+        expect(statusEl.textContent).toBe('Not configured');
+      }
+    });
+  });
+
+  it('shows "Configured" status for a provider that is set', async () => {
+    const status = vi.fn().mockImplementation((_scope: string, provider: string) =>
+      Promise.resolve({ set: provider === 'anthropic' })
+    );
+    const ctx = makeCtx({ status });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-status-anthropic').textContent).toBe('Configured');
+      expect(screen.getByTestId('provider-status-ollama').textContent).toBe('Not configured');
+    });
+  });
+
+  it('calls status with projectDir and provider id', async () => {
+    const status = vi.fn().mockResolvedValue({ set: false });
+    const ctx = makeCtx({ status });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      for (const provider of PROVIDER_METADATA) {
+        expect(status).toHaveBeenCalledWith('/test/project', provider.id);
+      }
+    });
+  });
+
+  it('shows empty-state prompt when all providers are not configured', async () => {
+    const ctx = makeCtx({ status: vi.fn().mockResolvedValue({ set: false }) });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-empty-prompt')).toBeDefined();
+    });
+  });
+
+  it('does not show empty-state prompt when at least one provider is configured', async () => {
+    const status = vi.fn().mockImplementation((_scope: string, provider: string) =>
+      Promise.resolve({ set: provider === 'anthropic' })
+    );
+    const ctx = makeCtx({ status });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-status-anthropic'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('providers-empty-prompt')).toBeNull();
+    });
+  });
+
+  it('expand button shows "Configure" for unconfigured provider', async () => {
+    const ctx = makeCtx({ status: vi.fn().mockResolvedValue({ set: false }) });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      const btn = screen.getByTestId('provider-expand-anthropic');
+      expect(btn.textContent).toBe('Configure');
+    });
+  });
+
+  it('expand button shows "Edit" for configured provider', async () => {
+    const ctx = makeCtx({
+      status: vi.fn().mockImplementation((_scope: string, provider: string) =>
+        Promise.resolve({ set: provider === 'anthropic' })
+      ),
+    });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-expand-anthropic').textContent).toBe('Edit');
+    });
+  });
+
+  it('clicking expand button shows the provider form', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    expect(screen.getByTestId('provider-form-anthropic')).toBeDefined();
+  });
+
+  it('clicking expand again collapses the form', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    expect(screen.getByTestId('provider-form-anthropic')).toBeDefined();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    expect(screen.queryByTestId('provider-form-anthropic')).toBeNull();
+  });
+
+  it('renders field inputs for the expanded provider', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    expect(screen.getByTestId('provider-field-anthropic-apiKey')).toBeDefined();
+  });
+
+  it('Ollama form shows Base URL field', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-ollama'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-ollama'));
+    });
+    expect(screen.getByTestId('provider-field-ollama-baseUrl')).toBeDefined();
+  });
+
+  it('password-type fields use type="password" so values are never exposed', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    const input = screen.getByTestId('provider-field-anthropic-apiKey') as HTMLInputElement;
+    expect(input.type).toBe('password');
+  });
+
+  it('required-field validation blocks save when Ollama Base URL is empty', async () => {
+    const setBundle = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeCtx({ setBundle });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-ollama'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-ollama'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-save-ollama'));
+    });
+    expect(setBundle).not.toHaveBeenCalled();
+    expect(screen.getByTestId('provider-error-ollama')).toBeDefined();
+    expect(screen.getByTestId('provider-error-ollama').textContent).toContain('Base URL');
+  });
+
+  it('save calls setBundle with scope and provider id and bundle', async () => {
+    const setBundle = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeCtx({ setBundle });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('provider-field-anthropic-apiKey'), {
+        target: { value: 'sk-ant-test123' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-save-anthropic'));
+    });
+    await waitFor(() => {
+      expect(setBundle).toHaveBeenCalledWith('/test/project', 'anthropic', {
+        apiKey: 'sk-ant-test123',
+      });
+    });
+  });
+
+  it('save for Ollama with Base URL calls setBundle correctly', async () => {
+    const setBundle = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeCtx({ setBundle });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-ollama'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-ollama'));
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('provider-field-ollama-baseUrl'), {
+        target: { value: 'http://localhost:11434/v1' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-save-ollama'));
+    });
+    await waitFor(() => {
+      expect(setBundle).toHaveBeenCalledWith('/test/project', 'ollama', {
+        baseUrl: 'http://localhost:11434/v1',
+      });
+    });
+  });
+
+  it('successful save collapses the form and updates status to Configured', async () => {
+    const setBundle = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeCtx({ setBundle });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('provider-field-anthropic-apiKey'), {
+        target: { value: 'sk-ant-test123' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-save-anthropic'));
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('provider-form-anthropic')).toBeNull();
+      expect(screen.getByTestId('provider-status-anthropic').textContent).toBe('Configured');
+    });
+  });
+
+  it('Remove button is not shown when provider is not configured', async () => {
+    const ctx = makeCtx({ status: vi.fn().mockResolvedValue({ set: false }) });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-expand-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    expect(screen.queryByTestId('provider-remove-anthropic')).toBeNull();
+  });
+
+  it('Remove button is shown when provider is configured', async () => {
+    const status = vi.fn().mockImplementation((_scope: string, provider: string) =>
+      Promise.resolve({ set: provider === 'anthropic' })
+    );
+    const ctx = makeCtx({ status });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-status-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-remove-anthropic')).toBeDefined();
+    });
+  });
+
+  it('remove calls providerSecrets.remove with scope and provider id', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const status = vi.fn().mockImplementation((_scope: string, provider: string) =>
+      Promise.resolve({ set: provider === 'anthropic' })
+    );
+    const ctx = makeCtx({ status, remove });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-status-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    await waitFor(() => screen.getByTestId('provider-remove-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-remove-anthropic'));
+    });
+    await waitFor(() => {
+      expect(remove).toHaveBeenCalledWith('/test/project', 'anthropic');
+    });
+  });
+
+  it('remove updates status to Not configured', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const status = vi.fn().mockImplementation((_scope: string, provider: string) =>
+      Promise.resolve({ set: provider === 'anthropic' })
+    );
+    const ctx = makeCtx({ status, remove });
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-status-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    await waitFor(() => screen.getByTestId('provider-remove-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-remove-anthropic'));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-status-anthropic').textContent).toBe('Not configured');
+    });
+  });
+
+  it('raw secret values are never rendered in the DOM', async () => {
+    const ctx = makeCtx();
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('providers-pane'));
+    expect(screen.queryByText('sk-ant-secret-value')).toBeNull();
+    expect(screen.queryByText('AKIAIOSFODNN7EXAMPLE')).toBeNull();
+  });
+
+  it('project switch re-fetches statuses with new scope', async () => {
+    const status = vi.fn().mockResolvedValue({ set: false });
+    const ctx = makeCtx({ status });
+    const pane = buildProvidersPane(ctx);
+    const { rerender } = render(<>{pane.render()}</>);
+    await waitFor(() => expect(status).toHaveBeenCalled());
+
+    const callCountAfterFirst = status.mock.calls.length;
+
+    const ctx2 = { ...ctx, projectDir: '/other/project', providerSecrets: { ...ctx.providerSecrets, status } };
+    const pane2 = buildProvidersPane(ctx2);
+    rerender(<>{pane2.render()}</>);
+
+    await waitFor(() => {
+      expect(status.mock.calls.length).toBeGreaterThan(callCountAfterFirst);
+      const newCalls = status.mock.calls.slice(callCountAfterFirst);
+      expect(newCalls.some((call) => call[0] === '/other/project')).toBe(true);
+    });
+  });
+
+  it('shows routing warning when removed provider models are routed to touchpoints', async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const status = vi.fn().mockImplementation((_scope: string, provider: string) =>
+      Promise.resolve({ set: provider === 'anthropic' })
+    );
+    const getEffective = vi.fn().mockResolvedValue({
+      outer: { backend: 'claude', provider: 'anthropic', model: 'opus' },
+      execution: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    });
+    const ctx = makeCtx({ status, remove });
+    ctx.routing.getEffective = getEffective;
+    const pane = buildProvidersPane(ctx);
+    render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('provider-status-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-expand-anthropic'));
+    });
+    await waitFor(() => screen.getByTestId('provider-remove-anthropic'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('provider-remove-anthropic'));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-remove-warning-anthropic')).toBeDefined();
+      const warning = screen.getByTestId('provider-remove-warning-anthropic');
+      expect(warning.textContent).toContain('outer');
+      expect(warning.textContent).toContain('execution');
+    });
+  });
+
+  it('no cross-project bleed: second project uses its own scope', async () => {
+    const status = vi.fn()
+      .mockResolvedValue({ set: false });
+    const ctx = makeCtx({ status });
+    const pane = buildProvidersPane(ctx);
+    const { rerender } = render(<>{pane.render()}</>);
+    await waitFor(() => screen.getByTestId('providers-pane'));
+
+    const ctx2 = {
+      ...ctx,
+      projectDir: '/other/project',
+      providerSecrets: makeProviderSecrets({
+        status: vi.fn().mockResolvedValue({ set: true }),
+      }),
+    };
+    const pane2 = buildProvidersPane(ctx2);
+    rerender(<>{pane2.render()}</>);
+
+    await waitFor(() => {
+      for (const provider of PROVIDER_METADATA) {
+        expect(screen.getByTestId(`provider-status-${provider.id}`).textContent).toBe('Configured');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the "Coming soon" Providers placeholder in the project config modal with a working Providers pane. Users can add, edit, and remove credentials for each known provider, with configured/not-configured status badges and an empty-state prompt when nothing is set up. Required fields are validated before save, and removing a provider that is still bound to model-routing touchpoints surfaces a warning listing which touchpoints will need a key.

This wires a new `providerSecrets` API into the config pane context (status / setBundle / remove) and threads a `provider` field through the model-routing types so routing assignments and effective config can be matched back to the provider that supplies their key.

## QA plan

1. Open a project's config modal and select the Providers tab.
2. With no credentials set, confirm every provider shows "Not configured" and the empty-state prompt appears.
3. Click Configure on a provider, leave a required field blank, and Save — confirm the required-field error shows and nothing is saved.
4. Fill in valid credentials and Save — confirm the badge flips to "Configured" and the form collapses.
5. Re-open the same provider with Edit, change a value, and Save — confirm the update sticks.
6. Assign that provider to a model-routing touchpoint, then Remove it — confirm the warning lists the affected touchpoints and the badge returns to "Not configured".

Closes #536