### PR TITLE
[639] fix: per-phase backend routing and needs_key status

### DIFF
--- a/sandstorm-cli/docker/phase-model-helper.sh
+++ b/sandstorm-cli/docker/phase-model-helper.sh
@@ -38,12 +38,9 @@ model_args_for_phase() {
   fi
 
   if [[ "$m" == *"/"* ]]; then
-    # OpenCode provider/model (contains '/') — not runnable in this image
-    log_loop "WARNING: phase=$phase model='$m' requires OpenCode backend (not available); using task model"
-    RESOLVED_MODEL_ARGS=("${MODEL_ARGS[@]}")
-    if [ -n "${TASK_MODEL:-}" ]; then
-      log_loop "phase=$phase model=${TASK_MODEL} (task fallback)"
-    fi
+    # OpenCode provider/model (contains '/') — no Claude --model arg needed for this phase
+    RESOLVED_MODEL_ARGS=()
+    log_loop "phase=$phase model=$m (opencode, no claude --model arg)"
     return
   fi
 

--- a/sandstorm-cli/docker/task-runner.sh
+++ b/sandstorm-cli/docker/task-runner.sh
@@ -205,14 +205,70 @@ run_opencode() {
   return ${PIPESTATUS[0]}
 }
 
-# Dispatch to run_claude or run_opencode based on AGENT_BACKEND.
-# Same signature as run_claude — Claude-specific extra args are dropped for OpenCode.
+# Dispatch to run_claude or run_opencode based on per-phase routing from PHASE_ROUTING_JSON.
+# Falls back to global AGENT_BACKEND when PHASE_ROUTING_JSON is absent (backward compat).
+# Same signature as run_claude — phase is $4.
 run_agent() {
-  if [ "${AGENT_BACKEND:-claude}" = "opencode" ]; then
-    run_opencode "$1" "$2" "$3" "$4" "$5"
-  else
-    run_claude "$@"
+  local prompt_file="$1"
+  local raw_log="${2:-/tmp/claude-raw.log}"
+  local task_log="${3:-/tmp/claude-task.log}"
+  local phase="${4:-execution}"
+  local iteration="${5:-1}"
+  shift 5 2>/dev/null || shift $#
+  local extra_args=("$@")
+
+  # Resolve per-phase backend and provider from routing JSON (fall back to global AGENT_BACKEND)
+  local backend="${AGENT_BACKEND:-claude}"
+  local provider=""
+  local phase_model=""
+  if [ -n "${PHASE_ROUTING_JSON:-}" ]; then
+    local _b _p _m
+    _b=$(printf '%s' "$PHASE_ROUTING_JSON" | jq -r --arg ph "$phase" '.[$ph].backend // empty' 2>/dev/null || true)
+    _p=$(printf '%s' "$PHASE_ROUTING_JSON" | jq -r --arg ph "$phase" '.[$ph].provider // empty' 2>/dev/null || true)
+    _m=$(printf '%s' "$PHASE_ROUTING_JSON" | jq -r --arg ph "$phase" '.[$ph].model // empty' 2>/dev/null || true)
+    [ -n "$_b" ] && backend="$_b"
+    [ -n "$_p" ] && provider="$_p"
+    [ -n "$_m" ] && phase_model="$_m"
   fi
+
+  if [ "$backend" = "opencode" ]; then
+    local config_file="/tmp/sandstorm-opencode-${provider}.json"
+    local _saved_oc_config="${OPENCODE_CONFIG:-}"
+    local _saved_oc_model="${OPENCODE_MODEL:-}"
+    export OPENCODE_CONFIG="$config_file"
+    [ -n "$phase_model" ] && export OPENCODE_MODEL="$phase_model"
+    run_opencode "$prompt_file" "$raw_log" "$task_log" "$phase" "$iteration"
+    local _ret=$?
+    export OPENCODE_CONFIG="${_saved_oc_config}"
+    export OPENCODE_MODEL="${_saved_oc_model}"
+    return $_ret
+  else
+    run_claude "$prompt_file" "$raw_log" "$task_log" "$phase" "$iteration" "${extra_args[@]}"
+  fi
+}
+
+# Check all phases in PHASE_ROUTING_JSON for missing credentials.
+# An opencode phase without /tmp/sandstorm-opencode-<provider>.json present means
+# the provider has no credentials configured (needs_key).
+# Sets global TASK_NEEDS_KEY=1 and writes /tmp/claude-task-needs-key.txt on failure.
+check_all_phase_credentials() {
+  TASK_NEEDS_KEY=0
+  if [ -z "${PHASE_ROUTING_JSON:-}" ]; then return; fi
+  local phase backend provider config_file
+  for phase in execution review meta_review; do
+    backend=$(printf '%s' "$PHASE_ROUTING_JSON" | jq -r --arg p "$phase" '.[$p].backend // empty' 2>/dev/null || true)
+    provider=$(printf '%s' "$PHASE_ROUTING_JSON" | jq -r --arg p "$phase" '.[$p].provider // empty' 2>/dev/null || true)
+    if [ "$backend" = "opencode" ] && [ -n "$provider" ]; then
+      config_file="/tmp/sandstorm-opencode-${provider}.json"
+      if [ ! -f "$config_file" ]; then
+        log_loop "Phase '$phase' requires provider '$provider' but no credentials are configured (needs_key)"
+        TASK_NEEDS_KEY=1
+        printf "Phase '%s' requires provider '%s' but no credentials are configured.\n" "$phase" "$provider" \
+          > /tmp/claude-task-needs-key.txt
+        return
+      fi
+    fi
+  done
 }
 
 # Check if there are code changes in the workspace.
@@ -687,6 +743,19 @@ while true; do
     fi
     export OPENCODE_MODEL
 
+    # Read per-phase routing JSON (written by stack.sh --phase-routing-json).
+    # Supersedes --backend/--backend-model for per-phase backend+provider+model selection.
+    PHASE_ROUTING_JSON=""
+    if [ -f /tmp/claude-task-phase-routing.json ]; then
+      PHASE_ROUTING_JSON=$(cat /tmp/claude-task-phase-routing.json 2>/dev/null || true)
+      if ! printf '%s' "$PHASE_ROUTING_JSON" | jq . > /dev/null 2>&1; then
+        log_loop "WARNING: /tmp/claude-task-phase-routing.json is malformed — ignoring per-phase routing"
+        PHASE_ROUTING_JSON=""
+      fi
+      rm -f /tmp/claude-task-phase-routing.json
+    fi
+    export PHASE_ROUTING_JSON
+
     echo ""
     echo "=========================================="
     echo "  Task: $LABEL"
@@ -698,6 +767,25 @@ while true; do
       [ -n "$OPENCODE_MODEL" ] && echo "  OpenCode model: $OPENCODE_MODEL"
     fi
     echo "=========================================="
+
+    # Credentials check: fail fast if any phase lacks required provider credentials
+    check_all_phase_credentials
+    if [ "${TASK_NEEDS_KEY:-0}" -eq 1 ]; then
+      rm -f /tmp/claude-task-prompt.txt
+      echo 1 > /tmp/claude-task.exit
+      echo "needs_key" > /tmp/claude-task.status
+      rm -f /tmp/claude-task.pid
+      echo ""
+      echo "=========================================="
+      echo "  Task finished — NEEDS KEY"
+      echo "  $(cat /tmp/claude-task-needs-key.txt 2>/dev/null)"
+      echo "=========================================="
+      echo ""
+      echo "ready" > /tmp/claude-ready
+      echo "Waiting for tasks..."
+      continue
+    fi
+
     echo "running" > /tmp/claude-task.status
     echo $$ > /tmp/claude-task.pid
 

--- a/sandstorm-cli/lib/stack.sh
+++ b/sandstorm-cli/lib/stack.sh
@@ -425,6 +425,7 @@ case "$COMMAND" in
     TASK_RESUME_SESSION_ID=""
     TASK_BACKEND=""
     TASK_BACKEND_MODEL=""
+    TASK_PHASE_ROUTING_JSON=""
     while true; do
       case "${1:-}" in
         --sync) SYNC_MODE=true; shift ;;
