### PR TITLE
[616] feat: per-epic telemetry cost rollups

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -399,15 +399,6 @@ function getRefineDescriptor(projectDir: string) {
   return registry.getEffectiveTouchpointDescriptor(projectDir, 'refine');
 }
 
-function resolveRefineModel(projectDir: string): string | undefined {
-  const routing = registry.getEffectiveRoutingFor(projectDir, 'refine');
-  if (routing.backend === 'opencode') {
-    console.warn('[refine] backend=opencode unsupported for host path; falling back to legacy outer model');
-    return registry.getLegacyEffectiveModels(projectDir).outer_model;
-  }
-  return routing.model;
-}
-
 async function handleSpecCheck(
   ticketId: string,
   projectDir: string
@@ -425,7 +416,7 @@ async function handleSpecCheck(
   const references = await resolveTicketReferences(ctx.ticketBody);
   const referencesSection = renderResolvedReferences(references);
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody, referencesSection || undefined, ctx.epicContext);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, undefined, 'refine');
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -685,7 +676,7 @@ export function spawnSpecCheck(
     const references = await resolveTicketReferences(res.ctx.ticketBody);
     const referencesSection = renderResolvedReferences(references);
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody, referencesSection || undefined, res.ctx.epicContext);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, undefined, 'refine');
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 

--- a/src/main/control-plane/registry.ts
+++ b/src/main/control-plane/registry.ts
@@ -2259,6 +2259,18 @@ export class Registry {
     ).all(epicId) as EpicTask[];
   }
 
