### PR TITLE
[660] fix: always pass dispatched prompt via --file

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -1313,9 +1313,14 @@ export class StackManager {
       if (model) cliArgs.push('--model', model);
       cliArgs.push('--models-json', phaseModelsJson);
       cliArgs.push('--phase-routing-json', phaseRoutingJson);
-      cliArgs.push(prompt);
+      const promptTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sandstorm-task-'));
+      const promptTmpFile = path.join(promptTmpDir, 'prompt.txt');
+      await fs.promises.writeFile(promptTmpFile, prompt, 'utf-8');
+      cliArgs.push('--file', promptTmpFile);
 
-      const result = await this.runCli(stack.project_dir, cliArgs);
+      const result = await this.runCli(stack.project_dir, cliArgs).finally(() => {
+        fs.promises.rm(promptTmpDir, { recursive: true, force: true }).catch(() => {});
+      });
 
       if (result.exitCode !== 0) {
         throw new SandstormError(

--- a/tests/contract/state-files.ts
+++ b/tests/contract/state-files.ts
@@ -1,0 +1,694 @@
+/**
+ * Exhaustive state-file contract for the Sandstorm task-runner.
+ *
+ * Every /tmp/claude-* and /tmp/sandstorm-* file exchanged by task-runner.sh
+ * and stack.sh is enumerated here with its producer, consumer, format, and
+ * lifecycle metadata.
+ *
+ * This artifact is the single source of truth for the IPC contract between
+ * the host (stack.sh) and the container (task-runner.sh / inner Claude).
+ *
+ * Dynamic files (numbered suffixes) use a base pattern plus a suffixRange.
+ * The actual path for iteration N is:  `${pattern.replace('{N}', N)}`
+ *
+ * T0-reachable files can be tested without invoking the task-runner main
+ * loop.  They are either:
+ *   - Written by stack.sh before dispatch (input files), or
+ *   - Written by helper functions sourced from the pre-loop section of
+ *     task-runner.sh (check_for_stop_and_ask, check_for_token_limit, etc.)
+ *
+ * T3 covers loop- and verify-written files (marked t0Reachable: false).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type FileProducer =
+  | 'stack.sh'      // host-side dispatch script
+  | 'task-runner'   // sandstorm-cli/docker/task-runner.sh
+  | 'inner-agent'   // Claude / OpenCode running inside the container
+  | 'entrypoint'    // container entrypoint.sh (pre-task-runner setup)
+
+export type FileConsumer =
+  | 'task-runner'   // task-runner.sh main loop or helpers
+  | 'stack.sh'      // host reads status/output files
+  | 'monitor'       // Sandstorm Desktop / external monitors (IPC)
+  | 'check-fn'      // helper functions sourced from task-runner.sh
+
+export type FileFormat =
+  | 'trigger'       // presence matters; content is ignored (empty or arbitrary)
+  | 'text'          // plain UTF-8 text, single value or human-readable prose
+  | 'json'          // single valid JSON document
+  | 'ndjson'        // newline-delimited JSON (one JSON object per line)
+  | 'kvlines'       // key=value lines (e.g. execution_started_at=...)
+  | 'numeric'       // bare integer string
+  | 'status'        // one of a defined set of status token strings
+
+export type WhenWritten =
+  | 'pre-task'      // written by stack.sh before the trigger is set
+  | 'task-start'    // written by task-runner at the very start of processing a task
+  | 'execution'     // written during the initial execution agent pass
+  | 'review'        // written during the review agent pass
+  | 'meta-review'   // written during the meta-review agent pass
+  | 'verify'        // written during the verify step
+  | 'task-end'      // written just before task-runner marks the task complete
+  | 'idle'          // written when task-runner is waiting for a trigger
+  | 'per-iteration' // written once per loop iteration (numbered suffix)
+
+export interface StateFile {
+  /**
+   * Exact path (for static files) or glob-like pattern with {N} for dynamic
+   * indexed files (e.g. '/tmp/claude-review-verdict-{N}.txt').
+   */
+  pattern: string
+
+  /** Human-readable description of this file's purpose. */
+  description: string
+
+  /** Which process writes this file. */
+  producer: FileProducer | FileProducer[]
+
+  /**
+   * Which process(es) read this file.
+   * 'monitor' means it is polled by Sandstorm Desktop via IPC.
+   */
+  consumer: FileConsumer | FileConsumer[]
+
+  /** Content format of this file. */
+  format: FileFormat
+
+  /** When in the task lifecycle is this file written. */
+  whenWritten: WhenWritten
+
+  /**
+   * True when this file is only written in some scenarios (e.g. only when
+   * a model override is provided, or only on token-limit events).
+   */
+  conditional: boolean
+
+  /**
+   * For files with a numeric suffix {N}, the inclusive range of valid N.
+   * Absent for static-path files.
+   */
+  suffixRange?: { min: number; max: number }
+
+  /**
+   * For status files: the exhaustive set of valid values.
+   * Absent for non-status files.
+   */
+  statusValues?: readonly string[]
+
+  /**
+   * True if this file can be tested without invoking the task-runner main
+   * loop (i.e. it is written by stack.sh or by a pre-loop helper function).
+   */
+  t0Reachable: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Schema — all state files
+// ---------------------------------------------------------------------------
+
+export const STATE_FILES: readonly StateFile[] = [
+
+  // ── Stack.sh → task-runner input files ───────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-task-trigger',
+    description:
+      'Presence of this file triggers the task-runner to start a new task. ' +
+      'Written by "touch" in stack.sh; deleted by task-runner at task start.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'trigger',
+    whenWritten: 'pre-task',
+    conditional: false,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-prompt.txt',
+    description:
+      'Full task prompt text piped into the execution agent. ' +
+      'Written by stack.sh; read and deleted by task-runner after dispatch.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'pre-task',
+    conditional: false,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-label.txt',
+    description:
+      'One-liner label (first 80 chars of prompt) for display in dashboards. ' +
+      'Written by stack.sh; consumed by external monitors, not by task-runner.sh itself.',
+    producer: 'stack.sh',
+    consumer: 'monitor',
+    format: 'text',
+    whenWritten: 'pre-task',
+    conditional: false,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-model.txt',
+    description:
+      'Optional Claude model override (e.g. "claude-opus-4-8"). ' +
+      'Written only when --model is passed to stack.sh; deleted after read.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-models.json',
+    description:
+      'Optional per-phase model map JSON ({"execution":"...", "review":"..."}). ' +
+      'Written only when --models-json is passed to stack.sh; deleted after read.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'json',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-resume.txt',
+    description:
+      'Optional Claude session ID to resume. ' +
+      'Written only when --resume is passed to stack.sh; deleted after read.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-backend.txt',
+    description:
+      'Optional agent backend selector ("claude" or "opencode"). ' +
+      'Written only when --backend is passed to stack.sh; deleted after read.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-backend-model.txt',
+    description:
+      'Optional OpenCode provider/model string. ' +
+      'Written only when --backend-model is passed to stack.sh; deleted after read.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-task-phase-routing.json',
+    description:
+      'Optional per-phase backend+provider+model routing JSON. ' +
+      'Supersedes --backend/--backend-model when present. ' +
+      'Written only when --phase-routing-json is passed to stack.sh; deleted after read.',
+    producer: 'stack.sh',
+    consumer: 'task-runner',
+    format: 'json',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  // ── Task-runner readiness / status files ─────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-ready',
+    description:
+      'Contains the string "ready" when task-runner is idle and waiting for a ' +
+      'trigger. Removed at task start, restored on task completion or error.',
+    producer: 'task-runner',
+    consumer: ['stack.sh', 'monitor'],
+    format: 'text',
+    whenWritten: 'idle',
+    conditional: false,
+    statusValues: ['ready'],
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task.pid',
+    description:
+      'PID of the task-runner process ($$) written at task start, removed at task end.',
+    producer: 'task-runner',
+    consumer: ['stack.sh', 'monitor'],
+    format: 'numeric',
+    whenWritten: 'task-start',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task.status',
+    description:
+      'Current task status token. Updated at each lifecycle transition.',
+    producer: 'task-runner',
+    consumer: ['stack.sh', 'monitor'],
+    format: 'status',
+    whenWritten: 'task-start',
+    conditional: false,
+    statusValues: [
+      'running',
+      'completed',
+      'failed',
+      'token_limited',
+      'needs_human',
+      'needs_key',
+      'verify_blocked_environmental',
+    ],
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task.exit',
+    description:
+      'Numeric exit code of the last agent invocation. Written at task end.',
+    producer: 'task-runner',
+    consumer: ['stack.sh', 'monitor'],
+    format: 'numeric',
+    whenWritten: 'task-end',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task.review-iterations',
+    description:
+      'Running count of total review iterations completed (0 at start, ' +
+      'incremented each time a review agent runs).',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'numeric',
+    whenWritten: 'task-start',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task.verify-retries',
+    description:
+      'Running count of consecutive verify failures (0 at start, ' +
+      'incremented each time verify fails).',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'numeric',
+    whenWritten: 'task-start',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task-needs-key.txt',
+    description:
+      'Human-readable message explaining which phase/provider is missing credentials. ' +
+      'Written only when a phase credential check fails (needs_key status).',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'text',
+    whenWritten: 'task-start',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  // ── Execution agent artifacts ─────────────────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-raw.log',
+    description:
+      'Raw NDJSON stream-json output from the execution agent (claude or opencode). ' +
+      'Truncated to empty at each task start. Appended during each execution pass.',
+    producer: 'task-runner',
+    consumer: ['task-runner', 'monitor'],
+    format: 'ndjson',
+    whenWritten: 'execution',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-task.log',
+    description:
+      'Formatted (human-readable) output of the execution agent, produced by the ' +
+      'jq filter in run_claude. This is what task-output reads.',
+    producer: 'task-runner',
+    consumer: ['task-runner', 'monitor'],
+    format: 'text',
+    whenWritten: 'execution',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-tokens-execution',
+    description:
+      'Cumulative token count for the execution phase (input+output tokens). ' +
+      'Written by the token-counter.sh subprocess during run_claude.',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'numeric',
+    whenWritten: 'execution',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-execute-output-{N}.txt',
+    description:
+      'Outcome marker for execution pass N. ' +
+      'First line is EXECUTE_PASS or EXECUTE_FAIL; subsequent lines are the ' +
+      'last 50 lines of claude-task.log for that pass. ' +
+      'N=0 is the initial execution; N=1..MAX_TOTAL_REVIEW_ITERATIONS are ' +
+      'subsequent fix passes (one per review cycle).',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'text',
+    whenWritten: 'per-iteration',
+    conditional: false,
+    suffixRange: { min: 0, max: 5 },
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-execution-summary.txt',
+    description:
+      'Snapshot of the last 50 lines of claude-task.log after the initial ' +
+      'execution pass.  Used by the meta-review agent to understand what the ' +
+      'execution agent did.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'execution',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  // ── Phase timing ──────────────────────────────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-phase-timing.txt',
+    description:
+      'ISO 8601 timestamps for each phase boundary, appended progressively. ' +
+      'Keys: execution_started_at, execution_finished_at, review_started_at, ' +
+      'review_finished_at, verify_started_at, verify_finished_at.',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'kvlines',
+    whenWritten: 'task-start',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  // ── Review agent artifacts ────────────────────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-review-raw.log',
+    description:
+      'Raw NDJSON stream-json output from the review agent. ' +
+      'Overwritten each time a review agent runs.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'ndjson',
+    whenWritten: 'review',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-review-task.log',
+    description:
+      'Formatted (human-readable) output of the review agent. ' +
+      'Overwritten each time a review agent runs.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'review',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-review-prompt.txt',
+    description:
+      'Temporary file holding the assembled review prompt (template + original task). ' +
+      'Created by run_review, deleted immediately after the review agent completes.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'review',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-review-output.txt',
+    description:
+      'Copy of claude-review-task.log captured when the review agent returns ' +
+      'REVIEW_FAIL or crashes. Used as context for the next execution pass.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'review',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-review-verdict-{N}.txt',
+    description:
+      'Review verdict for iteration N. ' +
+      'Contains "REVIEW_PASS" on pass, or the full review output on fail. ' +
+      'N starts at 1 and increments each review cycle up to MAX_TOTAL_REVIEW_ITERATIONS=5.',
+    producer: 'task-runner',
+    consumer: ['task-runner', 'monitor'],
+    format: 'text',
+    whenWritten: 'per-iteration',
+    conditional: false,
+    suffixRange: { min: 1, max: 5 },
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-tokens-review',
+    description:
+      'Cumulative token count for the review phase. ' +
+      'Written by the token-counter.sh subprocess during review agent runs.',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'numeric',
+    whenWritten: 'review',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  // ── Meta-review agent artifacts ───────────────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-meta-review-prompt.txt',
+    description:
+      'Temporary prompt file for the meta-review agent. ' +
+      'Deleted immediately after the meta-review agent completes.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'meta-review',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-meta-review-task.log',
+    description:
+      'Formatted output of the meta-review agent. ' +
+      'Deleted at final task status (copied to claude-meta-review.txt first).',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'meta-review',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-meta-review-raw.log',
+    description:
+      'Raw NDJSON stream from the meta-review agent. ' +
+      'Deleted at final task status.',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'ndjson',
+    whenWritten: 'meta-review',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-meta-review.txt',
+    description:
+      'Persisted copy of the meta-review agent output (guidance prose). ' +
+      'Injected into the next execution-agent prompt via inject_meta_review_guidance().',
+    producer: 'task-runner',
+    consumer: 'task-runner',
+    format: 'text',
+    whenWritten: 'meta-review',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-tokens-meta_review',
+    description:
+      'Cumulative token count for the meta_review phase. ' +
+      'Written by the token-counter.sh subprocess during meta-review agent runs.',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'numeric',
+    whenWritten: 'meta-review',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  // ── Verify artifacts ──────────────────────────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-verify.log',
+    description:
+      'Complete output of .sandstorm/verify.sh for the most recent verify run. ' +
+      'Overwritten on each verify attempt.',
+    producer: 'task-runner',
+    consumer: ['task-runner', 'monitor'],
+    format: 'text',
+    whenWritten: 'verify',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-verify-output-{N}.txt',
+    description:
+      'Numbered verify outcome for outer iteration N. ' +
+      'First line is VERIFY_PASS, VERIFY_FAIL, or VERIFY_INFRA; ' +
+      'subsequent lines are the last 50 lines of verify output.',
+    producer: 'task-runner',
+    consumer: 'monitor',
+    format: 'text',
+    whenWritten: 'per-iteration',
+    conditional: false,
+    suffixRange: { min: 1, max: 5 },
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/claude-verify-environmental.txt',
+    description:
+      'Written when verify_blocked_environmental is set. ' +
+      'Contains a "VERIFY_FAIL_FINGERPRINT: <line>" identifying the ' +
+      'infra error that caused the environmental block.',
+    producer: 'task-runner',
+    consumer: ['stack.sh', 'monitor'],
+    format: 'text',
+    whenWritten: 'verify',
+    conditional: true,
+    t0Reachable: false,
+  },
+
+  // ── STOP_AND_ASK artifacts ────────────────────────────────────────────────
+
+  {
+    pattern: '/tmp/claude-stop-reason.txt',
+    description:
+      'Reason string extracted from the STOP_AND_ASK: line in the agent output. ' +
+      'Written by check_for_stop_and_ask() (a pre-loop helper function).',
+    producer: 'task-runner',
+    consumer: ['stack.sh', 'monitor'],
+    format: 'text',
+    whenWritten: 'execution',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  {
+    pattern: '/tmp/claude-stop-questions.json',
+    description:
+      'Structured JSON array of RefineQuestion objects written by the inner agent ' +
+      'to /tmp/claude-stop-questions.json before emitting STOP_AND_ASK. ' +
+      'Read by check_for_stop_and_ask() and forwarded to the loop log.',
+    producer: 'inner-agent',
+    consumer: ['task-runner', 'monitor'],
+    format: 'json',
+    whenWritten: 'execution',
+    conditional: true,
+    t0Reachable: true,
+  },
+
+  // ── Runtime config files (written by entrypoint / setup) ─────────────────
+
+  {
+    pattern: '/tmp/sandstorm-mcp.json',
+    description:
+      'MCP server configuration passed to claude via --mcp-config. ' +
+      'Written by the container entrypoint before task-runner starts.',
+    producer: 'entrypoint',
+    consumer: 'task-runner',
+    format: 'json',
+    whenWritten: 'pre-task',
+    conditional: false,
+    t0Reachable: false,
+  },
+
+  {
+    pattern: '/tmp/sandstorm-opencode-{provider}.json',
+    description:
+      'OpenCode provider credentials/config for a specific provider. ' +
+      'The {provider} suffix is a provider name (e.g. "anthropic", "openai"). ' +
+      'Written by the container entrypoint; checked for presence by ' +
+      'check_all_phase_credentials().',
+    producer: 'entrypoint',
+    consumer: 'task-runner',
+    format: 'json',
+    whenWritten: 'pre-task',
+    conditional: true,
+    t0Reachable: false,
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Convenience views
+// ---------------------------------------------------------------------------
+
+/** All files that can be tested without invoking the main loop. */
+export const T0_REACHABLE = STATE_FILES.filter((f) => f.t0Reachable)
+
+/** All files written (or pre-written) by stack.sh — the host-side inputs. */
+export const STACK_INPUT_FILES = STATE_FILES.filter(
+  (f) => f.producer === 'stack.sh',
+)
+
+/** All files with a dynamic numeric suffix {N}. */
+export const DYNAMIC_FILES = STATE_FILES.filter((f) => f.suffixRange != null)
+
+/** All possible status token values for claude-task.status. */
+export const TASK_STATUS_VALUES: readonly string[] = STATE_FILES.find(
+  (f) => f.pattern === '/tmp/claude-task.status',
+)!.statusValues!

--- a/tests/fixtures/bare-git-helpers.sh
+++ b/tests/fixtures/bare-git-helpers.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# bare-git-helpers.sh — fixture helpers for tests that need a real git repo.
+#
+# Source this file after setup_harness (from bash-harness.sh) has been called
+# so $tmpdir is available.
+#
+# Functions:
+#
+#   make_bare_repo [dest]   — initialise a bare repository at $dest
+#                             (default: $tmpdir/bare.git); prints the path
+#   make_work_repo [bare]   — clone from $bare (default: $tmpdir/bare.git)
+#                             into $tmpdir/work; configures user identity;
+#                             creates an initial commit; prints the work-tree path
+#
+# Usage pattern (in a bash test script):
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/../fixtures/bash-harness.sh"
+#   source "$(dirname "${BASH_SOURCE[0]}")/../fixtures/bare-git-helpers.sh"
+#   setup_harness
+#   BARE="$(make_bare_repo)"
+#   WORK="$(make_work_repo "$BARE")"
+#   # push to $BARE from $WORK as a real remote
+
+make_bare_repo() {
+  local dest="${1:-${tmpdir}/bare.git}"
+  git init --bare -q "$dest"
+  echo "$dest"
+}
+
+make_work_repo() {
+  local bare="${1:-${tmpdir}/bare.git}"
+  local work="${tmpdir}/work"
+  git clone -q "$bare" "$work"
+  git -C "$work" config user.email "sandstorm-test@example.com"
+  git -C "$work" config user.name "Sandstorm Test"
+  # Create an initial commit so the repo has a HEAD ref for push tests
+  echo "initial" > "${work}/README"
+  git -C "$work" add README
+  git -C "$work" commit -q -m "initial commit"
+  git -C "$work" push -q origin HEAD 2>/dev/null || true
+  echo "$work"
+}

--- a/tests/fixtures/bash-harness.sh
+++ b/tests/fixtures/bash-harness.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# bash-harness.sh — reusable harness for task-runner.sh helper function tests.
+#
+# Source this file, then call:
+#
+#   setup_harness              — creates per-test $tmpdir, puts fake-claude on
+#                                PATH as 'claude', sets $TASK_RUNNER, traps
+#                                cleanup on EXIT
+#   source_task_runner_helpers — sed-extracts all helper functions from
+#                                task-runner.sh (up to but not including the
+#                                main loop), rewrites /tmp/ → $tmpdir/ so
+#                                file writes are isolated, then evals the result
+#   assert_no_tmp_leak [label] — fails (return 1 + message to stderr) if any
+#                                /tmp/claude-* files exist in real /tmp after
+#                                the test has run; under the /tmp/→$tmpdir/
+#                                substitution this should always be empty
+#
+# Usage pattern (in a bash test script):
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/../fixtures/bash-harness.sh"
+#   setup_harness
+#   source_task_runner_helpers
+#   # ... test code ...
+#   assert_no_tmp_leak "my-test"
+#
+# Design:
+#   - $tmpdir is per-call (mktemp -d) and removed by EXIT trap
+#   - fake-claude is a symlink at $tmpdir/bin/claude so it shadows any real
+#     claude binary; FAKE_CLAUDE_MODE controls the output mode
+#   - The /tmp/ substitution is the same pattern used in the pre-existing
+#     task-runner-environmental-scope.sh and task-runner-scope-smoke.sh tests
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_FAKE_CLAUDE_BIN="${HARNESS_DIR}/fake-claude"
+
+setup_harness() {
+  tmpdir=$(mktemp -d)
+  export tmpdir
+
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  # Create a per-test bin directory with a 'claude' entry pointing at fake-claude
+  local _bin_dir="${tmpdir}/bin"
+  mkdir -p "$_bin_dir"
+  ln -sf "$_FAKE_CLAUDE_BIN" "${_bin_dir}/claude"
+
+  # Prepend to PATH so 'claude' resolves to our stub inside eval'd helper code
+  export PATH="${_bin_dir}:${PATH}"
+
+  # Resolve task-runner.sh from the repo root (two dirs up from fixtures/)
+  TASK_RUNNER="${HARNESS_DIR}/../../sandstorm-cli/docker/task-runner.sh"
+  TASK_RUNNER="$(realpath "$TASK_RUNNER" 2>/dev/null || echo "")"
+
+  if [ ! -f "${TASK_RUNNER:-}" ]; then
+    echo "SKIP: task-runner.sh not found at ${TASK_RUNNER:-<unresolved>}" >&2
+    exit 0
+  fi
+
+  export TASK_RUNNER
+}
+
+# Source helper functions from task-runner.sh (everything before "# ─── Main Loop").
+# Rewrites /tmp/ → $tmpdir/ so all state-file reads/writes are isolated.
+# Must be called after setup_harness.
+source_task_runner_helpers() {
+  local _func_src
+  _func_src=$(sed -n '1,/^# ─── Main Loop/p' "$TASK_RUNNER" | head -n -1)
+  # Isolate all /tmp/ file references to tmpdir
+  _func_src="${_func_src//\/tmp\//$tmpdir/}"
+  eval "$_func_src"
+}
+
+# Assert no /tmp/claude-* files leaked into the real /tmp directory.
+# Prints a FAIL message to stderr and returns 1 if any are found.
+# Under the /tmp/→$tmpdir/ substitution used by source_task_runner_helpers,
+# this should always pass; failures indicate a substitution gap.
+assert_no_tmp_leak() {
+  local _label="${1:-}"
+  local _leaked
+  _leaked=$(find /tmp -maxdepth 1 -name 'claude-*' 2>/dev/null | sort)
+  if [ -n "$_leaked" ]; then
+    local _prefix=""
+    [ -n "$_label" ] && _prefix="[$_label] "
+    printf 'FAIL: %s/tmp/claude-* files leaked into real /tmp:\n' "$_prefix" >&2
+    printf '%s\n' "$_leaked" >&2
+    return 1
+  fi
+  return 0
+}

--- a/tests/fixtures/fake-claude
+++ b/tests/fixtures/fake-claude
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# fake-claude — test stub for the claude CLI.
+#
+# Accepts (and ignores) all real claude CLI flags so it can stand in for the
+# binary on PATH.  Output mode is controlled by the FAKE_CLAUDE_MODE env var:
+#
+#   normal        (default) valid stream-json completion
+#   token_limit   exit 0 with rate_limit_event (rejected) + error result (429)
+#   review_pass   valid stream-json with REVIEW_PASS in the result field
+#   review_fail   valid stream-json with REVIEW_FAIL in the result field
+#   meta_pass     valid stream-json with META_VERDICT: VIABLE in the result
+#   meta_fail     valid stream-json with META_VERDICT: NO_VIABLE_PATH in the result
+#
+# Extra output can be injected via FAKE_CLAUDE_TEXT (appended to assistant text).
+# Session ID can be overridden via FAKE_CLAUDE_SESSION_ID.
+
+set -euo pipefail
+
+# Consume all arguments (flags + positional) without interpreting them
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dangerously-skip-permissions|--verbose|--include-partial-messages|--print|--strict-mcp-config)
+      shift ;;
+    --output-format|--mcp-config|--model|--resume|-p|--permission-prompt-tool)
+      shift 2 ;;
+    -)
+      # stdin as prompt — read and discard
+      cat /dev/stdin > /dev/null
+      shift ;;
+    *)
+      shift ;;
+  esac
+done
+
+MODE="${FAKE_CLAUDE_MODE:-normal}"
+SESSION_ID="${FAKE_CLAUDE_SESSION_ID:-fake-session-t0}"
+EXTRA_TEXT="${FAKE_CLAUDE_TEXT:-}"
+
+emit_init() {
+  printf '{"type":"system","subtype":"init","session_id":"%s","tools":[]}\n' "$SESSION_ID"
+}
+
+emit_assistant() {
+  local text="$1"
+  # Escape newlines and quotes inside JSON text value
+  local escaped
+  escaped=$(printf '%s' "$text" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n')
+  escaped="${escaped%\\n}"  # remove trailing \n we just added
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":"%s"}]}}\n' "$escaped"
+}
+
+emit_result() {
+  local result_text="$1"
+  local is_error="${2:-false}"
+  local extra="${3:-}"
+  local escaped
+  escaped=$(printf '%s' "$result_text" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n')
+  escaped="${escaped%\\n}"
+  if [ -n "$extra" ]; then
+    printf '{"type":"result","subtype":"success","is_error":%s,%s"result":"%s","session_id":"%s"}\n' \
+      "$is_error" "$extra" "$escaped" "$SESSION_ID"
+  else
+    printf '{"type":"result","subtype":"success","is_error":%s,"result":"%s","session_id":"%s"}\n' \
+      "$is_error" "$escaped" "$SESSION_ID"
+  fi
+}
+
+case "$MODE" in
+  token_limit)
+    emit_init
+    printf '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":9999999999,"rateLimitType":"five_hour"}}\n'
+    emit_result "You've hit your session limit · resets 5:20am (UTC)" true '"api_error_status":429,'
+    ;;
+  review_pass)
+    emit_init
+    local_text="Code review complete.${EXTRA_TEXT:+ $EXTRA_TEXT}"$'\n'"REVIEW_PASS"
+    emit_assistant "$local_text"
+    emit_result "REVIEW_PASS"
+    ;;
+  review_fail)
+    emit_init
+    local_text="Review found issues.${EXTRA_TEXT:+ $EXTRA_TEXT}"$'\n'"REVIEW_FAIL"
+    emit_assistant "$local_text"
+    emit_result "REVIEW_FAIL"
+    ;;
+  meta_pass)
+    emit_init
+    local_text="Meta-review analysis.${EXTRA_TEXT:+ $EXTRA_TEXT}"$'\n'"META_VERDICT: VIABLE"
+    emit_assistant "$local_text"
+    emit_result "META_VERDICT: VIABLE"
+    ;;
+  meta_fail)
+    emit_init
+    local_text="Meta-review: no viable path.${EXTRA_TEXT:+ $EXTRA_TEXT}"$'\n'"META_VERDICT: NO_VIABLE_PATH"
+    emit_assistant "$local_text"
+    emit_result "META_VERDICT: NO_VIABLE_PATH"
+    ;;
+  normal|*)
+    emit_init
+    local_text="Task completed successfully.${EXTRA_TEXT:+ $EXTRA_TEXT}"
+    emit_assistant "$local_text"
+    emit_result "Task completed successfully."
+    ;;
+esac
+
+exit 0

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -427,13 +427,14 @@ describe('StackManager', () => {
       expect(callArgs).toContain('--model');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      // Prompt is the last positional arg; runCli handles E2BIG protection
-      // internally (writes to temp file) when the prompt exceeds 64 KB.
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Fix the bug');
+      // Prompt is always written to a temp file and passed via --file so spawn
+      // never receives a large argv entry (E2BIG protection, always-on).
+      expect(callArgs).toContain('--file');
+      const promptFile = callArgs[callArgs.indexOf('--file') + 1];
+      expect(fs.readFileSync(promptFile, 'utf-8')).toBe('Fix the bug');
     });
 
