### PR TITLE
[662] fix: add cross-product tests for model routing precedence

### DIFF
--- a/tests/unit/model-routing.test.ts
+++ b/tests/unit/model-routing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Registry } from '../../src/main/control-plane/registry';
 import { TOUCHPOINTS, PRESETS, CLAUDE_MODELS, OPENCODE_MODELS, getAvailableModels } from '../../src/main/control-plane/routing';
-import type { TouchpointId, PresetId } from '../../src/main/control-plane/routing';
+import type { TouchpointId, PresetId, RoutingAssignment } from '../../src/main/control-plane/routing';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -524,6 +524,89 @@ describe('Model Routing', () => {
         expect(typeof desc.backend).toBe('string');
         expect(typeof desc.provider).toBe('string');
         expect(typeof desc.model).toBe('string');
+      }
+    });
+  });
+
+  // ==========================================================================
+  // Contract: touchpoint × precedence layer cross-product (all 7 × 5)
+  // ==========================================================================
+  describe('contract: touchpoint × precedence layer', () => {
+    const PRESET_IDS: PresetId[] = ['max_quality', 'balanced', 'budget'];
+    const OUTER_LEGACY: TouchpointId[] = ['outer', 'refine', 'pr_description'];
+    const INNER_LEGACY: TouchpointId[] = ['execution', 'review', 'meta_review', 'merge_conflict'];
+
+    // Layer 1: project explicit assignment wins over global preset for every touchpoint
+    describe('layer 1: project explicit assignment wins for all 7 touchpoints', () => {
+      for (const touchpoint of TOUCHPOINTS) {
+        it(`${touchpoint}: project explicit assignment wins over conflicting global preset`, () => {
+          const explicit: RoutingAssignment = { backend: 'claude', provider: 'anthropic', model: 'haiku' };
+          registry.setProjectRouting('/proj/layer1', {
+            assignments: { [touchpoint]: explicit },
+          });
+          registry.setGlobalRouting({ preset: 'max_quality' });
+          expect(registry.getEffectiveRoutingFor('/proj/layer1', touchpoint)).toEqual(explicit);
+        });
+      }
+    });
+
+    // Layer 2: project preset resolves to PRESETS[preset][touchpoint] for every preset × touchpoint
+    describe('layer 2: project preset resolves to PRESETS[preset][touchpoint] for all 7 touchpoints', () => {
+      for (const presetId of PRESET_IDS) {
+        for (const touchpoint of TOUCHPOINTS) {
+          it(`${presetId}/${touchpoint}: project preset resolves correctly`, () => {
+            registry.setProjectRouting('/proj/layer2', { preset: presetId });
+            expect(registry.getEffectiveRoutingFor('/proj/layer2', touchpoint)).toEqual(
+              PRESETS[presetId][touchpoint],
+            );
+          });
+        }
+      }
+    });
+
+    // Layer 3: global explicit assignment applies for every touchpoint when no project routing
+    describe('layer 3: global explicit assignment applies for all 7 touchpoints', () => {
+      for (const touchpoint of TOUCHPOINTS) {
+        it(`${touchpoint}: global explicit assignment applies when no project routing exists`, () => {
+          const explicit: RoutingAssignment = { backend: 'claude', provider: 'anthropic', model: 'haiku' };
+          registry.setGlobalRouting({ assignments: { [touchpoint]: explicit } });
+          expect(registry.getEffectiveRoutingFor('/proj/no-project-layer3', touchpoint)).toEqual(explicit);
+        });
+      }
+    });
+
+    // Layer 4: global preset resolves to PRESETS[preset][touchpoint] for every preset × touchpoint
+    describe('layer 4: global preset resolves to PRESETS[preset][touchpoint] for all 7 touchpoints', () => {
+      for (const presetId of PRESET_IDS) {
+        for (const touchpoint of TOUCHPOINTS) {
+          it(`${presetId}/${touchpoint}: global preset resolves correctly`, () => {
+            registry.setGlobalRouting({ preset: presetId });
+            expect(registry.getEffectiveRoutingFor('/proj/no-project-layer4', touchpoint)).toEqual(
+              PRESETS[presetId][touchpoint],
+            );
+          });
+        }
+      }
+    });
+
+    // Layer 5: legacy fallback — outer/refine/pr_description → outer_model; the other four → inner_model
+    describe('layer 5: legacy fallback routes correctly for all 7 touchpoints', () => {
+      for (const touchpoint of OUTER_LEGACY) {
+        it(`${touchpoint}: legacy fallback resolves to outer_model`, () => {
+          registry.setGlobalModelSettings({ inner_model: 'sonnet', outer_model: 'haiku' });
+          expect(registry.getEffectiveRoutingFor('/proj/no-routing-layer5', touchpoint)).toEqual(
+            { backend: 'claude', provider: 'anthropic', model: 'haiku' },
+          );
+        });
+      }
+
+      for (const touchpoint of INNER_LEGACY) {
+        it(`${touchpoint}: legacy fallback resolves to inner_model`, () => {
+          registry.setGlobalModelSettings({ inner_model: 'sonnet', outer_model: 'haiku' });
+          expect(registry.getEffectiveRoutingFor('/proj/no-routing-layer5', touchpoint)).toEqual(
+            { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+          );
+        });
       }
     });
   });


### PR DESCRIPTION
## Summary

Adds a contract test block to `tests/unit/model-routing.test.ts` that exhaustively exercises `Registry.getEffectiveRoutingFor` across the full cross-product of all 7 routing touchpoints and the 5 precedence layers that resolve them. Previously the precedence layers were only spot-checked; this locks down the resolution order so a regression in any single touchpoint × layer combination is caught.

The new block asserts each layer in priority order:

- Layer 1: a project explicit assignment wins over a conflicting global preset, for every touchpoint.
- Layer 2: a project preset resolves to `PRESETS[preset][touchpoint]` for every preset × touchpoint.
- Layer 3: a global explicit assignment applies for every touchpoint when no project routing exists.
- Layer 4: a global preset resolves to `PRESETS[preset][touchpoint]` for every preset × touchpoint.
- Layer 5: legacy fallback routes `outer`/`refine`/`pr_description` to `outer_model` and the other four touchpoints to `inner_model`.

Test-only change; no production source is touched.

## QA plan

1. Run `npm test tests/unit/model-routing.test.ts` and confirm all 121 tests pass, including the new `contract: touchpoint × precedence layer` describe block.
2. Skim the new block to confirm the layer ordering matches the intended precedence (project explicit > project preset > global explicit > global preset > legacy fallback).
3. Confirm no files outside `tests/unit/model-routing.test.ts` are modified.

Closes #662