### PR TITLE
[658] fix: reconcile stale terminal stack status from container

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { Registry, Stack, StackHistoryRecord, Task, TokenUsage } from './registry';
+import { Registry, Stack, StackHistoryRecord, StackStatus, Task, TokenUsage } from './registry';
 import { PortAllocator, ServicePort } from './port-allocator';
 import { PortProxy } from './port-proxy';
 import { TaskWatcher, WorkflowProgressData } from './task-watcher';
@@ -945,6 +945,158 @@ export class StackManager {
   }
 
   /**
+   * Reconcile a stale terminal stack status by reading the container's
+   * authoritative /tmp/claude-task.status file and driving the registry to match.
+   * Mirrors the status→registry mapping in task-watcher.ts exactly.
+   * Guards against overwriting session_paused or rate_limited stacks.
+   */
+  async reconcileStatus(stackId: string): Promise<{
+    outcome: 'reconciled' | 'container_gone' | 'guarded';
+    status?: StackStatus;
+  }> {
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
+
+    if (stack.status === 'session_paused' || stack.status === 'rate_limited') {
+      return { outcome: 'guarded' };
+    }
+
+    const runtime = this.getRuntimeForStack(stack);
+    const composeProjectName = composeProjectNameFor(stack.project, stack.id);
+
+    let containers;
+    try {
+      containers = await runtime.listContainers({ name: `${composeProjectName}-claude` });
+    } catch (err) {
+      console.debug(`[StackManager] reconcileStatus: container list failed for ${stackId}:`, err);
+      return { outcome: 'container_gone' };
+    }
+
+    const container = containers[0] ?? null;
+    if (!container || container.status !== 'running') {
+      console.debug(`[StackManager] reconcileStatus: container absent or not running for ${stackId}`);
+      return { outcome: 'container_gone' };
+    }
+
+    let containerStatus: string;
+    try {
+      const result = await runtime.exec(container.id, ['cat', '/tmp/claude-task.status']);
+      containerStatus = result.stdout.trim();
+    } catch {
+      return { outcome: 'container_gone' };
+    }
+
+    const task = this.registry.getMostRecentTask(stackId);
+
+    if (containerStatus === 'running') {
+      this.registry.updateStackStatus(stackId, 'running');
+      if (task) this.registry.reopenTaskForResume(task.id);
+      this.taskWatcher.watch(stackId, container.id);
+      this.notifyUpdate();
+      return { outcome: 'reconciled', status: 'running' };
+    }
+
+    if (containerStatus === 'token_limited') {
+      this.registry.updateStackStatus(stackId, 'session_paused');
+      this.notifyUpdate();
+      return { outcome: 'reconciled', status: 'session_paused' };
+    }
+
+    if (containerStatus === 'needs_human' || containerStatus === 'unknown') {
+      let stopReason = containerStatus === 'unknown'
+        ? 'Investigation returned unknown state — needs human review'
+        : 'Agent signaled STOP_AND_ASK — needs human intervention';
+      let questionsJson: string | null = null;
+
+      if (containerStatus === 'needs_human') {
+        try {
+          const reasonResult = await runtime.exec(container.id, ['cat', '/tmp/claude-stop-reason.txt']);
+          if (reasonResult.stdout.trim()) stopReason = reasonResult.stdout.trim();
+        } catch { /* best effort */ }
+        try {
+          const questionsResult = await runtime.exec(container.id, ['cat', '/tmp/claude-stop-questions.json']);
+          if (questionsResult.stdout.trim()) {
+            const parsed = JSON.parse(questionsResult.stdout.trim());
+            if (Array.isArray(parsed) && parsed.every(
+              (q: unknown) => q && typeof q === 'object' &&
+                typeof (q as Record<string, unknown>).id === 'string' &&
+                typeof (q as Record<string, unknown>).question === 'string'
+            )) {
+              questionsJson = questionsResult.stdout.trim();
+            }
+          }
+        } catch { /* best effort — malformed/absent JSON falls back to null */ }
+      }
+
+      if (task) {
+        this.registry.completeTaskNeedsHuman(task.id, stopReason, questionsJson);
+      } else {
+        this.registry.updateStackStatus(stackId, 'needs_human');
+      }
+      this.notifyUpdate();
+      return { outcome: 'reconciled', status: 'needs_human' };
+    }
+
+    if (containerStatus === 'needs_key') {
+      let keyReason = 'A phase provider has no credentials configured — add credentials in provider settings';
+      try {
+        const reasonResult = await runtime.exec(container.id, ['cat', '/tmp/claude-task-needs-key.txt']);
+        if (reasonResult.stdout.trim()) keyReason = reasonResult.stdout.trim();
+      } catch { /* best effort */ }
+
+      if (task) {
+        this.registry.completeTaskNeedsKey(task.id, keyReason);
+      } else {
+        this.registry.updateStackStatus(stackId, 'needs_key');
+      }
+      this.notifyUpdate();
+      return { outcome: 'reconciled', status: 'needs_key' };
+    }
+
+    if (containerStatus === 'verify_blocked_environmental') {
+      let envReason = 'Verify failed repeatedly — likely an environmental issue (missing binary, missing service, etc.)';
+      try {
+        const envResult = await runtime.exec(container.id, ['cat', '/tmp/claude-verify-environmental.txt']);
+        if (envResult.stdout.trim()) envReason = `Verify blocked (environmental): ${envResult.stdout.trim()}`;
+      } catch { /* best effort */ }
+
+      if (task) {
+        this.registry.completeTaskVerifyBlockedEnvironmental(task.id, envReason);
+      } else {
+        this.registry.updateStackStatus(stackId, 'verify_blocked_environmental');
+      }
+      this.notifyUpdate();
+      return { outcome: 'reconciled', status: 'verify_blocked_environmental' };
+    }
+
+    if (containerStatus === 'completed' || containerStatus === 'failed') {
+      let exitCode = containerStatus === 'completed' ? 0 : 1;
+      try {
+        const exitResult = await runtime.exec(container.id, ['cat', '/tmp/claude-task.exit']);
+        const parsed = parseInt(exitResult.stdout.trim(), 10);
+        if (!isNaN(parsed)) exitCode = parsed;
+      } catch { /* best effort */ }
+
+      if (task) {
+        this.registry.completeTask(task.id, exitCode);
+      } else {
+        this.registry.updateStackStatus(stackId, containerStatus as 'completed' | 'failed');
+      }
+      this.notifyUpdate();
+      return { outcome: 'reconciled', status: containerStatus as 'completed' | 'failed' };
+    }
+
+    // Unrecognized status — surface to user as needs_human
+    if (task) {
+      this.registry.completeTaskNeedsHuman(task.id, `Unrecognized container status: ${containerStatus}`);
+    } else {
+      this.registry.updateStackStatus(stackId, 'needs_human');
+    }
+    this.notifyUpdate();
+    return { outcome: 'reconciled', status: 'needs_human' };
+  }
+
+  /**
    * Resume a needs_human stack by providing answers to the agent's questions.
    * Uses --resume <session_id> if available; falls back to fresh dispatch if not.
    */