+  getAllEpicTasks(): EpicTask[] {
+    return this.db.prepare(
+      'SELECT epic_id, ticket_id, role, origin, crit_id, gap_cycles, done FROM epic_tasks'
+    ).all() as EpicTask[];
+  }
+
+  getAllEpicIds(): string[] {
+    return (this.db.prepare(
+      'SELECT DISTINCT epic_id FROM epic_tasks ORDER BY epic_id'
+    ).all() as { epic_id: string }[]).map((r) => r.epic_id);
+  }
+
   /**
    * Reverse lookup: find the epic a ticket belongs to. Read-only; consumes the
    * existing `epic_tasks` table shape (no write, no schema change).

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -94,7 +94,7 @@ import { getLatestUserAnswers, ANSWER_COMMENT_MARKER, GATE_FAIL_REPORT_MARKER } 
 import { KANBAN_COLUMNS } from '../shared/kanban';
 import os from 'os';
 import { createUsageEngine, clearUsageCache } from './telemetry/usage-engine';
-import type { DateRange, ByTicketEntry } from './telemetry/usage-engine';
+import type { DateRange, ByTicketEntry, ByEpicEntry } from './telemetry/usage-engine';
 import { readEphemeralTimingRecords } from './agent/ephemeral-timing';
 import { ORCHESTRATOR_TICKET_ID } from './telemetry/types';
 import { TicketRollupStore } from './telemetry/rollup-store';
@@ -829,6 +829,17 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       .filter((r) => r.ticketId != null && r.stage != null)
       .map((r) => ({ ticketId: r.ticketId!, stage: r.stage!, tokens: r.tokens ?? 0 }));
     return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords, taskPhaseWeights).getByTicket(range);
+  });
+
+  ipcMain.handle('stats:telemetry:byEpic', async (_event, range?: DateRange): Promise<ByEpicEntry[]> => {
+    const stepWeights = registry.getStepWeightsByTicket();
+    const taskPhaseWeights = registry.getTaskPhaseTokensByTicket();
+    const allEphemeral = readEphemeralTimingRecords(agentBackend.getEphemeralTimingPath());
+    const ephemeralRecords = allEphemeral
+      .filter((r) => r.ticketId != null && r.stage != null)
+      .map((r) => ({ ticketId: r.ticketId!, stage: r.stage!, tokens: r.tokens ?? 0 }));
+    const epicTasks = registry.getAllEpicTasks();
+    return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords, taskPhaseWeights).getByEpic(epicTasks, range);
   });
 
   ipcMain.handle('stats:telemetry:refresh', async () => {

--- a/src/main/telemetry/aggregator.ts
+++ b/src/main/telemetry/aggregator.ts
@@ -7,8 +7,9 @@ import fs from 'fs';
 import path from 'path';
 import { computeCost } from './pricing';
 import type { RawUsageEntry } from './parser';
-import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
+import type { DateRange, TokenCounts, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry, ByEpicEntry } from './types';
 import { ORCHESTRATOR_TICKET_ID } from './types';
+import type { EpicTask } from '../control-plane/registry';
 import { computeLifecycleSplit } from './lifecycle-split';
 import type { LifecycleWeights } from './lifecycle-split';
 import type { TaskPhaseWeightRow } from '../control-plane/registry';
@@ -410,5 +411,94 @@ export function aggregateByTicket(
       unpriced: data.unpriced,
     } satisfies ByTicketEntry;
   });
+}
+
+/**
+ * Aggregate per-ticket attribution into per-epic rollups.
+ *
+ * byTicket: pre-computed per-ticket results (from aggregateByTicket).
+ * epicTasks: membership rows from epic_tasks (injected, electron-free).
+ *
+ * build + reconcile partition total by epic_tasks.role.
+ * reconcileRework is an overlay (not a partition): gap tickets also count in
+ * their role bucket (build or reconcile). Invariant: reconcileRework.cost ≤ build.cost + reconcile.cost.
+ * ORCHESTRATOR_TICKET_ID is excluded from all rollups.
+ */
+export function aggregateByEpic(
+  byTicket: ByTicketEntry[],
+  epicTasks: EpicTask[],
+): ByEpicEntry[] {
+  if (epicTasks.length === 0) return [];
+
+  // Index byTicket for O(1) lookup
+  const ticketIndex = new Map<string, ByTicketEntry>();
+  for (const entry of byTicket) {
+    if (entry.ticketId !== ORCHESTRATOR_TICKET_ID) {
+      ticketIndex.set(entry.ticketId, entry);
+    }
+  }
+
+  // Group epic_tasks by epic_id
+  const epicMap = new Map<string, EpicTask[]>();
+  for (const task of epicTasks) {
+    if (!epicMap.has(task.epic_id)) epicMap.set(task.epic_id, []);
+    epicMap.get(task.epic_id)!.push(task);
+  }
+
+  function addTokenCounts(acc: TokenCounts, src: TokenCounts): void {
+    acc.input += src.input;
+    acc.output += src.output;
+    acc.cacheCreate += src.cacheCreate;
+    acc.cacheRead += src.cacheRead;
+    acc.total += src.total;
+  }
+
+  const results: ByEpicEntry[] = [];
+
+  for (const [epicId, tasks] of epicMap) {
+    const total = { cost: 0, tokens: zeroTokens() };
+    const build = { cost: 0, tokens: zeroTokens() };
+    const reconcile = { cost: 0, tokens: zeroTokens() };
+    const reconcileRework = { cost: 0, tokens: zeroTokens() };
+
+    for (const task of tasks) {
+      const entry = ticketIndex.get(task.ticket_id);
+      if (!entry) continue;
+
+      // Accumulate total
+      total.cost += entry.cost;
+      addTokenCounts(total.tokens, entry.tokens);
+
+      // Partition by role
+      if (task.role === 'build') {
+        build.cost += entry.cost;
+        addTokenCounts(build.tokens, entry.tokens);
+      } else {
+        reconcile.cost += entry.cost;
+        addTokenCounts(reconcile.tokens, entry.tokens);
+      }
+
+      // reconcileRework overlay: gap tickets regardless of role
+      if (task.origin === 'gap') {
+        reconcileRework.cost += entry.cost;
+        addTokenCounts(reconcileRework.tokens, entry.tokens);
+      }
+    }
+
+    // memberCount = distinct tickets with data in byTicket (excludes tasks with no spend)
+    const memberCount = tasks.filter((t) => ticketIndex.has(t.ticket_id)).length;
+
+    results.push({
+      epicId,
+      cost: total.cost,
+      tokens: total.tokens,
+      build,
+      reconcile,
+      reconcileRework,
+      memberCount,
+    } satisfies ByEpicEntry);
+  }
+
+  return results;
 }
 

--- a/src/main/telemetry/lifecycle-split.ts
+++ b/src/main/telemetry/lifecycle-split.ts
@@ -10,10 +10,10 @@
 
 import type { LifecycleCosts } from './types';
 
-export type LifecycleStage = 'refine' | 'spec' | 'execution' | 'review' | 'verify' | 'pr';
+export type LifecycleStage = 'refine' | 'spec' | 'execution' | 'review' | 'verify' | 'pr' | 'reconcile';
 
 export const LIFECYCLE_STAGES: readonly LifecycleStage[] = [
-  'refine', 'spec', 'execution', 'review', 'verify', 'pr',
+  'refine', 'spec', 'execution', 'review', 'verify', 'pr', 'reconcile',
 ];
 
 export type LifecycleWeights = Partial<Record<LifecycleStage, number>>;
