### PR TITLE
[641] fix: resolve external ticket references before dispatch

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -11,6 +11,7 @@ import { stackManager, agentBackend, registry } from '../index';
 import { fetchTicketWithConfig, updateTicketWithConfig } from '../control-plane/ticket-config';
 import type { ProjectTicketConfig } from '../control-plane/registry';
 import { getDefaultSpecQualityGate } from '../spec-quality-gate';
+import { resolveTicketReferences, renderResolvedReferences } from '../control-plane/ticket-references';
 import {
   createSchedule,
   listSchedules,
@@ -247,7 +248,8 @@ async function resolveSpecContext(
   return { ok: true, ctx: { ticketBody, gate: getDefaultSpecQualityGate() } };
 }
 
-export function buildSpecCheckPrompt(gate: string, ticketBody: string): string {
+export function buildSpecCheckPrompt(gate: string, ticketBody: string, referencesSection?: string): string {
+  const refBlock = referencesSection ? `\n${referencesSection}\n` : '';
   return `You are a spec quality gate evaluator. Evaluate the ticket below against every criterion in the quality gate. Be strict — if you'd have to guess, it's a FAIL.
 
 ## Quality Gate Criteria
@@ -257,6 +259,7 @@ ${gate}
 ## Ticket
 
 ${ticketBody}
+${refBlock}
 
 ## Instructions
 
@@ -330,7 +333,9 @@ async function handleSpecCheck(
   if (!res.ok) return res.result;
   const { ctx } = res;
 
-  const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody);
+  const references = await resolveTicketReferences(ctx.ticketBody);
+  const referencesSection = renderResolvedReferences(references);
+  const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody, referencesSection || undefined);
   const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
@@ -560,7 +565,9 @@ export function spawnSpecCheck(
     if (!res.ok) return res.result;
     if (cancelled) throw new Error('Cancelled');
 
-    const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody);
+    const references = await resolveTicketReferences(res.ctx.ticketBody);
+    const referencesSection = renderResolvedReferences(references);
+    const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody, referencesSection || undefined);
     const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -10,6 +10,7 @@ import { ContainerRuntime, Container, ContainerStats } from '../runtime/types';
 import { SandstormError, ErrorCode } from '../errors';
 import { fetchRawBodyWithConfig, fetchTicketWithConfig, updateTicketWithConfig } from './ticket-config';
 import { referencesTicket } from './ticket-fetcher';
+import { resolveTicketReferences, renderResolvedReferences } from './ticket-references';
 import { workspacePathFor } from './pr-creator';
 import { parseTokenUsage } from './token-parser';
 
@@ -1227,6 +1228,14 @@ export class StackManager {
           prompt = `${ticketContext}\n\n---\n\n## Task\n\n${prompt}`;
         }
       }
+    }
+
+    // Resolve any external references (gists, mockups, docs) cited in the prompt
+    // and append their content so the inner agent has the full spec without egress.
+    const references = await resolveTicketReferences(prompt);
+    const referencesSection = renderResolvedReferences(references);
+    if (referencesSection) {
+      prompt = `${prompt}\n\n---\n\n${referencesSection}`;
     }
 
     const task = this.registry.createTask(stackId, prompt, model);

