### PR TITLE
[628] fix: route host touchpoints to opencode providers

### DIFF
--- a/src/main/agent/backend-router.ts
+++ b/src/main/agent/backend-router.ts
@@ -31,10 +31,19 @@ import type {
   StackInfo,
 } from './types';
 import type { BackendType } from '../control-plane/backend-resolution';
+import type { TouchpointId } from '../control-plane/routing';
+
+type TouchpointDescriptor = {
+  backend: BackendType;
+  provider: string;
+  model: string;
+  credentials: Record<string, string> | null;
+};
 
 export class BackendRouter implements AgentBackend {
   private readonly factories: Partial<Record<BackendType, () => AgentBackend>>;
   private readonly selector: (projectDir: string) => BackendType;
+  private readonly descriptorSelector?: (projectDir: string, touchpoint: TouchpointId) => TouchpointDescriptor;
   private readonly instances: Partial<Record<BackendType, AgentBackend>> = {};
 
   // tabId → backend type. Sticky until resetSession clears it.
@@ -61,9 +70,11 @@ export class BackendRouter implements AgentBackend {
   constructor(
     factories: Partial<Record<BackendType, () => AgentBackend>>,
     selector: (projectDir: string) => BackendType,
+    descriptorSelector?: (projectDir: string, touchpoint: TouchpointId) => TouchpointDescriptor,
   ) {
     this.factories = factories;
     this.selector = selector;
+    this.descriptorSelector = descriptorSelector;
   }
 
   /**
@@ -182,10 +193,10 @@ export class BackendRouter implements AgentBackend {
     timeoutMs?: number,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    touchpoint?: string,
   ): Promise<string> {
-    const type = this.selector(projectDir);
-    this.lastProjectBackendId = type;
-    return this.getBackend(type).runEphemeralAgent(prompt, projectDir, timeoutMs, attribution, model);
+    const { type, resolvedModel } = this.resolveEphemeralRouting(projectDir, touchpoint, model);
+    return this.getBackend(type).runEphemeralAgent(prompt, projectDir, timeoutMs, attribution, resolvedModel);
   }
 
   spawnEphemeralAgent(
@@ -195,10 +206,35 @@ export class BackendRouter implements AgentBackend {
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    touchpoint?: string,
   ): { promise: Promise<string>; cancel: () => void } {
+    const { type, resolvedModel } = this.resolveEphemeralRouting(projectDir, touchpoint, model);
+    return this.getBackend(type).spawnEphemeralAgent(prompt, projectDir, timeoutMs, onChunk, attribution, resolvedModel);
+  }
+
+  /**
+   * Resolve backend type and model string for an ephemeral call.
+   * When a touchpoint is provided and a descriptorSelector is wired, uses the
+   * per-touchpoint descriptor for routing. For OpenCode, encodes the model as
+   * "providerID/modelID" so OpenCodeBackend.splitModel can decode it correctly.
+   * Falls back to the outer selector when no touchpoint is supplied.
+   */
+  private resolveEphemeralRouting(
+    projectDir: string,
+    touchpoint?: string,
+    model?: string,
+  ): { type: BackendType; resolvedModel: string | undefined } {
+    if (touchpoint && this.descriptorSelector) {
+      const desc = this.descriptorSelector(projectDir, touchpoint as TouchpointId);
+      this.lastProjectBackendId = desc.backend;
+      const resolvedModel = desc.backend === 'opencode'
+        ? `${desc.provider}/${desc.model}`
+        : desc.model;
+      return { type: desc.backend, resolvedModel };
+    }
     const type = this.selector(projectDir);
     this.lastProjectBackendId = type;
-    return this.getBackend(type).spawnEphemeralAgent(prompt, projectDir, timeoutMs, onChunk, attribution, model);
+    return { type, resolvedModel: model };
   }
 
   spawnEphemeralSession(

--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -361,6 +361,7 @@ export class ClaudeBackend implements AgentBackend {
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    _touchpoint?: string,
   ): { promise: Promise<string>; cancel: () => void } {
     const claudeBin = getClaudeBin();
     const args = [
@@ -538,6 +539,7 @@ export class ClaudeBackend implements AgentBackend {
     timeoutMs = 300_000,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    _touchpoint?: string,
   ): Promise<string> {
     return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs, undefined, attribution, model).promise;
   }

--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -39,6 +39,7 @@ import type {
 import { handleToolCall } from '../claude/tools';
 import { acquireBridge, type BridgeHandle } from './bridge-server';
 import { generateOuterOpencodeConfig } from '../opencode-config';
+import { buildProviderEntry } from '../../shared/opencode-providers';
 import {
   type AgentBackend,
   type ChatMessage,
@@ -131,9 +132,11 @@ function splitModel(effective: { provider?: string; model?: string }): { provide
 // static import of the full registry module (which would create a circular
 // dependency at load time — same reason syncCredentials uses a dynamic import).
 interface RegistryRef {
-  getGlobalBackendSettings(): { outer_provider: string | null; outer_model: string | null };
+  getGlobalBackendSettings(): { outer_provider: string | null; outer_model: string | null; inner_provider?: string | null; inner_model?: string | null };
   getBackendSecretBundle(key: string, surface: 'inner' | 'outer'): Record<string, string> | null;
   getEffectiveBackend(projectDir: string, surface: 'inner' | 'outer'): { backend: string; provider?: string; model?: string };
+  getStoredProviderKeys(scope: string): string[];
+  getProviderSecretBundle(key: string, provider: string): Record<string, string> | null;
 }
 
 export class OpenCodeBackend implements AgentBackend {
@@ -157,6 +160,10 @@ export class OpenCodeBackend implements AgentBackend {
 
   // SSE loop abort controller
   private eventLoopAbort: AbortController | null = null;
+
+  // JSON signature of the provider map last used to start the server.
+  // Used to detect when syncCredentials needs to restart the server.
+  private serverProviderSignature = '';
 
   constructor() {
     this.ephemeralTimingPath = this.resolveEphemeralTimingPath();
@@ -215,18 +222,20 @@ export class OpenCodeBackend implements AgentBackend {
     process.env.SANDSTORM_BRIDGE_URL = this.bridge.url;
     process.env.SANDSTORM_BRIDGE_TOKEN = this.bridge.token;
 
-    // Forward full config (mcp + provider) so non-Anthropic provider credentials
-    // and baseURL reach the opencode serve process.
-    // NOTE: the outer opencode serve is a single app-wide process whose provider
-    // credentials come from global settings. A project that overrides outer_provider
-    // to a provider whose credentials exist only at project scope (not global) will
-    // route per-session to that provider but the server config may lack its credentials,
-    // surfacing an auth error via agent:error. Full per-project outer credential
-    // isolation is a follow-up task.
+    // Build multi-provider config: include every globally-stored provider so the
+    // long-lived server can dispatch ephemeral sessions to any configured provider+model
+    // without per-call credential injection or server restarts.
+    const allProviders = this.buildGlobalProviderMap(registry as RegistryRef);
     const sdkConfig: OpenCodeConfig = {
       mcp: outerConfig.mcp as OpenCodeConfig['mcp'],
-      provider: outerConfig.provider as OpenCodeConfig['provider'],
+      // Merge outer provider with all other globally-stored providers.
+      provider: {
+        ...outerConfig.provider as OpenCodeConfig['provider'],
+        ...allProviders,
+      },
     };
+    this.serverProviderSignature = JSON.stringify(allProviders);
+
     const server = await createOpencodeServer({ hostname: '127.0.0.1', config: sdkConfig });
     this.serverClose = server.close;
     this.client = createOpencodeClient({ baseUrl: server.url });
@@ -252,6 +261,24 @@ export class OpenCodeBackend implements AgentBackend {
 
   setMainWindow(win: BrowserWindow | null): void {
     this.mainWindow = win;
+  }
+
+  // --- Provider config helpers ---
+
+  /**
+   * Build a merged provider map containing every globally-stored provider's
+   * credentials. Called at init and syncCredentials to keep the OpenCode server
+   * aware of all configured providers without per-call credential injection.
+   */
+  private buildGlobalProviderMap(reg: RegistryRef): OpenCodeConfig['provider'] {
+    const providerIds = reg.getStoredProviderKeys('global');
+    const result: OpenCodeConfig['provider'] = {};
+    for (const providerId of providerIds) {
+      const bundle = reg.getProviderSecretBundle('global', providerId) ?? {};
+      const { providerKey, config } = buildProviderEntry(providerId, bundle);
+      result[providerKey] = config;
+    }
+    return result;
   }
 
   // --- SSE event loop (persistent sessions only) ---
@@ -498,6 +525,7 @@ export class OpenCodeBackend implements AgentBackend {
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    _touchpoint?: string,
   ): { promise: Promise<string>; cancel: () => void } {
     if (!this.client) {
       return { promise: Promise.resolve(''), cancel: () => {} };
@@ -514,10 +542,12 @@ export class OpenCodeBackend implements AgentBackend {
       if (!session) throw new Error('Failed to create ephemeral session');
 
       try {
-        // Resolve per-session model routing from the project's effective backend config.
-        const modelParts = this.registryRef
-          ? splitModel(this.registryRef.getEffectiveBackend(projectDir, 'outer'))
-          : null;
+        // When a model string is provided (as "providerID/modelID" or plain "modelID"),
+        // use it directly — the caller (BackendRouter) has already resolved the correct
+        // touchpoint descriptor. Otherwise fall back to the outer model from registry.
+        const modelParts = model
+          ? splitModel({ model })
+          : (this.registryRef ? splitModel(this.registryRef.getEffectiveBackend(projectDir, 'outer')) : null);
 
         const { data: response } = await this.client!.session.prompt({
           path: { id: session.id },
@@ -595,6 +625,7 @@ export class OpenCodeBackend implements AgentBackend {
     timeoutMs = 300_000,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    _touchpoint?: string,
   ): Promise<string> {
     return this.spawnEphemeralAgent(prompt, projectDir, timeoutMs, undefined, attribution, model)
       .promise;
@@ -693,6 +724,52 @@ export class OpenCodeBackend implements AgentBackend {
     // Dynamic import to avoid a circular dependency at load time.
     const { registry } = await import('../index');
 
+    // --- Host-side: keep OpenCode server's provider map current ---
+    // If new providers have been configured since initialize(), restart the server so
+    // ephemeral sessions can use any provider without credential injection per call.
+    if (this.client && this.registryRef) {
+      const newProviderMap = this.buildGlobalProviderMap(this.registryRef);
+      const newSignature = JSON.stringify(newProviderMap);
+      if (newSignature !== this.serverProviderSignature) {
+        // Restart the host OpenCode server with the updated provider set.
+        this.eventLoopAbort?.abort();
+        this.serverClose?.();
+
+        const { createOpencodeClient } = await import('@opencode-ai/sdk');
+        const { createOpencodeServer } = await import('@opencode-ai/sdk/server');
+        const globalSettings = registry.getGlobalBackendSettings();
+        const providerId = globalSettings.outer_provider ?? undefined;
+        const bundle = registry.getBackendSecretBundle('global', 'outer') ?? undefined;
+        const model = globalSettings.outer_model ?? undefined;
+        const shimPath = path.join(__dirname, 'orchestration-mcp-shim.cjs');
+        if (this.bridge) {
+          const outerConfig = generateOuterOpencodeConfig({
+            shimPath,
+            bridgeUrl: this.bridge.url,
+            bridgeToken: this.bridge.token,
+            instructionsPath: path.join(cliDir, 'SANDSTORM_OUTER.md'),
+            providerId,
+            bundle,
+            model,
+          });
+          const sdkConfig: OpenCodeConfig = {
+            mcp: outerConfig.mcp as OpenCodeConfig['mcp'],
+            provider: {
+              ...outerConfig.provider as OpenCodeConfig['provider'],
+              ...newProviderMap,
+            },
+          };
+          const server = await createOpencodeServer({ hostname: '127.0.0.1', config: sdkConfig });
+          this.serverClose = server.close;
+          this.client = createOpencodeClient({ baseUrl: server.url });
+          this.serverProviderSignature = newSignature;
+          this.eventLoopAbort = new AbortController();
+          void this.startEventLoop(this.eventLoopAbort.signal);
+        }
+      }
+    }
+
+    // --- Container-side: sync inner provider credentials ---
     const globalSettings = registry.getGlobalBackendSettings();
     const providerId = globalSettings.inner_provider ?? 'anthropic';
     const bundle = registry.getBackendSecretBundle('global', 'inner') ?? {};

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -122,6 +122,7 @@ export interface AgentBackend {
     timeoutMs?: number,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    touchpoint?: string,
   ): Promise<string>;
 
   /** Spawn a cancellable one-shot agent process; returns a promise and a cancel function */
@@ -132,6 +133,7 @@ export interface AgentBackend {
     onChunk?: (event: EphemeralStreamEvent) => void,
     attribution?: { ticketId?: string; stage?: string },
     model?: string,
+    touchpoint?: string,
   ): { promise: Promise<string>; cancel: () => void };
 
   /**

--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -11,6 +11,7 @@ import { stackManager, agentBackend, registry } from '../index';
 import { fetchTicketWithConfig, updateTicketWithConfig } from '../control-plane/ticket-config';
 import type { ProjectTicketConfig } from '../control-plane/registry';
 import { getDefaultSpecQualityGate } from '../spec-quality-gate';
+import { showNotification } from '../tray';
 import {
   createSchedule,
   listSchedules,
@@ -313,13 +314,12 @@ Mark at most one option per question with \`"recommended": true\` when you have 
 `;
 }
 
-function resolveRefineModel(projectDir: string): string | undefined {
-  const routing = registry.getEffectiveRoutingFor(projectDir, 'refine');
-  if (routing.backend === 'opencode') {
-    console.warn('[refine] backend=opencode unsupported for host path; falling back to legacy outer model');
-    return registry.getLegacyEffectiveModels(projectDir).outer_model;
-  }
-  return routing.model;
+/**
+ * Resolve the touchpoint descriptor for the 'refine' touchpoint.
+ * Returns null when credentials are missing (caller must surface a needs-key outcome).
+ */
+function getRefineDescriptor(projectDir: string) {
+  return registry.getEffectiveTouchpointDescriptor(projectDir, 'refine');
 }
 
 async function handleSpecCheck(
@@ -330,8 +330,14 @@ async function handleSpecCheck(
   if (!res.ok) return res.result;
   const { ctx } = res;
 
+  const descriptor = getRefineDescriptor(projectDir);
+  if (descriptor.backend === 'opencode' && descriptor.credentials === null) {
+    showNotification('Refine blocked', `Ticket ${ticketId}: provider ${descriptor.provider} needs an API key`);
+    return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
+  }
+
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, undefined, 'refine');
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -527,15 +533,21 @@ async function handleSpecRefine(
   if (!res.ok) return res.result;
   const { ctx } = res;
 
+  const descriptor = getRefineDescriptor(projectDir);
+  if (descriptor.backend === 'opencode' && descriptor.credentials === null) {
+    showNotification('Refine blocked', `Ticket ${ticketId}: provider ${descriptor.provider} needs an API key`);
+    return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
+  }
+
   if (!userAnswers) {
     const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody);
-    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, resolveRefineModel(projectDir));
+    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   }
 
   const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, resolveRefineModel(projectDir));
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
   return applySpecRefineResult(ticketId, projectDir, result, true);
 }
 
@@ -560,8 +572,14 @@ export function spawnSpecCheck(
     if (!res.ok) return res.result;
     if (cancelled) throw new Error('Cancelled');
 
+    const descriptor = getRefineDescriptor(projectDir);
+    if (descriptor.backend === 'opencode' && descriptor.credentials === null) {
+      showNotification('Refine blocked', `Ticket ${ticketId}: provider ${descriptor.provider} needs an API key`);
+      return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
+    }
+
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, undefined, 'refine');
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 
@@ -633,6 +651,12 @@ export function spawnSpecRefine(
     if (!res.ok) return res.result;
     if (cancelled) throw new Error('Cancelled');
 
+    const descriptor = getRefineDescriptor(projectDir);
+    if (descriptor.backend === 'opencode' && descriptor.credentials === null) {
+      showNotification('Refine blocked', `Ticket ${ticketId}: provider ${descriptor.provider} needs an API key`);
+      return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
+    }
+
     const key = refineSessionKey(projectDir, ticketId);
 
     if (userAnswers) {
@@ -656,7 +680,7 @@ export function spawnSpecRefine(
       // No pooled session (timed out, app restarted, etc.) — fall back to a
       // cold ephemeral so the user's answers still produce a result.
       const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(
-        answerPrompt, projectDir, 0, onChunk, { ticketId, stage: 'refine' }, resolveRefineModel(projectDir),
+        answerPrompt, projectDir, 0, onChunk, { ticketId, stage: 'refine' }, undefined, 'refine',
       );
       activeDispose = epCancel;
       if (cancelled) { epCancel(); throw new Error('Cancelled'); }

--- a/src/main/control-plane/dark-factory-orchestrator.ts
+++ b/src/main/control-plane/dark-factory-orchestrator.ts
@@ -206,11 +206,11 @@ export class DarkFactoryOrchestrator {
 
     const workspace = workspacePathFor(projectDir, stackId);
 
-    const prRouting = this.registry.getEffectiveRoutingFor(projectDir, 'pr_description');
-    const prModel = prRouting.backend === 'opencode'
-      ? (console.warn('[pr_description] backend=opencode unsupported for host path; falling back to legacy outer model'),
-         this.registry.getLegacyEffectiveModels(projectDir).outer_model)
-      : prRouting.model;
+    const prDescriptor = this.registry.getEffectiveTouchpointDescriptor(projectDir, 'pr_description');
+    if (prDescriptor.backend === 'opencode' && prDescriptor.credentials === null) {
+      showNotification('Dark factory: PR draft blocked', `Ticket ${ticketId}: provider ${prDescriptor.provider} needs an API key`);
+      return;
+    }
 
     let draft: { title: string; body: string };
     try {
@@ -218,7 +218,7 @@ export class DarkFactoryOrchestrator {
         { stackId, workspace, ticket: stack.ticket },
         {
           runEphemeral: (prompt, dir, timeoutMs) =>
-            this.agentBackend.runEphemeralAgent(prompt, dir, timeoutMs, undefined, prModel),
+            this.agentBackend.runEphemeralAgent(prompt, dir, timeoutMs, undefined, undefined, 'pr_description'),
           fetchTaskTail: (id) => this.stackManager.getTaskOutput(id, 50).catch(() => ''),
         },
       );
@@ -337,12 +337,12 @@ export class DarkFactoryOrchestrator {
           `Merge the base branch (main) into the PR branch, resolve all conflicts, and push the result. ` +
           `Use git fetch origin, git merge origin/main, resolve conflicts, git add, git commit, then git push.`;
 
-        const mcRouting = this.registry.getEffectiveRoutingFor(projectDir, 'merge_conflict');
-        const mcModel = mcRouting.backend === 'opencode'
-          ? (console.warn('[merge_conflict] backend=opencode unsupported for host path; falling back to legacy inner model'),
-             this.registry.getLegacyEffectiveModels(projectDir).inner_model)
-          : mcRouting.model;
-        await this.agentBackend.runEphemeralAgent(prompt, projectDir, 300_000, undefined, mcModel);
+        const mcDescriptor = this.registry.getEffectiveTouchpointDescriptor(projectDir, 'merge_conflict');
+        if (mcDescriptor.backend === 'opencode' && mcDescriptor.credentials === null) {
+          showNotification('Dark factory: merge-conflict blocked', `Ticket ${ticketId}: provider ${mcDescriptor.provider} needs an API key`);
+          return false;
+        }
+        await this.agentBackend.runEphemeralAgent(prompt, projectDir, 300_000, undefined, undefined, 'merge_conflict');
 
         // Push the resolved state
         await this.stackManager.push(stackId, `fix: resolve merge conflicts for PR #${prNumber}`);

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -2143,6 +2143,13 @@ export class Registry {
     ).run(key, provider);
   }
 
+  getStoredProviderKeys(scope: string): string[] {
+    const rows = this.db.prepare(
+      'SELECT provider FROM provider_secrets WHERE key = ?'
+    ).all(scope) as { provider: string }[];
+    return rows.map(r => r.provider);
+  }
+
   getEffectiveTouchpointDescriptor(
     projectDir: string,
     touchpoint: TouchpointId,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -184,6 +184,7 @@ async function initializeApp(): Promise<void> {
       opencode: () => new OpenCodeBackend(),
     },
     (projectDir) => registry.getEffectiveBackend(projectDir, 'outer').backend,
+    (projectDir, touchpoint) => registry.getEffectiveTouchpointDescriptor(projectDir, touchpoint),
   );
   await agentBackend.initialize();
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1623,11 +1623,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   ipcMain.handle('pr:draftBody', async (_event, stackId: string) => {
     const stack = await stackManager.getStackWithServices(stackId);
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
-    const prRouting = registry.getEffectiveRoutingFor(stack.project_dir, 'pr_description');
-    const prModel = prRouting.backend === 'opencode'
-      ? (console.warn('[pr_description] backend=opencode unsupported for host path; falling back to legacy outer model'),
-         registry.getLegacyEffectiveModels(stack.project_dir).outer_model)
-      : prRouting.model;
+    const prDescriptor = registry.getEffectiveTouchpointDescriptor(stack.project_dir, 'pr_description');
+    if (prDescriptor.backend === 'opencode' && prDescriptor.credentials === null) {
+      return { status: 'needs_key' as const, backend: prDescriptor.backend, provider: prDescriptor.provider };
+    }
     return draftPullRequest(
       {
         stackId,
@@ -1636,7 +1635,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       },
       {
         runEphemeral: (prompt, projectDir, timeoutMs) =>
-          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }, prModel),
+          agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }, undefined, 'pr_description'),
         fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
       },
     );
@@ -1716,11 +1715,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
 
     const workspace = workspacePathFor(stack.project_dir, stackId);
-    const prRouting = registry.getEffectiveRoutingFor(stack.project_dir, 'pr_description');
-    const prModel = prRouting.backend === 'opencode'
-      ? (console.warn('[pr_description] backend=opencode unsupported for host path; falling back to legacy outer model'),
-         registry.getLegacyEffectiveModels(stack.project_dir).outer_model)
-      : prRouting.model;
+    const prDescriptor = registry.getEffectiveTouchpointDescriptor(stack.project_dir, 'pr_description');
+    if (prDescriptor.backend === 'opencode' && prDescriptor.credentials === null) {
+      return { status: 'needs_key' as const, backend: prDescriptor.backend, provider: prDescriptor.provider };
+    }
 
     let draft: { title: string; body: string };
     try {
@@ -1728,7 +1726,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         { stackId, workspace, ticket: stack.ticket },
         {
           runEphemeral: (prompt, projectDir, timeoutMs) =>
-            agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }, prModel),
+            agentBackend.runEphemeralAgent(prompt, projectDir, timeoutMs, { ticketId: stack.ticket ?? undefined, stage: 'pr' }, undefined, 'pr_description'),
           fetchTaskTail: (id) => stackManager.getTaskOutput(id, 50).catch(() => ''),
         },
       );

--- a/tests/unit/agent/backend-router.test.ts
+++ b/tests/unit/agent/backend-router.test.ts
@@ -10,6 +10,7 @@ import { BackendRouter } from '../../../src/main/agent/backend-router';
 import { FakeAgentBackend } from './agent-backend-conformance.test';
 import type { AgentBackend } from '../../../src/main/agent/types';
 import type { BackendType } from '../../../src/main/control-plane/backend-resolution';
+import type { TouchpointId } from '../../../src/main/control-plane/routing';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -27,6 +28,20 @@ function makeRouter(
       opencode: () => opencodeBackend,
     },
     selector,
+  );
+}
+
+type TestDescriptor = { backend: BackendType; provider: string; model: string; credentials: Record<string, string> | null };
+
+function makeRouterWithDescriptor(
+  claudeBackend: AgentBackend,
+  opencodeBackend: AgentBackend,
+  descriptorSelector: (projectDir: string, touchpoint: TouchpointId) => TestDescriptor,
+): BackendRouter {
+  return new BackendRouter(
+    { claude: () => claudeBackend, opencode: () => opencodeBackend },
+    () => 'claude', // outer selector always says claude (all-claude project)
+    descriptorSelector,
   );
 }
 
@@ -334,5 +349,89 @@ describe('BackendRouter', () => {
     expect(claudeFake.getHistory('tab-z').messages[0].content).toBe('test message');
     claudeOnly.resetSession('tab-z');
     expect(claudeFake.getHistory('tab-z').messages).toHaveLength(0);
+  });
+
+  // --- Touchpoint-aware ephemeral routing via descriptorSelector ---
+
+  describe('touchpoint-aware ephemeral routing', () => {
+    let claudeFakeTp: FakeAgentBackend;
+    let opencodeFakeTp: FakeAgentBackend;
+
+    beforeEach(() => {
+      claudeFakeTp = new FakeAgentBackend('Claude-tp');
+      opencodeFakeTp = new FakeAgentBackend('OpenCode-tp');
+    });
+
+    it('routes runEphemeralAgent to opencode when pr_description descriptor says opencode', async () => {
+      const descriptor: TestDescriptor = {
+        backend: 'opencode', provider: 'openai', model: 'gpt-4o', credentials: {},
+      };
+      const router = makeRouterWithDescriptor(claudeFakeTp, opencodeFakeTp, () => descriptor);
+
+      await router.runEphemeralAgent('draft PR', '/project', undefined, undefined, undefined, 'pr_description');
+
+      expect(opencodeFakeTp.runEphemeralAgentMock).toHaveBeenCalledOnce();
+      expect(claudeFakeTp.runEphemeralAgentMock).not.toHaveBeenCalled();
+      // model is encoded as "providerID/modelID" for OpenCode
+      expect(opencodeFakeTp.runEphemeralAgentMock).toHaveBeenCalledWith(
+        'draft PR', '/project', undefined, undefined, 'openai/gpt-4o',
+      );
+    });
+
+    it('routes spawnEphemeralAgent to opencode with providerID/modelID encoding', async () => {
+      const descriptor: TestDescriptor = {
+        backend: 'opencode', provider: 'anthropic', model: 'claude-3-5-sonnet', credentials: {},
+      };
+      const router = makeRouterWithDescriptor(claudeFakeTp, opencodeFakeTp, () => descriptor);
+
+      const { promise } = router.spawnEphemeralAgent(
+        'resolve conflict', '/project', undefined, undefined, undefined, undefined, 'merge_conflict',
+      );
+      await promise;
+
+      expect(opencodeFakeTp.spawnEphemeralAgentMock).toHaveBeenCalledOnce();
+      expect(opencodeFakeTp.spawnEphemeralAgentMock).toHaveBeenCalledWith(
+        'resolve conflict', '/project', undefined, undefined, undefined, 'anthropic/claude-3-5-sonnet',
+      );
+    });
+
+    it('routes to claude and passes descriptor.model when touchpoint descriptor says claude', async () => {
+      const descriptor: TestDescriptor = {
+        backend: 'claude', provider: 'anthropic', model: 'haiku', credentials: {},
+      };
+      const router = makeRouterWithDescriptor(claudeFakeTp, opencodeFakeTp, () => descriptor);
+
+      await router.runEphemeralAgent('refine spec', '/project', undefined, undefined, undefined, 'refine');
+
+      expect(claudeFakeTp.runEphemeralAgentMock).toHaveBeenCalledOnce();
+      expect(opencodeFakeTp.runEphemeralAgentMock).not.toHaveBeenCalled();
+      expect(claudeFakeTp.runEphemeralAgentMock).toHaveBeenCalledWith(
+        'refine spec', '/project', undefined, undefined, 'haiku',
+      );
+    });
+
+    it('falls back to outer selector when no touchpoint is provided (all-claude regression)', async () => {
+      // Descriptor says opencode, but no touchpoint passed → selector() rules
+      const descriptor: TestDescriptor = {
+        backend: 'opencode', provider: 'openai', model: 'gpt-4o', credentials: {},
+      };
+      const router = makeRouterWithDescriptor(claudeFakeTp, opencodeFakeTp, () => descriptor);
+
+      await router.runEphemeralAgent('prompt', '/project'); // no touchpoint arg
+
+      expect(claudeFakeTp.runEphemeralAgentMock).toHaveBeenCalledOnce();
+      expect(opencodeFakeTp.runEphemeralAgentMock).not.toHaveBeenCalled();
+    });
+
+    it('passes correct projectDir and touchpoint to the descriptorSelector', async () => {
+      const descriptorSpy = vi.fn<[string, TouchpointId], TestDescriptor>().mockReturnValue({
+        backend: 'claude', provider: 'anthropic', model: 'sonnet', credentials: {},
+      });
+      const router = makeRouterWithDescriptor(claudeFakeTp, opencodeFakeTp, descriptorSpy);
+
+      await router.runEphemeralAgent('prompt', '/myproject', undefined, undefined, undefined, 'pr_description');
+
+      expect(descriptorSpy).toHaveBeenCalledWith('/myproject', 'pr_description');
+    });
   });
 });

--- a/tests/unit/agent/opencode-backend.test.ts
+++ b/tests/unit/agent/opencode-backend.test.ts
@@ -36,6 +36,8 @@ const {
   mockGetGlobalBackendSettings,
   mockGetBackendSecretBundle,
   mockGetEffectiveBackend,
+  mockGetStoredProviderKeys,
+  mockGetProviderSecretBundle,
 } = vi.hoisted(() => {
   const mockBridgeRelease = vi.fn();
   const mockBridge = {
@@ -67,6 +69,8 @@ const {
     provider: undefined,
     model: undefined,
   });
+  const mockGetStoredProviderKeys = vi.fn().mockReturnValue([]);
+  const mockGetProviderSecretBundle = vi.fn().mockReturnValue(null);
 
   return {
     mockBridgeRelease,
@@ -81,6 +85,8 @@ const {
     mockGetGlobalBackendSettings,
     mockGetBackendSecretBundle,
     mockGetEffectiveBackend,
+    mockGetStoredProviderKeys,
+    mockGetProviderSecretBundle,
   };
 });
 
@@ -106,6 +112,8 @@ vi.mock('../../../src/main/index', () => ({
     getGlobalBackendSettings: mockGetGlobalBackendSettings,
     getBackendSecretBundle: mockGetBackendSecretBundle,
     getEffectiveBackend: mockGetEffectiveBackend,
+    getStoredProviderKeys: mockGetStoredProviderKeys,
+    getProviderSecretBundle: mockGetProviderSecretBundle,
   },
   cliDir: '/tmp/sandstorm-cli',
 }));
@@ -1102,6 +1110,84 @@ describe('OpenCodeBackend auth', () => {
 
   it('syncCredentials resolves without error', async () => {
     await expect(backend.syncCredentials([])).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncCredentials — server restart when provider signature changes
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend syncCredentials provider restart', () => {
+  let backend: OpenCodeBackend;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+    mockSessionCreate.mockResolvedValue({
+      data: { id: 'oc-session-1', projectID: 'proj', directory: '/project', title: '' },
+    });
+    mockGetStoredProviderKeys.mockReturnValue([]);
+    mockGetProviderSecretBundle.mockReturnValue(null);
+    mockGetGlobalBackendSettings.mockReturnValue({
+      inner_backend: 'opencode',
+      inner_provider: 'anthropic',
+      inner_model: null,
+      outer_backend: 'claude',
+      outer_provider: null,
+      outer_model: null,
+    });
+    mockGetBackendSecretBundle.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    backend?.destroy();
+    // Restore defaults so other describe blocks are unaffected
+    mockGetStoredProviderKeys.mockReturnValue([]);
+    mockGetProviderSecretBundle.mockReturnValue(null);
+  });
+
+  it('syncCredentials restarts opencode server when provider signature changes', async () => {
+    // Initialize with no stored providers — signature is '{}'
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+
+    const callCountAfterInit = (createOpencodeServer as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Simulate a new provider being stored since initialize() ran
+    mockGetStoredProviderKeys.mockReturnValue(['openai']);
+    mockGetProviderSecretBundle.mockReturnValue({ api_key: 'sk-test' });
+
+    // Provide a fresh server response for the restart call
+    (createOpencodeServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      url: 'http://127.0.0.1:18766',
+      close: mockServerClose,
+    });
+    mockEventSubscribe.mockResolvedValue({ stream: makeMockStream() });
+
+    await backend.syncCredentials([]);
+
+    // Server should have been created a second time
+    expect(createOpencodeServer).toHaveBeenCalledTimes(callCountAfterInit + 1);
+
+    // The restart call must include the new provider in its config
+    const restartCall = (createOpencodeServer as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(restartCall?.config?.provider).toHaveProperty('openai');
+  });
+
+  it('syncCredentials does not restart server when provider signature is unchanged', async () => {
+    // Initialize with openai already stored
+    mockGetStoredProviderKeys.mockReturnValue(['openai']);
+    mockGetProviderSecretBundle.mockReturnValue({ api_key: 'sk-test' });
+
+    backend = new OpenCodeBackend();
+    await backend.initialize();
+
+    const callCountAfterInit = (createOpencodeServer as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Same provider keys — signature unchanged
+    await backend.syncCredentials([]);
+
+    expect(createOpencodeServer).toHaveBeenCalledTimes(callCountAfterInit);
   });
 });
 

--- a/tests/unit/dark-factory-orchestrator.test.ts
+++ b/tests/unit/dark-factory-orchestrator.test.ts
@@ -69,6 +69,7 @@ function makeRegistry(overrides: Partial<{
   listProjects: () => { directory: string }[];
   getEffectiveRoutingFor: (dir: string, touchpoint: string) => { backend: string; model: string };
   getLegacyEffectiveModels: (dir: string) => { inner_model: string; outer_model: string };
+  getEffectiveTouchpointDescriptor: (dir: string, touchpoint: string) => { backend: string; provider: string; model: string; credentials: Record<string, string> | null };
 }> = {}) {
   return {
     getDarkFactoryEnabled: vi.fn().mockReturnValue(false),
@@ -79,6 +80,7 @@ function makeRegistry(overrides: Partial<{
     listProjects: vi.fn().mockReturnValue([]),
     getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'sonnet' }),
     getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
+    getEffectiveTouchpointDescriptor: vi.fn().mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'sonnet', credentials: {} }),
     ...overrides,
   };
 }
@@ -804,7 +806,8 @@ describe('DarkFactoryOrchestrator', () => {
         '/proj',
         300_000,
         undefined,
-        expect.any(String),
+        undefined,
+        'merge_conflict',
       );
       expect(registry.setBoardTicketColumn).toHaveBeenCalledWith('T-1', '/proj', 'merged');
     });
@@ -838,8 +841,10 @@ describe('DarkFactoryOrchestrator', () => {
       expect(mergedCalls).toHaveLength(0);
     });
 
-    it('passes resolved merge_conflict model to runEphemeralAgent', async () => {
-      registry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+    it('passes merge_conflict touchpoint to runEphemeralAgent', async () => {
+      registry.getEffectiveTouchpointDescriptor.mockReturnValue({
+        backend: 'claude', provider: 'anthropic', model: 'haiku', credentials: {},
+      });
 
       let viewCallCount = 0;
       mockExecFile.mockImplementation(
@@ -866,25 +871,20 @@ describe('DarkFactoryOrchestrator', () => {
         expect.any(String),
         expect.any(Number),
         undefined,
-        'haiku',
+        undefined,
+        'merge_conflict',
       );
     });
 
-    it('falls back to legacy inner model and warns when merge_conflict backend is opencode', async () => {
-      registry.getEffectiveRoutingFor.mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
-      registry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('blocks and notifies when merge_conflict backend needs API key', async () => {
+      registry.getEffectiveTouchpointDescriptor.mockReturnValue({
+        backend: 'opencode', provider: 'openai', model: 'gpt-4', credentials: null,
+      });
 
-      let viewCallCount = 0;
       mockExecFile.mockImplementation(
         (_cmd: unknown, args: string[], _opts: unknown, cb: (...a: unknown[]) => void) => {
           if ((args as string[]).includes('view')) {
-            viewCallCount++;
-            if (viewCallCount <= 1) {
-              cb(null, JSON.stringify({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }), '');
-            } else {
-              cb(null, JSON.stringify({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }), '');
-            }
+            cb(null, JSON.stringify({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }), '');
           } else {
             cb(null, '', '');
           }
@@ -895,15 +895,11 @@ describe('DarkFactoryOrchestrator', () => {
       orchestrator.handlePrCreated('stack-1', 99);
       await new Promise((r) => setTimeout(r, 100));
 
-      expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.any(Number),
-        undefined,
-        'sonnet',
+      expect(agentBackend.runEphemeralAgent).not.toHaveBeenCalled();
+      expect(vi.mocked(showNotification)).toHaveBeenCalledWith(
+        expect.stringContaining('merge-conflict blocked'),
+        expect.stringContaining('openai'),
       );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
-      warnSpy.mockRestore();
     });
   });
 
@@ -928,11 +924,8 @@ describe('DarkFactoryOrchestrator', () => {
       );
     });
 
-    it('passes resolved pr_description model via runEphemeral closure', async () => {
-      registry.getEffectiveRoutingFor.mockImplementation((_dir: string, touchpoint: string) => {
-        if (touchpoint === 'pr_description') return { backend: 'claude', model: 'haiku' };
-        return { backend: 'claude', model: 'sonnet' };
-      });
+    it('passes pr_description touchpoint via runEphemeral closure', async () => {
+      // default descriptor: backend=claude, credentials={}
 
       orchestrator.handleTaskCompleted('stack-1', {} as never);
       await new Promise((r) => setTimeout(r, 50));
@@ -946,34 +939,24 @@ describe('DarkFactoryOrchestrator', () => {
         '/proj',
         undefined,
         undefined,
-        'haiku',
+        undefined,
+        'pr_description',
       );
     });
 
-    it('falls back to legacy outer model and warns when pr_description backend is opencode', async () => {
-      registry.getEffectiveRoutingFor.mockImplementation((_dir: string, touchpoint: string) => {
-        if (touchpoint === 'pr_description') return { backend: 'opencode', model: 'gpt-4' };
-        return { backend: 'claude', model: 'sonnet' };
+    it('blocks and notifies when pr_description backend needs API key', async () => {
+      registry.getEffectiveTouchpointDescriptor.mockReturnValue({
+        backend: 'opencode', provider: 'openai', model: 'gpt-4', credentials: null,
       });
-      registry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       orchestrator.handleTaskCompleted('stack-1', {} as never);
       await new Promise((r) => setTimeout(r, 50));
 
-      const [, deps] = vi.mocked(draftPullRequest).mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
-      agentBackend.runEphemeralAgent.mockResolvedValue('draft');
-      await deps.runEphemeral('test prompt', '/proj');
-
-      expect(agentBackend.runEphemeralAgent).toHaveBeenCalledWith(
-        'test prompt',
-        '/proj',
-        undefined,
-        undefined,
-        'opus',
+      expect(vi.mocked(draftPullRequest)).not.toHaveBeenCalled();
+      expect(vi.mocked(showNotification)).toHaveBeenCalledWith(
+        expect.stringContaining('PR draft blocked'),
+        expect.stringContaining('openai'),
       );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
-      warnSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -95,6 +95,7 @@ const {
     getEffectiveRouting: vi.fn().mockReturnValue({}),
     getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'haiku' }),
     getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
+    getEffectiveTouchpointDescriptor: vi.fn().mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'haiku', credentials: {} }),
     getProjectRouting: vi.fn().mockReturnValue(null),
     setProjectRouting: vi.fn(),
     removeProjectRouting: vi.fn(),
@@ -3094,12 +3095,10 @@ describe('IPC Handlers', () => {
       mockStackManager.getStackWithServices.mockResolvedValue(STACK);
       mockStackManager.getTaskOutput = vi.fn().mockResolvedValue('');
       mockDraftPullRequest.mockResolvedValue({ title: 'feat: T-1', body: 'PR body' });
-      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
-      mockRegistry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      mockRegistry.getEffectiveTouchpointDescriptor.mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'haiku', credentials: {} });
     });
 
-    it('pr:draftBody forwards resolved pr_description model to runEphemeralAgent', async () => {
-      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+    it('pr:draftBody passes touchpoint "pr_description" to runEphemeralAgent', async () => {
       mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
 
       await invokeHandler('pr:draftBody', 'stack-1');
@@ -3112,34 +3111,21 @@ describe('IPC Handlers', () => {
         '/proj',
         undefined,
         expect.objectContaining({ stage: 'pr' }),
-        'haiku',
-      );
-    });
-
-    it('pr:draftBody falls back to legacy outer model and warns when pr_description backend is opencode', async () => {
-      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
-      mockRegistry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
-
-      await invokeHandler('pr:draftBody', 'stack-1');
-
-      const [, deps] = mockDraftPullRequest.mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
-      await deps.runEphemeral('test prompt', '/proj');
-
-      expect(mockAgentBackend.runEphemeralAgent).toHaveBeenCalledWith(
-        'test prompt',
-        '/proj',
         undefined,
-        expect.objectContaining({ stage: 'pr' }),
-        'opus',
+        'pr_description',
       );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
-      warnSpy.mockRestore();
     });
 
-    it('pr:createAuto forwards resolved pr_description model to runEphemeralAgent', async () => {
-      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'claude', model: 'haiku' });
+    it('pr:draftBody returns needs_key when opencode backend has no credentials', async () => {
+      mockRegistry.getEffectiveTouchpointDescriptor.mockReturnValue({ backend: 'opencode', provider: 'openai', model: 'gpt-4o', credentials: null });
+
+      const result = await invokeHandler('pr:draftBody', 'stack-1');
+
+      expect(result).toMatchObject({ status: 'needs_key', backend: 'opencode', provider: 'openai' });
+      expect(mockDraftPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('pr:createAuto passes touchpoint "pr_description" to runEphemeralAgent', async () => {
       mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
       mockStackManager.push = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
       const { execFile } = await import('child_process');
@@ -3160,37 +3146,18 @@ describe('IPC Handlers', () => {
         '/proj',
         undefined,
         expect.objectContaining({ stage: 'pr' }),
-        'haiku',
+        undefined,
+        'pr_description',
       );
     });
 
-    it('pr:createAuto falls back to legacy outer model and warns when pr_description backend is opencode', async () => {
-      mockRegistry.getEffectiveRoutingFor.mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
-      mockRegistry.getLegacyEffectiveModels.mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      mockAgentBackend.runEphemeralAgent.mockResolvedValue('PR text');
-      const { execFile } = await import('child_process');
-      vi.mocked(execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-        (_cmd: unknown, _args: unknown, _opts: unknown, cb: (...a: unknown[]) => void) => {
-          cb(null, JSON.stringify({ url: 'https://gh/pr/1', number: 1 }), '');
-          return {} as never;
-        },
-      );
+    it('pr:createAuto returns needs_key when opencode backend has no credentials', async () => {
+      mockRegistry.getEffectiveTouchpointDescriptor.mockReturnValue({ backend: 'opencode', provider: 'openai', model: 'gpt-4o', credentials: null });
 
-      await invokeHandler('pr:createAuto', 'stack-1');
+      const result = await invokeHandler('pr:createAuto', 'stack-1');
 
-      const [, deps] = mockDraftPullRequest.mock.calls[0] as [unknown, { runEphemeral: (p: string, d: string, t?: number) => Promise<string> }];
-      await deps.runEphemeral('test prompt', '/proj');
-
-      expect(mockAgentBackend.runEphemeralAgent).toHaveBeenCalledWith(
-        'test prompt',
-        '/proj',
-        undefined,
-        expect.objectContaining({ stage: 'pr' }),
-        'opus',
-      );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
-      warnSpy.mockRestore();
+      expect(result).toMatchObject({ status: 'needs_key', backend: 'opencode', provider: 'openai' });
+      expect(mockDraftPullRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/model-routing.test.ts
+++ b/tests/unit/model-routing.test.ts
@@ -230,6 +230,11 @@ describe('Model Routing', () => {
       expect(registry.getProjectRouting('/proj/a')).toBeNull();
     });
 
+    it('getStoredProviderKeys returns providers stored under a scope', () => {
+      registry.setProviderSecretBundle('global', 'openai', { api_key: 'sk-test' });
+      expect(registry.getStoredProviderKeys('global')).toEqual(['openai']);
+    });
+
     it('different projects have independent routing', () => {
       registry.setProjectRouting('/proj/a', { preset: 'budget' });
       registry.setProjectRouting('/proj/b', { preset: 'max_quality' });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleToolCall, validateProjectDir, _clearTicketBodyCacheForTests, _disposeAllRefineSessionsForTests, spawnSpecRefine, spawnSpecCheck } from '../../src/main/claude/tools';
 import type { EphemeralSessionHandle } from '../../src/main/agent/types';
 
+vi.mock('../../src/main/tray', () => ({
+  showNotification: vi.fn(),
+}));
+
 // Mock the stackManager, agentBackend, and registry imports
 vi.mock('../../src/main/index', () => ({
   stackManager: {
@@ -18,6 +22,7 @@ vi.mock('../../src/main/index', () => ({
     getProjectTicketConfig: vi.fn().mockReturnValue({ provider: 'github' }),
     getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'sonnet' }),
     getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
+    getEffectiveTouchpointDescriptor: vi.fn().mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'sonnet', credentials: {} }),
   },
 }));
 
@@ -192,7 +197,8 @@ describe('MCP tools', () => {
         '/proj',
         1_800_000,
         { ticketId: '42', stage: 'spec' },
-        expect.anything(),
+        undefined,
+        'refine',
       );
       expect(result.passed).toBe(true);
       expect(result.report).toContain('PASS');
@@ -566,7 +572,8 @@ describe('MCP tools', () => {
         '/proj',
         1_800_000,
         { ticketId: '42', stage: 'refine' },
-        expect.anything(),
+        undefined,
+        'refine',
       );
       expect(result.passed).toBe(true);
       expect(result.updatedBody).toContain('Better spec');
@@ -931,9 +938,9 @@ describe('MCP tools', () => {
   });
 
   // -------------------------------------------------------------------------
-  // refine routing — model passthrough tests
+  // refine routing — touchpoint dispatch tests
   // -------------------------------------------------------------------------
-  describe('refine routing — model passthrough', () => {
+  describe('refine routing — touchpoint dispatch', () => {
     beforeEach(() => {
       _clearTicketBodyCacheForTests();
       vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: T-99\nbody text');
@@ -942,48 +949,46 @@ describe('MCP tools', () => {
         promise: Promise.resolve('## Spec Quality Gate: PASS'),
         cancel: vi.fn(),
       });
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'sonnet' });
-      vi.mocked(registry.getLegacyEffectiveModels).mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
+      vi.mocked(registry.getEffectiveTouchpointDescriptor).mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'sonnet', credentials: {} });
     });
 
-    it('handleSpecCheck forwards resolved refine model to runEphemeralAgent', async () => {
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'haiku' });
-
+    it('handleSpecCheck passes touchpoint "refine" to runEphemeralAgent', async () => {
       await handleToolCall('spec_check', { ticketId: 'T-99', projectDir: '/proj' });
 
       const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       const lastCall = calls[calls.length - 1];
-      expect(lastCall[4]).toBe('haiku');
+      expect(lastCall[4]).toBeUndefined(); // model not passed directly
+      expect(lastCall[5]).toBe('refine');  // touchpoint passed
     });
 
-    it('spawnSpecCheck forwards resolved refine model to spawnEphemeralAgent', async () => {
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'opus' });
-
+    it('spawnSpecCheck passes touchpoint "refine" to spawnEphemeralAgent', async () => {
       spawnSpecCheck('T-99', '/proj');
       await vi.waitFor(() => expect(agentBackend.spawnEphemeralAgent).toHaveBeenCalled());
 
       const calls = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls;
       const lastCall = calls[calls.length - 1];
-      expect(lastCall[5]).toBe('opus');
+      expect(lastCall[5]).toBeUndefined(); // model not passed directly
+      expect(lastCall[6]).toBe('refine');  // touchpoint passed
     });
 
-    it('falls back to legacy outer model and warns when refine backend is opencode', async () => {
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'opencode', model: 'gpt-4' });
-      vi.mocked(registry.getLegacyEffectiveModels).mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' });
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('shows needs_key notification and does NOT run agent when opencode backend has no credentials', async () => {
+      const { showNotification } = await import('../../src/main/tray');
+      vi.mocked(registry.getEffectiveTouchpointDescriptor).mockReturnValue({
+        backend: 'opencode', provider: 'openai', model: 'gpt-4o', credentials: null,
+      });
 
-      await handleToolCall('spec_check', { ticketId: 'T-99', projectDir: '/proj' });
+      const result = await handleToolCall('spec_check', { ticketId: 'T-99', projectDir: '/proj' });
 
-      const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
-      const lastCall = calls[calls.length - 1];
-      expect(lastCall[4]).toBe('opus');
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('opencode'));
-      warnSpy.mockRestore();
+      expect(vi.mocked(showNotification)).toHaveBeenCalledWith(
+        'Refine blocked',
+        expect.stringContaining('openai'),
+      );
+      expect(agentBackend.runEphemeralAgent).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ status: 'needs_key', backend: 'opencode', provider: 'openai' });
     });
 
-    it('handleSpecRefine initial forwards resolved refine model to runEphemeralAgent', async () => {
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'haiku' });
+    it('handleSpecRefine initial passes touchpoint "refine" to runEphemeralAgent', async () => {
       vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
         '## Spec Quality Gate: FAIL\n\n### Questions Requiring User Answers\n1. What?',
       );
@@ -993,11 +998,11 @@ describe('MCP tools', () => {
       const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       const lastCall = calls[calls.length - 1];
-      expect(lastCall[4]).toBe('haiku');
+      expect(lastCall[4]).toBeUndefined(); // model not passed
+      expect(lastCall[5]).toBe('refine');
     });
 
-    it('handleSpecRefine answer forwards resolved refine model to runEphemeralAgent', async () => {
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'haiku' });
+    it('handleSpecRefine answer passes touchpoint "refine" to runEphemeralAgent', async () => {
       vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
         '## Updated Ticket Body\n\n# Issue: Updated\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
       );
@@ -1008,12 +1013,12 @@ describe('MCP tools', () => {
       const calls = vi.mocked(agentBackend.runEphemeralAgent).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       const lastCall = calls[calls.length - 1];
-      expect(lastCall[4]).toBe('haiku');
+      expect(lastCall[4]).toBeUndefined();
+      expect(lastCall[5]).toBe('refine');
     });
 
-    it('spawnSpecRefine cold fallback forwards resolved refine model to spawnEphemeralAgent', async () => {
+    it('spawnSpecRefine cold fallback passes touchpoint "refine" to spawnEphemeralAgent', async () => {
       _disposeAllRefineSessionsForTests();
-      vi.mocked(registry.getEffectiveRoutingFor).mockReturnValue({ backend: 'claude', model: 'opus' });
       vi.mocked(agentBackend.spawnEphemeralAgent).mockReturnValue({
         promise: Promise.resolve(
           '## Updated Ticket Body\n\n# Issue: Cold\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
@@ -1028,7 +1033,8 @@ describe('MCP tools', () => {
       const calls = vi.mocked(agentBackend.spawnEphemeralAgent).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       const lastCall = calls[calls.length - 1];
-      expect(lastCall[5]).toBe('opus');
+      expect(lastCall[5]).toBeUndefined(); // model not passed
+      expect(lastCall[6]).toBe('refine');
     });
   });
 });


### PR DESCRIPTION
## Summary

Host-side ephemeral touchpoints (`refine` spec-check/refine, `pr_description`, `merge_conflict`) previously could not run on the OpenCode backend: each call warned `backend=opencode unsupported for host path` and silently fell back to the legacy outer/inner model. This change makes those touchpoints route correctly through OpenCode with the right provider, model, and credentials.

- `BackendRouter` now accepts a descriptor selector and resolves each ephemeral call via the per-touchpoint descriptor (backend, provider, model, credentials). For OpenCode it encodes the model as `providerID/modelID` so `splitModel` decodes it; otherwise it falls back to the outer selector when no touchpoint is supplied.
- `OpenCodeBackend` builds a merged provider map from every globally-stored provider at `initialize()`, so the long-lived server can dispatch ephemeral sessions to any configured provider+model without per-call credential injection. `syncCredentials` tracks a provider-map signature and restarts the server when the set of configured providers changes.
- Callers (`tools.ts` refine paths, `dark-factory-orchestrator`, `ipc` PR-draft handlers) now resolve the touchpoint descriptor up front. When an OpenCode touchpoint has no credentials, they return a `needs_key` outcome (and show a tray notification on the dark-factory/refine paths) instead of silently degrading.
- `Registry.getStoredProviderKeys(scope)` lists providers stored under a scope to drive the merged provider map.

## QA plan

1. With only Anthropic configured, run a spec refine/check and draft a PR body from a stack — confirm behavior is unchanged.
2. Configure a non-Anthropic OpenCode provider (e.g. OpenAI) globally with a valid key and route `refine` / `pr_description` to it; trigger spec-check, PR draft, and a merge-conflict resolution and confirm each runs on the selected provider+model rather than falling back.
3. Route a touchpoint to an OpenCode provider that has no stored key; confirm the refine and dark-factory paths surface a tray notification and a `needs_key` result, and the `pr:draftBody` IPC returns `{ status: 'needs_key' }` instead of erroring.
4. After the server is already running, add a new provider key, trigger a credential sync, and confirm the OpenCode server restarts and the new provider becomes usable without an app restart.

Closes #628