@@ -40,6 +40,7 @@ export function computeLifecycleSplit(
     review: weights.review ?? 0,
     verify: 0,  // always zero — no LLM spend
     pr: weights.pr ?? 0,
+    reconcile: 0,  // no per-ticket producer yet; sourced from epic_tasks.role in aggregateByEpic
   };
 
   if (cost === 0) {
@@ -68,5 +69,14 @@ export function computeLifecycleSplit(
   }
   splits[largestStage] += residual;
 
-  return splits;
+  // Return only the six LifecycleCosts keys — reconcile is tracked in effective but
+  // has no per-ticket producer yet (it is sourced from epic_tasks.role at the epic level).
+  return {
+    refine: splits.refine,
+    spec: splits.spec,
+    execution: splits.execution,
+    review: splits.review,
+    verify: splits.verify,
+    pr: splits.pr,
+  };
 }

--- a/src/main/telemetry/types.ts
+++ b/src/main/telemetry/types.ts
@@ -67,6 +67,24 @@ export interface ByModelEntry {
   unpriced: boolean; // true when no price is known for this model
 }
 
+/**
+ * Per-epic cost rollup derived from per-ticket attribution joined with epic_tasks membership.
+ *
+ * build + reconcile partitions the total by epic_tasks.role.
+ * reconcileRework is an overlay dimension (not a partition): it covers tickets with
+ * origin='gap', which also land in build or reconcile by their role. The invariant is
+ * reconcileRework.cost ≤ build.cost + reconcile.cost.
+ */
+export interface ByEpicEntry {
+  epicId: string;
+  cost: number;
+  tokens: TokenCounts;
+  build: { cost: number; tokens: TokenCounts };
+  reconcile: { cost: number; tokens: TokenCounts };
+  reconcileRework: { cost: number; tokens: TokenCounts };
+  memberCount: number;
+}
+
 export interface SessionEntry {
   sid: string;
   ticket: string | null;  // ticket attributed from stack manifest; null for host/orchestrator sessions

--- a/src/main/telemetry/usage-engine.ts
+++ b/src/main/telemetry/usage-engine.ts
@@ -14,13 +14,14 @@
 
 import fs from 'fs';
 import { parseTranscriptRoots, findJSONLFiles, type ParseResult } from './parser';
-import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions, aggregateByTicket } from './aggregator';
+import { aggregateSummary, aggregateDaily, aggregateByModel, aggregateSessions, aggregateByTicket, aggregateByEpic } from './aggregator';
 import type { StepWeightRow, EphemeralWeightRecord, TaskPhaseWeightRow } from './aggregator';
-import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry } from './types';
+import type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry, ByEpicEntry } from './types';
+import type { EpicTask } from '../control-plane/registry';
 
 export type { StepWeightRow, EphemeralWeightRecord, TaskPhaseWeightRow };
 
-export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry };
+export type { DateRange, TelemetrySummary, DailyEntry, ByModelEntry, SessionEntry, ByTicketEntry, ByEpicEntry };
 
 export interface UsageEngine {
   getSummary(range: DateRange): TelemetrySummary;
@@ -28,6 +29,7 @@ export interface UsageEngine {
   getByModel(range: DateRange): ByModelEntry[];
   getSessions(range: DateRange): SessionEntry[];
   getByTicket(range?: DateRange): ByTicketEntry[];
+  getByEpic(epicTasks: EpicTask[], range?: DateRange): ByEpicEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +132,18 @@ export function createUsageEngine(
           })
         : entries;
       return aggregateByTicket(filtered, stackRoots, stepWeights, ephemeralRecords, taskPhaseWeights);
+    },
+
+    getByEpic(epicTasks: EpicTask[], range?: DateRange): ByEpicEntry[] {
+      const { entries } = loadCached(roots);
+      const filtered = range
+        ? entries.filter((e) => {
+            const date = e.timestamp.slice(0, 10);
+            return date >= range.since && date <= range.until;
+          })
+        : entries;
+      const byTicket = aggregateByTicket(filtered, stackRoots, stepWeights, ephemeralRecords, taskPhaseWeights);
+      return aggregateByEpic(byTicket, epicTasks);
     },
   };
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { ByTicketEntry } from '@main/telemetry/types';
+import type { ByTicketEntry, ByEpicEntry } from '@main/telemetry/types';
 
 export type ScheduleAction =
   | { kind: 'run-script'; scriptName: string };
@@ -291,6 +291,7 @@ export interface SandstormAPI {
     byModel: (range: { since: string; until: string }) => Promise<unknown[]>;
     session: (range: { since: string; until: string }) => Promise<unknown[]>;
     byTicket: (range?: { since: string; until: string }) => Promise<ByTicketEntry[]>;
+    byEpic: (range?: { since: string; until: string }) => Promise<ByEpicEntry[]>;
     refresh: () => Promise<{ ok: true }>;
   };
   on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