@@ -1272,6 +1424,7 @@ export class StackManager {
     const task = this.registry.createTask(stackId, prompt, model);
 
     const runtime = this.getRuntimeForStack(stack);
+    let promptTmpDir: string | undefined;
 
     try {
       let claudeContainer = await this.findClaudeContainer(stack, runtime);
@@ -1313,9 +1466,13 @@ export class StackManager {
       if (model) cliArgs.push('--model', model);
       cliArgs.push('--models-json', phaseModelsJson);
       cliArgs.push('--phase-routing-json', phaseRoutingJson);
-      cliArgs.push(prompt);
+      promptTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sandstorm-task-'));
+      const promptTmpFile = path.join(promptTmpDir, 'prompt.txt');
+      await fs.promises.writeFile(promptTmpFile, prompt, 'utf-8');
+      cliArgs.push('--file', promptTmpFile);
 
       const result = await this.runCli(stack.project_dir, cliArgs);
+      fs.promises.rm(promptTmpDir, { recursive: true, force: true }).catch(() => {});
 
       if (result.exitCode !== 0) {
         throw new SandstormError(
@@ -1332,6 +1489,9 @@ export class StackManager {
 
       return { id: task.id, stack_id: stackId, status: task.status };
     } catch (err) {
+      if (promptTmpDir) {
+        fs.promises.rm(promptTmpDir, { recursive: true, force: true }).catch(() => {});
+      }
       // Task was created but dispatch failed — mark it as failed so the
       // stack doesn't stay stuck in 'running' status forever.
       this.registry.completeTask(task.id, 1);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1134,6 +1134,10 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return stackManager.recheckCompletedStack(stackId);
   });
 
+  ipcMain.handle('stacks:reconcileStatus', async (_event, stackId: string) => {
+    return stackManager.reconcileStatus(stackId);
+  });
+
   ipcMain.handle('stacks:selfHealContinue', async (_event, stackId: string) => {
     await stackManager.selfHealContinue(stackId);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -80,6 +80,10 @@ export interface SandstormAPI {
     recheckCompleted: (stackId: string) => Promise<{
       outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
     }>;
+    reconcileStatus: (stackId: string) => Promise<{
+      outcome: 'reconciled' | 'container_gone' | 'guarded';
+      status?: string;
+    }>;
   };
   tasks: {
     dispatch: (stackId: string, prompt: string, model?: string) => Promise<unknown>;
@@ -339,6 +343,8 @@ const api: SandstormAPI = {
       ipcRenderer.invoke('stacks:restartWithFindings', stackId, updatedTicketBody),
     recheckCompleted: (stackId: string) =>
       ipcRenderer.invoke('stacks:recheckCompleted', stackId),
+    reconcileStatus: (stackId: string) =>
+      ipcRenderer.invoke('stacks:reconcileStatus', stackId),
   },
   tasks: {
     dispatch: (stackId, prompt, model?) =>

--- a/src/renderer/components/StackTableRow.tsx
+++ b/src/renderer/components/StackTableRow.tsx
@@ -47,7 +47,7 @@ export function StackTableRow({
   showProject?: boolean;
   columnWidths?: Record<string, number>;
 }) {
-  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation, recheckCompletedStack } = useAppStore();
+  const { selectStack, refreshStacks, stackMetrics, setShowCreatePRDialog, resumeStackWithContinuation, recheckCompletedStack, reconcileStatus } = useAppStore();
   const metrics: StackMetrics | undefined = stackMetrics[stack.id];
   const [duration, setDuration] = useState(() =>
     getStackDuration(stack.created_at, stack.updated_at, stack.status),
@@ -55,6 +55,8 @@ export function StackTableRow({
   const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
+  const [reconcileMessage, setReconcileMessage] = useState<string | null>(null);
+  const [isReconciling, setIsReconciling] = useState(false);
   const [continuing, setContinuing] = useState(false);
   const rowRef = useRef<HTMLTableRowElement>(null);
   const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -147,6 +149,27 @@ export function StackTableRow({
       }
     } catch (err) {
       alert(`Failed to re-check: ${err}`);
+    }
+  };
+
+  const handleReconcileStatus = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isReconciling) return;
+    setIsReconciling(true);
+    setReconcileMessage(null);
+    try {
+      const result = await reconcileStatus(stack.id);
+      if (result.outcome === 'container_gone') {
+        setReconcileMessage('Container not running');
+        setTimeout(() => setReconcileMessage(null), 4000);
+      } else if (result.outcome === 'guarded') {
+        setReconcileMessage('Already managed');
+        setTimeout(() => setReconcileMessage(null), 4000);
+      }
+    } catch (err) {
+      alert(`Failed to re-check status: ${err}`);
+    } finally {
+      setIsReconciling(false);
     }
   };
 
@@ -313,6 +336,22 @@ export function StackTableRow({
               >
                 🆕 Make PR
               </button>
+            )}
+            {['completed', 'failed', 'pushed', 'pr_created', 'verify_blocked_environmental'].includes(stack.status) && (
+              <>
+                <button
+                  onClick={handleReconcileStatus}
+                  disabled={isReconciling}
+                  className="text-[10px] font-medium px-2 py-0.5 rounded bg-sandstorm-surface text-sandstorm-muted border border-sandstorm-border hover:bg-sandstorm-surface-hover transition-colors disabled:opacity-40"
+                  data-testid={`row-reconcile-status-${stack.id}`}
+                  title="Re-check the actual container status and update registry"
+                >
+                  {isReconciling ? '…' : 'Re-check'}
+                </button>
+                {reconcileMessage && (
+                  <span className="text-[10px] text-sandstorm-muted">{reconcileMessage}</span>
+                )}
+              </>
             )}
             {/* Teardown — always visible (#316). Was opacity-0 group-hover
                 but the user couldn't reach it without the popover blocking. */}

--- a/src/renderer/components/TicketCard.tsx
+++ b/src/renderer/components/TicketCard.tsx
@@ -26,6 +26,7 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
     retryRefinementForTicket,
     resumeStackWithContinuation,
     recheckCompletedStack,
+    reconcileStatus,
     startStackForTicket,
     stackCreateErrors,
     stackCreateInFlight,
@@ -51,6 +52,8 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
   const [showMoveToBacklogDialog, setShowMoveToBacklogDialog] = useState(false);
   const [showAnswerModal, setShowAnswerModal] = useState(false);
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
+  const [reconcileMessage, setReconcileMessage] = useState<string | null>(null);
+  const [isReconciling, setIsReconciling] = useState(false);
   const [isContinuing, setIsContinuing] = useState(false);
 
   const stack = getTicketStack(ticket.ticket_id, stacks);
@@ -128,6 +131,26 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
       }
     } catch (err) {
       alert(`Failed to re-check: ${err}`);
+    }
+  };
+
+  const handleReconcileStatus = async () => {
+    if (!stack || isReconciling) return;
+    setIsReconciling(true);
+    setReconcileMessage(null);
+    try {
+      const result = await reconcileStatus(stack.id);
+      if (result.outcome === 'container_gone') {
+        setReconcileMessage('Container not running — cannot re-check status.');
+        setTimeout(() => setReconcileMessage(null), 4000);
+      } else if (result.outcome === 'guarded') {
+        setReconcileMessage('Stack is actively managed — no re-check needed.');
+        setTimeout(() => setReconcileMessage(null), 4000);
+      }
+    } catch (err) {
+      alert(`Failed to re-check status: ${err}`);
+    } finally {
+      setIsReconciling(false);
     }
   };
 
@@ -444,6 +467,21 @@ export function TicketCard({ ticket, stacks }: TicketCardProps) {
                 'Create PR'
               )}
             </button>
+          )}
+          {stack && ['completed', 'failed', 'pushed', 'pr_created', 'verify_blocked_environmental'].includes(stack.status) && (
+            <div>
+              <button
+                onClick={() => void handleReconcileStatus()}
+                disabled={isReconciling}
+                className="w-full text-xs py-1 px-3 rounded-md bg-sandstorm-surface text-sandstorm-muted border border-sandstorm-border hover:bg-sandstorm-surface-hover transition-colors font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+                data-testid={`ticket-card-reconcile-status-${ticket.ticket_id}`}
+              >
+                {isReconciling ? 'Checking…' : 'Re-check status'}
+              </button>
+              {reconcileMessage && (
+                <p className="mt-1 text-xs text-sandstorm-muted">{reconcileMessage}</p>
+              )}
+            </div>
           )}
           {discardErrorBlock}
         </div>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -523,6 +523,10 @@ interface AppState {
   recheckCompletedStack: (stackId: string) => Promise<{
     outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
   }>;
+  reconcileStatus: (stackId: string) => Promise<{
+    outcome: 'reconciled' | 'container_gone' | 'guarded';
+    status?: string;
+  }>;
 
   // Kanban board
   boardTickets: TicketBoardEntry[];
@@ -726,6 +730,10 @@ declare global {
         restartWithFindings: (stackId: string, updatedTicketBody: string) => Promise<{ newStackId: string }>;
         recheckCompleted: (stackId: string) => Promise<{
           outcome: 'resuming_with_session' | 'resumed_fresh' | 'not_token_limited' | 'container_gone' | 'idle';
+        }>;
+        reconcileStatus: (stackId: string) => Promise<{
+          outcome: 'reconciled' | 'container_gone' | 'guarded';
+          status?: string;
         }>;
       };
       tasks: {
@@ -1221,6 +1229,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   recheckCompletedStack: async (stackId: string) => {
     const result = await window.sandstorm.stacks.recheckCompleted(stackId);
+    await get().refreshStacks();
+    return result;
+  },
+
+  reconcileStatus: async (stackId: string) => {
+    const result = await window.sandstorm.stacks.reconcileStatus(stackId);
     await get().refreshStacks();
     return result;
   },

--- a/tests/unit/components/StackTableRow.test.tsx
+++ b/tests/unit/components/StackTableRow.test.tsx
@@ -507,3 +507,62 @@ describe('StackTableRow verify_blocked_environmental', () => {
     expect(screen.queryByTestId('row-continue-verify-blocked-test-stack')).toBeNull();
   });
 });
+
+describe('StackTableRow reconcileStatus Re-check button', () => {
+  beforeEach(() => {
+    mockSandstormApi();
+    useAppStore.setState({ stacks: [], selectedStackId: null, stackMetrics: {} });
+  });
+
+  it.each([
+    'completed',
+    'failed',
+    'pushed',
+    'pr_created',
+    'verify_blocked_environmental',
+  ])('renders Re-check button for %s status', (status) => {
+    renderRow(makeStack({ status: status as any }));
+    expect(screen.getByTestId('row-reconcile-status-test-stack')).toBeDefined();
+  });
+
+  it('does not render Re-check button for needs_human status', () => {
+    renderRow(makeStack({ status: 'needs_human' }));
+    expect(screen.queryByTestId('row-reconcile-status-test-stack')).toBeNull();
+  });
+
+  it('does not render Re-check button for running status', () => {
+    renderRow(makeStack({ status: 'running' }));
+    expect(screen.queryByTestId('row-reconcile-status-test-stack')).toBeNull();
+  });
+
+  it('does not render Re-check button for session_paused status', () => {
+    renderRow(makeStack({ status: 'session_paused' }));
+    expect(screen.queryByTestId('row-reconcile-status-test-stack')).toBeNull();
+  });
+
+  it('calls reconcileStatus store action when Re-check is clicked', async () => {
+    (window.sandstorm.stacks.reconcileStatus as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ outcome: 'reconciled', status: 'needs_human' });
+    renderRow(makeStack({ status: 'completed' }));
+
+    await act(async () => {
+      screen.getByTestId('row-reconcile-status-test-stack').click();
+    });
+
+    expect(window.sandstorm.stacks.reconcileStatus).toHaveBeenCalledWith('test-stack');
+  });
+
+  it('shows container_gone message when reconcile returns container_gone', async () => {
+    (window.sandstorm.stacks.reconcileStatus as ReturnType<typeof vi.fn>)
+      .mockResolvedValue({ outcome: 'container_gone' });
+    renderRow(makeStack({ status: 'completed' }));
+
+    await act(async () => {
+      screen.getByTestId('row-reconcile-status-test-stack').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Container not running')).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/components/TicketCard.test.tsx
+++ b/tests/unit/components/TicketCard.test.tsx
@@ -441,6 +441,74 @@ describe('TicketCard', () => {
     expect(screen.getByTestId('ticket-card-create-pr-42')).toBeDefined();
   });
 
+  it('in_stack: shows Re-check status button for completed stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-reconcile-status-42')).toBeDefined();
+  });
+
+  it('in_stack: shows Re-check status button for failed stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'failed', pr_url: null, pr_number: null, error: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-reconcile-status-42')).toBeDefined();
+  });
+
+  it('in_stack: shows Re-check status button for pushed stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pushed', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-reconcile-status-42')).toBeDefined();
+  });
+
+  it('in_stack: shows Re-check status button for pr_created stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'pr_created', pr_url: 'https://github.com/o/r/pull/1', pr_number: 1 } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-reconcile-status-42')).toBeDefined();
+  });
+
+  it('in_stack: shows Re-check status button for verify_blocked_environmental stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'verify_blocked_environmental', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.getByTestId('ticket-card-reconcile-status-42')).toBeDefined();
+  });
+
+  it('in_stack: does NOT show Re-check status button for needs_human stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'needs_human', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-reconcile-status-42')).toBeNull();
+  });
+
+  it('in_stack: does NOT show Re-check status button for running stack', () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'running', pr_url: null, pr_number: null } as any;
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+    expect(screen.queryByTestId('ticket-card-reconcile-status-42')).toBeNull();
+  });
+
+  it('in_stack: clicking Re-check status calls reconcileStatus store action', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
+    api.stacks.reconcileStatus.mockResolvedValue({ outcome: 'reconciled', status: 'needs_human' });
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ticket-card-reconcile-status-42'));
+    });
+
+    expect(api.stacks.reconcileStatus).toHaveBeenCalledWith('s1');
+  });
+
+  it('in_stack: shows container_gone feedback message after Re-check status when container not running', async () => {
+    const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
+    api.stacks.reconcileStatus.mockResolvedValue({ outcome: 'container_gone' });
+    render(<TicketCard ticket={makeTicket('in_stack') as any} stacks={[stack]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ticket-card-reconcile-status-42'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/container not running/i)).toBeDefined();
+    });
+  });
+
   it('in_stack: clicking Create PR calls pr.createAuto and does NOT open the dialog on success', async () => {
     const stack = { id: 's1', ticket: '42', project_dir: PROJECT_DIR, status: 'completed', pr_url: null, pr_number: null } as any;
     api.pr.createAuto.mockResolvedValue({ status: 'created', url: 'https://github.com/o/r/pull/1', number: 1 });

--- a/tests/unit/components/setup.ts
+++ b/tests/unit/components/setup.ts
@@ -38,6 +38,8 @@ export function mockSandstormApi() {
       askClarifyingQuestions: vi.fn().mockResolvedValue(undefined),
       selfHealContinue: vi.fn().mockResolvedValue(undefined),
       restartWithFindings: vi.fn().mockResolvedValue({ newStackId: 'feat/123-fix-r2' }),
+      recheckCompleted: vi.fn().mockResolvedValue({ outcome: 'not_token_limited' }),
+      reconcileStatus: vi.fn().mockResolvedValue({ outcome: 'container_gone' }),
     },
     tasks: {
       dispatch: vi.fn().mockResolvedValue({ id: 1, stack_id: 'test', prompt: '', model: null, status: 'running' }),

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -2777,6 +2777,7 @@ describe('IPC Handlers', () => {
       'stacks:selfHealContinue',
       'stacks:restartWithFindings',
       'stacks:recheckCompleted',
+      'stacks:reconcileStatus',
       'stats:telemetry:summary',
       'stats:telemetry:daily',
       'stats:telemetry:byModel',

--- a/tests/unit/reconcile-status.test.ts
+++ b/tests/unit/reconcile-status.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  StackManager,
+} from '../../src/main/control-plane/stack-manager';
+import { Registry } from '../../src/main/control-plane/registry';
+import { PortAllocator } from '../../src/main/control-plane/port-allocator';
+import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
+import { ContainerRuntime } from '../../src/main/runtime/types';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `sandstorm-reconcile-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function createMockRuntime(containerStatus = 'running'): ContainerRuntime {
+  return {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([
+      {
+        id: 'claude-container-1',
+        name: 'sandstorm-proj-test-stack-claude-1',
+        image: 'sandstorm-claude',
+        status: 'running' as const,
+        state: 'running',
+        ports: [],
+        labels: {},
+        created: new Date().toISOString(),
+      },
+    ]),
+    inspect: vi.fn(),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    exec: vi.fn().mockImplementation((_id: string, cmd: string[]) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') {
+        return Promise.resolve({ exitCode: 0, stdout: containerStatus, stderr: '' });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+}
+
+describe('StackManager.reconcileStatus', () => {
+  let registry: Registry;
+  let portAllocator: PortAllocator;
+  let taskWatcher: TaskWatcher;
+  let runtime: ContainerRuntime;
+  let manager: StackManager;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    runtime = createMockRuntime('needs_human');
+    portAllocator = new PortAllocator(registry, [40000, 40099]);
+    taskWatcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 100 });
+    manager = new StackManager(registry, portAllocator, taskWatcher, runtime, runtime, '/fake/cli');
+  });
+
+  afterEach(() => {
+    taskWatcher.unwatchAll();
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  function makeRegistryStack(status: string = 'completed') {
+    const stack = registry.createStack({
+      id: 'test-stack',
+      project: 'proj',
+      project_dir: '/proj',
+      ticket: null,
+      branch: null,
+      description: null,
+      status: status as any,
+      runtime: 'docker',
+    });
+    return stack;
+  }
+
+  function makeRegistryTask(stackId: string = 'test-stack') {
+    return registry.createTask(stackId, 'test prompt');
+  }
+
+  // --- Guard tests ---
+
+  it('returns guarded for session_paused stack without touching registry', async () => {
+    makeRegistryStack('session_paused');
+    const updateSpy = vi.spyOn(registry, 'updateStackStatus');
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('guarded');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns guarded for rate_limited stack without touching registry', async () => {
+    makeRegistryStack('rate_limited');
+    const updateSpy = vi.spyOn(registry, 'updateStackStatus');
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('guarded');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  // --- container_gone tests ---
+
+  it('returns container_gone when listContainers throws', async () => {
+    makeRegistryStack('completed');
+    vi.mocked(runtime.listContainers).mockRejectedValueOnce(new Error('Docker down'));
+
+    const result = await manager.reconcileStatus('test-stack');
+    expect(result.outcome).toBe('container_gone');
+  });
+
+  it('returns container_gone when no containers found', async () => {
+    makeRegistryStack('completed');
+    vi.mocked(runtime.listContainers).mockResolvedValueOnce([]);
+
+    const result = await manager.reconcileStatus('test-stack');
+    expect(result.outcome).toBe('container_gone');
+  });
+
+  it('returns container_gone when container is not running', async () => {
+    makeRegistryStack('completed');
+    vi.mocked(runtime.listContainers).mockResolvedValueOnce([
+      {
+        id: 'c1',
+        name: 'test',
+        image: 'img',
+        status: 'exited' as any,
+        state: 'exited',
+        ports: [],
+        labels: {},
+        created: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await manager.reconcileStatus('test-stack');
+    expect(result.outcome).toBe('container_gone');
+  });
+
+  it('returns container_gone when exec of status file throws', async () => {
+    makeRegistryStack('completed');
+    vi.mocked(runtime.exec).mockRejectedValueOnce(new Error('exec failed'));
+
+    const result = await manager.reconcileStatus('test-stack');
+    expect(result.outcome).toBe('container_gone');
+  });
+
+  // --- needs_human mapping ---
+
+  it('reconciles completed→needs_human via completeTaskNeedsHuman', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0); // mark task completed to simulate stale state
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'needs_human', stderr: '' });
+      if (file === '/tmp/claude-stop-reason.txt') return Promise.resolve({ exitCode: 0, stdout: 'Human review required', stderr: '' });
+      if (file === '/tmp/claude-stop-questions.json') return Promise.resolve({ exitCode: 0, stdout: '[{"id":"q1","question":"What to do?","options":[]}]', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('needs_human');
+    expect(registry.getStack('test-stack')!.status).toBe('needs_human');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.status).toBe('needs_human');
+    expect(updatedTask?.warnings).toBe('Human review required');
+  });
+
+  it('reads questions JSON for needs_human and stores them', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    const questionsJson = '[{"id":"q1","question":"Proceed?","options":[{"id":"yes","label":"Yes"}]}]';
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'needs_human', stderr: '' });
+      if (file === '/tmp/claude-stop-questions.json') return Promise.resolve({ exitCode: 0, stdout: questionsJson, stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    await manager.reconcileStatus('test-stack');
+
+    const questions = registry.getNeedsHumanQuestions('test-stack');
+    expect(questions).toBe(questionsJson);
+  });
+
+  it('reconciles via updateStackStatus when no task exists for needs_human', async () => {
+    makeRegistryStack('completed');
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'needs_human', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('needs_human');
+    expect(registry.getStack('test-stack')!.status).toBe('needs_human');
+  });
+
+  // --- unknown mapping ---
+
+  it('maps unknown container status to needs_human', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'unknown', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('needs_human');
+    expect(registry.getStack('test-stack')!.status).toBe('needs_human');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.warnings).toContain('unknown state');
+  });
+
+  // --- needs_key mapping ---
+
+  it('maps needs_key container status to needs_key stack status', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'needs_key', stderr: '' });
+      if (file === '/tmp/claude-task-needs-key.txt') return Promise.resolve({ exitCode: 0, stdout: 'Missing GITHUB_TOKEN', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('needs_key');
+    expect(registry.getStack('test-stack')!.status).toBe('needs_key');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.status).toBe('needs_key');
+    expect(updatedTask?.warnings).toBe('Missing GITHUB_TOKEN');
+  });
+
+  // --- verify_blocked_environmental mapping ---
+
+  it('maps verify_blocked_environmental to verify_blocked_environmental stack status', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'verify_blocked_environmental', stderr: '' });
+      if (file === '/tmp/claude-verify-environmental.txt') return Promise.resolve({ exitCode: 0, stdout: 'pg_dump not found', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('verify_blocked_environmental');
+    expect(registry.getStack('test-stack')!.status).toBe('verify_blocked_environmental');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.status).toBe('needs_human');
+    expect(updatedTask?.warnings).toContain('pg_dump not found');
+  });
+
+  // --- token_limited mapping ---
+
+  it('maps token_limited to session_paused', async () => {
+    makeRegistryStack('completed');
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'token_limited', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('session_paused');
+    expect(registry.getStack('test-stack')!.status).toBe('session_paused');
+  });
+
+  // --- completed / failed mapping ---
+
+  it('maps completed container status to completed stack with exit code 0', async () => {
+    makeRegistryStack('pushed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'completed', stderr: '' });
+      if (file === '/tmp/claude-task.exit') return Promise.resolve({ exitCode: 0, stdout: '0', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('completed');
+    expect(registry.getStack('test-stack')!.status).toBe('completed');
+  });
+
+  it('maps failed container status to failed stack with non-zero exit code', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'failed', stderr: '' });
+      if (file === '/tmp/claude-task.exit') return Promise.resolve({ exitCode: 0, stdout: '2', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('failed');
+    expect(registry.getStack('test-stack')!.status).toBe('failed');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.exit_code).toBe(2);
+  });
+
+  // --- running mapping ---
+
+  it('maps running container status: reopens task and starts watcher', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0); // mark completed (stale)
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'running', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const watchSpy = vi.spyOn(taskWatcher, 'watch');
+
+    const result = await manager.reconcileStatus('test-stack');
+
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('running');
+    expect(registry.getStack('test-stack')!.status).toBe('running');
+    expect(watchSpy).toHaveBeenCalledWith('test-stack', 'claude-container-1');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.status).toBe('running');
+  });
+
+  // --- idempotency ---
+
+  it('is idempotent when stack already has correct status (needs_human→needs_human)', async () => {
+    makeRegistryStack('needs_human');
+    const task = makeRegistryTask();
+    // Simulate task already in needs_human state
+    registry.completeTaskNeedsHuman(task.id, 'Prior stop', null);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'needs_human', stderr: '' });
+      if (file === '/tmp/claude-stop-reason.txt') return Promise.resolve({ exitCode: 0, stdout: 'Prior stop', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('needs_human');
+    expect(registry.getStack('test-stack')!.status).toBe('needs_human');
+  });
+
+  // --- unrecognized status ---
+
+  it('treats unrecognized container status as needs_human', async () => {
+    makeRegistryStack('completed');
+    const task = makeRegistryTask();
+    registry.completeTask(task.id, 0);
+
+    vi.mocked(runtime.exec).mockImplementation((_id, cmd) => {
+      const file = cmd[cmd.length - 1];
+      if (file === '/tmp/claude-task.status') return Promise.resolve({ exitCode: 0, stdout: 'totally_unknown_state', stderr: '' });
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await manager.reconcileStatus('test-stack');
+    expect(result.outcome).toBe('reconciled');
+    expect(result.status).toBe('needs_human');
+    expect(registry.getStack('test-stack')!.status).toBe('needs_human');
+    const updatedTask = registry.getMostRecentTask('test-stack');
+    expect(updatedTask?.warnings).toContain('totally_unknown_state');
+  });
+
+  // --- throws when stack not found ---
+
+  it('throws STACK_NOT_FOUND when stack does not exist', async () => {
+    await expect(manager.reconcileStatus('nonexistent')).rejects.toThrow(/not found/i);
+  });
+});

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -427,13 +427,13 @@ describe('StackManager', () => {
       expect(callArgs).toContain('--model');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      // Prompt is the last positional arg; runCli handles E2BIG protection
-      // internally (writes to temp file) when the prompt exceeds 64 KB.
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Fix the bug');
+      // dispatchTask always writes the prompt to a temp file and passes --file.
+      expect(callArgs).toContain('--file');
+      const fileIdx = callArgs.indexOf('--file');
+      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Fix the bug');
     });
 
-    it('regression (E2BIG): a >128KB prompt is passed to runCli as the last positional arg', async () => {
+    it('regression (E2BIG): a >128KB prompt is written to a temp file and passed via --file', async () => {
       registry.createStack(makeStack('huge-prompt'));
       const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
         stdout: 'Task dispatched.',
@@ -447,12 +447,11 @@ describe('StackManager', () => {
       await manager.dispatchTask('huge-prompt', hugePrompt);
 
       const [, callArgs] = runCliSpy.mock.calls[0];
-      // dispatchTask passes the prompt as the last positional arg to runCli.
-      // runCli handles E2BIG protection internally: if the last arg exceeds
-      // 64 KB it writes to a temp file and substitutes --file <path> before
-      // spawning — so spawn never sees a large argv entry.
-      expect(callArgs[callArgs.length - 1]).toBe(hugePrompt);
-      expect(callArgs).not.toContain('--file');
+      // dispatchTask always writes the prompt to a temp file and passes --file,
+      // so spawn never sees a large argv entry regardless of prompt size.
+      expect(callArgs).toContain('--file');
+      const fileIdx = callArgs.indexOf('--file');
+      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe(hugePrompt);
       // The full prompt is still persisted to the registry intact.
       const persisted = registry.getTasksForStack('huge-prompt');
       expect(persisted[0].prompt).toBe(hugePrompt);
@@ -506,8 +505,9 @@ describe('StackManager', () => {
       expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('opus');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Complex task');
+      expect(callArgs).toContain('--file');
+      const fileIdx = callArgs.indexOf('--file');
+      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Complex task');
     });
 
     it('resolves "auto" model to undefined and omits from CLI args', async () => {
@@ -528,8 +528,9 @@ describe('StackManager', () => {
       expect(callArgs).not.toContain('--model');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
+      expect(callArgs).toContain('--file');
+      const fileIdx = callArgs.indexOf('--file');
+      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Simple task');
     });
 
     it('uses effective default model when not provided', async () => {
@@ -552,8 +553,9 @@ describe('StackManager', () => {
       expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('sonnet');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
+      expect(callArgs).toContain('--file');
+      const fileIdx = callArgs.indexOf('--file');
+      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Simple task');
     });
 
     it('includes per-phase model map in CLI args', async () => {


### PR DESCRIPTION
## Summary

Stacks could get stuck displaying a stale terminal status (completed, failed, pushed, pr_created, verify_blocked_environmental) in the registry while the underlying container had actually moved on to a different state. This adds a way to reconcile the registry against the container's authoritative truth.

A new `reconcileStatus` method on `StackManager` reads the container's `/tmp/claude-task.status` file and drives the registry to match, mirroring the status to registry mapping used by `task-watcher.ts` (running, token_limited/session_paused, needs_human, needs_key, verify_blocked_environmental, completed/failed, plus an unrecognized fallback to needs_human). It guards against clobbering stacks that are already actively managed (session_paused or rate_limited) and returns a clear outcome when the container is gone. The method is wired through IPC, preload, and the renderer store, and exposed as a "Re-check status" button on both `TicketCard` and `StackTableRow` for stacks in a terminal state.

This branch also makes `dispatchTask` always write the task prompt to a temp file and pass it via `--file`, rather than as a positional argv entry. This removes reliance on `runCli`'s internal E2BIG handling so spawn never sees a large argv entry regardless of prompt size; the temp dir is cleaned up on both success and failure. Unit tests are updated and added accordingly.

## QA plan

1. Start a stack and let it reach a terminal status (e.g. completed or failed). Confirm a "Re-check status" button appears on its TicketCard and as "Re-check" on its table row.
2. Verify the button is NOT shown for running, needs_human, or session_paused stacks.
3. With the container still running but its registry status stale, click Re-check and confirm the displayed status updates to match the container's actual `/tmp/claude-task.status`.
4. Click Re-check on a stack whose container has been torn down and confirm the "Container not running" message appears and clears after a few seconds.
5. Dispatch a task with a very large prompt and confirm it dispatches successfully without an argv-too-long error.

Closes #658