### PR TITLE
[657] fix: consolidate E2BIG prompt handling into runCli

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -399,14 +399,6 @@ function getRefineDescriptor(projectDir: string) {
   return registry.getEffectiveTouchpointDescriptor(projectDir, 'refine');
 }
 
-function resolveRefineModel(projectDir: string): string | undefined {
-  const routing = registry.getEffectiveRoutingFor(projectDir, 'refine');
-  if (routing.backend === 'opencode') {
-    console.warn('[refine] backend=opencode unsupported for host path; falling back to legacy outer model');
-    return registry.getLegacyEffectiveModels(projectDir).outer_model;
-  }
-  return routing.model;
-}
 
 async function handleSpecCheck(
   ticketId: string,
@@ -425,7 +417,7 @@ async function handleSpecCheck(
   const references = await resolveTicketReferences(ctx.ticketBody);
   const referencesSection = renderResolvedReferences(references);
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody, referencesSection || undefined, ctx.epicContext);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
+  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, undefined, 'refine');
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -685,7 +677,7 @@ export function spawnSpecCheck(
     const references = await resolveTicketReferences(res.ctx.ticketBody);
     const referencesSection = renderResolvedReferences(references);
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody, referencesSection || undefined, res.ctx.epicContext);
-    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, resolveRefineModel(projectDir));
+    const { promise: ep, cancel: epCancel } = agentBackend.spawnEphemeralAgent(prompt, projectDir, 0, onChunk, { ticketId, stage: 'spec' }, undefined, 'refine');
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -302,67 +302,60 @@ export class StackManager {
 
   /**
    * Run a sandstorm CLI command in the given project directory.
+   *
+   * E2BIG protection: Linux's per-argument limit (MAX_ARG_STRLEN) is 128 KB.
+   * If the last positional arg (typically a large dispatch prompt) exceeds
+   * 64 KB, it is written to a temp file and passed as `--file <path>` instead,
+   * so spawn never receives an oversized argument. Callers always pass the
+   * prompt as the last positional arg; this method handles the substitution
+   * transparently, keeping the spy-visible arg list clean for tests.
    */
-  runCli(
+  async runCli(
     projectDir: string,
     args: string[],
     env?: Record<string, string>
   ): Promise<CliResult> {
-    return new Promise((resolve, reject) => {
-      const child = spawn('bash', [this.getCliBin(), ...args], {
-        cwd: projectDir,
-        env: {
-          ...process.env,
-          ...env,
-          PATH: [
-            `${process.env.HOME}/.local/bin`,
-            '/opt/homebrew/bin',
-            '/usr/local/bin',
-            '/usr/local/sbin',
-            process.env.PATH,
-          ].join(':'),
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
+    const MAX_ARG_BYTES = 64 * 1024;
+    let spawnArgs = args;
+    let tmpDir: string | undefined;
 
-      let stdout = '';
-      let stderr = '';
-      child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
-      child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
-      child.on('close', (code) =>
-        resolve({ stdout, stderr, exitCode: code ?? 1 })
-      );
-      child.on('error', reject);
-    });
-  }
-
-  /**
-   * Run a CLI `task` dispatch, passing the prompt via a temp `--file` rather
-   * than as a positional CLI argument.
-   *
-   * A dispatch prompt is the ticket body plus up to ~1 MB of inlined external
-   * references (see resolveTicketReferences). Passed as a single argv entry it
-   * overflows Linux's per-argument limit (MAX_ARG_STRLEN = 128 KB) and makes
-   * `spawn` throw `E2BIG` on the host before the CLI even runs. The CLI's
-   * `task` command already accepts `--file <path>` and reads the prompt from
-   * it, so route large prompts through a temp file. No size limit applies to
-   * file contents.
-   *
-   * `cliArgs` must contain every flag EXCEPT the positional prompt; the prompt
-   * is appended as `--file <tmp>`.
-   */
-  private async runCliTaskFile(
-    projectDir: string,
-    cliArgs: string[],
-    prompt: string
-  ): Promise<CliResult> {
-    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sandstorm-task-'));
-    const tmpFile = path.join(tmpDir, 'prompt.txt');
-    await fs.promises.writeFile(tmpFile, prompt, 'utf-8');
     try {
-      return await this.runCli(projectDir, [...cliArgs, '--file', tmpFile]);
+      const lastArg = args[args.length - 1];
+      if (lastArg && !lastArg.startsWith('-') && Buffer.byteLength(lastArg, 'utf8') > MAX_ARG_BYTES) {
+        tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sandstorm-task-'));
+        const tmpFile = path.join(tmpDir, 'prompt.txt');
+        await fs.promises.writeFile(tmpFile, lastArg, 'utf-8');
+        spawnArgs = [...args.slice(0, -1), '--file', tmpFile];
+      }
+
+      return await new Promise<CliResult>((resolve, reject) => {
+        const child = spawn('bash', [this.getCliBin(), ...spawnArgs], {
+          cwd: projectDir,
+          env: {
+            ...process.env,
+            ...env,
+            PATH: [
+              `${process.env.HOME}/.local/bin`,
+              '/opt/homebrew/bin',
+              '/usr/local/bin',
+              '/usr/local/sbin',
+              process.env.PATH,
+            ].join(':'),
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
+        child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+        child.on('close', (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+        child.on('error', reject);
+      });
     } finally {
-      fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      if (tmpDir) {
+        fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      }
     }
   }
 
@@ -786,8 +779,9 @@ export class StackManager {
 
     const cliArgs = ['task', stackId, '--resume', task.session_id!];
     if (task.model) cliArgs.push('--model', task.model);
+    cliArgs.push(continuationPrompt);
 
-    const result = await this.runCliTaskFile(stack.project_dir, cliArgs, continuationPrompt);
+    const result = await this.runCli(stack.project_dir, cliArgs);
     if (result.exitCode !== 0) {
       this.registry.updateStackStatus(stackId, 'session_paused');
       this.notifyUpdate();
@@ -829,8 +823,9 @@ export class StackManager {
 
     const cliArgs = ['task', stackId, '--resume', task.session_id!];
     if (task.model) cliArgs.push('--model', task.model);
+    cliArgs.push(investigationPrompt);
 
-    const result = await this.runCliTaskFile(stack.project_dir, cliArgs, investigationPrompt);
+    const result = await this.runCli(stack.project_dir, cliArgs);
     if (result.exitCode !== 0) {
       this.registry.updateStackStatus(stackId, 'needs_human');
       this.notifyUpdate();
@@ -1318,8 +1313,9 @@ export class StackManager {
       if (model) cliArgs.push('--model', model);
       cliArgs.push('--models-json', phaseModelsJson);
       cliArgs.push('--phase-routing-json', phaseRoutingJson);
+      cliArgs.push(prompt);
 
-      const result = await this.runCliTaskFile(stack.project_dir, cliArgs, prompt);
+      const result = await this.runCli(stack.project_dir, cliArgs);
 
       if (result.exitCode !== 0) {
         throw new SandstormError(

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -427,14 +427,13 @@ describe('StackManager', () => {
       expect(callArgs).toContain('--model');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      // Prompt is passed via --file (temp file), NOT as a positional argv entry,
-      // so large prompts can't overflow MAX_ARG_STRLEN and throw spawn E2BIG.
-      expect(callArgs).toContain('--file');
-      expect(callArgs).not.toContain('Fix the bug');
-      expect(callArgs[callArgs.length - 1]).toMatch(/prompt\.txt$/);
+      // Prompt is the last positional arg; runCli handles E2BIG protection
+      // internally (writes to temp file) when the prompt exceeds 64 KB.
+      expect(callArgs).not.toContain('--file');
+      expect(callArgs[callArgs.length - 1]).toBe('Fix the bug');
     });
 
-    it('regression (E2BIG): a >128KB prompt never reaches argv', async () => {
+    it('regression (E2BIG): a >128KB prompt is passed to runCli as the last positional arg', async () => {
       registry.createStack(makeStack('huge-prompt'));
       const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
         stdout: 'Task dispatched.',
@@ -448,11 +447,12 @@ describe('StackManager', () => {
       await manager.dispatchTask('huge-prompt', hugePrompt);
 
       const [, callArgs] = runCliSpy.mock.calls[0];
-      // No single argv entry approaches the 128KB ceiling, and the prompt
-      // content is absent from argv entirely — it goes through --file.
-      expect(callArgs.every((a) => a.length < 128 * 1024)).toBe(true);
-      expect(callArgs.some((a) => a.includes(hugePrompt))).toBe(false);
-      expect(callArgs).toContain('--file');
+      // dispatchTask passes the prompt as the last positional arg to runCli.
+      // runCli handles E2BIG protection internally: if the last arg exceeds
+      // 64 KB it writes to a temp file and substitutes --file <path> before
+      // spawning — so spawn never sees a large argv entry.
+      expect(callArgs[callArgs.length - 1]).toBe(hugePrompt);
+      expect(callArgs).not.toContain('--file');
       // The full prompt is still persisted to the registry intact.
       const persisted = registry.getTasksForStack('huge-prompt');
       expect(persisted[0].prompt).toBe(hugePrompt);
@@ -506,8 +506,8 @@ describe('StackManager', () => {
       expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('opus');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).toContain('--file');
-      expect(callArgs).not.toContain('Complex task');
+      expect(callArgs).not.toContain('--file');
+      expect(callArgs[callArgs.length - 1]).toBe('Complex task');
     });
 
     it('resolves "auto" model to undefined and omits from CLI args', async () => {
@@ -528,8 +528,8 @@ describe('StackManager', () => {
       expect(callArgs).not.toContain('--model');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).toContain('--file');
-      expect(callArgs).not.toContain('Simple task');
+      expect(callArgs).not.toContain('--file');
+      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
     });
 
     it('uses effective default model when not provided', async () => {
@@ -552,8 +552,8 @@ describe('StackManager', () => {
       expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('sonnet');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).toContain('--file');
-      expect(callArgs).not.toContain('Simple task');
+      expect(callArgs).not.toContain('--file');
+      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
     });
 
     it('includes per-phase model map in CLI args', async () => {
@@ -2391,6 +2391,59 @@ describe('StackManager', () => {
       expect(dockerRt.exec).toHaveBeenCalled();
       expect(podmanRt.exec).not.toHaveBeenCalled();
       expect(podmanRt.listContainers).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runCli E2BIG protection', () => {
+    // Tests for the internal arg-substitution logic in runCli.
+    // We use a real bash script as the fake CLI so we can inspect exactly what
+    // argv entries spawn receives — no mocking of runCli or spawn is needed.
+    let cliDir: string;
+    let testManager: StackManager;
+
+    beforeEach(async () => {
+      cliDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sandstorm-cli-test-'));
+      const binDir = path.join(cliDir, 'bin');
+      await fs.promises.mkdir(binDir);
+      // Script prints each positional arg on its own line so the test can parse them.
+      const script = '#!/bin/bash\nfor arg in "$@"; do\n  printf "%s\\n" "$arg"\ndone\n';
+      await fs.promises.writeFile(path.join(binDir, 'sandstorm'), script, { mode: 0o755 });
+
+      testManager = new StackManager(
+        registry, portAllocator, taskWatcher, runtime, runtime, cliDir
+      );
+    });
+
+    afterEach(async () => {
+      await fs.promises.rm(cliDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    it('substitutes --file <path> when the last positional arg exceeds 64 KB', async () => {
+      const largeArg = 'x'.repeat(65 * 1024); // 65,536 bytes — above the 64 KB threshold
+      const result = await testManager.runCli('/tmp', ['task', 'stack-1', largeArg]);
+
+      const printedArgs = result.stdout.trim().split('\n').filter(Boolean);
+
+      // The raw large arg must NOT be passed to spawn — it was written to a temp file
+      expect(printedArgs).not.toContain(largeArg);
+      // The --file substitution flag must be present
+      expect(printedArgs).toContain('--file');
+      const fileIdx = printedArgs.indexOf('--file');
+      const tmpFilePath = printedArgs[fileIdx + 1];
+      // The substituted path must point to a sandstorm temp file containing the prompt
+      expect(tmpFilePath).toMatch(/sandstorm-task-/);
+      expect(tmpFilePath).toMatch(/prompt\.txt$/);
+    });
+
+    it('passes a small last positional arg directly to spawn without --file substitution', async () => {
+      const smallArg = 'Fix the bug in auth module';
+      const result = await testManager.runCli('/tmp', ['task', 'stack-1', smallArg]);
+
+      const printedArgs = result.stdout.trim().split('\n').filter(Boolean);
+
+      // Small arg passes through verbatim; no --file flag is injected
+      expect(printedArgs[printedArgs.length - 1]).toBe(smallArg);
+      expect(printedArgs).not.toContain('--file');
     });
   });
 


### PR DESCRIPTION
## Summary

Large dispatch prompts (ticket body plus up to ~1 MB of inlined references) overflow Linux's per-argument limit (MAX_ARG_STRLEN = 128 KB) and make `spawn` throw `E2BIG` before the CLI runs. This was previously handled by a separate `runCliTaskFile` helper that callers had to remember to use, and whose temp-dir setup ran outside its `try` block — so a failing `writeFile` (disk full, permissions) leaked the temp directory because the `finally` cleanup was never reached.

The E2BIG protection now lives inside `runCli` itself. Callers pass the prompt as the last positional arg; `runCli` transparently writes it to a temp `--file <path>` when it exceeds 64 KB, and the temp-dir creation, write, and spawn all run inside a single `try` so the `finally` always cleans up regardless of where a failure occurs. The dispatch, continuation, and investigation call sites are simplified to plain `runCli` calls, and `runCliTaskFile` is removed.

Separately, `tools.ts` drops the host-side `resolveRefineModel` helper and instead passes the `refine` stage name through to the agent backend, letting the backend resolve routing/model rather than duplicating that logic (including the opencode fallback) on the host.

## QA plan

- Dispatch a task with a small prompt and confirm it reaches the inner agent normally (prompt passed directly as an argv entry, no temp file).
- Dispatch a task with a very large prompt (>128 KB, e.g. a ticket with large inlined references) and confirm it dispatches without an `E2BIG` error and the inner agent receives the full prompt.
- After a large-prompt dispatch, confirm no `sandstorm-task-*` directories are left behind in the OS temp dir.
- Exercise the resume/continuation and investigation paths with large prompts and confirm they behave the same.
- Run a refine/spec-check on a ticket and confirm the correct model/backend is used.

Closes #657