@@ -541,6 +542,7 @@ const api: SandstormAPI = {
     byModel: (range) => ipcRenderer.invoke('stats:telemetry:byModel', range),
     session: (range) => ipcRenderer.invoke('stats:telemetry:session', range),
     byTicket: (range) => ipcRenderer.invoke('stats:telemetry:byTicket', range),
+    byEpic: (range) => ipcRenderer.invoke('stats:telemetry:byEpic', range),
     refresh: () => ipcRenderer.invoke('stats:telemetry:refresh'),
   },
   on: (channel, callback) => {

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -81,6 +81,7 @@ const {
     getDb: vi.fn().mockReturnValue({}),
     getStepWeightsByTicket: vi.fn().mockReturnValue([]),
     getTaskPhaseTokensByTicket: vi.fn().mockReturnValue([]),
+    getAllEpicTasks: vi.fn().mockReturnValue([]),
     getGlobalBackendSettings: vi.fn().mockReturnValue({ inner_backend: 'claude', outer_backend: 'claude', inner_provider: null, inner_model: null, outer_provider: null, outer_model: null }),
     setGlobalBackendSettings: vi.fn(),
     getProjectBackendSettings: vi.fn().mockReturnValue(null),
@@ -196,6 +197,7 @@ const {
     getByModel: vi.fn(),
     getSessions: vi.fn(),
     getByTicket: vi.fn().mockReturnValue([]),
+    getByEpic: vi.fn().mockReturnValue([]),
   };
 
   const mockRollupStoreInstance = {
@@ -763,6 +765,26 @@ describe('IPC Handlers', () => {
       const result = await invokeHandler('stats:telemetry:byTicket');
 
       expect(mockUsageEngine.getByTicket).toHaveBeenCalledOnce();
+      expect(result).toEqual(entries);
+    });
+
+    it('stats:telemetry:byEpic delegates to usageEngine.getByEpic and returns the array', async () => {
+      const entries = [
+        {
+          epicId: 'EPIC-1',
+          cost: 5.0,
+          tokens: { input: 1000, output: 500, cacheCreate: 0, cacheRead: 0, total: 1500 },
+          build: { cost: 3.0, tokens: { input: 600, output: 300, cacheCreate: 0, cacheRead: 0, total: 900 } },
+          reconcile: { cost: 2.0, tokens: { input: 400, output: 200, cacheCreate: 0, cacheRead: 0, total: 600 } },
+          reconcileRework: { cost: 1.0, tokens: { input: 200, output: 100, cacheCreate: 0, cacheRead: 0, total: 300 } },
+          memberCount: 3,
+        },
+      ];
+      mockUsageEngine.getByEpic.mockReturnValueOnce(entries);
+
+      const result = await invokeHandler('stats:telemetry:byEpic');
+
+      expect(mockUsageEngine.getByEpic).toHaveBeenCalledOnce();
       expect(result).toEqual(entries);
     });
 
@@ -2760,6 +2782,7 @@ describe('IPC Handlers', () => {
       'stats:telemetry:byModel',
       'stats:telemetry:session',
       'stats:telemetry:byTicket',
+      'stats:telemetry:byEpic',
       'stats:telemetry:refresh',
     ];
 

--- a/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
@@ -135,7 +135,8 @@ describe('dispatchTask — reference resolution', () => {
     await manager.dispatchTask('ref-stack', prompt, undefined, { forceBypass: true });
 
     const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
-    const deliveredPrompt = cliArgs[cliArgs.length - 1];
+    const filePath = cliArgs[cliArgs.indexOf('--file') + 1];
+    const deliveredPrompt = fs.readFileSync(filePath, 'utf-8');
 
     expect(deliveredPrompt).toContain('## Resolved References');
     expect(deliveredPrompt).toContain('mockup content');
@@ -156,7 +157,8 @@ describe('dispatchTask — reference resolution', () => {
     await manager.dispatchTask('noref-stack', prompt, undefined, { forceBypass: true });
 
     const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
-    const deliveredPrompt = cliArgs[cliArgs.length - 1];
+    const filePath = cliArgs[cliArgs.indexOf('--file') + 1];
+    const deliveredPrompt = fs.readFileSync(filePath, 'utf-8');
 
     expect(deliveredPrompt).toBe(prompt);
     expect(deliveredPrompt).not.toContain('## Resolved References');
@@ -190,7 +192,8 @@ describe('dispatchTask — reference resolution', () => {
     await manager.dispatchTask('sep-stack', 'Build per spec at https://example.com/doc', undefined, { forceBypass: true });
 
     const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
-    const deliveredPrompt = cliArgs[cliArgs.length - 1];
+    const filePath = cliArgs[cliArgs.indexOf('--file') + 1];
+    const deliveredPrompt = fs.readFileSync(filePath, 'utf-8');
 
     expect(deliveredPrompt).toContain('\n\n---\n\n');
     expect(deliveredPrompt).toContain('## Resolved References');

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1976,3 +1976,86 @@ describe('Registry', () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// getAllEpicTasks / getAllEpicIds
+// ---------------------------------------------------------------------------
+
+describe('getAllEpicTasks and getAllEpicIds', () => {
+  let dbPath: string;
+  let registry: Registry;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  it('getAllEpicTasks returns empty array when no epic_tasks exist', () => {
+    expect(registry.getAllEpicTasks()).toEqual([]);
+  });
+
+  it('getAllEpicIds returns empty array when no epic_tasks exist', () => {
+    expect(registry.getAllEpicIds()).toEqual([]);
+  });
+
+  it('getAllEpicTasks returns all rows across all epics', () => {
+    registry.upsertEpicTask('EPIC-A', 'TICKET-1', { role: 'build', origin: 'planned' });
+    registry.upsertEpicTask('EPIC-A', 'TICKET-2', { role: 'reconcile', origin: 'gap' });
+    registry.upsertEpicTask('EPIC-B', 'TICKET-3', { role: 'build', origin: 'planned' });
+
+    const tasks = registry.getAllEpicTasks();
+    expect(tasks).toHaveLength(3);
+
+    const epicIds = tasks.map((t) => t.epic_id);
+    expect(epicIds).toContain('EPIC-A');
+    expect(epicIds).toContain('EPIC-B');
+
+    const ticket1 = tasks.find((t) => t.ticket_id === 'TICKET-1');
+    expect(ticket1?.role).toBe('build');
+    expect(ticket1?.origin).toBe('planned');
+
+    const ticket2 = tasks.find((t) => t.ticket_id === 'TICKET-2');
+    expect(ticket2?.role).toBe('reconcile');
+    expect(ticket2?.origin).toBe('gap');
+  });
+
+  it('getAllEpicTasks returns EpicTask shape with all fields', () => {
+    registry.upsertEpicTask('EPIC-1', 'TICKET-X', { role: 'build', origin: 'planned', critId: 'CRIT-99' });
+
+    const [task] = registry.getAllEpicTasks();
+    expect(typeof task.epic_id).toBe('string');
+    expect(typeof task.ticket_id).toBe('string');
+    expect(task.role).toBe('build');
+    expect(task.origin).toBe('planned');
+    expect(task.crit_id).toBe('CRIT-99');
+    expect(typeof task.gap_cycles).toBe('number');
+    expect(typeof task.done).toBe('number');
+  });
+
+  it('getAllEpicIds returns distinct epic IDs in order', () => {
+    registry.upsertEpicTask('EPIC-Z', 'TICKET-1', { role: 'build', origin: 'planned' });
+    registry.upsertEpicTask('EPIC-A', 'TICKET-2', { role: 'build', origin: 'planned' });
+    registry.upsertEpicTask('EPIC-Z', 'TICKET-3', { role: 'reconcile', origin: 'gap' });
+
+    const ids = registry.getAllEpicIds();
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain('EPIC-A');
+    expect(ids).toContain('EPIC-Z');
+    // Should be sorted
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  it('getAllEpicIds returns each epic_id once even with multiple tickets', () => {
+    registry.upsertEpicTask('EPIC-1', 'T-A', { role: 'build', origin: 'planned' });
+    registry.upsertEpicTask('EPIC-1', 'T-B', { role: 'reconcile', origin: 'gap' });
+    registry.upsertEpicTask('EPIC-1', 'T-C', { role: 'build', origin: 'planned' });
+
+    const ids = registry.getAllEpicIds();
+    expect(ids).toEqual(['EPIC-1']);
+  });
+});

--- a/tests/unit/telemetry/aggregate-by-epic.test.ts
+++ b/tests/unit/telemetry/aggregate-by-epic.test.ts
@@ -1,0 +1,204 @@
+/**
+ * aggregate-by-epic.test.ts — unit tests for aggregateByEpic
+ *
+ * aggregateByEpic is electron-free: it accepts pre-computed ByTicketEntry[]
+ * and EpicTask[] injected arrays, so no filesystem or SQLite setup is needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { aggregateByEpic } from '../../../src/main/telemetry/aggregator';
+import type { ByTicketEntry } from '../../../src/main/telemetry/types';
+import type { EpicTask } from '../../../src/main/control-plane/registry';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTicket(ticketId: string, cost: number, tokens?: Partial<ByTicketEntry['tokens']>): ByTicketEntry {
+  return {
+    ticketId,
+    model: 'claude-sonnet-4-5',
+    cost,
+    tokens: {
+      input: tokens?.input ?? 100,
+      output: tokens?.output ?? 50,
+      cacheCreate: tokens?.cacheCreate ?? 0,
+      cacheRead: tokens?.cacheRead ?? 0,
+      total: tokens?.total ?? 150,
+    },
+    cacheHit: 0,
+    lifecycle: null,
+    unpriced: false,
+  };
+}
+
+function makeTask(
+  epic_id: string,
+  ticket_id: string,
+  role: 'build' | 'reconcile',
+  origin: 'planned' | 'gap' = 'planned',
+): EpicTask {
+  return { epic_id, ticket_id, role, origin, crit_id: null, gap_cycles: 0, done: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('aggregateByEpic', () => {
+  it('returns empty array when epicTasks is empty', () => {
+    const byTicket = [makeTicket('TICKET-1', 1.0)];
+    expect(aggregateByEpic(byTicket, [])).toEqual([]);
+  });
+
+  it('produces zero-cost entry per epic when byTicket is empty', () => {
+    const epicTasks = [makeTask('EPIC-1', 'TICKET-1', 'build')];
+    const result = aggregateByEpic([], epicTasks);
+    expect(result).toHaveLength(1);
+    expect(result[0].epicId).toBe('EPIC-1');
+    expect(result[0].cost).toBe(0);
+    expect(result[0].memberCount).toBe(0);
+  });
+
+  it('sums cost and tokens from member tickets', () => {
+    const byTicket = [
+      makeTicket('TICKET-A', 1.0, { input: 100, output: 50, cacheCreate: 0, cacheRead: 0, total: 150 }),
+      makeTicket('TICKET-B', 2.0, { input: 200, output: 100, cacheCreate: 0, cacheRead: 0, total: 300 }),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-1', 'TICKET-A', 'build'),
+      makeTask('EPIC-1', 'TICKET-B', 'build'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(epic.epicId).toBe('EPIC-1');
+    expect(epic.cost).toBe(3.0);
+    expect(epic.tokens.input).toBe(300);
+    expect(epic.tokens.output).toBe(150);
+    expect(epic.tokens.total).toBe(450);
+    expect(epic.memberCount).toBe(2);
+  });
+
+  it('partitions cost into build vs reconcile by role', () => {
+    const byTicket = [
+      makeTicket('T-BUILD', 2.0),
+      makeTicket('T-RECONCILE', 1.0),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-1', 'T-BUILD', 'build'),
+      makeTask('EPIC-1', 'T-RECONCILE', 'reconcile'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(epic.build.cost).toBe(2.0);
+    expect(epic.reconcile.cost).toBe(1.0);
+    expect(epic.cost).toBe(3.0);
+  });
+
+  it('reconcileRework is overlay of gap tickets regardless of role', () => {
+    const byTicket = [
+      makeTicket('T-PLANNED-BUILD', 1.0),
+      makeTicket('T-GAP-BUILD', 2.0),
+      makeTicket('T-GAP-RECONCILE', 0.5),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-1', 'T-PLANNED-BUILD', 'build', 'planned'),
+      makeTask('EPIC-1', 'T-GAP-BUILD', 'build', 'gap'),
+      makeTask('EPIC-1', 'T-GAP-RECONCILE', 'reconcile', 'gap'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(epic.reconcileRework.cost).toBeCloseTo(2.5);  // gap tickets only
+    expect(epic.build.cost).toBeCloseTo(3.0);  // planned + gap build
+    expect(epic.reconcile.cost).toBeCloseTo(0.5);  // gap reconcile
+  });
+
+  it('reconcileRework cost is <= build.cost + reconcile.cost (overlay invariant)', () => {
+    const byTicket = [
+      makeTicket('T1', 1.0),
+      makeTicket('T2', 2.0),
+      makeTicket('T3', 0.5),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-1', 'T1', 'build', 'gap'),
+      makeTask('EPIC-1', 'T2', 'reconcile', 'gap'),
+      makeTask('EPIC-1', 'T3', 'build', 'planned'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(epic.reconcileRework.cost).toBeLessThanOrEqual(epic.build.cost + epic.reconcile.cost);
+  });
+
+  it('excludes ORCHESTRATOR_TICKET_ID from rollups', () => {
+    const byTicket = [
+      makeTicket('__orchestrator__', 99.0),
+      makeTicket('TICKET-REAL', 1.0),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-1', '__orchestrator__', 'build'),
+      makeTask('EPIC-1', 'TICKET-REAL', 'build'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    // orchestrator is excluded even if listed in epic_tasks
+    expect(epic.cost).toBe(1.0);
+    expect(epic.memberCount).toBe(1);
+  });
+
+  it('produces one entry per distinct epic_id', () => {
+    const byTicket = [
+      makeTicket('TA', 1.0),
+      makeTicket('TB', 2.0),
+      makeTicket('TC', 3.0),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-A', 'TA', 'build'),
+      makeTask('EPIC-B', 'TB', 'build'),
+      makeTask('EPIC-B', 'TC', 'reconcile'),
+    ];
+    const result = aggregateByEpic(byTicket, epicTasks);
+    expect(result).toHaveLength(2);
+    const epicA = result.find((e) => e.epicId === 'EPIC-A')!;
+    const epicB = result.find((e) => e.epicId === 'EPIC-B')!;
+    expect(epicA.cost).toBe(1.0);
+    expect(epicB.cost).toBe(5.0);
+  });
+
+  it('tickets not in byTicket do not contribute to cost (member still counted as 0 spend)', () => {
+    const byTicket = [makeTicket('TICKET-A', 5.0)];
+    const epicTasks = [
+      makeTask('EPIC-1', 'TICKET-A', 'build'),
+      makeTask('EPIC-1', 'TICKET-MISSING', 'build'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(epic.cost).toBe(5.0);
+    // TICKET-MISSING has no entry so memberCount only includes tickets with data
+    expect(epic.memberCount).toBe(1);
+  });
+
+  it('ByEpicEntry has the correct shape', () => {
+    const byTicket = [makeTicket('T1', 1.0)];
+    const epicTasks = [makeTask('EPIC-1', 'T1', 'build')];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(typeof epic.epicId).toBe('string');
+    expect(typeof epic.cost).toBe('number');
+    expect(typeof epic.memberCount).toBe('number');
+    expect(Object.keys(epic.tokens).sort()).toEqual(['cacheCreate', 'cacheRead', 'input', 'output', 'total'].sort());
+    expect(Object.keys(epic.build).sort()).toEqual(['cost', 'tokens'].sort());
+    expect(Object.keys(epic.reconcile).sort()).toEqual(['cost', 'tokens'].sort());
+    expect(Object.keys(epic.reconcileRework).sort()).toEqual(['cost', 'tokens'].sort());
+  });
+
+  it('reconcileRework tokens match the gap ticket tokens', () => {
+    const gapTokens = { input: 80, output: 40, cacheCreate: 10, cacheRead: 5, total: 135 };
+    const byTicket = [
+      makeTicket('T-GAP', 1.5, gapTokens),
+      makeTicket('T-PLANNED', 0.5),
+    ];
+    const epicTasks = [
+      makeTask('EPIC-1', 'T-GAP', 'reconcile', 'gap'),
+      makeTask('EPIC-1', 'T-PLANNED', 'reconcile', 'planned'),
+    ];
+    const [epic] = aggregateByEpic(byTicket, epicTasks);
+    expect(epic.reconcileRework.tokens.input).toBe(80);
+    expect(epic.reconcileRework.tokens.output).toBe(40);
+    expect(epic.reconcileRework.tokens.cacheCreate).toBe(10);
+    expect(epic.reconcileRework.tokens.cacheRead).toBe(5);
+    expect(epic.reconcileRework.tokens.total).toBe(135);
+  });
+});

--- a/tests/unit/telemetry/lifecycle-split.test.ts
+++ b/tests/unit/telemetry/lifecycle-split.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { computeLifecycleSplit, LIFECYCLE_STAGES } from '../../../src/main/telemetry/lifecycle-split';
+import type { LifecycleCosts } from '../../../src/main/telemetry/types';
 
-const STAGES = LIFECYCLE_STAGES;
+// LIFECYCLE_STAGES includes 'reconcile' (7 items) — used by aggregateByEpic role bucketing.
+// computeLifecycleSplit returns LifecycleCosts (6 keys), which excludes 'reconcile' because
+// reconcile has no per-ticket weight producer; it is sourced at the epic level.
+const LC_KEYS: (keyof LifecycleCosts)[] = ['refine', 'spec', 'execution', 'review', 'verify', 'pr'];
 
 describe('computeLifecycleSplit', () => {
   // --- Sum invariant ---
@@ -9,7 +13,7 @@ describe('computeLifecycleSplit', () => {
   it('sum invariant: all stage values sum to cost exactly', () => {
     const result = computeLifecycleSplit(10.5, { execution: 3, review: 1 });
     expect(result).not.toBeNull();
-    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    const sum = LC_KEYS.reduce((s, stage) => s + result![stage], 0);
     expect(Math.abs(sum - 10.5)).toBeLessThan(1e-10);
   });
 
@@ -17,7 +21,7 @@ describe('computeLifecycleSplit', () => {
     const cost = 0.001234;
     const result = computeLifecycleSplit(cost, { refine: 2, spec: 3, execution: 7, review: 5, pr: 1 });
     expect(result).not.toBeNull();
-    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    const sum = LC_KEYS.reduce((s, stage) => s + result![stage], 0);
     expect(Math.abs(sum - cost)).toBeLessThan(1e-10);
   });
 
@@ -25,16 +29,16 @@ describe('computeLifecycleSplit', () => {
     const cost = 7.77;
     const result = computeLifecycleSplit(cost, { execution: 100 });
     expect(result).not.toBeNull();
-    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    const sum = LC_KEYS.reduce((s, stage) => s + result![stage], 0);
     expect(Math.abs(sum - cost)).toBeLessThan(1e-10);
   });
 
-  // --- Six keys always present ---
+  // --- Six LifecycleCosts keys always present (reconcile excluded from return) ---
 
   it('six keys always present: only execution+review weights given', () => {
     const result = computeLifecycleSplit(5.0, { execution: 3, review: 1 });
     expect(result).not.toBeNull();
-    expect(Object.keys(result!).sort()).toEqual(STAGES.slice().sort());
+    expect(Object.keys(result!).sort()).toEqual(LC_KEYS.slice().sort());
     expect(result!.refine).toBe(0);
     expect(result!.spec).toBe(0);
     expect(result!.verify).toBe(0);
@@ -44,7 +48,12 @@ describe('computeLifecycleSplit', () => {
   it('six keys always present: all stages have weights', () => {
     const result = computeLifecycleSplit(1.0, { refine: 1, spec: 1, execution: 1, review: 1, pr: 1 });
     expect(result).not.toBeNull();
-    expect(Object.keys(result!).sort()).toEqual(STAGES.slice().sort());
+    expect(Object.keys(result!).sort()).toEqual(LC_KEYS.slice().sort());
+  });
+
+  it('LIFECYCLE_STAGES includes reconcile for epic-level role bucketing', () => {
+    expect(LIFECYCLE_STAGES).toContain('reconcile');
+    expect(LIFECYCLE_STAGES.length).toBe(7);
   });
 
   // --- Skipped stage → 0 ---
@@ -82,7 +91,7 @@ describe('computeLifecycleSplit', () => {
   it('zero cost returns all-zero object', () => {
     const result = computeLifecycleSplit(0, { execution: 10, review: 5 });
     expect(result).not.toBeNull();
-    for (const stage of STAGES) {
+    for (const stage of LC_KEYS) {
       expect(result![stage]).toBe(0);
     }
   });
@@ -90,7 +99,7 @@ describe('computeLifecycleSplit', () => {
   it('zero cost with no weights returns all-zero object', () => {
     const result = computeLifecycleSplit(0, {});
     expect(result).not.toBeNull();
-    for (const stage of STAGES) {
+    for (const stage of LC_KEYS) {
       expect(result![stage]).toBe(0);
     }
   });
@@ -136,7 +145,7 @@ describe('computeLifecycleSplit', () => {
     const cost = 1.0 / 3.0; // 0.333...
     const result = computeLifecycleSplit(cost, { execution: 1 });
     expect(result).not.toBeNull();
-    const sum = STAGES.reduce((s, stage) => s + result![stage], 0);
+    const sum = LC_KEYS.reduce((s, stage) => s + result![stage], 0);
     expect(Math.abs(sum - cost)).toBeLessThan(1e-10);
     expect(result!.execution).toBeCloseTo(cost, 10);
   });


### PR DESCRIPTION
## Summary

Adds a per-epic cost dimension to telemetry. Per-ticket attribution is now rolled up into per-epic totals by joining ticket spend with `epic_tasks` membership, exposed through a new `stats:telemetry:byEpic` IPC channel and preload binding.

Each epic rollup partitions total cost and tokens into `build` and `reconcile` buckets by `epic_tasks.role`, plus a `reconcileRework` overlay covering `origin='gap'` tickets (these still count in their role bucket, so the invariant `reconcileRework.cost <= build.cost + reconcile.cost` holds). The orchestrator ticket is excluded from all rollups, and `memberCount` reflects only tickets that actually have spend.

Supporting changes:
- Registry gains `getAllEpicTasks()` and `getAllEpicIds()` read-only accessors over the existing `epic_tasks` table.
- A `reconcile` lifecycle stage is registered; it has no per-ticket producer yet, so `computeLifecycleSplit` keeps returning the six existing per-ticket keys and reconcile is sourced from `epic_tasks.role` at the epic level.
- Refine spec-check now passes the `refine` touchpoint role to the agent backend instead of resolving the model inline, removing the obsolete `resolveRefineModel` helper.

## QA plan

1. Open the app with a project that has epics recorded in `epic_tasks`.
2. From the telemetry/stats view (or via the `byEpic` API), request the per-epic breakdown and confirm each epic shows total, build, reconcile, and reconcileRework figures.
3. Verify build + reconcile cost equals the epic total, and reconcileRework never exceeds build + reconcile.
4. Confirm the orchestrator ticket does not appear in any epic rollup and `memberCount` matches the number of member tickets that have spend.
5. Trigger a scheduled refine/spec-check and confirm it still runs with the expected model routing.

Closes #616