### PR TITLE
feat: altitude-aware spec gate + decide-and-record + epic-context givens (#647)

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -184,6 +184,12 @@ export async function handleToolCall(
 interface SpecContext {
   ticketBody: string;
   gate: string;
+  /**
+   * Verbatim parent-epic body (prefixed with a role/criterion line) when the
+   * ticket is linked to an epic. Omitted for standalone tickets or when the
+   * epic body fetch fails/returns empty — the gate then behaves as before.
+   */
+  epicContext?: string;
 }
 
 /**
@@ -246,11 +252,79 @@ async function resolveSpecContext(
     };
   }
 
-  return { ok: true, ctx: { ticketBody, gate: getDefaultSpecQualityGate() } };
+  const epicContext = await resolveEpicContext(ticketId, config, projectDir, toolName);
+
+  return { ok: true, ctx: { ticketBody, gate: getDefaultSpecQualityGate(), epicContext } };
 }
 
-export function buildSpecCheckPrompt(gate: string, ticketBody: string, referencesSection?: string): string {
+/**
+ * Reverse-lookup the parent epic for a ticket and build the verbatim epic
+ * context block. Returns undefined when the ticket is standalone, the epic
+ * body fetch fails, or the body is empty — in those cases the gate runs
+ * exactly as before (no epic section, no regression).
+ */
+async function resolveEpicContext(
+  ticketId: string,
+  config: ProjectTicketConfig,
+  projectDir: string,
+  toolName: string,
+): Promise<string | undefined> {
+  const link = registry.getEpicForTicket(ticketId);
+  if (!link) return undefined;
+
+  let epicBody: string | null = null;
+  try {
+    epicBody = await getTicketBodyCached(link.epicId, config, projectDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[sandstorm] ${toolName}: failed to fetch epic ${link.epicId} body for ticket ${ticketId}: ${msg} — omitting epic context`,
+    );
+    return undefined;
+  }
+
+  if (!epicBody || !epicBody.trim()) {
+    console.warn(
+      `[sandstorm] ${toolName}: epic ${link.epicId} for ticket ${ticketId} returned an empty body — omitting epic context`,
+    );
+    return undefined;
+  }
+
+  const roleLine = `This ticket's role in the epic: role=${link.role}, serves acceptance criterion=${link.critId ?? 'none'}`;
+  return `${roleLine}\n\n${epicBody}`;
+}
+
+/**
+ * Phase-1 three-way classification shared by all spec-gate prompt builders.
+ * Beyond the legacy self-resolvable / requires-human split it adds the
+ * "implementation discretion — decide and record" path plus the Decision
+ * Altitude filter, so decisions that are neither code-derivable nor
+ * behavior-significant are decided by the evaluator instead of bubbling up as
+ * user questions.
+ */
+const PHASE1_THREE_WAY_CLASSIFICATION = `For each assumption, classify it into exactly one of three resolution types:
+- **Self-resolvable (verified fact)**: Validatable by reading code, APIs, or schemas. Use Read/Grep/Glob now and report what you found with file:line citations. State the verified fact or confirm the assumption is incorrect with evidence. Describing what you would check without checking is not sufficient.
+- **Requires human input (decision-significant question)**: Passes the Decision Altitude filter — a different answer would change observable behavior, system architecture, product intent, or a cross-ticket contract. Formulate a specific question that must be answered before the spec is complete.
+- **Implementation discretion — decide and record**: Fails the Decision Altitude filter — a different answer would NOT change observable behavior, architecture, product intent, or a cross-ticket contract (e.g. internal data structures, helper/function placement, symbol/variable naming, file organization, non-behavioral constants, logging/comment style). Do NOT emit a user question for these; pick a reasonable option and record the decision plus a one-line rationale.`;
+
+/** Phase-1 instruction injected only when an Epic Context block is present. */
+const EPIC_PHASE1_LINE = `An Epic Context section is provided above. Treat every contract, vocabulary term, and acceptance decision in it as a fixed given: validate the ticket for consistency only, and do NOT surface a question whose answer is already in the epic context or propose redefining an epic-owned shape.`;
+
+/** Render the optional Epic Context block inserted before `## Instructions`. */
+function buildEpicContextBlock(epicContext?: string): string {
+  if (!epicContext) return '';
+  return `\n## Epic Context (already-decided givens — do NOT re-litigate)\n\n${epicContext}\n`;
+}
+
+export function buildSpecCheckPrompt(
+  gate: string,
+  ticketBody: string,
+  referencesSection?: string,
+  epicContext?: string,
+): string {
   const refBlock = referencesSection ? `\n${referencesSection}\n` : '';
+  const epicBlock = buildEpicContextBlock(epicContext);
+  const epicPhase1 = epicContext ? `\n${EPIC_PHASE1_LINE}\n` : '';
   return `You are a spec quality gate evaluator. Evaluate the ticket below against every criterion in the quality gate. Be strict — if you'd have to guess, it's a FAIL.
 
 ## Quality Gate Criteria
@@ -260,17 +334,17 @@ ${gate}
 ## Ticket
 
 ${ticketBody}
-${refBlock}
+${refBlock}${epicBlock}
 
 ## Instructions
 
 ### Phase 1: Assumption Resolution
 Before evaluating pass/fail, identify every assumption in the ticket (explicit "Assumes..." statements AND implicit assumptions you would make if starting this task).
 
-For each assumption, classify it:
-- **Self-resolvable**: Can be validated by reading code, checking APIs, schemas, or running commands. For these, Use Read/Grep/Glob now and report what you found with file:line citations. State the verified fact or confirm the assumption is incorrect with evidence. Describing what you would check without checking is not sufficient.
-- **Requires human input**: Business logic context, domain knowledge, behavioral expectations, product direction, edge case decisions — things the codebase can't answer. For these, formulate a specific question that must be answered before the spec is complete.
+${PHASE1_THREE_WAY_CLASSIFICATION}
 
+Because this check is read-only (it returns a report and does not edit the ticket), list every decided-and-recorded decision in your report under a "Recorded Decisions" note rather than asking the user about it.
+${epicPhase1}
 ### Phase 2: Evaluation
 For each criterion, determine PASS or FAIL.
 
@@ -287,7 +361,7 @@ Respond in EXACTLY this format (no other text before or after):
 ### Assumption Resolution
 | # | Assumption | Type | Resolution |
 |---|-----------|------|------------|
-| 1 | <assumption text> | Self-resolvable / Requires human input | <verified fact OR specific question> |
+| 1 | <assumption text> | Self-resolvable / Requires human input / Decided-and-recorded | <verified fact OR specific question OR recorded decision + one-line rationale> |
 ...
 
 ### Results
@@ -350,7 +424,7 @@ async function handleSpecCheck(
 
   const references = await resolveTicketReferences(ctx.ticketBody);
   const referencesSection = renderResolvedReferences(references);
-  const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody, referencesSection || undefined);
+  const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody, referencesSection || undefined, ctx.epicContext);
   const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
@@ -360,7 +434,13 @@ async function handleSpecCheck(
   };
 }
 
-export function buildSpecRefineInitialPrompt(gate: string, ticketBody: string): string {
+export function buildSpecRefineInitialPrompt(
+  gate: string,
+  ticketBody: string,
+  epicContext?: string,
+): string {
+  const epicBlock = buildEpicContextBlock(epicContext);
+  const epicPhase1 = epicContext ? `\n${EPIC_PHASE1_LINE}\n` : '';
   return `You are a spec quality gate evaluator. Evaluate the ticket below against every criterion in the quality gate. Be strict.
 
 ## Quality Gate Criteria
@@ -370,14 +450,15 @@ ${gate}
 ## Ticket
 
 ${ticketBody}
+${epicBlock}
 
 ## Instructions
 
 ### Phase 1: Assumption Resolution
-Identify every assumption (explicit and implicit). For each:
-- **Self-resolvable** (can check code/APIs/schemas): Use Read/Grep/Glob now and report what you found with file:line citations. Describing what you would verify without verifying is not sufficient.
-- **Requires human input** (business logic, domain knowledge, product direction): Formulate a specific blocking question.
+Identify every assumption (explicit and implicit). ${PHASE1_THREE_WAY_CLASSIFICATION}
 
+You produce an updated ticket body below — write each decided-and-recorded decision inline into it (the decision plus a one-line rationale) so the executor reads a decision, not a blank. Do NOT ask the user about an implementation-discretion item.
+${epicPhase1}
 ### Phase 2: Evaluation
 Apply ALL criteria from the quality gate, including:
 - **Zero Unresolved Assumptions**: FAIL if any assumptions remain unverified/unanswered.
@@ -393,7 +474,7 @@ Respond in EXACTLY this format:
 ### Assumption Resolution
 | # | Assumption | Type | Resolution |
 |---|-----------|------|------------|
-| 1 | <assumption text> | Self-resolvable / Requires human input | <verified fact OR specific question> |
+| 1 | <assumption text> | Self-resolvable / Requires human input / Decided-and-recorded | <verified fact OR specific question OR recorded decision + one-line rationale> |
 ...
 
 ### Results
@@ -423,7 +504,14 @@ Mark at most one option per question with \`"recommended": true\` when you have 
 `;
 }
 
-export function buildSpecRefineAnswerPrompt(gate: string, ticketBody: string, userAnswers: string): string {
+export function buildSpecRefineAnswerPrompt(
+  gate: string,
+  ticketBody: string,
+  userAnswers: string,
+  epicContext?: string,
+): string {
+  const epicBlock = buildEpicContextBlock(epicContext);
+  const epicPhase1 = epicContext ? `\n${EPIC_PHASE1_LINE}\n` : '';
   return `You are a spec quality gate evaluator performing a refinement step.
 
 ## Quality Gate Criteria
@@ -433,7 +521,7 @@ ${gate}
 ## Current Ticket
 
 ${ticketBody}
-
+${epicBlock}
 ## User's Answers to Gap Questions
 
 ${userAnswers}
@@ -441,10 +529,12 @@ ${userAnswers}
 ## Instructions
 
 1. Incorporate the user's answers into the ticket body. Preserve existing content — add clarifications inline or in new sections, don't delete anything. Replace resolved assumptions with verified facts (e.g., "Verified: function X returns Y (see src/path/file.ts:42)").
-2. Re-evaluate the updated ticket against ALL quality gate criteria, including:
-   - **Zero Unresolved Assumptions**: Any remaining assumptions must be resolved. Listing them is not enough.
+2. Resolve every assumption to one of three types. ${PHASE1_THREE_WAY_CLASSIFICATION}
+   Write each decided-and-recorded decision inline into the updated ticket body (decision plus a one-line rationale). Do NOT ask the user about an implementation-discretion item.
+3. Re-evaluate the updated ticket against ALL quality gate criteria, including:
+   - **Zero Unresolved Assumptions**: Any remaining assumptions must be resolved (verified fact, decision-significant question, or decided-and-recorded). Listing them is not enough.
    - **Dependency Contracts**: Cross-ticket/module references need explicit contracts (format, timing, verification).
-3. If it still FAILs, ask new specific questions for the remaining gaps.
+4. If it still FAILs, ask new specific questions for the remaining gaps.${epicPhase1}
 
 Respond in EXACTLY this format:
 
@@ -457,7 +547,7 @@ Respond in EXACTLY this format:
 ### Assumption Resolution
 | # | Assumption | Type | Resolution |
 |---|-----------|------|------------|
-| 1 | <assumption text> | Self-resolvable / Requires human input | <verified fact OR answered> |
+| 1 | <assumption text> | Self-resolvable / Requires human input / Decided-and-recorded | <verified fact OR answered OR recorded decision + one-line rationale> |
 ...
 
 ### Results
@@ -554,13 +644,13 @@ async function handleSpecRefine(
   }
 
   if (!userAnswers) {
-    const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody);
+    const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody, ctx.epicContext);
     const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   }
 
-  const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers);
+  const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers, ctx.epicContext);
   const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
   return applySpecRefineResult(ticketId, projectDir, result, true);
 }
@@ -594,7 +684,7 @@ export function spawnSpecCheck(
 
     const references = await resolveTicketReferences(res.ctx.ticketBody);
     const referencesSection = renderResolvedReferences(references);
-    const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody, referencesSection || undefined);
+    const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody, referencesSection || undefined, res.ctx.epicContext);
     const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
@@ -679,7 +769,7 @@ export function spawnSpecRefine(
       // After-answers pass. Reuse the held session if we have one; otherwise
       // cold-start with the full answer prompt.
       const pooled = refineSessionPool.get(key);
-      const answerPrompt = buildSpecRefineAnswerPrompt(res.ctx.gate, res.ctx.ticketBody, userAnswers);
+      const answerPrompt = buildSpecRefineAnswerPrompt(res.ctx.gate, res.ctx.ticketBody, userAnswers, res.ctx.epicContext);
 
       if (pooled) {
         clearTimeout(pooled.idleTimer);
@@ -706,7 +796,7 @@ export function spawnSpecRefine(
 
     // Initial-questions pass. Spawn a long-lived session so the after-answers
     // pass can reuse it.
-    const initialPrompt = buildSpecRefineInitialPrompt(res.ctx.gate, res.ctx.ticketBody);
+    const initialPrompt = buildSpecRefineInitialPrompt(res.ctx.gate, res.ctx.ticketBody, res.ctx.epicContext);
     const handle = agentBackend.spawnEphemeralSession(initialPrompt, projectDir, 0, onChunk);
     // Cancel during the initial pass must dispose the live handle even though
     // it isn't pooled yet — otherwise SIGTERM never reaches the held subprocess.

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -2259,6 +2259,24 @@ export class Registry {
     ).all(epicId) as EpicTask[];
   }
 
+  /**
+   * Reverse lookup: find the epic a ticket belongs to. Read-only; consumes the
+   * existing `epic_tasks` table shape (no write, no schema change).
+   *
+   * A ticket maps to at most one epic in practice. If multiple `epic_tasks`
+   * rows reference the same ticket, the first by `epic_id` ordering is returned
+   * deterministically so repeated calls are stable.
+   */
+  getEpicForTicket(
+    ticketId: string,
+  ): { epicId: string; role: EpicTaskRole; critId: string | null } | null {
+    const row = this.db.prepare(
+      'SELECT epic_id, role, crit_id FROM epic_tasks WHERE ticket_id = ? ORDER BY epic_id LIMIT 1'
+    ).get(ticketId) as { epic_id: string; role: EpicTaskRole; crit_id: string | null } | undefined;
+    if (!row) return null;
+    return { epicId: row.epic_id, role: row.role, critId: row.crit_id };
+  }
+
   upsertEpicTask(
     epicId: string,
     ticketId: string,

--- a/src/main/spec-quality-gate.ts
+++ b/src/main/spec-quality-gate.ts
@@ -32,6 +32,27 @@ or "how should this be verified" — tests are always required. Specify the conc
 e2e / Playwright / visual browser verification is **not required** (not yet available
 in the stack container). Do NOT fail the gate because e2e tests are absent.
 
+## Decision Altitude
+
+Not every open decision deserves a human. A question may be surfaced to the user
+**only if a different answer would change observable behavior, system architecture,
+product intent, or a cross-ticket contract.** Everything else is implementation
+discretion and MUST be decided-and-recorded by the evaluator, never asked.
+
+Examples that MUST NOT be asked — decide-and-record instead:
+
+- internal data structures
+- helper / function placement
+- symbol / variable naming
+- file organization
+- non-behavioral constants
+- logging / comment style
+
+This mirrors the \`to-prd\` altitude: architectural choices only — no file paths, no
+code snippets. A decision that is behavior-significant but *looks* small is still
+asked: the filter keys on whether a different answer changes
+behavior/architecture/intent/contract, not on apparent size.
+
 ---
 
 ## Criteria
@@ -73,11 +94,12 @@ Are the impacted areas of the codebase identified?
 - Point the agent at the right part of the codebase.
 
 ### Assumptions — Zero Unresolved
-List every assumption the agent would make if it started now.
+List every assumption the agent would make if it started now. Every assumption MUST be driven to one of **three** legal resolutions:
+- **Verified fact** — answerable by reading code, checking APIs, schemas, or running commands. The evaluator MUST validate it and replace it with a verified fact (cite \`file:line\`) or flag it as incorrect with evidence.
+- **Decision-significant question** — passes the Decision Altitude filter: a different answer would change observable behavior, system architecture, product intent, or a cross-ticket contract. Surface it as an explicit question that blocks the gate.
+- **Decided-and-recorded** — fails the Decision Altitude filter: pure implementation discretion (a different answer would NOT change behavior/architecture/intent/contract). The evaluator picks a reasonable option and records the decision plus a one-line rationale in the ticket; it does **not** ask the user.
 - **Assumptions are ambiguity. Ambiguity means the spec is incomplete.**
-- If an assumption can be validated by reading code, checking APIs, or running commands — the evaluator MUST validate it and replace it with a verified fact or flag it as incorrect.
-- If an assumption requires human input (business logic, domain knowledge, product direction, edge case decisions) — it MUST be surfaced as an explicit question that blocks the gate.
-- The gate MUST NOT pass with unresolved assumptions. Every assumption must become either a verified fact or an answered question.
+- The gate MUST NOT pass while any assumption is *unresolved*. "Decided-and-recorded" counts as resolved — the decision is pinned in the ticket, so the executor still cannot improvise; only the decider moves from the human to the evaluator. A bare list of assumptions is never sufficient.
 
 ### Dependency Contracts
 When the ticket references another ticket, module, or external system's output:
@@ -94,6 +116,13 @@ If the ticket is part of a larger epic or multi-ticket effort:
 - If it cannot point to an acceptance behavior it serves, either the epic's acceptance definition is incomplete or the ticket is scope creep — resolve before dispatch.
 - This is the per-ticket coverage check only. It does NOT require end-to-end or visual verification, and it does NOT replace a whole-epic acceptance review (a green ticket is progress, not proof the whole behavior works assembled).
 - Skip this criterion for standalone tickets with no parent epic.
+
+### Epic Context — treat as givens
+If an **Epic Context** block is present (the ticket is linked to a parent epic):
+- Every contract, vocabulary term, and acceptance decision in the epic context is **fixed** — an already-decided given, not something to re-derive.
+- Check the ticket only for *consistency* with the epic context; validate that its own/extend/consume role and served acceptance criterion match what the epic decided.
+- The evaluator MUST NOT surface a question whose answer is already in the epic context, and MUST NOT propose redefining an epic-owned shape.
+- Skip this criterion when no Epic Context block is present.
 
 ### Intent Congruence
 Does the proposed approach actually achieve the ticket's stated goal?

--- a/tests/unit/control-plane/registry.epic.test.ts
+++ b/tests/unit/control-plane/registry.epic.test.ts
@@ -140,6 +140,41 @@ describe('Registry — epic tables (migration 26)', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // getEpicForTicket (reverse lookup)
+  // ---------------------------------------------------------------------------
+
+  describe('getEpicForTicket', () => {
+    it('returns null for a ticket not linked to any epic', () => {
+      expect(registry.getEpicForTicket('orphan-ticket')).toBeNull();
+    });
+
+    it('returns the linked epic, role, and critId for a linked ticket', () => {
+      registry.upsertEpicTask('ep-rev', 'tkt-rev', { role: 'reconcile', origin: 'gap', critId: 'crit-9' });
+      expect(registry.getEpicForTicket('tkt-rev')).toEqual({
+        epicId: 'ep-rev',
+        role: 'reconcile',
+        critId: 'crit-9',
+      });
+    });
+
+    it('returns null critId when the linked task has no criterion', () => {
+      registry.upsertEpicTask('ep-nc', 'tkt-nc', { role: 'build', origin: 'planned', critId: null });
+      expect(registry.getEpicForTicket('tkt-nc')).toEqual({
+        epicId: 'ep-nc',
+        role: 'build',
+        critId: null,
+      });
+    });
+
+    it('picks the first epic by epic_id ordering when a ticket links to multiple', () => {
+      registry.upsertEpicTask('ep-zeta', 'multi-tkt', { role: 'build', origin: 'planned' });
+      registry.upsertEpicTask('ep-alpha', 'multi-tkt', { role: 'reconcile', origin: 'gap', critId: 'c' });
+      const result = registry.getEpicForTicket('multi-tkt');
+      expect(result?.epicId).toBe('ep-alpha');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // incrementGapCycles
   // ---------------------------------------------------------------------------
 

--- a/tests/unit/spec-quality-gate.test.ts
+++ b/tests/unit/spec-quality-gate.test.ts
@@ -27,7 +27,7 @@ describe('getDefaultSpecQualityGate', () => {
     const content = getDefaultSpecQualityGate();
     expect(content).toContain('### Assumptions — Zero Unresolved');
     expect(content).toContain('Assumptions are ambiguity');
-    expect(content).toContain('MUST NOT pass with unresolved assumptions');
+    expect(content).toContain('MUST NOT pass while any assumption is *unresolved*');
   });
 
   it('includes dependency contracts criterion', () => {
@@ -78,6 +78,34 @@ describe('getDefaultSpecQualityGate', () => {
     const content = getDefaultSpecQualityGate();
     expect(content).toContain('### Verify Before Asking');
     expect(content).toContain('file:line');
+  });
+
+  it('includes the Decision Altitude section with the altitude filter', () => {
+    const content = getDefaultSpecQualityGate();
+    expect(content).toContain('## Decision Altitude');
+    expect(content).toContain(
+      'a different answer would change observable behavior, system architecture,',
+    );
+    // Non-asking examples are enumerated as decide-and-record.
+    expect(content).toContain('symbol / variable naming');
+    expect(content).toContain('non-behavioral constants');
+  });
+
+  it('Assumptions criterion defines all three resolution types', () => {
+    const content = getDefaultSpecQualityGate();
+    expect(content).toContain('three** legal resolutions');
+    expect(content).toContain('**Verified fact**');
+    expect(content).toContain('**Decision-significant question**');
+    expect(content).toContain('**Decided-and-recorded**');
+    // Decided-and-recorded still counts as resolved (pin-everything invariant).
+    expect(content).toContain('"Decided-and-recorded" counts as resolved');
+  });
+
+  it('includes the Epic Context — treat as givens criterion', () => {
+    const content = getDefaultSpecQualityGate();
+    expect(content).toContain('### Epic Context — treat as givens');
+    expect(content).toContain('already-decided given');
+    expect(content).toContain('MUST NOT surface a question whose answer is already in the epic context');
   });
 
   it('starts with a markdown heading', () => {

--- a/tests/unit/tools-spec-prompts.test.ts
+++ b/tests/unit/tools-spec-prompts.test.ts
@@ -172,6 +172,60 @@ describe('buildSpecRefineAnswerPrompt', () => {
   });
 });
 
+describe('spec-gate builders — Decision Altitude + decide-and-record', () => {
+  const ALTITUDE = 'a different answer would change observable behavior, system architecture, product intent, or a cross-ticket contract';
+  const DECIDE_RECORD = 'Implementation discretion — decide and record';
+  const GUARD = 'Do NOT emit a user question for these';
+
+  const builders: Array<[string, () => string]> = [
+    ['buildSpecCheckPrompt', () => buildSpecCheckPrompt(GATE, TICKET)],
+    ['buildSpecRefineInitialPrompt', () => buildSpecRefineInitialPrompt(GATE, TICKET)],
+    ['buildSpecRefineAnswerPrompt', () => buildSpecRefineAnswerPrompt(GATE, TICKET, ANSWERS)],
+  ];
+
+  for (const [name, build] of builders) {
+    describe(name, () => {
+      it('includes the altitude filter, decide-and-record path, and the discretion guard', () => {
+        const prompt = build();
+        expect(prompt).toContain(ALTITUDE);
+        expect(prompt).toContain(DECIDE_RECORD);
+        expect(prompt).toContain(GUARD);
+      });
+    });
+  }
+});
+
+const EPIC_CONTEXT = "This ticket's role in the epic: role=build, serves acceptance criterion=crit-7\n\n# Parent Epic\n\nEpic body verbatim.";
+
+describe('spec-gate builders — Epic Context plumbing', () => {
+  const epicBuilders: Array<[string, (epic?: string) => string]> = [
+    ['buildSpecCheckPrompt', (epic) => buildSpecCheckPrompt(GATE, TICKET, undefined, epic)],
+    ['buildSpecRefineInitialPrompt', (epic) => buildSpecRefineInitialPrompt(GATE, TICKET, epic)],
+    ['buildSpecRefineAnswerPrompt', (epic) => buildSpecRefineAnswerPrompt(GATE, TICKET, ANSWERS, epic)],
+  ];
+
+  for (const [name, build] of epicBuilders) {
+    describe(name, () => {
+      it('inserts the Epic Context section and role/crit line when epicContext is passed', () => {
+        const prompt = build(EPIC_CONTEXT);
+        expect(prompt).toContain('## Epic Context (already-decided givens — do NOT re-litigate)');
+        expect(prompt).toContain("This ticket's role in the epic: role=build, serves acceptance criterion=crit-7");
+        expect(prompt).toContain('Epic body verbatim.');
+        // Phase-1 instruction to treat the epic as fixed givens is present.
+        expect(prompt).toContain('Treat every contract, vocabulary term, and acceptance decision in it as a fixed given');
+      });
+
+      it('omits the Epic Context section when epicContext is not passed (no regression)', () => {
+        const prompt = build(undefined);
+        // The gate criteria text mentions "### Epic Context" as a criterion, so
+        // assert against the unique injected block header instead.
+        expect(prompt).not.toContain('## Epic Context (already-decided givens — do NOT re-litigate)');
+        expect(prompt).not.toContain('Treat every contract, vocabulary term, and acceptance decision in it as a fixed given');
+      });
+    });
+  }
+});
+
 describe('built-in gate verification policy', () => {
   it('gate is always non-empty (resolveSpecContext always has a gate)', () => {
     expect(GATE).toBeTruthy();

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../src/main/index', () => ({
     getEffectiveRoutingFor: vi.fn().mockReturnValue({ backend: 'claude', model: 'sonnet' }),
     getLegacyEffectiveModels: vi.fn().mockReturnValue({ inner_model: 'sonnet', outer_model: 'opus' }),
     getEffectiveTouchpointDescriptor: vi.fn().mockReturnValue({ backend: 'claude', provider: 'anthropic', model: 'sonnet', credentials: {} }),
+    getEpicForTicket: vi.fn().mockReturnValue(null),
   },
 }));
 


### PR DESCRIPTION
Closes #647.

Implements the altitude-aware spec quality gate so the refine/spec-check flow stops escalating pure implementation decisions to the user.

## Changes
- **`src/main/spec-quality-gate.ts`** — new **Decision Altitude** section: a question may be surfaced to the user *only if a different answer would change observable behavior, system architecture, product intent, or a cross-ticket contract*. Everything else (data structures, naming, file placement, non-behavioral constants, logging/comment style) is **decided-and-recorded by the evaluator, never asked**. Rewrote **Assumptions — Zero Unresolved** into three legal resolutions (Verified fact / Decision-significant question / Decided-and-recorded) and added the **Epic Context — treat as givens** criterion.
- **`src/main/claude/tools.ts`** — `SpecContext` gains `epicContext?`; `resolveSpecContext` reverse-looks-up the parent epic via `getEpicForTicket`, fetches the epic body through the existing cached path, and injects an `## Epic Context` block into all three prompt builders (omits-with-warning on empty/failed fetch — no regression).
- **`src/main/control-plane/registry.ts`** — read-only `getEpicForTicket` (deterministic `ORDER BY epic_id LIMIT 1`).

## Tests
16 new tests across `spec-quality-gate.test.ts`, `tools-spec-prompts.test.ts`, and `registry.epic.test.ts` — all passing. `npm run typecheck` clean.

## Known gate caveat
`verify.sh` runs the full `npm test`, which currently has **3 pre-existing, unrelated failures** in `tests/unit/tools.test.ts` (model-routing touchpoint assertions on `handleSpecCheck`/`spawnSpecCheck` — red on clean `main`, fallout from the #645/#646 routing work). This PR introduces **zero new failures** (suite went 3-failed/4239-passed → 3-failed/4255-passed). Those 3 are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)