@@ -434,6 +435,7 @@ case "$COMMAND" in
         --resume) TASK_RESUME_SESSION_ID="$2"; shift 2 ;;
         --backend) TASK_BACKEND="$2"; shift 2 ;;
         --backend-model) TASK_BACKEND_MODEL="$2"; shift 2 ;;
+        --phase-routing-json) TASK_PHASE_ROUTING_JSON="$2"; shift 2 ;;
         *) break ;;
       esac
     done
@@ -511,6 +513,12 @@ case "$COMMAND" in
       if [ -n "$TASK_BACKEND_MODEL" ]; then
         echo "$TASK_BACKEND_MODEL" | docker exec -i -u claude "$CONTAINER_NAME" \
           bash -c "cat > /tmp/claude-task-backend-model.txt"
+      fi
+
+      # Write per-phase routing JSON if provided (supersedes --backend/--backend-model)
+      if [ -n "$TASK_PHASE_ROUTING_JSON" ]; then
+        printf '%s' "$TASK_PHASE_ROUTING_JSON" | docker exec -i -u claude "$CONTAINER_NAME" \
+          bash -c "cat > /tmp/claude-task-phase-routing.json"
       fi
 
       # Trigger the task runner (runs as the container's main process, output goes to docker logs)

--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -693,10 +693,6 @@ export class OpenCodeBackend implements AgentBackend {
     // Dynamic import to avoid a circular dependency at load time.
     const { registry } = await import('../index');
 
-    const globalSettings = registry.getGlobalBackendSettings();
-    const providerId = globalSettings.inner_provider ?? 'anthropic';
-    const bundle = registry.getBackendSecretBundle('global', 'inner') ?? {};
-
     for (const stack of stacks) {
       if (stack.status !== 'running' && stack.status !== 'up') continue;
       const claudeService = stack.services?.find((s) => s.name === 'claude');
@@ -711,20 +707,35 @@ export class OpenCodeBackend implements AgentBackend {
           'rm -f ~/.local/share/opencode/auth.json && mkdir -p ~/.local/share/opencode',
         ]);
 
-        // 2. Write the generated OpenCode config with actual credential values
-        //    directly to the config file the task runner reads.
-        const { generateOpencodeConfig } = await import('../opencode-config');
-        const config = generateOpencodeConfig({ providerId, bundle, model: globalSettings.inner_model ?? undefined });
-        const configJson = JSON.stringify(config, null, 2);
+        // 2. Collect distinct opencode providers across all container phases.
+        //    For each provider, store its credentials bundle and one representative model.
+        const providerMap = new Map<string, { credentials: Record<string, string> | null; model: string }>();
+        if (stack.project_dir) {
+          for (const touchpoint of ['execution', 'review', 'meta_review'] as const) {
+            const desc = registry.getEffectiveTouchpointDescriptor(stack.project_dir, touchpoint);
+            if (desc.backend === 'opencode' && !providerMap.has(desc.provider)) {
+              providerMap.set(desc.provider, { credentials: desc.credentials, model: desc.model });
+            }
+          }
+        }
 
-        const writeProc = spawn('docker', [
-          'exec', '-i', '-u', 'claude', claudeService.containerId,
-          'bash', '-c', 'cat > /tmp/sandstorm-opencode.json',
-        ], { stdio: ['pipe', 'ignore', 'ignore'] });
-        writeProc.on('error', () => {});
-        writeProc.stdin.write(configJson);
-        writeProc.stdin.end();
-        await new Promise<void>((resolve) => writeProc.on('close', () => resolve()));
+        // 3. Write one config file per distinct provider that has credentials.
+        //    Providers without credentials are skipped; their absence signals needs_key
+        //    to the task runner.
+        const { generateOpencodeConfig } = await import('../opencode-config');
+        for (const [providerId, { credentials, model }] of providerMap) {
+          if (!credentials) continue;
+          const config = generateOpencodeConfig({ providerId, bundle: credentials, model: model || undefined });
+          const configJson = JSON.stringify(config, null, 2);
+          const writeProc = spawn('docker', [
+            'exec', '-i', '-u', 'claude', claudeService.containerId,
+            'bash', '-c', 'cat > "$1"', '--', `/tmp/sandstorm-opencode-${providerId}.json`,
+          ], { stdio: ['pipe', 'ignore', 'ignore'] });
+          writeProc.on('error', () => {});
+          writeProc.stdin.write(configJson);
+          writeProc.stdin.end();
+          await new Promise<void>((resolve) => writeProc.on('close', () => resolve()));
+        }
       } catch {
         // Best effort per container
       }

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -77,6 +77,7 @@ export interface StackServiceInfo {
 
 export interface StackInfo {
   status: string;
+  project_dir?: string;
   services?: StackServiceInfo[];
 }
 

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -57,6 +57,7 @@ export type StackStatus =
   | 'completed'
   | 'failed'
   | 'needs_human'
+  | 'needs_key'
   | 'verify_blocked_environmental'
   | 'idle'
   | 'stopped'
@@ -71,7 +72,7 @@ export interface Task {
   prompt: string;
   model: string | null;
   resolved_model: string | null;
-  status: 'running' | 'completed' | 'failed' | 'interrupted' | 'needs_human';
+  status: 'running' | 'completed' | 'failed' | 'interrupted' | 'needs_human' | 'needs_key';
   exit_code: number | null;
   warnings: string | null;
   session_id: string | null;
@@ -1030,6 +1031,19 @@ export class Registry {
       "SELECT branch FROM stack_history WHERE ticket = ? AND branch IS NOT NULL"
     ).all(ticketId) as { branch: string }[];
     return [...active, ...history].map((r) => r.branch);
+  }
+
+  completeTaskNeedsKey(taskId: number, reason: string): void {
+    this.db.prepare(
+      "UPDATE tasks SET status = 'needs_key', exit_code = 1, warnings = ?, finished_at = datetime('now') WHERE id = ?"
+    ).run(reason, taskId);
+
+    const task = this.db.prepare(
+      'SELECT stack_id FROM tasks WHERE id = ?'
+    ).get(taskId) as { stack_id: string } | undefined;
+    if (task) {
+      this.updateStackStatus(task.stack_id, 'needs_key');
+    }
   }
 
   completeTaskVerifyBlockedEnvironmental(taskId: number, reason: string): void {

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -12,6 +12,7 @@ import { fetchRawBodyWithConfig, fetchTicketWithConfig, updateTicketWithConfig }
 import { referencesTicket } from './ticket-fetcher';
 import { workspacePathFor } from './pr-creator';
 import { parseTokenUsage } from './token-parser';
+import type { TouchpointId } from './routing';
 
 const execFileAsync = promisify(execFile);
 
@@ -1183,7 +1184,13 @@ export class StackManager {
     stackId: string,
     prompt: string,
     model?: string,
-    opts?: { gateApproved?: boolean; forceBypass?: boolean; skipTicketFetch?: boolean }
+    opts?: {
+      gateApproved?: boolean;
+      forceBypass?: boolean;
+      skipTicketFetch?: boolean;
+      /** Override which touchpoint drives the execution phase routing (default: 'execution'). */
+      executionTouchpoint?: TouchpointId;
+    }
   ): Promise<DispatchTaskResult> {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
@@ -1252,25 +1259,27 @@ export class StackManager {
       // handles credential sync (OAuth), writes files as the correct user
       // (`-u claude`), and creates the trigger file with proper ownership —
       // preventing the infinite-loop and not-logged-in bugs.
-      const phaseModels = this.registry.getContainerPhaseModels(stack.project_dir);
+      const execTouchpoint = opts?.executionTouchpoint ?? 'execution';
+      const execDesc = this.registry.getEffectiveTouchpointDescriptor(stack.project_dir, execTouchpoint);
+      const reviewDesc = this.registry.getEffectiveTouchpointDescriptor(stack.project_dir, 'review');
+      const metaDesc = this.registry.getEffectiveTouchpointDescriptor(stack.project_dir, 'meta_review');
+
+      // --models-json: kept for backward-compat single-backend stacks
       const phaseModelsJson = JSON.stringify({
-        execution:   phaseModels.execution.model   || 'auto',
-        review:      phaseModels.review.model      || 'auto',
-        meta_review: phaseModels.meta_review.model || 'auto',
+        execution:   execDesc.model   || 'auto',
+        review:      reviewDesc.model || 'auto',
+        meta_review: metaDesc.model   || 'auto',
+      });
+      // --phase-routing-json: per-phase backend+provider+model for mixed-backend stacks
+      const phaseRoutingJson = JSON.stringify({
+        execution:   { backend: execDesc.backend,   provider: execDesc.provider,   model: execDesc.model   || 'auto' },
+        review:      { backend: reviewDesc.backend, provider: reviewDesc.provider, model: reviewDesc.model || 'auto' },
+        meta_review: { backend: metaDesc.backend,   provider: metaDesc.provider,   model: metaDesc.model   || 'auto' },
       });
       const cliArgs = ['task', stackId];
       if (model) cliArgs.push('--model', model);
       cliArgs.push('--models-json', phaseModelsJson);
-
-      // Resolve the project's effective inner backend and pass it to the CLI
-      // so the runner can dispatch to the correct agent (claude or opencode).
-      const effectiveBackend = this.registry.getEffectiveBackend(stack.project_dir, 'inner');
-      if (effectiveBackend.backend === 'opencode') {
-        cliArgs.push('--backend', 'opencode');
-        if (effectiveBackend.provider && effectiveBackend.model) {
-          cliArgs.push('--backend-model', `${effectiveBackend.provider}/${effectiveBackend.model}`);
-        }
-      }
+      cliArgs.push('--phase-routing-json', phaseRoutingJson);
 
       cliArgs.push(prompt);
       const result = await this.runCli(stack.project_dir, cliArgs);
@@ -2275,14 +2284,10 @@ export class StackManager {
     ].join('\n');
 
     try {
-      const mcRouting = this.registry.getEffectiveRoutingFor(projectDir, 'merge_conflict');
-      const mcModel = mcRouting.backend === 'opencode'
-        ? (console.warn('[merge_conflict] backend=opencode unsupported for container path; falling back to legacy inner model'),
-           this.registry.getLegacyEffectiveModels(projectDir).inner_model)
-        : mcRouting.model;
-      const dispatchResult = await this.dispatchTask(stackId!, resolvePrompt, mcModel, {
+      const dispatchResult = await this.dispatchTask(stackId!, resolvePrompt, undefined, {
         gateApproved: true,
         skipTicketFetch: true,
+        executionTouchpoint: 'merge_conflict',
       });
 
       const terminalTask = await this.awaitTaskCompletion(stackId!, dispatchResult.id);

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -43,7 +43,7 @@ export const LIVENESS_STALL_THRESHOLD_MS = 5 * 60_000;
 
 /** Terminal statuses used by the liveness check's idempotency guard */
 const LIVENESS_TERMINAL_STATUSES = new Set([
-  'completed', 'failed', 'needs_human', 'verify_blocked_environmental', 'token_limited',
+  'completed', 'failed', 'needs_human', 'needs_key', 'verify_blocked_environmental', 'token_limited',
 ]);
 
 export class TaskWatcher extends EventEmitter {
@@ -785,6 +785,36 @@ export class TaskWatcher extends EventEmitter {
           task, stackId, 'needs_human', 1, containerId,
           'Investigation returned unknown state — needs human review'
         );
+        return;
+      }
+
+      if (status === 'needs_key') {
+        // Stale-poll guard: wait until "running" has been seen (same pattern as other terminal statuses).
+        // needs_key is written before "running" so the guard is lenient — accept after MAX_STALE_POLLS.
+        if (!this.seenRunning.get(stackId)) {
+          const staleCount = (this.stalePollCounts.get(stackId) ?? 0) + 1;
+          this.stalePollCounts.set(stackId, staleCount);
+          if (staleCount < MAX_STALE_POLLS) {
+            this.schedulePoll(stackId, containerId, this.pollInterval);
+            return;
+          }
+        }
+        let keyReason = 'A phase provider has no credentials configured — add credentials in provider settings';
+        try {
+          const reasonResult = await runtime.exec(containerId, ['cat', '/tmp/claude-task-needs-key.txt']);
+          if (reasonResult.stdout.trim()) keyReason = reasonResult.stdout.trim();
+        } catch { /* best effort */ }
+        this.registry.completeTaskNeedsKey(task.id, keyReason);
+        const needsKeyTask = {
+          ...task,
+          status: 'needs_key' as const,
+          exit_code: 1,
+          warnings: keyReason,
+          finished_at: new Date().toISOString(),
+        };
+        this.emit('task:failed', { stackId, task: needsKeyTask });
+        this.onStatusChange?.();
+        this.unwatch(stackId);
         return;
       }
 

--- a/tests/unit/main/opencode-syncCredentials.test.ts
+++ b/tests/unit/main/opencode-syncCredentials.test.ts
@@ -23,15 +23,13 @@ vi.mock('child_process', async (importOriginal) => {
 // Mock the '../index' import to return a fake registry
 vi.mock('../../../src/main/index', () => ({
   registry: {
-    getGlobalBackendSettings: vi.fn().mockReturnValue({
-      inner_backend: 'opencode',
-      inner_provider: 'anthropic',
-      inner_model: null,
-      outer_backend: 'claude',
-      outer_provider: null,
-      outer_model: null,
+    getEffectiveTouchpointDescriptor: vi.fn().mockImplementation((_projectDir: string, touchpoint: string) => {
+      if (touchpoint === 'execution') {
+        return { backend: 'opencode', provider: 'anthropic', model: 'claude-sonnet-4-6', credentials: { apiKey: 'sk-test-key' } };
+      }
+      // review and meta_review default to claude
+      return { backend: 'claude', provider: 'anthropic', model: 'opus', credentials: null };
     }),
-    getBackendSecretBundle: vi.fn().mockReturnValue({ apiKey: 'sk-test-bedrock' }),
   },
   cliDir: '/fake/cli',
 }));
@@ -40,7 +38,7 @@ vi.mock('../../../src/main/index', () => ({
 vi.mock('../../../src/main/opencode-config', () => ({
   generateOpencodeConfig: vi.fn().mockReturnValue({
     model: 'anthropic/claude-sonnet-4-6',
-    provider: { anthropic: { apiKey: 'sk-test-bedrock' } },
+    provider: { anthropic: { apiKey: 'sk-test-key' } },
     permission: 'allow',
     instructions: ['/home/claude/.claude/CLAUDE.md'],
     mcp: {},
@@ -71,7 +69,7 @@ describe('OpenCodeBackend.syncCredentials', () => {
   it('skips stacks with no claude service', async () => {
     const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
-      { status: 'running', services: [{ name: 'app', status: 'running', containerId: 'cid1' }] },
+      { status: 'running', project_dir: '/proj', services: [{ name: 'app', status: 'running', containerId: 'cid1' }] },
     ];
     await backend.syncCredentials(stacks);
     expect(spawn).not.toHaveBeenCalled();
@@ -80,12 +78,11 @@ describe('OpenCodeBackend.syncCredentials', () => {
   it('calls docker exec to clean auth.json for running stacks', async () => {
     const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
-      { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'abc123' }] },
+      { status: 'running', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'abc123' }] },
     ];
     await backend.syncCredentials(stacks);
 
     const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
-    // Should have been called at least once for auth.json cleanup
     expect(calls.length).toBeGreaterThanOrEqual(1);
 
     // First call should be the auth.json cleanup
@@ -98,17 +95,17 @@ describe('OpenCodeBackend.syncCredentials', () => {
     expect(scriptArg).toContain('rm -f');
   });
 
-  it('writes generated config to /tmp/sandstorm-opencode.json', async () => {
+  it('writes generated config to /tmp/sandstorm-opencode-<provider>.json', async () => {
     const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
-      { status: 'up', services: [{ name: 'claude', status: 'running', containerId: 'def456' }] },
+      { status: 'up', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'def456' }] },
     ];
     await backend.syncCredentials(stacks);
 
     const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
-    // Second docker exec should write the config file
+    // A docker exec should write the provider-specific config file
     const configWriteCall = calls.find(([, args]: [string, string[]]) =>
-      args.some((a: string) => a.includes('sandstorm-opencode.json')),
+      args.some((a: string) => a.includes('sandstorm-opencode-anthropic.json')),
     );
     expect(configWriteCall).toBeDefined();
     const [, args] = configWriteCall;
@@ -116,32 +113,76 @@ describe('OpenCodeBackend.syncCredentials', () => {
     expect(args).toContain('def456');
   });
 
-  it('proceeds with empty bundle when no credentials are stored', async () => {
-    const { registry } = await import('../../../src/main/index');
-    (registry.getBackendSecretBundle as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
-
+  it('skips writing config when stack has no project_dir', async () => {
+    const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
       { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'ghi789' }] },
     ];
-    // Should not throw
+    // Should not throw, and no provider config should be written (no project_dir to look up routing)
     await expect(backend.syncCredentials(stacks)).resolves.toBeUndefined();
+    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
+    const configWriteCall = calls.find(([, args]: [string, string[]]) =>
+      args.some((a: string) => a.includes('sandstorm-opencode-')),
+    );
+    expect(configWriteCall).toBeUndefined();
   });
 
-  it('selects non-Anthropic active credential when provider is bedrock', async () => {
+  it('skips provider config when credentials are null (signals needs_key to task runner)', async () => {
     const { registry } = await import('../../../src/main/index');
-    (registry.getGlobalBackendSettings as ReturnType<typeof vi.fn>).mockReturnValueOnce({
-      inner_backend: 'opencode',
-      inner_provider: 'amazon-bedrock',
-      inner_model: null,
-    });
-    (registry.getBackendSecretBundle as ReturnType<typeof vi.fn>).mockReturnValueOnce({
-      region: 'us-east-1',
-      bearerToken: 'bt-bedrock-active',
+    // All phases return null credentials
+    (registry.getEffectiveTouchpointDescriptor as ReturnType<typeof vi.fn>).mockReturnValue({
+      backend: 'opencode', provider: 'amazon-bedrock', model: null, credentials: null,
     });
 
     const { generateOpencodeConfig } = await import('../../../src/main/opencode-config');
     const stacks: StackInfo[] = [
-      { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'jkl012' }] },
+      { status: 'running', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'jkl012' }] },
+    ];
+    await backend.syncCredentials(stacks);
+
+    // generateOpencodeConfig should NOT be called (no credentials → no config file)
+    expect(generateOpencodeConfig).not.toHaveBeenCalled();
+  });
+
+  it('writes one config per distinct provider across phases', async () => {
+    const { registry } = await import('../../../src/main/index');
+    // execution + review both use amazon-bedrock; meta_review uses a different provider
+    (registry.getEffectiveTouchpointDescriptor as ReturnType<typeof vi.fn>).mockImplementation((_: string, tp: string) => {
+      if (tp === 'meta_review') {
+        return { backend: 'opencode', provider: 'openrouter', model: 'llama', credentials: { apiKey: 'or-key' } };
+      }
+      return { backend: 'opencode', provider: 'amazon-bedrock', model: 'claude-sonnet', credentials: { region: 'us-east-1' } };
+    });
+
+    const { spawn } = await import('child_process');
+    const stacks: StackInfo[] = [
+      { status: 'running', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'mno345' }] },
+    ];
+    await backend.syncCredentials(stacks);
+
+    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
+    const bedrockCall = calls.find(([, args]: [string, string[]]) =>
+      args.some((a: string) => a.includes('sandstorm-opencode-amazon-bedrock.json')),
+    );
+    const orCall = calls.find(([, args]: [string, string[]]) =>
+      args.some((a: string) => a.includes('sandstorm-opencode-openrouter.json')),
+    );
+    expect(bedrockCall).toBeDefined();
+    expect(orCall).toBeDefined();
+  });
+
+  it('selects non-Anthropic active credential when provider is bedrock', async () => {
+    const { registry } = await import('../../../src/main/index');
+    (registry.getEffectiveTouchpointDescriptor as ReturnType<typeof vi.fn>).mockReturnValue({
+      backend: 'opencode',
+      provider: 'amazon-bedrock',
+      model: 'claude-sonnet-3-5',
+      credentials: { region: 'us-east-1', bearerToken: 'bt-bedrock-active' },
+    });
+
+    const { generateOpencodeConfig } = await import('../../../src/main/opencode-config');
+    const stacks: StackInfo[] = [
+      { status: 'running', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'jkl012' }] },
     ];
     await backend.syncCredentials(stacks);
 

--- a/tests/unit/stack-manager-auto-resolve.test.ts
+++ b/tests/unit/stack-manager-auto-resolve.test.ts
@@ -197,8 +197,8 @@ describe('StackManager.autoResolveConflicts internals', () => {
       expect(dispatchTaskSpy).toHaveBeenCalledWith(
         'stack-1',
         expect.any(String),
-        expect.anything(),
-        expect.objectContaining({ gateApproved: true })
+        undefined,
+        expect.objectContaining({ gateApproved: true, executionTouchpoint: 'merge_conflict' })
       );
     });
 
@@ -328,8 +328,8 @@ describe('StackManager.autoResolveConflicts internals', () => {
       expect(dispatchTaskSpy).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
-        expect.anything(),
-        expect.objectContaining({ gateApproved: true })
+        undefined,
+        expect.objectContaining({ gateApproved: true, executionTouchpoint: 'merge_conflict' })
       );
     });
 
@@ -399,34 +399,34 @@ describe('StackManager.autoResolveConflicts internals', () => {
       mockGhFn.mockResolvedValue(ghViewJson('CONFLICTING'));
     });
 
-    it('dispatches with legacy inner model when no routing configured', async () => {
+    it('dispatches with executionTouchpoint=merge_conflict and undefined model', async () => {
       await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
 
-      const [, , model] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, ...unknown[]];
-      const legacy = registry.getLegacyEffectiveModels(PROJECT_DIR);
-      expect(model).toBe(legacy.inner_model);
+      const [, , model, opts] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, Record<string, unknown>];
+      // Model is now undefined — routing is driven by executionTouchpoint in --phase-routing-json
+      expect(model).toBeUndefined();
+      expect(opts.executionTouchpoint).toBe('merge_conflict');
     });
 
-    it('dispatches with resolved merge_conflict model when routing is configured', async () => {
+    it('dispatches with executionTouchpoint=merge_conflict when routing is configured', async () => {
       registry.setProjectRouting(PROJECT_DIR, { assignments: { merge_conflict: { backend: 'claude', model: 'haiku' } }, preset: null });
 
       await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
 
-      const [, , model] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, ...unknown[]];
-      expect(model).toBe('haiku');
+      const [, , model, opts] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, Record<string, unknown>];
+      expect(model).toBeUndefined();
+      expect(opts.executionTouchpoint).toBe('merge_conflict');
     });
 
-    it('falls back to legacy inner model and logs warning when merge_conflict backend is opencode', async () => {
+    it('dispatches with executionTouchpoint=merge_conflict for opencode merge_conflict routing (no fallback)', async () => {
       registry.setProjectRouting(PROJECT_DIR, { assignments: { merge_conflict: { backend: 'opencode', model: 'some-opencode-model' } }, preset: null });
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       await manager.autoResolveConflicts(TICKET, PROJECT_DIR);
 
-      const [, , model] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, ...unknown[]];
-      const legacy = registry.getLegacyEffectiveModels(PROJECT_DIR);
-      expect(model).toBe(legacy.inner_model);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
-      warnSpy.mockRestore();
+      const [, , model, opts] = dispatchTaskSpy.mock.calls[0] as [string, string, string | undefined, Record<string, unknown>];
+      // No fallback warning — opencode is now supported for container merge_conflict dispatch
+      expect(model).toBeUndefined();
+      expect(opts.executionTouchpoint).toBe('merge_conflict');
     });
   });
 });

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -420,11 +420,14 @@ describe('StackManager', () => {
 
       // Should delegate to CLI `task` command (handles cred sync + user perms)
       // When no model is specified, the effective default (sonnet) is used.
-      // --models-json carries the per-phase routing map (all sonnet with no routing configured).
-      expect(runCliSpy).toHaveBeenCalledWith(
-        '/proj',
-        ['task', 'dispatch-test', '--model', 'sonnet', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Fix the bug']
-      );
+      // --models-json carries the per-phase model map; --phase-routing-json carries full routing.
+      const [, callArgs] = runCliSpy.mock.calls[0];
+      expect(callArgs[0]).toBe('task');
+      expect(callArgs[1]).toBe('dispatch-test');
+      expect(callArgs).toContain('--model');
+      expect(callArgs).toContain('--models-json');
+      expect(callArgs).toContain('--phase-routing-json');
+      expect(callArgs[callArgs.length - 1]).toBe('Fix the bug');
     });
 
     it('throws when dispatching to non-existent stack', async () => {
@@ -469,12 +472,13 @@ describe('StackManager', () => {
       // response no longer echoes it.
       const persisted = registry.getTasksForStack('model-test');
       expect(persisted[0].model).toBe('opus');
-      // Single --model is for attribution; --models-json carries per-phase routing
-      // (registry default is sonnet for all phases when no routing is configured).
-      expect(runCliSpy).toHaveBeenCalledWith(
-        '/proj',
-        ['task', 'model-test', '--model', 'opus', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Complex task']
-      );
+      // Single --model is for attribution; --models-json and --phase-routing-json carry per-phase routing.
+      const [, callArgs] = runCliSpy.mock.calls[0];
+      expect(callArgs).toContain('--model');
+      expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('opus');
+      expect(callArgs).toContain('--models-json');
+      expect(callArgs).toContain('--phase-routing-json');
+      expect(callArgs[callArgs.length - 1]).toBe('Complex task');
     });
 
     it('resolves "auto" model to undefined and omits from CLI args', async () => {
@@ -490,11 +494,12 @@ describe('StackManager', () => {
       // "auto" should resolve to null in the DB (undefined → null via registry)
       const persisted = registry.getTasksForStack('auto-model');
       expect(persisted[0].model).toBeNull();
-      // Single --model is omitted for 'auto'; --models-json is still sent.
-      expect(runCliSpy).toHaveBeenCalledWith(
-        '/proj',
-        ['task', 'auto-model', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Simple task']
-      );
+      // Single --model is omitted for 'auto'; --models-json and --phase-routing-json are still sent.
+      const [, callArgs] = runCliSpy.mock.calls[0];
+      expect(callArgs).not.toContain('--model');
+      expect(callArgs).toContain('--models-json');
+      expect(callArgs).toContain('--phase-routing-json');
+      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
     });
 
     it('uses effective default model when not provided', async () => {
@@ -511,11 +516,13 @@ describe('StackManager', () => {
       // on the registry Task, not echoed in the MCP response.
       const persisted = registry.getTasksForStack('no-model');
       expect(persisted[0].model).toBe('sonnet');
-      // Legacy/no-routing: all phases use the same model as the single task model.
-      expect(runCliSpy).toHaveBeenCalledWith(
-        '/proj',
-        ['task', 'no-model', '--model', 'sonnet', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', 'Simple task']
-      );
+      // Legacy/no-routing: --models-json and --phase-routing-json are sent alongside --model.
+      const [, callArgs] = runCliSpy.mock.calls[0];
+      expect(callArgs).toContain('--model');
+      expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('sonnet');
+      expect(callArgs).toContain('--models-json');
+      expect(callArgs).toContain('--phase-routing-json');
+      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
     });
 
     it('includes per-phase model map in CLI args', async () => {
@@ -577,18 +584,29 @@ describe('StackManager', () => {
       const [, args] = runCliSpy.mock.calls[0];
       const singleModel = args[args.indexOf('--model') + 1];
       const jsonIdx = args.indexOf('--models-json');
-      const parsed = JSON.parse(args[jsonIdx + 1]);
-      expect(parsed.execution).toBe(singleModel);
-      expect(parsed.review).toBe(singleModel);
-      expect(parsed.meta_review).toBe(singleModel);
+      const modelsJson = JSON.parse(args[jsonIdx + 1]);
+      expect(modelsJson.execution).toBe(singleModel);
+      expect(modelsJson.review).toBe(singleModel);
+      expect(modelsJson.meta_review).toBe(singleModel);
+
+      // --phase-routing-json should carry backend+provider+model per phase
+      const routingIdx = args.indexOf('--phase-routing-json');
+      expect(routingIdx).toBeGreaterThan(-1);
+      const routing = JSON.parse(args[routingIdx + 1]);
+      expect(routing.execution.model).toBe(singleModel);
+      expect(routing.review.model).toBe(singleModel);
+      expect(routing.meta_review.model).toBe(singleModel);
     });
 
-    it('passes --backend opencode and --backend-model when inner backend is opencode with provider+model', async () => {
+    it('includes opencode backend in --phase-routing-json when execution phase is opencode', async () => {
       registry.createStack(makeStack('oc-backend'));
-      vi.spyOn(registry, 'getEffectiveBackend').mockReturnValue({
-        backend: 'opencode',
-        provider: 'anthropic',
-        model: 'claude-sonnet-4-6',
+      // Configure opencode routing for all inner phases
+      registry.setProjectRouting('/proj', {
+        assignments: {
+          execution:   { backend: 'opencode', provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          review:      { backend: 'opencode', provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          meta_review: { backend: 'opencode', provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
       });
       const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
         stdout: 'Task dispatched.',
@@ -598,16 +616,26 @@ describe('StackManager', () => {
 
       await manager.dispatchTask('oc-backend', 'Do the work', 'sonnet');
 
-      expect(runCliSpy).toHaveBeenCalledWith(
-        '/proj',
-        ['task', 'oc-backend', '--model', 'sonnet', '--models-json', '{"execution":"sonnet","review":"sonnet","meta_review":"sonnet"}', '--backend', 'opencode', '--backend-model', 'anthropic/claude-sonnet-4-6', 'Do the work']
-      );
+      const callArgs = runCliSpy.mock.calls[0][1] as string[];
+      expect(callArgs).toContain('--phase-routing-json');
+      const routingJson = callArgs[callArgs.indexOf('--phase-routing-json') + 1];
+      const routing = JSON.parse(routingJson);
+      expect(routing.execution.backend).toBe('opencode');
+      expect(routing.execution.provider).toBe('anthropic');
+      expect(routing.execution.model).toBe('claude-sonnet-4-6');
+      // Old --backend/--backend-model flags are superseded by --phase-routing-json
+      expect(callArgs).not.toContain('--backend');
+      expect(callArgs).not.toContain('--backend-model');
     });
 
-    it('passes --backend opencode without --backend-model when provider/model absent', async () => {
-      registry.createStack(makeStack('oc-no-model'));
-      vi.spyOn(registry, 'getEffectiveBackend').mockReturnValue({
-        backend: 'opencode',
+    it('includes all phases in --phase-routing-json for mixed backend stacks', async () => {
+      registry.createStack(makeStack('mixed-backend'));
+      registry.setProjectRouting('/proj', {
+        assignments: {
+          execution:   { backend: 'opencode', provider: 'openrouter', model: 'llama' },
+          review:      { backend: 'claude', provider: 'anthropic', model: 'opus' },
+          meta_review: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+        },
       });
       const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
         stdout: 'Task dispatched.',
@@ -615,19 +643,19 @@ describe('StackManager', () => {
         exitCode: 0,
       });
 
-      await manager.dispatchTask('oc-no-model', 'Do work', 'sonnet');
+      await manager.dispatchTask('mixed-backend', 'Do work');
 
       const callArgs = runCliSpy.mock.calls[0][1] as string[];
-      expect(callArgs).toContain('--backend');
-      expect(callArgs).toContain('opencode');
-      expect(callArgs).not.toContain('--backend-model');
+      const routingJson = callArgs[callArgs.indexOf('--phase-routing-json') + 1];
+      const routing = JSON.parse(routingJson);
+      expect(routing.execution.backend).toBe('opencode');
+      expect(routing.execution.provider).toBe('openrouter');
+      expect(routing.review.backend).toBe('claude');
+      expect(routing.meta_review.backend).toBe('claude');
     });
 
-    it('does NOT pass --backend when inner backend is claude (default)', async () => {
+    it('always includes --phase-routing-json (never falls back to --backend/--backend-model)', async () => {
       registry.createStack(makeStack('claude-backend'));
-      vi.spyOn(registry, 'getEffectiveBackend').mockReturnValue({
-        backend: 'claude',
-      });
       const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
         stdout: 'Task dispatched.',
         stderr: '',
@@ -637,6 +665,7 @@ describe('StackManager', () => {
       await manager.dispatchTask('claude-backend', 'Fix bug', 'sonnet');
 
       const callArgs = runCliSpy.mock.calls[0][1] as string[];
+      expect(callArgs).toContain('--phase-routing-json');
       expect(callArgs).not.toContain('--backend');
       expect(callArgs).not.toContain('--backend-model');
     });

--- a/tests/unit/task-runner-review-loop.test.ts
+++ b/tests/unit/task-runner-review-loop.test.ts
@@ -435,7 +435,7 @@ describe('task-runner.sh dual-loop workflow', () => {
     it('does not use `local` in the outer/inner while loops', () => {
       // Find all `local ` usages and verify they are inside function bodies.
       // Functions in the script: log_loop, run_claude, run_opencode, run_agent, check_for_diff, run_review, run_verify, check_for_stop_and_ask
-      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance', 'needs_node_modules_reconcile', 'reconcile_app_node_modules', '_get_task_changed_files', 'classify_verify_failure_scope']
+      const functionNames = ['log_loop', 'run_claude', 'run_opencode', 'run_agent', 'check_all_phase_credentials', 'check_for_diff', 'run_review', 'run_verify', 'is_infra_error_only', 'check_for_stop_and_ask', 'check_for_token_limit', 'run_meta_review', 'inject_meta_review_guidance', 'needs_node_modules_reconcile', 'reconcile_app_node_modules', '_get_task_changed_files', 'classify_verify_failure_scope']
 
       // Collect the line ranges of all function bodies
       const functionRanges: Array<{ start: number; end: number }> = []
@@ -1193,6 +1193,96 @@ describe('SANDSTORM_INNER.md workflow section', () => {
 
   it('explains the needs_human stack status', () => {
     expect(innerMd).toContain('needs_human')
+  })
+})
+
+// ── Per-phase backend routing (issue #639 / MR-14) ──────────────────────────
+
+const phaseModelHelperPath = resolve(__dirname, '../../sandstorm-cli/docker/phase-model-helper.sh')
+const phaseModelHelper = readFileSync(phaseModelHelperPath, 'utf-8')
+
+describe('per-phase backend/provider routing (#639)', () => {
+  describe('task-runner.sh PHASE_ROUTING_JSON plumbing', () => {
+    it('reads /tmp/claude-task-phase-routing.json when present', () => {
+      expect(taskRunner).toContain('claude-task-phase-routing.json')
+    })
+
+    it('exports PHASE_ROUTING_JSON', () => {
+      expect(taskRunner).toContain('export PHASE_ROUTING_JSON')
+    })
+
+    it('validates phase-routing-json is valid JSON before using it', () => {
+      // Malformed JSON is discarded with a warning
+      expect(taskRunner).toContain('claude-task-phase-routing.json is malformed')
+    })
+
+    it('has check_all_phase_credentials function', () => {
+      expect(taskRunner).toContain('check_all_phase_credentials()')
+    })
+
+    it('check_all_phase_credentials checks execution, review and meta_review phases', () => {
+      const fnStart = taskRunner.indexOf('check_all_phase_credentials()')
+      const fnEnd = taskRunner.indexOf('\n}', fnStart)
+      const fnBody = taskRunner.substring(fnStart, fnEnd)
+      expect(fnBody).toContain('execution')
+      expect(fnBody).toContain('review')
+      expect(fnBody).toContain('meta_review')
+    })
+
+    it('check_all_phase_credentials checks for opencode config file existence', () => {
+      const fnStart = taskRunner.indexOf('check_all_phase_credentials()')
+      const fnEnd = taskRunner.indexOf('\n}', fnStart)
+      const fnBody = taskRunner.substring(fnStart, fnEnd)
+      expect(fnBody).toContain('sandstorm-opencode-')
+      expect(fnBody).toContain('! -f')
+    })
+
+    it('writes needs_key status when phase credentials are missing', () => {
+      expect(taskRunner).toContain('needs_key')
+      expect(taskRunner).toContain('TASK_NEEDS_KEY')
+    })
+
+    it('writes /tmp/claude-task-needs-key.txt with reason on needs_key', () => {
+      expect(taskRunner).toContain('claude-task-needs-key.txt')
+    })
+
+    it('restores OPENCODE_CONFIG after each opencode phase invocation', () => {
+      const fnStart = taskRunner.indexOf('run_agent()')
+      const fnEnd = taskRunner.indexOf('\n}', fnStart)
+      const fnBody = taskRunner.substring(fnStart, fnEnd)
+      expect(fnBody).toContain('_saved_oc_config')
+      expect(fnBody).toContain('OPENCODE_CONFIG="${_saved_oc_config}"')
+    })
+
+    it('sets per-phase OPENCODE_CONFIG from PHASE_ROUTING_JSON provider', () => {
+      const fnStart = taskRunner.indexOf('run_agent()')
+      const fnEnd = taskRunner.indexOf('\n}', fnStart)
+      const fnBody = taskRunner.substring(fnStart, fnEnd)
+      expect(fnBody).toContain('/tmp/sandstorm-opencode-')
+    })
+
+    it('falls back to global AGENT_BACKEND when PHASE_ROUTING_JSON is absent', () => {
+      const fnStart = taskRunner.indexOf('run_agent()')
+      const fnEnd = taskRunner.indexOf('\n}', fnStart)
+      const fnBody = taskRunner.substring(fnStart, fnEnd)
+      expect(fnBody).toContain('AGENT_BACKEND:-claude')
+    })
+  })
+
+  describe('phase-model-helper.sh OpenCode passthrough', () => {
+    it('does not drop OpenCode provider/model values (no longer warns or falls back)', () => {
+      // The old code had a warning: "requires OpenCode backend (not available)"
+      expect(phaseModelHelper).not.toContain('requires OpenCode backend (not available)')
+    })
+
+    it('sets RESOLVED_MODEL_ARGS=() for OpenCode provider/model values', () => {
+      // When model contains '/', it's an opencode model — no claude --model arg needed
+      const slashCheckIdx = phaseModelHelper.indexOf('"/"*')
+      expect(slashCheckIdx).toBeGreaterThan(-1)
+      // After the slash check, the code should set RESOLVED_MODEL_ARGS=()
+      const afterCheck = phaseModelHelper.substring(slashCheckIdx)
+      expect(afterCheck.substring(0, 200)).toContain('RESOLVED_MODEL_ARGS=()')
+    })
   })
 })
 

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -1498,4 +1498,54 @@ describe('TaskWatcher', () => {
     const stack = registry.getStack('watch-stack');
     expect(stack?.status).toBe('verify_blocked_environmental');
   });
+
+  it('emits task:failed and records needs_key status when phase has no credentials', async () => {
+    const keyReason = "Phase 'execution' requires provider 'openrouter' but no credentials are configured.";
+    const runtime: ContainerRuntime = {
+      name: 'mock',
+      composeUp: vi.fn(),
+      composeDown: vi.fn(),
+      listContainers: vi.fn().mockResolvedValue([]),
+      inspect: vi.fn(),
+      logs: vi.fn(),
+      exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
+        const cmdStr = cmd.join(' ');
+        if (cmdStr.includes('/tmp/claude-task.status')) {
+          // Transition: running → needs_key (seenRunning=true bypasses stale poll guard)
+          const callCount = (runtime.exec as ReturnType<typeof vi.fn>).mock.calls.length;
+          return { exitCode: 0, stdout: callCount <= 2 ? 'running' : 'needs_key', stderr: '' };
+        }
+        if (cmdStr.includes('/tmp/claude-task-needs-key.txt')) {
+          return { exitCode: 0, stdout: keyReason, stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }),
+      isAvailable: vi.fn().mockResolvedValue(true),
+      version: vi.fn().mockResolvedValue('Mock 1.0'),
+    };
+
+    const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
+    registry.createTask('watch-stack', 'test task');
+
+    const failedPromise = new Promise<void>((resolve) => {
+      watcher.on('task:failed', ({ stackId, task }) => {
+        expect(stackId).toBe('watch-stack');
+        expect(task.status).toBe('needs_key');
+        expect(task.warnings).toBe(keyReason);
+        resolve();
+      });
+    });
+
+    watcher.watch('watch-stack', 'container-123');
+    await failedPromise;
+    watcher.unwatchAll();
+
+    await new Promise((r) => setTimeout(r, 50));
+    const updatedTask = registry.getMostRecentTask('watch-stack');
+    expect(updatedTask?.status).toBe('needs_key');
+    expect(updatedTask?.warnings).toBe(keyReason);
+
+    const stack = registry.getStack('watch-stack');
+    expect(stack?.status).toBe('needs_key');
+  });
 });


### PR DESCRIPTION
## Summary

Enables mixed-backend agent stacks where each phase (execution, review, meta_review, merge_conflict) can independently target its own backend, provider, and model, instead of forcing every phase onto a single global inner backend.

The control plane now resolves an effective touchpoint descriptor per phase and passes a `--phase-routing-json` payload (backend + provider + model) to the CLI alongside the existing `--models-json` (kept for backward compatibility). The task runner dispatches each phase to `run_claude` or `run_opencode` based on that routing, falling back to the global `AGENT_BACKEND` when no routing JSON is present.

Credential sync now writes one OpenCode config file per distinct provider used across a stack's phases (`/tmp/sandstorm-opencode-<provider>.json`). A provider with no credentials is skipped rather than written. Before running, the task runner checks every routed opencode phase for its config file; a missing one means the provider has no key configured, so the task is marked with the new terminal `needs_key` status. The watcher surfaces the reason (from `/tmp/claude-task-needs-key.txt`), completes the task, and updates the stack status accordingly. The merge-conflict resolver now routes through its own `merge_conflict` touchpoint instead of warning and falling back to the legacy inner model.

## QA plan

1. Configure a stack where execution uses Claude and review/meta_review use an OpenCode provider with valid credentials; dispatch a task and confirm each phase runs on its assigned backend.
2. Configure a phase to use an OpenCode provider that has no credentials; dispatch a task and confirm it ends in `needs_key` with a message naming the phase and provider, and that the stack status reflects `needs_key`.
3. Trigger a merge-conflict resolution and confirm it dispatches through the `merge_conflict` touchpoint without the legacy fallback warning.
4. Confirm a single-backend stack with no per-phase overrides still dispatches correctly (backward-compat path).

Closes #639