--- a/src/main/control-plane/ticket-references.ts
+++ b/src/main/control-plane/ticket-references.ts
@@ -1,0 +1,251 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface TicketReference {
+  url: string;
+  kind: 'gist' | 'github' | 'other';
+  content: string | null;
+  error?: string;
+  truncated?: boolean;
+  capped?: boolean;
+}
+
+const PER_FETCH_BYTE_LIMIT = 256 * 1024; // 256 KB
+const TOTAL_BYTE_LIMIT = 1024 * 1024;    // 1 MB
+const FETCH_TIMEOUT_MS = 10_000;
+
+const PRIVATE_HOST_RE = /^(localhost|127\.\d+\.\d+\.\d+|0\.0\.0\.0|::1)$/i;
+const PRIVATE_CIDR_RE = /^(10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+|169\.254\.\d+\.\d+)$/;
+
+function isPrivateHost(hostname: string): boolean {
+  return PRIVATE_HOST_RE.test(hostname) || PRIVATE_CIDR_RE.test(hostname);
+}
+
+function extractGistId(url: URL): string | null {
+  // https://gist.github.com/<user>/<id> or https://gist.github.com/<id>
+  const parts = url.pathname.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? null;
+}
+
+function extractGithubApiPath(url: URL): string | null {
+  // Convert github.com or raw.githubusercontent.com to a gh api path
+  if (url.hostname === 'raw.githubusercontent.com') {
+    // raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>
+    // → repos/<owner>/<repo>/contents/<path>?ref=<branch>
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length < 4) return null;
+    const [owner, repo, ref, ...rest] = parts;
+    return `/repos/${owner}/${repo}/contents/${rest.join('/')}?ref=${ref}`;
+  }
+  // github.com/<owner>/<repo>/blob/<branch>/<path>
+  const parts = url.pathname.split('/').filter(Boolean);
+  const blobIdx = parts.indexOf('blob');
+  if (blobIdx >= 2 && blobIdx + 1 < parts.length) {
+    const [owner, repo] = parts;
+    const ref = parts[blobIdx + 1];
+    const filePath = parts.slice(blobIdx + 2).join('/');
+    return `/repos/${owner}/${repo}/contents/${filePath}?ref=${ref}`;
+  }
+  return null;
+}
+
+function classifyUrl(url: URL): 'gist' | 'github' | 'other' {
+  if (url.hostname === 'gist.github.com') return 'gist';
+  if (url.hostname === 'github.com' || url.hostname === 'raw.githubusercontent.com') return 'github';
+  return 'other';
+}
+
+async function fetchGist(url: URL): Promise<{ content: string | null; error?: string; truncated?: boolean }> {
+  const gistId = extractGistId(url);
+  if (!gistId) return { content: null, error: 'invalid-gist-url' };
+
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['gist', 'view', gistId, '--raw'],
+      { timeout: FETCH_TIMEOUT_MS, maxBuffer: PER_FETCH_BYTE_LIMIT + 1024 }
+    );
+    if (stdout.length > PER_FETCH_BYTE_LIMIT) {
+      return { content: stdout.slice(0, PER_FETCH_BYTE_LIMIT), truncated: true };
+    }
+    return { content: stdout };
+  } catch (err: unknown) {
+    const e = err as { message?: string; stderr?: string; killed?: boolean; code?: string };
+    if (e.killed || e.code === 'ETIMEDOUT') return { content: null, error: 'timeout' };
+    const msg = e.stderr?.trim() || e.message || 'unknown error';
+    return { content: null, error: msg.includes('not found') || msg.includes('404') ? '404' : msg };
+  }
+}
+
+async function fetchGithub(url: URL): Promise<{ content: string | null; error?: string; truncated?: boolean }> {
+  const apiPath = extractGithubApiPath(url);
+  if (!apiPath) {
+    // Fall back to raw fetch for github URLs we can't parse as file refs
+    return fetchOther(url);
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['api', apiPath, '--header', 'Accept: application/vnd.github.raw+json'],
+      { timeout: FETCH_TIMEOUT_MS, maxBuffer: PER_FETCH_BYTE_LIMIT + 1024 }
+    );
+    if (stdout.length > PER_FETCH_BYTE_LIMIT) {
+      return { content: stdout.slice(0, PER_FETCH_BYTE_LIMIT), truncated: true };
+    }
+    return { content: stdout };
+  } catch (err: unknown) {
+    const e = err as { message?: string; stderr?: string; killed?: boolean; code?: string };
+    if (e.killed || e.code === 'ETIMEDOUT') return { content: null, error: 'timeout' };
+    const msg = e.stderr?.trim() || e.message || 'unknown error';
+    return { content: null, error: msg.includes('404') || msg.includes('Not Found') ? '404' : msg };
+  }
+}
+
+async function fetchOther(url: URL): Promise<{ content: string | null; error?: string; truncated?: boolean }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(url.toString(), { signal: controller.signal });
+    clearTimeout(timer);
+
+    if (!resp.ok) {
+      return { content: null, error: resp.status === 404 ? '404' : `http-${resp.status}` };
+    }
+
+    const reader = resp.body?.getReader();
+    if (!reader) {
+      const text = await resp.text();
+      if (text.length > PER_FETCH_BYTE_LIMIT) {
+        return { content: text.slice(0, PER_FETCH_BYTE_LIMIT), truncated: true };
+      }
+      return { content: text };
+    }
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let truncated = false;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > PER_FETCH_BYTE_LIMIT) {
+        const remaining = PER_FETCH_BYTE_LIMIT - (total - value.length);
+        if (remaining > 0) chunks.push(value.slice(0, remaining));
+        truncated = true;
+        reader.cancel().catch(() => {});
+        break;
+      }
+      chunks.push(value);
+    }
+
+    const decoder = new TextDecoder();
+    const content = chunks.map(c => decoder.decode(c, { stream: true })).join('') + decoder.decode();
+    return { content, ...(truncated ? { truncated: true } : {}) };
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    const e = err as { name?: string; message?: string };
+    if (e.name === 'AbortError') return { content: null, error: 'timeout' };
+    return { content: null, error: e.message || 'network-error' };
+  }
+}
+
+function extractUrls(body: string): string[] {
+  const seen = new Set<string>();
+  const results: string[] = [];
+  const re = /https?:\/\/[^\s\)"'<>]+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    // Strip trailing punctuation that's likely not part of the URL
+    const raw = m[0].replace(/[.,;:!?]+$/, '');
+    if (!seen.has(raw)) {
+      seen.add(raw);
+      results.push(raw);
+    }
+  }
+  return results;
+}
+
+/**
+ * Resolves all external http(s) links found in the ticket body.
+ * Returns one TicketReference per unique URL, deduplicated.
+ */
+export async function resolveTicketReferences(ticketBody: string): Promise<TicketReference[]> {
+  const rawUrls = extractUrls(ticketBody);
+  if (rawUrls.length === 0) return [];
+
+  const references: TicketReference[] = [];
+  let totalBytes = 0;
+
+  for (const raw of rawUrls) {
+    let url: URL;
+    try {
+      url = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') continue;
+
+    if (isPrivateHost(url.hostname)) {
+      references.push({ url: raw, kind: classifyUrl(url), content: null, error: 'blocked-private-host' });
+      continue;
+    }
+
+    if (totalBytes >= TOTAL_BYTE_LIMIT) {
+      references.push({ url: raw, kind: classifyUrl(url), content: null, capped: true });
+      continue;
+    }
+
+    const kind = classifyUrl(url);
+    let result: { content: string | null; error?: string; truncated?: boolean };
+
+    if (kind === 'gist') {
+      result = await fetchGist(url);
+    } else if (kind === 'github') {
+      result = await fetchGithub(url);
+    } else {
+      result = await fetchOther(url);
+    }
+
+    if (result.content !== null) {
+      totalBytes += result.content.length;
+    }
+
+    const ref: TicketReference = { url: raw, kind, content: result.content };
+    if (result.error) ref.error = result.error;
+    if (result.truncated) ref.truncated = true;
+    references.push(ref);
+  }
+
+  return references;
+}
+
+/**
+ * Renders a "## Resolved References" section for injection into prompts.
+ * Returns empty string if no references were resolved.
+ */
+export function renderResolvedReferences(references: TicketReference[]): string {
+  if (references.length === 0) return '';
+
+  const lines: string[] = ['## Resolved References', ''];
+  for (const ref of references) {
+    lines.push(`### ${ref.url}`);
+    if (ref.capped) {
+      lines.push('_Skipped: total fetch budget exceeded._');
+    } else if (ref.content === null) {
+      lines.push(`_Could not fetch: ${ref.error ?? 'unknown error'}_`);
+    } else {
+      if (ref.truncated) lines.push('_Note: content truncated at 256 KB._');
+      lines.push('');
+      lines.push('```');
+      lines.push(ref.content);
+      lines.push('```');
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}

--- a/src/main/spec-quality-gate.ts
+++ b/src/main/spec-quality-gate.ts
@@ -85,7 +85,7 @@ When the ticket references another ticket, module, or external system's output:
 - Read/write timing must be compatible — if the source writes at end-of-process and the consumer reads mid-process, that's a conflict.
 - How contract compatibility is verified must be specified.
 - If the data source doesn't exist yet, the ticket must include creating it or explicitly depend on a ticket that does.
-- The contract must resolve to an enforced artifact — a committed type/interface, a schema, or a contract test — not prose. A contract that exists only in an epic description, a code comment, or an unmerged sibling ticket's text is NOT a contract; FAIL the ticket until the owning ticket lands the artifact (or this ticket creates it). (Consuming existing committed code/types is fine — that IS an enforced artifact.)
+- The contract must resolve to an enforced artifact — a committed type/interface, a schema, or a contract test — not prose. A contract that exists only in an epic description, a code comment, or an unmerged sibling ticket's text is NOT a contract; FAIL the ticket until the owning ticket lands the artifact (or this ticket creates it). (Consuming existing committed code/types is fine — that IS an enforced artifact.) This rule applies to CODE contracts only — design/reference material (mockups, specs, docs) may remain external; their content is resolved and supplied in the "## Resolved References" section and must be evaluated there.
 - Name the single owner of each shared surface the ticket touches; a consumer or extender must reference that owner and must not redefine the shape.
 
 ### Contribution to the Whole
@@ -127,7 +127,7 @@ If a question is partially code-derivable:
 - State the verified fact with a \`file:line\` citation.
 - Ask only the residual judgment question (the part not in the code).
 
-Verification limit: static reading only. If answering requires executing code or hitting an external service, treat as "not feasible to verify statically" and escalate to the user.
+Verification limit: static reading only. If answering requires executing code, treat as "not feasible to verify statically" and escalate to the user. Exception: external links cited in the ticket body (gists, mockups, design docs) are resolved by the host before evaluation — their content is supplied in the "## Resolved References" section below the ticket. Treat that resolved content as part of the spec. A broken or unreachable referenced link (shown as an error in the Resolved References section) is itself a FAIL — surface the error rather than ignoring it.
 
 Hallucination guard: every claimed verification MUST include a \`file:line\` citation. A verification without a citation is not a verification.
 `;

--- a/tests/main/control-plane/ticket-references.test.ts
+++ b/tests/main/control-plane/ticket-references.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoist mocks so vi.mock factories can reference them.
+// ---------------------------------------------------------------------------
+const { mockExecFile, mockFetch } = vi.hoisted(() => {
+  const mockExecFile = vi.fn();
+  const mockFetch = vi.fn();
+  return { mockExecFile, mockFetch };
+});
+
+vi.mock('child_process', async () => {
+  const util = await import('util');
+  const execFileFn = vi.fn();
+  // Make promisify(execFile) return our mockExecFile
+  (execFileFn as any)[util.promisify.custom] = mockExecFile;
+  return { execFile: execFileFn };
+});
+
+// Replace global fetch
+vi.stubGlobal('fetch', mockFetch);
+
+import { resolveTicketReferences, renderResolvedReferences } from '../../../src/main/control-plane/ticket-references';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeReadableStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i++]);
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function makeResponse(body: string, status = 200): Response {
+  const encoder = new TextEncoder();
+  const stream = makeReadableStream([encoder.encode(body)]);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: stream,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockFetch.mockResolvedValue(makeResponse(''));
+  mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+});
+
+// ---------------------------------------------------------------------------
+// URL extraction / classification
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — no links', () => {
+  it('returns [] for a body with no http(s) links', async () => {
+    const refs = await resolveTicketReferences('No links here at all.');
+    expect(refs).toEqual([]);
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-http(s) schemes', async () => {
+    const refs = await resolveTicketReferences('See ftp://example.com and file:///tmp/foo');
+    expect(refs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gist links → gh gist view --raw
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — gist', () => {
+  it('fetches a gist via gh gist view --raw', async () => {
+    mockExecFile.mockResolvedValue({ stdout: 'gist content here', stderr: '' });
+    const body = 'Check the mockup at https://gist.github.com/user/abc123def456';
+    const refs = await resolveTicketReferences(body);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].kind).toBe('gist');
+    expect(refs[0].content).toBe('gist content here');
+    expect(refs[0].url).toBe('https://gist.github.com/user/abc123def456');
+    // Assert the correct mechanism (promisified — 3 args, no callback)
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['gist', 'view', 'abc123def456', '--raw'],
+      expect.any(Object)
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns error for an unreachable gist', async () => {
+    mockExecFile.mockRejectedValue(Object.assign(new Error('not found'), { stderr: 'gist not found (404)' }));
+    const refs = await resolveTicketReferences('https://gist.github.com/user/badid');
+    expect(refs[0].content).toBeNull();
+    expect(refs[0].error).toBe('404');
+  });
+
+  it('returns timeout error for a killed process', async () => {
+    mockExecFile.mockRejectedValue(Object.assign(new Error('timeout'), { killed: true }));
+    const refs = await resolveTicketReferences('https://gist.github.com/user/slowid');
+    expect(refs[0].content).toBeNull();
+    expect(refs[0].error).toBe('timeout');
+  });
+
+  it('truncates gist content at 256 KB', async () => {
+    const big = 'x'.repeat(300 * 1024);
+    mockExecFile.mockResolvedValue({ stdout: big, stderr: '' });
+    const refs = await resolveTicketReferences('https://gist.github.com/user/bigid');
+    expect(refs[0].truncated).toBe(true);
+    expect(refs[0].content!.length).toBe(256 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub links → gh api
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — github', () => {
+  it('fetches a github file link via gh api', async () => {
+    mockExecFile.mockResolvedValue({ stdout: 'file content', stderr: '' });
+    const url = 'https://github.com/owner/repo/blob/main/src/foo.ts';
+    const refs = await resolveTicketReferences(url);
+    expect(refs[0].kind).toBe('github');
+    expect(refs[0].content).toBe('file content');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['api', '/repos/owner/repo/contents/src/foo.ts?ref=main', '--header', 'Accept: application/vnd.github.raw+json'],
+      expect.any(Object)
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches raw.githubusercontent.com via gh api', async () => {
+    mockExecFile.mockResolvedValue({ stdout: 'raw file', stderr: '' });
+    const url = 'https://raw.githubusercontent.com/owner/repo/main/README.md';
+    const refs = await resolveTicketReferences(url);
+    expect(refs[0].kind).toBe('github');
+    expect(refs[0].content).toBe('raw file');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['api', '/repos/owner/repo/contents/README.md?ref=main', '--header', 'Accept: application/vnd.github.raw+json'],
+      expect.any(Object)
+    );
+  });
+
+  it('returns 404 error for missing github file', async () => {
+    mockExecFile.mockRejectedValue(Object.assign(new Error('not found'), { stderr: 'HTTP 404 Not Found' }));
+    const refs = await resolveTicketReferences('https://github.com/owner/repo/blob/main/missing.ts');
+    expect(refs[0].content).toBeNull();
+    expect(refs[0].error).toBe('404');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-GitHub http(s) links → Node fetch()
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — other', () => {
+  it('fetches a non-GitHub http(s) link via fetch()', async () => {
+    mockFetch.mockResolvedValue(makeResponse('page content', 200));
+    const refs = await resolveTicketReferences('https://example.com/mockup.html');
+    expect(refs[0].kind).toBe('other');
+    expect(refs[0].content).toBe('page content');
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns http-404 error for a 404 response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, body: null } as unknown as Response);
+    const refs = await resolveTicketReferences('https://example.com/gone');
+    expect(refs[0].content).toBeNull();
+    expect(refs[0].error).toBe('404');
+  });
+
+  it('returns http-500 error for a 500 response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, body: null } as unknown as Response);
+    const refs = await resolveTicketReferences('https://example.com/broken');
+    expect(refs[0].content).toBeNull();
+    expect(refs[0].error).toBe('http-500');
+  });
+
+  it('returns timeout error on AbortError', async () => {
+    mockFetch.mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+    const refs = await resolveTicketReferences('https://example.com/slow');
+    expect(refs[0].content).toBeNull();
+    expect(refs[0].error).toBe('timeout');
+  });
+
+  it('truncates content at 256 KB via streamed read', async () => {
+    const big = 'y'.repeat(300 * 1024);
+    mockFetch.mockResolvedValue(makeResponse(big, 200));
+    const refs = await resolveTicketReferences('https://example.com/bigfile');
+    expect(refs[0].truncated).toBe(true);
+    expect(refs[0].content!.length).toBeLessThanOrEqual(256 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSRF guard — private/loopback hosts
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — SSRF guard', () => {
+  const privateHosts = [
+    'http://localhost/admin',
+    'http://127.0.0.1/secret',
+    'http://0.0.0.0/bad',
+    'http://10.0.0.1/internal',
+    'http://172.16.5.5/private',
+    'http://192.168.1.1/router',
+    'http://169.254.169.254/metadata',
+  ];
+
+  for (const url of privateHosts) {
+    it(`blocks ${url} as blocked-private-host`, async () => {
+      const refs = await resolveTicketReferences(url);
+      expect(refs).toHaveLength(1);
+      expect(refs[0].content).toBeNull();
+      expect(refs[0].error).toBe('blocked-private-host');
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — deduplication', () => {
+  it('fetches each unique URL only once', async () => {
+    mockFetch.mockResolvedValue(makeResponse('content', 200));
+    const body = 'https://example.com/page https://example.com/page https://example.com/page';
+    const refs = await resolveTicketReferences(body);
+    expect(refs).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches two different URLs separately', async () => {
+    mockFetch.mockResolvedValue(makeResponse('content', 200));
+    const body = 'https://example.com/a https://example.com/b';
+    const refs = await resolveTicketReferences(body);
+    expect(refs).toHaveLength(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Total cap
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — total cap', () => {
+  it('marks remaining references as capped when total exceeds 1 MB', async () => {
+    // Each URL returns 300 KB → truncated to 256 KB per fetch.
+    // After 4 fetches: 4 × 256 KB = 1 MB total → 5th URL is capped.
+    const big = 'z'.repeat(300 * 1024);
+    // Use mockImplementation so each fetch call gets a fresh Response (fresh stream)
+    mockFetch.mockImplementation(() => Promise.resolve(makeResponse(big, 200)));
+
+    const urls = [
+      'https://example.com/u1',
+      'https://example.com/u2',
+      'https://example.com/u3',
+      'https://example.com/u4',
+      'https://example.com/u5',
+    ];
+    const refs = await resolveTicketReferences(urls.join(' '));
+    const capped = refs.filter(r => r.capped);
+    expect(capped.length).toBeGreaterThan(0);
+    // The 5th URL should have been skipped without calling fetch
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed body with multiple kinds
+// ---------------------------------------------------------------------------
+describe('resolveTicketReferences — mixed body', () => {
+  it('extracts gist, github, and other links from the same body', async () => {
+    mockExecFile.mockResolvedValue({ stdout: 'fetched content', stderr: '' });
+    mockFetch.mockResolvedValue(makeResponse('other content', 200));
+
+    const body = [
+      'Gist: https://gist.github.com/user/abc123',
+      'File: https://github.com/owner/repo/blob/main/src/foo.ts',
+      'Docs: https://docs.example.com/spec',
+    ].join('\n');
+
+    const refs = await resolveTicketReferences(body);
+    expect(refs).toHaveLength(3);
+    expect(refs.find(r => r.kind === 'gist')).toBeDefined();
+    expect(refs.find(r => r.kind === 'github')).toBeDefined();
+    expect(refs.find(r => r.kind === 'other')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderResolvedReferences
+// ---------------------------------------------------------------------------
+describe('renderResolvedReferences', () => {
+  it('returns empty string for empty array', () => {
+    expect(renderResolvedReferences([])).toBe('');
+  });
+
+  it('renders a section header with content', () => {
+    const refs = [{ url: 'https://example.com/doc', kind: 'other' as const, content: 'hello world' }];
+    const rendered = renderResolvedReferences(refs);
+    expect(rendered).toContain('## Resolved References');
+    expect(rendered).toContain('https://example.com/doc');
+    expect(rendered).toContain('hello world');
+  });
+
+  it('renders broken-link error', () => {
+    const refs = [{ url: 'https://example.com/gone', kind: 'other' as const, content: null, error: '404' }];
+    const rendered = renderResolvedReferences(refs);
+    expect(rendered).toContain('Could not fetch');
+    expect(rendered).toContain('404');
+  });
+
+  it('renders capped reference', () => {
+    const refs = [{ url: 'https://example.com/large', kind: 'other' as const, content: null, capped: true }];
+    const rendered = renderResolvedReferences(refs);
+    expect(rendered).toContain('total fetch budget exceeded');
+  });
+
+  it('renders truncated flag', () => {
+    const refs = [{ url: 'https://example.com/big', kind: 'other' as const, content: 'abcd', truncated: true }];
+    const rendered = renderResolvedReferences(refs);
+    expect(rendered).toContain('truncated');
+  });
+});

--- a/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for dispatchTask reference resolution (ticket #641).
+ * Verifies that external links cited in a prompt are resolved and appended
+ * to the prompt delivered to the inner agent, and that the no-link case
+ * leaves the prompt unchanged.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { StackManager } from '../../../../src/main/control-plane/stack-manager';
+import { Registry } from '../../../../src/main/control-plane/registry';
+import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
+import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
+import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+
+// ---------------------------------------------------------------------------
+// Mock ticket-references so we don't hit the network or gh CLI.
+// ---------------------------------------------------------------------------
+const { mockResolveTicketReferences, mockRenderResolvedReferences } = vi.hoisted(() => ({
+  mockResolveTicketReferences: vi.fn(),
+  mockRenderResolvedReferences: vi.fn(),
+}));
+
+vi.mock('../../../../src/main/control-plane/ticket-references', () => ({
+  resolveTicketReferences: mockResolveTicketReferences,
+  renderResolvedReferences: mockRenderResolvedReferences,
+}));
+
+// Also mock ticket-config so fetchTicketWithConfig is controllable.
+vi.mock('../../../../src/main/control-plane/ticket-config', async () => {
+  const actual = await vi.importActual('../../../../src/main/control-plane/ticket-config');
+  return { ...actual, fetchTicketWithConfig: vi.fn().mockResolvedValue(null) };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `sm-dispatch-refs-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function createMockRuntime(): ContainerRuntime {
+  return {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([
+      {
+        id: 'claude-cid',
+        name: 'sandstorm-proj-mystack-claude-1',
+        image: 'sandstorm-claude',
+        status: 'running' as const,
+        state: 'running',
+        ports: [],
+        labels: {},
+        created: new Date().toISOString(),
+      },
+    ]),
+    inspect: vi.fn().mockResolvedValue({}),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+function makeStack(id: string) {
+  return {
+    id,
+    project: 'proj',
+    project_dir: '/proj',
+    ticket: null,
+    branch: null,
+    description: null,
+    status: 'up' as const,
+    runtime: 'docker' as const,
+  };
+}
+
+const REFS_SECTION = '## Resolved References\n\n### https://gist.github.com/user/abc\n\n```\nmockup content\n```\n';
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe('dispatchTask — reference resolution', () => {
+  let registry: Registry;
+  let portAllocator: PortAllocator;
+  let taskWatcher: TaskWatcher;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime();
+    portAllocator = new PortAllocator(registry, [40000, 40099]);
+    taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+
+    // Default: no references resolved
+    mockResolveTicketReferences.mockResolvedValue([]);
+    mockRenderResolvedReferences.mockReturnValue('');
+  });
+
+  afterEach(() => {
+    taskWatcher.unwatchAll();
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  it('appends resolved references block to the prompt delivered to runCli', async () => {
+    registry.createStack(makeStack('ref-stack'));
+    const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+      stdout: 'ok', stderr: '', exitCode: 0,
+    });
+
+    // Simulate a gist reference being resolved
+    mockResolveTicketReferences.mockResolvedValue([
+      { url: 'https://gist.github.com/user/abc', kind: 'gist', content: 'mockup content' },
+    ]);
+    mockRenderResolvedReferences.mockReturnValue(REFS_SECTION);
+
+    const prompt = 'Implement the mockup at https://gist.github.com/user/abc';
+    await manager.dispatchTask('ref-stack', prompt, undefined, { forceBypass: true });
+
+    const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
+    const deliveredPrompt = cliArgs[cliArgs.length - 1];
+
+    expect(deliveredPrompt).toContain('## Resolved References');
+    expect(deliveredPrompt).toContain('mockup content');
+    expect(deliveredPrompt).toContain(prompt);
+  });
+
+  it('leaves prompt unchanged when the body has no external links (no-op)', async () => {
+    registry.createStack(makeStack('noref-stack'));
+    const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+      stdout: 'ok', stderr: '', exitCode: 0,
+    });
+
+    // No references
+    mockResolveTicketReferences.mockResolvedValue([]);
+    mockRenderResolvedReferences.mockReturnValue('');
+
+    const prompt = 'Fix the bug in the auth module';
+    await manager.dispatchTask('noref-stack', prompt, undefined, { forceBypass: true });
+
+    const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
+    const deliveredPrompt = cliArgs[cliArgs.length - 1];
+
+    expect(deliveredPrompt).toBe(prompt);
+    expect(deliveredPrompt).not.toContain('## Resolved References');
+  });
+
+  it('calls resolveTicketReferences with the full prompt text', async () => {
+    registry.createStack(makeStack('args-stack'));
+    vi.spyOn(manager, 'runCli').mockResolvedValue({
+      stdout: 'ok', stderr: '', exitCode: 0,
+    });
+
+    const prompt = 'Implement feature at https://example.com/spec';
+    await manager.dispatchTask('args-stack', prompt, undefined, { forceBypass: true });
+
+    expect(mockResolveTicketReferences).toHaveBeenCalledWith(
+      expect.stringContaining('https://example.com/spec')
+    );
+  });
+
+  it('appended section is separated by a horizontal rule', async () => {
+    registry.createStack(makeStack('sep-stack'));
+    const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
+      stdout: 'ok', stderr: '', exitCode: 0,
+    });
+
+    mockResolveTicketReferences.mockResolvedValue([
+      { url: 'https://example.com/doc', kind: 'other', content: 'design doc' },
+    ]);
+    mockRenderResolvedReferences.mockReturnValue('## Resolved References\n\n### https://example.com/doc\n\ndesign doc\n');
+
+    await manager.dispatchTask('sep-stack', 'Build per spec at https://example.com/doc', undefined, { forceBypass: true });
+
+    const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
+    const deliveredPrompt = cliArgs[cliArgs.length - 1];
+
+    expect(deliveredPrompt).toContain('\n\n---\n\n');
+    expect(deliveredPrompt).toContain('## Resolved References');
+  });
+});

--- a/tests/unit/tools-spec-prompts.test.ts
+++ b/tests/unit/tools-spec-prompts.test.ts
@@ -17,6 +17,11 @@ vi.mock('../../src/main/control-plane/ticket-config', () => ({
   updateTicketWithConfig: vi.fn(),
 }));
 
+vi.mock('../../src/main/control-plane/ticket-references', () => ({
+  resolveTicketReferences: vi.fn().mockResolvedValue([]),
+  renderResolvedReferences: vi.fn().mockReturnValue(''),
+}));
+
 vi.mock('../../src/main/control-plane/registry', () => ({}));
 
 vi.mock('../../src/main/scheduler', () => ({
@@ -187,5 +192,47 @@ describe('built-in gate verification policy', () => {
 
   it('gate does not require automated visual verification', () => {
     expect(GATE).not.toContain('### Automated Visual Verification');
+  });
+
+  it('gate allows external design/reference links (not treated as incomplete spec)', () => {
+    expect(GATE).toContain('design/reference material');
+    expect(GATE).toContain('Resolved References');
+  });
+
+  it('gate still requires code contracts to be committed artifacts', () => {
+    expect(GATE).toContain('CODE contracts only');
+    expect(GATE).toContain('committed type/interface');
+  });
+
+  it('gate treats broken referenced links as a FAIL', () => {
+    expect(GATE).toContain('broken or unreachable referenced link');
+    expect(GATE).toContain('FAIL');
+  });
+});
+
+describe('buildSpecCheckPrompt — with resolved references', () => {
+  const GIST_URL = 'https://gist.github.com/user/abc123unique';
+  const REFS_SECTION = `## Resolved References\n\n### ${GIST_URL}\n\n\`\`\`\nmockup content\n\`\`\`\n`;
+
+  it('includes resolved references content when section is provided', () => {
+    const prompt = buildSpecCheckPrompt(GATE, TICKET, REFS_SECTION);
+    expect(prompt).toContain(GIST_URL);
+    expect(prompt).toContain('mockup content');
+  });
+
+  it('does not include specific reference URLs when section is not provided', () => {
+    const prompt = buildSpecCheckPrompt(GATE, TICKET);
+    expect(prompt).not.toContain(GIST_URL);
+  });
+
+  it('does not include specific reference URLs when empty string provided', () => {
+    const prompt = buildSpecCheckPrompt(GATE, TICKET, '');
+    expect(prompt).not.toContain(GIST_URL);
+  });
+
+  it('still embeds gate and ticket when references are present', () => {
+    const prompt = buildSpecCheckPrompt(GATE, TICKET, REFS_SECTION);
+    expect(prompt).toContain(GATE);
+    expect(prompt).toContain(TICKET);
   });
 });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -55,8 +55,14 @@ vi.mock('../../src/main/spec-quality-gate', () => ({
   getDefaultSpecQualityGate: vi.fn().mockReturnValue('### Problem Statement\nIs the why clear?'),
 }));
 
+vi.mock('../../src/main/control-plane/ticket-references', () => ({
+  resolveTicketReferences: vi.fn().mockResolvedValue([]),
+  renderResolvedReferences: vi.fn().mockReturnValue(''),
+}));
+
 import { stackManager, agentBackend, registry } from '../../src/main/index';
 import { fetchTicketWithConfig, updateTicketWithConfig } from '../../src/main/control-plane/ticket-config';
+import { resolveTicketReferences, renderResolvedReferences } from '../../src/main/control-plane/ticket-references';
 import { createSchedule, listSchedules, updateSchedule, deleteSchedule } from '../../src/main/scheduler';
 import { syncAllProjectsCrontab } from '../../src/main/scheduler/scheduler-manager';
 
@@ -927,6 +933,30 @@ describe('MCP tools', () => {
       await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
       const [, , timeoutArg] = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls[0];
       expect(timeoutArg).toBe(0);
+    });
+
+    it('spawnSpecCheck calls resolveTicketReferences with the ticket body', async () => {
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: body with [ref](http://example.com)');
+      vi.mocked(resolveTicketReferences).mockResolvedValue([{ url: 'http://example.com', kind: 'other', content: 'ref content' }]);
+      vi.mocked(renderResolvedReferences).mockReturnValue('## External References\n\nref content');
+
+      spawnSpecCheck('42', '/proj');
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
+
+      expect(resolveTicketReferences).toHaveBeenCalledWith('# Issue: body with [ref](http://example.com)');
+    });
+
+    it('spawnSpecCheck forwards renderResolvedReferences output to buildSpecCheckPrompt via spawnEphemeralAgent prompt', async () => {
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: body');
+      vi.mocked(resolveTicketReferences).mockResolvedValue([{ url: 'http://example.com', kind: 'other', content: 'ref content' }]);
+      vi.mocked(renderResolvedReferences).mockReturnValue('## External References\n\nref content');
+
+      spawnSpecCheck('42', '/proj');
+      await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
+
+      const [promptArg] = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls[0];
+      expect(promptArg).toContain('## External References');
+      expect(promptArg).toContain('ref content');
     });
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
   ],
   test: {
-    include: ['tests/unit/**/*.test.{ts,tsx}'],
+    include: ['tests/unit/**/*.test.{ts,tsx}', 'tests/main/**/*.test.{ts,tsx}'],
     environment: 'node',
     testTimeout: 10000,
     cache: false,


### PR DESCRIPTION
## Summary

Tickets and prompts often cite external material (GitHub gists, repo files, design docs, mockups) by link. Previously the inner agent and the spec quality gate only saw the bare URL and had no way to read the content, so design/reference links got flagged as an incomplete spec and dispatched agents worked without the referenced material.

This adds a host-side reference resolver (`ticket-references.ts`) that scans a prompt for links, fetches their content via the `gh` CLI for gists and GitHub files and a plain fetch for other URLs, and renders a "Resolved References" section. Resolution is bounded — per-fetch and total byte caps, a fetch timeout, private/loopback host blocking — and broken links are surfaced as errors rather than silently dropped.

The resolved section is appended in two places: `dispatchTask` in the stack manager (so the inner agent gets full spec content without needing egress) and the spec-check prompt builder (so the gate evaluates the real content). The spec quality gate wording is updated to match: code contracts must still resolve to committed artifacts, but design/reference material may stay external and is evaluated from the Resolved References section, with an unreachable link counting as a FAIL.

## QA plan

1. Create a ticket whose body links a public gist and a GitHub file, dispatch it to a stack, and confirm the inner agent's prompt includes a "Resolved References" section with the fetched content.
2. Run the spec check on a ticket that references an external mockup link and confirm it is no longer failed for an incomplete spec.
3. Reference an unreachable or 404 link and confirm the resolved section reports the error and the spec check treats it as a FAIL.
4. Dispatch a ticket with no links and confirm the prompt is unchanged.

Closes #641