-    it('regression (E2BIG): a >128KB prompt is passed to runCli as the last positional arg', async () => {
+    it('regression (E2BIG): a >128KB prompt is written to a temp file and passed as --file', async () => {
       registry.createStack(makeStack('huge-prompt'));
       const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
         stdout: 'Task dispatched.',
@@ -447,12 +448,11 @@ describe('StackManager', () => {
       await manager.dispatchTask('huge-prompt', hugePrompt);
 
       const [, callArgs] = runCliSpy.mock.calls[0];
-      // dispatchTask passes the prompt as the last positional arg to runCli.
-      // runCli handles E2BIG protection internally: if the last arg exceeds
-      // 64 KB it writes to a temp file and substitutes --file <path> before
-      // spawning — so spawn never sees a large argv entry.
-      expect(callArgs[callArgs.length - 1]).toBe(hugePrompt);
-      expect(callArgs).not.toContain('--file');
+      // dispatchTask always writes the prompt to a temp file and passes --file,
+      // so spawn never receives a large argv entry regardless of prompt size.
+      expect(callArgs).toContain('--file');
+      const promptFile = callArgs[callArgs.indexOf('--file') + 1];
+      expect(fs.readFileSync(promptFile, 'utf-8')).toBe(hugePrompt);
       // The full prompt is still persisted to the registry intact.
       const persisted = registry.getTasksForStack('huge-prompt');
       expect(persisted[0].prompt).toBe(hugePrompt);
@@ -506,8 +506,7 @@ describe('StackManager', () => {
       expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('opus');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Complex task');
+      expect(callArgs).toContain('--file');
     });
 
     it('resolves "auto" model to undefined and omits from CLI args', async () => {
@@ -528,8 +527,7 @@ describe('StackManager', () => {
       expect(callArgs).not.toContain('--model');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
+      expect(callArgs).toContain('--file');
     });
 
     it('uses effective default model when not provided', async () => {
@@ -552,8 +550,7 @@ describe('StackManager', () => {
       expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('sonnet');
       expect(callArgs).toContain('--models-json');
       expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--file');
-      expect(callArgs[callArgs.length - 1]).toBe('Simple task');
+      expect(callArgs).toContain('--file');
     });
 
     it('includes per-phase model map in CLI args', async () => {

--- a/tests/unit/state-file-contract.sh
+++ b/tests/unit/state-file-contract.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# state-file-contract.sh — T0 bash contract tests for task-runner state files.
+#
+# Tests T0-reachable state files: those written by stack.sh (input files) and
+# those written by pre-main-loop helper functions (check_for_stop_and_ask).
+#
+# Uses bash-harness.sh to isolate all /tmp/ writes to a per-run tmpdir.
+#
+# Exit codes: 0 = all assertions passed, 1 = one or more failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the reusable harness
+# shellcheck source=../fixtures/bash-harness.sh
+source "${SCRIPT_DIR}/../fixtures/bash-harness.sh"
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+setup_harness
+source_task_runner_helpers
+# Suppress internal [LOOP] output from helper functions during tests
+log_loop() { :; }
+
+FAIL=0
+
+assert_pass() {
+  local label="$1"
+  echo "PASS [$label]"
+}
+
+assert_fail() {
+  local label="$1"
+  local msg="$2"
+  echo "FAIL [$label]: $msg" >&2
+  FAIL=1
+}
+
+# ── Group 1: stack.sh input files — format and writability ───────────────────
+#
+# For each input file that stack.sh writes before dispatching a task, we
+# simulate what stack.sh does (write the file) and assert the file exists with
+# the expected content.
+
+# 1a. claude-task-trigger (presence-only)
+touch "$tmpdir/claude-task-trigger"
+if [ -e "$tmpdir/claude-task-trigger" ]; then
+  assert_pass "input/trigger: file exists after touch"
+else
+  assert_fail "input/trigger: file exists after touch" "file not created"
+fi
+
+# 1b. claude-task-prompt.txt
+PROMPT_TEXT="Fix the auth bug in src/main/auth.ts"
+printf '%s\n' "$PROMPT_TEXT" > "$tmpdir/claude-task-prompt.txt"
+if [ "$(cat "$tmpdir/claude-task-prompt.txt")" = "$PROMPT_TEXT" ]; then
+  assert_pass "input/prompt.txt: content round-trips"
+else
+  assert_fail "input/prompt.txt: content round-trips" "content mismatch"
+fi
+
+# 1c. claude-task-label.txt (first 80 chars of prompt)
+LABEL_TEXT=$(echo "$PROMPT_TEXT" | head -1 | cut -c1-80)
+printf '%s\n' "$LABEL_TEXT" > "$tmpdir/claude-task-label.txt"
+if [ "$(cat "$tmpdir/claude-task-label.txt")" = "$LABEL_TEXT" ]; then
+  assert_pass "input/label.txt: content round-trips"
+else
+  assert_fail "input/label.txt: content round-trips" "content mismatch"
+fi
+
+# 1d. claude-task-model.txt (conditional: only when --model supplied)
+echo "claude-opus-4-8" > "$tmpdir/claude-task-model.txt"
+MODEL_READ=$(cat "$tmpdir/claude-task-model.txt" | tr -d '[:space:]')
+if [ "$MODEL_READ" = "claude-opus-4-8" ]; then
+  assert_pass "input/model.txt: model name round-trips"
+else
+  assert_fail "input/model.txt: model name round-trips" "got: $MODEL_READ"
+fi
+
+# 1e. claude-task-models.json (conditional: per-phase model map)
+MODELS_JSON='{"execution":"claude-sonnet-4-6","review":"claude-haiku-4-5-20251001"}'
+printf '%s' "$MODELS_JSON" > "$tmpdir/claude-task-models.json"
+if jq '.' "$tmpdir/claude-task-models.json" > /dev/null 2>&1; then
+  assert_pass "input/models.json: valid JSON"
+else
+  assert_fail "input/models.json: valid JSON" "jq rejected the content"
+fi
+EX_MODEL=$(jq -r '.execution' "$tmpdir/claude-task-models.json")
+if [ "$EX_MODEL" = "claude-sonnet-4-6" ]; then
+  assert_pass "input/models.json: execution key readable"
+else
+  assert_fail "input/models.json: execution key readable" "got: $EX_MODEL"
+fi
+
+# 1f. claude-task-resume.txt (conditional: session resume ID)
+RESUME_ID="sess-abc123xyz"
+printf '%s\n' "$RESUME_ID" > "$tmpdir/claude-task-resume.txt"
+RESUME_READ=$(cat "$tmpdir/claude-task-resume.txt" | tr -d '[:space:]')
+if [ "$RESUME_READ" = "$RESUME_ID" ]; then
+  assert_pass "input/resume.txt: session ID round-trips"
+else
+  assert_fail "input/resume.txt: session ID round-trips" "got: $RESUME_READ"
+fi
+
+# 1g. claude-task-backend.txt (conditional: "claude" or "opencode")
+for backend in claude opencode; do
+  echo "$backend" > "$tmpdir/claude-task-backend.txt"
+  BACK_READ=$(cat "$tmpdir/claude-task-backend.txt" | tr -d '[:space:]')
+  if [ "$BACK_READ" = "$backend" ]; then
+    assert_pass "input/backend.txt: '$backend' round-trips"
+  else
+    assert_fail "input/backend.txt: '$backend' round-trips" "got: $BACK_READ"
+  fi
+done
+
+# 1h. claude-task-backend-model.txt (conditional: OpenCode model)
+echo "anthropic/claude-sonnet-4-6" > "$tmpdir/claude-task-backend-model.txt"
+BKMODEL_READ=$(cat "$tmpdir/claude-task-backend-model.txt" | tr -d '[:space:]')
+if [ "$BKMODEL_READ" = "anthropic/claude-sonnet-4-6" ]; then
+  assert_pass "input/backend-model.txt: value round-trips"
+else
+  assert_fail "input/backend-model.txt: value round-trips" "got: $BKMODEL_READ"
+fi
+
+# 1i. claude-task-phase-routing.json (conditional: per-phase routing)
+ROUTING_JSON='{"execution":{"backend":"claude"},"review":{"backend":"opencode","provider":"anthropic"}}'
+printf '%s' "$ROUTING_JSON" > "$tmpdir/claude-task-phase-routing.json"
+if jq '.' "$tmpdir/claude-task-phase-routing.json" > /dev/null 2>&1; then
+  assert_pass "input/phase-routing.json: valid JSON"
+else
+  assert_fail "input/phase-routing.json: valid JSON" "jq rejected the content"
+fi
+REVIEW_BACKEND=$(jq -r '.review.backend' "$tmpdir/claude-task-phase-routing.json")
+if [ "$REVIEW_BACKEND" = "opencode" ]; then
+  assert_pass "input/phase-routing.json: review.backend readable"
+else
+  assert_fail "input/phase-routing.json: review.backend readable" "got: $REVIEW_BACKEND"
+fi
+
+# ── Group 2: check_for_stop_and_ask output — claude-stop-reason.txt ──────────
+
+# 2a. STOP_AND_ASK present → stop-reason.txt written with correct reason
+TASK_LOG="$tmpdir/claude-task.log"
+cat > "$TASK_LOG" << 'LOG'
+Starting task analysis...
+
+I see the failing test is out of scope.
+
+STOP_AND_ASK: tests/integration/foo.test.ts is out of scope per ticket
+LOG
+
+if check_for_stop_and_ask "$TASK_LOG"; then
+  STOP_REASON=$(cat "$tmpdir/claude-stop-reason.txt" 2>/dev/null || true)
+  if [ -n "$STOP_REASON" ]; then
+    assert_pass "stop-reason/written: file created by check_for_stop_and_ask"
+  else
+    assert_fail "stop-reason/written: file created by check_for_stop_and_ask" "file is empty"
+  fi
+  if echo "$STOP_REASON" | grep -q "out of scope"; then
+    assert_pass "stop-reason/content: reason text captured"
+  else
+    assert_fail "stop-reason/content: reason text captured" "got: $STOP_REASON"
+  fi
+else
+  assert_fail "stop-reason/detection: STOP_AND_ASK should be detected" "check_for_stop_and_ask returned 1"
+fi
+
+# 2b. No STOP_AND_ASK → stop-reason.txt NOT written (or retains previous value;
+#     we just care that detection returns 1)
+TASK_LOG2="$tmpdir/claude-task-no-stop.log"
+cat > "$TASK_LOG2" << 'LOG'
+Task completed successfully.
+No issues found.
+LOG
+
+rm -f "$tmpdir/claude-stop-reason.txt"
+if check_for_stop_and_ask "$TASK_LOG2"; then
+  assert_fail "stop-reason/no-detection: should not fire on clean log" "check_for_stop_and_ask returned 0 (false positive)"
+else
+  assert_pass "stop-reason/no-detection: clean log correctly not detected"
+  if [ ! -f "$tmpdir/claude-stop-reason.txt" ]; then
+    assert_pass "stop-reason/not-written: stop-reason.txt not written for clean log"
+  else
+    assert_fail "stop-reason/not-written: stop-reason.txt not written for clean log" "file appeared unexpectedly"
+  fi
+fi
+
+# 2c. Stop-questions JSON is valid JSON and readable when written by inner agent
+STOP_QUESTIONS_FILE="$tmpdir/claude-stop-questions.json"
+SAMPLE_QUESTIONS='[{"id":"q1","question":"What to do?","options":[{"id":"skip","label":"Skip","recommended":true}]}]'
+printf '%s\n' "$SAMPLE_QUESTIONS" > "$STOP_QUESTIONS_FILE"
+
+if jq '.' "$STOP_QUESTIONS_FILE" > /dev/null 2>&1; then
+  assert_pass "stop-questions/valid-json: file is parseable JSON"
+else
+  assert_fail "stop-questions/valid-json: file is parseable JSON" "jq rejected content"
+fi
+
+Q_ID=$(jq -r '.[0].id' "$STOP_QUESTIONS_FILE")
+if [ "$Q_ID" = "q1" ]; then
+  assert_pass "stop-questions/content: first question id readable"
+else
+  assert_fail "stop-questions/content: first question id readable" "got: $Q_ID"
+fi
+
+# Verify check_for_stop_and_ask still detects STOP_AND_ASK when questions file exists
+TASK_LOG3="$tmpdir/claude-task-with-questions.log"
+cat > "$TASK_LOG3" << 'LOG'
+Need guidance.
+
+STOP_AND_ASK: the fix requires out-of-scope changes
+LOG
+
+if check_for_stop_and_ask "$TASK_LOG3"; then
+  assert_pass "stop-questions/detection-with-file: STOP_AND_ASK detected when questions file present"
+else
+  assert_fail "stop-questions/detection-with-file: STOP_AND_ASK detected when questions file present" "returned 1"
+fi
+
+rm -f "$STOP_QUESTIONS_FILE"
+
+# ── Group 3: No /tmp/claude-* leaks ──────────────────────────────────────────
+
+if assert_no_tmp_leak "all-tests"; then
+  assert_pass "leak-check: no /tmp/claude-* files in real /tmp"
+else
+  assert_fail "leak-check: no /tmp/claude-* files in real /tmp" "files leaked"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+if [ $FAIL -eq 0 ]; then
+  echo ""
+  echo "All T0 state-file contract tests PASSED"
+  exit 0
+else
+  echo ""
+  echo "FAIL: one or more T0 state-file contract tests failed (see above)"
+  exit 1
+fi

--- a/tests/unit/state-file-contract.test.ts
+++ b/tests/unit/state-file-contract.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+import { spawnSync } from 'child_process'
+
+import {
+  STATE_FILES,
+  T0_REACHABLE,
+  STACK_INPUT_FILES,
+  DYNAMIC_FILES,
+  TASK_STATUS_VALUES,
+  type StateFile,
+} from '../../tests/contract/state-files'
+
+const TASK_RUNNER = resolve(__dirname, '../../sandstorm-cli/docker/task-runner.sh')
+const STACK_SH = resolve(__dirname, '../../sandstorm-cli/lib/stack.sh')
+const hasBash = spawnSync('which', ['bash'], { encoding: 'utf-8' }).status === 0
+
+// ---------------------------------------------------------------------------
+// Schema completeness and type-safety tests
+// ---------------------------------------------------------------------------
+
+describe('state-files schema', () => {
+  describe('structural requirements', () => {
+    it('exports a non-empty STATE_FILES array', () => {
+      expect(STATE_FILES).toBeDefined()
+      expect(Array.isArray(STATE_FILES)).toBe(true)
+      expect(STATE_FILES.length).toBeGreaterThan(20)
+    })
+
+    it('every entry has the required fields', () => {
+      const required: (keyof StateFile)[] = [
+        'pattern',
+        'description',
+        'producer',
+        'consumer',
+        'format',
+        'whenWritten',
+        'conditional',
+        't0Reachable',
+      ]
+      for (const file of STATE_FILES) {
+        for (const field of required) {
+          expect(file[field], `${file.pattern} is missing field '${field}'`).toBeDefined()
+        }
+      }
+    })
+
+    it('all patterns start with /tmp/', () => {
+      for (const file of STATE_FILES) {
+        expect(
+          file.pattern.startsWith('/tmp/'),
+          `${file.pattern} does not start with /tmp/`,
+        ).toBe(true)
+      }
+    })
+
+    it('all descriptions are non-empty strings', () => {
+      for (const file of STATE_FILES) {
+        expect(
+          typeof file.description === 'string' && file.description.length > 0,
+          `${file.pattern} has empty or missing description`,
+        ).toBe(true)
+      }
+    })
+
+    it('dynamic files have a suffixRange with min <= max', () => {
+      for (const file of DYNAMIC_FILES) {
+        expect(file.suffixRange, `${file.pattern} is dynamic but missing suffixRange`).toBeDefined()
+        expect(
+          file.suffixRange!.min <= file.suffixRange!.max,
+          `${file.pattern} has inverted suffixRange`,
+        ).toBe(true)
+      }
+    })
+
+    it('status files have non-empty statusValues arrays', () => {
+      const statusFiles = STATE_FILES.filter((f) => f.format === 'status')
+      expect(statusFiles.length).toBeGreaterThan(0)
+      for (const file of statusFiles) {
+        expect(
+          Array.isArray(file.statusValues) && file.statusValues!.length > 0,
+          `${file.pattern} has format 'status' but no statusValues`,
+        ).toBe(true)
+      }
+    })
+
+    it('no duplicate patterns', () => {
+      const patterns = STATE_FILES.map((f) => f.pattern)
+      const unique = new Set(patterns)
+      expect(unique.size).toBe(patterns.length)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // T0-reachable subset
+  // ---------------------------------------------------------------------------
+
+  describe('T0-reachable files', () => {
+    it('T0_REACHABLE is a non-empty subset of STATE_FILES', () => {
+      expect(T0_REACHABLE.length).toBeGreaterThan(0)
+      expect(T0_REACHABLE.length).toBeLessThan(STATE_FILES.length)
+      for (const f of T0_REACHABLE) {
+        expect(STATE_FILES).toContain(f)
+      }
+    })
+
+    it('all T0-reachable files are either stack.sh inputs or STOP_AND_ASK artifacts', () => {
+      for (const f of T0_REACHABLE) {
+        const isStackInput =
+          f.producer === 'stack.sh' ||
+          (Array.isArray(f.producer) && f.producer.includes('stack.sh'))
+        const isStopAsk =
+          f.pattern.includes('stop-reason') || f.pattern.includes('stop-questions')
+        expect(
+          isStackInput || isStopAsk,
+          `${f.pattern} is t0Reachable but is neither a stack.sh input nor a STOP_AND_ASK artifact`,
+        ).toBe(true)
+      }
+    })
+
+    it('stack input files are all T0-reachable', () => {
+      for (const f of STACK_INPUT_FILES) {
+        expect(
+          f.t0Reachable,
+          `stack.sh input file ${f.pattern} should be t0Reachable`,
+        ).toBe(true)
+      }
+    })
+
+    it('includes all 9 expected stack.sh input file patterns', () => {
+      const inputPatterns = STACK_INPUT_FILES.map((f) => f.pattern)
+      const expected = [
+        '/tmp/claude-task-trigger',
+        '/tmp/claude-task-prompt.txt',
+        '/tmp/claude-task-label.txt',
+        '/tmp/claude-task-model.txt',
+        '/tmp/claude-task-models.json',
+        '/tmp/claude-task-resume.txt',
+        '/tmp/claude-task-backend.txt',
+        '/tmp/claude-task-backend-model.txt',
+        '/tmp/claude-task-phase-routing.json',
+      ]
+      for (const p of expected) {
+        expect(inputPatterns, `missing stack.sh input file: ${p}`).toContain(p)
+      }
+    })
+
+    it('includes stop-reason.txt as T0-reachable', () => {
+      const f = STATE_FILES.find((sf) => sf.pattern === '/tmp/claude-stop-reason.txt')
+      expect(f).toBeDefined()
+      expect(f!.t0Reachable).toBe(true)
+    })
+
+    it('includes stop-questions.json as T0-reachable', () => {
+      const f = STATE_FILES.find((sf) => sf.pattern === '/tmp/claude-stop-questions.json')
+      expect(f).toBeDefined()
+      expect(f!.t0Reachable).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // TASK_STATUS_VALUES
+  // ---------------------------------------------------------------------------
+
+  describe('TASK_STATUS_VALUES', () => {
+    it('is a non-empty array of strings', () => {
+      expect(Array.isArray(TASK_STATUS_VALUES)).toBe(true)
+      expect(TASK_STATUS_VALUES.length).toBeGreaterThan(0)
+      for (const v of TASK_STATUS_VALUES) {
+        expect(typeof v).toBe('string')
+      }
+    })
+
+    it('includes the core lifecycle statuses', () => {
+      const core = ['running', 'completed', 'failed', 'token_limited', 'needs_human']
+      for (const s of core) {
+        expect(TASK_STATUS_VALUES, `missing status value: ${s}`).toContain(s)
+      }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Cross-reference with task-runner.sh source
+  // ---------------------------------------------------------------------------
+
+  describe('cross-reference with task-runner.sh', () => {
+    it('task-runner.sh exists', () => {
+      expect(existsSync(TASK_RUNNER)).toBe(true)
+    })
+
+    const knownPaths = [
+      '/tmp/claude-task-trigger',
+      '/tmp/claude-task-prompt.txt',
+      '/tmp/claude-task-model.txt',
+      '/tmp/claude-task-models.json',
+      '/tmp/claude-task-resume.txt',
+      '/tmp/claude-task-backend.txt',
+      '/tmp/claude-task-phase-routing.json',
+      '/tmp/claude-ready',
+      '/tmp/claude-task.pid',
+      '/tmp/claude-task.status',
+      '/tmp/claude-task.exit',
+      '/tmp/claude-task.review-iterations',
+      '/tmp/claude-task.verify-retries',
+      '/tmp/claude-raw.log',
+      '/tmp/claude-task.log',
+      '/tmp/claude-review-raw.log',
+      '/tmp/claude-review-task.log',
+      '/tmp/claude-stop-reason.txt',
+      '/tmp/claude-verify.log',
+      '/tmp/claude-phase-timing.txt',
+      '/tmp/claude-execution-summary.txt',
+    ]
+
+    for (const p of knownPaths) {
+      it(`schema includes known path ${p}`, () => {
+        const found = STATE_FILES.some((f) => f.pattern === p)
+        expect(found, `${p} is referenced in task-runner.sh but missing from schema`).toBe(true)
+      })
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Cross-reference with stack.sh source
+  // ---------------------------------------------------------------------------
+
+  describe('cross-reference with stack.sh', () => {
+    it('stack.sh exists', () => {
+      expect(existsSync(STACK_SH)).toBe(true)
+    })
+
+    it('schema covers all /tmp/ paths written by stack.sh task command', () => {
+      // These are the literal writes in the stack.sh "task" case
+      const stackWrites = [
+        '/tmp/claude-task-prompt.txt',
+        '/tmp/claude-task-label.txt',
+        '/tmp/claude-task-trigger',
+      ]
+      const patterns = STATE_FILES.map((f) => f.pattern)
+      for (const p of stackWrites) {
+        expect(patterns, `stack.sh writes ${p} but it is missing from schema`).toContain(p)
+      }
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bash-level T0 contract test (uses bash-harness.sh + state-file-contract.sh)
+// ---------------------------------------------------------------------------
+
+const contractSh = resolve(__dirname, 'state-file-contract.sh')
+
+describe.skipIf(!hasBash || !existsSync(contractSh))(
+  'T0 bash contract tests',
+  () => {
+    it(
+      'state-file-contract.sh: all T0 state-file assertions pass',
+      () => {
+        const result = spawnSync('bash', [contractSh], {
+          encoding: 'utf-8',
+          timeout: 30_000,
+        })
+        if (result.stdout) process.stdout.write(result.stdout)
+        if (result.stderr) process.stderr.write(result.stderr)
+        expect(result.status).toBe(0)
+      },
+      30_000,
+    )
+  },
+)


### PR DESCRIPTION
## Summary

`dispatchTask` previously passed the task prompt to the inner Claude CLI as a positional argument, falling back to a `--file` temp file only when the prompt exceeded the E2BIG threshold. That split path meant prompt handling differed by size and left the large-prompt route under-exercised.

This change makes `dispatchTask` always write the prompt to a temp file (`prompt.txt` under a sandstorm temp dir) and pass it via `--file <path>`, removing the positional-arg path entirely. Cleanup is fire-and-forget via `.finally()` after `runCli` settles, so the temp file lives long enough for callers to read it synchronously on the same tick while still being removed afterward.

Test assertions that expected the old behavior (prompt as the final positional arg, no `--file`) were updated to the always-on `--file` behavior, and the former E2BIG-specific regression test was renamed to reflect that `--file` is now used unconditionally.

## QA plan

1. Spin up a stack and dispatch a normal (small) task to the inner agent.
2. Confirm the agent receives and acts on the full prompt as before — behavior should be unchanged from the user's perspective.
3. Dispatch a task with a very large prompt (previously over the E2BIG limit) and confirm it is still delivered correctly.
4. While a task runs, verify the temp `prompt.txt` is present, then confirm it is cleaned up after the dispatch settles.

Closes #660