### PR TITLE
[682] fix: route image rebuild checks through container runtime

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -24,6 +24,7 @@ import {
   EphemeralSessionHandle,
   zeroSessionTokens,
 } from './types';
+import { ContainerRuntime } from '../runtime/types';
 import { appendEphemeralTiming, type EphemeralTimingRecord } from './ephemeral-timing';
 import { buildEphemeralAgentArgs } from './ephemeral-args';
 import { extractStreamEvents } from './ephemeral-stream-events';
@@ -90,16 +91,19 @@ export class ClaudeBackend implements AgentBackend {
   private logStream: fs.WriteStream | null = null;
   private timeoutMs: number;
   private modelResolver?: (projectDir: string) => string;
+  private resolveRuntime?: (stack: StackInfo) => ContainerRuntime;
   private rawCapture: RawCaptureSupervisor;
   private rawCaptureByTab = new Map<string, RawCaptureSession>();
   private ephemeralTimingPath: string;
 
   constructor(
     timeoutMs?: number,
-    modelResolver?: (projectDir: string) => string
+    modelResolver?: (projectDir: string) => string,
+    resolveRuntime?: (stack: StackInfo) => ContainerRuntime
   ) {
     this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.modelResolver = modelResolver;
+    this.resolveRuntime = resolveRuntime;
     this.initLogger();
     this.rawCapture = this.initRawCapture();
     this.ephemeralTimingPath = this.resolveEphemeralTimingPath();
@@ -824,13 +828,13 @@ export class ClaudeBackend implements AgentBackend {
         if (!claudeService?.containerId) continue;
 
         try {
-          const child = spawn('docker', [
-            'exec', '-i', '-u', 'claude', claudeService.containerId,
-            'bash', '-c', 'mkdir -p ~/.claude && cat > ~/.claude/.credentials.json',
-          ], { stdio: ['pipe', 'ignore', 'ignore'] });
-          child.stdin.write(creds);
-          child.stdin.end();
-          await new Promise<void>((resolve) => child.on('close', () => resolve()));
+          if (!this.resolveRuntime) throw new Error('resolveRuntime is required');
+          const runtime = this.resolveRuntime(stack);
+          await runtime.exec(
+            claudeService.containerId,
+            ['bash', '-c', 'mkdir -p ~/.claude && cat > ~/.claude/.credentials.json'],
+            { user: 'claude', input: creds }
+          );
         } catch {
           // Best effort per container
         }

--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -17,7 +17,6 @@
 
 import path from 'path';
 import os from 'os';
-import { spawn } from 'child_process';
 import { BrowserWindow } from 'electron';
 import { app } from 'electron';
 // @opencode-ai/sdk is ESM-only — static require() fails in the CJS bundle.
@@ -52,6 +51,7 @@ import {
   zeroSessionTokens,
 } from './types';
 import { appendEphemeralTiming, type EphemeralTimingRecord } from './ephemeral-timing';
+import { type ContainerRuntime } from '../runtime/types';
 import { cliDir } from '../index';
 
 // ---------------------------------------------------------------------------
@@ -166,7 +166,10 @@ export class OpenCodeBackend implements AgentBackend {
   // Used to detect when syncCredentials needs to restart the server.
   private serverProviderSignature = '';
 
-  constructor() {
+  private resolveRuntime?: (stack: StackInfo) => ContainerRuntime;
+
+  constructor(resolveRuntime?: (stack: StackInfo) => ContainerRuntime) {
+    this.resolveRuntime = resolveRuntime;
     this.ephemeralTimingPath = this.resolveEphemeralTimingPath();
   }
 
@@ -801,7 +804,7 @@ export class OpenCodeBackend implements AgentBackend {
         await this.execInContainer(claudeService.containerId, [
           'bash', '-c',
           'rm -f ~/.local/share/opencode/auth.json && mkdir -p ~/.local/share/opencode',
-        ]);
+        ], undefined, this.resolveRuntime?.(stack));
 
         // 2. Collect distinct opencode providers across all container phases.
         //    For each provider, store its credentials bundle and one representative model.
@@ -823,14 +826,9 @@ export class OpenCodeBackend implements AgentBackend {
           if (!credentials) continue;
           const config = generateOpencodeConfig({ providerId, bundle: credentials, model: model || undefined });
           const configJson = JSON.stringify(config, null, 2);
-          const writeProc = spawn('docker', [
-            'exec', '-i', '-u', 'claude', claudeService.containerId,
+          await this.execInContainer(claudeService.containerId, [
             'bash', '-c', 'cat > "$1"', '--', `/tmp/sandstorm-opencode-${providerId}.json`,
-          ], { stdio: ['pipe', 'ignore', 'ignore'] });
-          writeProc.on('error', () => {});
-          writeProc.stdin.write(configJson);
-          writeProc.stdin.end();
-          await new Promise<void>((resolve) => writeProc.on('close', () => resolve()));
+          ], configJson, this.resolveRuntime?.(stack));
         }
       } catch {
         // Best effort per container
@@ -838,14 +836,13 @@ export class OpenCodeBackend implements AgentBackend {
     }
   }
 
-  private execInContainer(containerId: string, cmd: string[]): Promise<void> {
-    return new Promise<void>((resolve) => {
-      const proc = spawn('docker', ['exec', '-u', 'claude', containerId, ...cmd], {
-        stdio: ['pipe', 'ignore', 'ignore'],
-      });
-      proc.stdin.end();
-      proc.on('close', () => resolve());
-      proc.on('error', () => resolve());
-    });
+  private async execInContainer(
+    containerId: string,
+    cmd: string[],
+    input?: string,
+    runtime?: ContainerRuntime
+  ): Promise<void> {
+    if (!runtime) throw new Error('execInContainer requires a ContainerRuntime');
+    await runtime.exec(containerId, cmd, { user: 'claude', input });
   }
 }

--- a/src/main/agent/types.ts
+++ b/src/main/agent/types.ts
@@ -79,6 +79,7 @@ export interface StackInfo {
   status: string;
   project_dir?: string;
   services?: StackServiceInfo[];
+  runtime?: 'docker' | 'podman';
 }
 
 export interface AgentBackend {

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -450,32 +450,22 @@ export class StackManager {
    * Compares the image's sandstorm.app-version label to the current app version.
    * Returns true if the image is outdated or missing a version stamp.
    */
-  async checkImageNeedsRebuild(projectDir: string): Promise<boolean> {
+  async checkImageNeedsRebuild(projectDir: string, runtime: ContainerRuntime): Promise<boolean> {
     if (this.appVersion === 'unknown') return false;
 
     try {
       const projectName = path.basename(projectDir).toLowerCase().replace(/[^a-z0-9]/g, '-');
       const imageName = `sandstorm-${projectName}-claude`;
 
-      // Use docker CLI to inspect the image label (works with any runtime)
-      const result = await new Promise<{ stdout: string; exitCode: number }>((resolve) => {
-        const child = spawn('docker', [
-          'image', 'inspect', imageName,
-          '--format', '{{index .Config.Labels "sandstorm.app-version"}}',
-        ], { stdio: ['ignore', 'pipe', 'pipe'] });
-        let stdout = '';
-        child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
-        child.on('close', (code) => resolve({ stdout: stdout.trim(), exitCode: code ?? 1 }));
-        child.on('error', () => resolve({ stdout: '', exitCode: 1 }));
-      });
+      const imageInfo = await runtime.inspectImage(imageName);
 
-      if (result.exitCode !== 0) {
+      if (!imageInfo) {
         // Image doesn't exist — will be built from scratch, no rebuild needed
         return false;
       }
 
-      const imageVersion = result.stdout;
-      if (!imageVersion || imageVersion === '<no value>') {
+      const imageVersion = imageInfo.labels['sandstorm.app-version'];
+      if (!imageVersion) {
         // Image exists but has no version label — needs rebuild to stamp it
         return true;
       }
@@ -489,7 +479,8 @@ export class StackManager {
   private async buildStackInBackground(opts: CreateStackOpts, _projectName: string): Promise<void> {
     try {
       // Check if the base image needs rebuilding due to app version change
-      const needsRebuild = await this.checkImageNeedsRebuild(opts.projectDir);
+      const buildRuntime = opts.runtime === 'podman' ? this.podmanRuntime : this.dockerRuntime;
+      const needsRebuild = await this.checkImageNeedsRebuild(opts.projectDir, buildRuntime);
       if (needsRebuild) {
         this.registry.updateStackStatus(opts.name, 'rebuilding');
         this.notifyUpdate();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, nativeTheme } from 'electron';
 import path from 'path';
-import { Registry } from './control-plane/registry';
+import { Registry, Stack } from './control-plane/registry';
 import { PortAllocator } from './control-plane/port-allocator';
 import { PortProxy } from './control-plane/port-proxy';
 import { TaskWatcher } from './control-plane/task-watcher';
@@ -9,7 +9,7 @@ import { DockerRuntime } from './runtime/docker';
 import { PodmanRuntime } from './runtime/podman';
 import { ContainerRuntime } from './runtime/types';
 import { DockerConnectionManager } from './runtime/docker-connection';
-import { AgentBackend, ClaudeBackend, OpenCodeBackend, BackendRouter } from './agent';
+import { AgentBackend, ClaudeBackend, OpenCodeBackend, BackendRouter, StackInfo } from './agent';
 import { registerIpcHandlers } from './ipc';
 import { createTray } from './tray';
 import { SessionMonitor } from './control-plane/session-monitor';
@@ -173,10 +173,11 @@ async function initializeApp(): Promise<void> {
   const modelResolver = (projectDir: string) => {
     return registry.getEffectiveRoutingFor(projectDir, 'outer').model;
   };
+  const resolveRuntime = (stack: StackInfo) => stackManager.getRuntimeForStack(stack as Stack);
   agentBackend = new BackendRouter(
     {
-      claude: () => new ClaudeBackend(undefined, modelResolver),
-      opencode: () => new OpenCodeBackend(),
+      claude: () => new ClaudeBackend(undefined, modelResolver, resolveRuntime),
+      opencode: () => new OpenCodeBackend(resolveRuntime),
     },
     (projectDir) => registry.getEffectiveRoutingFor(projectDir, 'outer').backend,
     (projectDir, touchpoint) => registry.getEffectiveTouchpointDescriptor(projectDir, touchpoint),

--- a/src/main/runtime/docker.ts
+++ b/src/main/runtime/docker.ts
@@ -233,22 +233,38 @@ export class DockerRuntime implements ContainerRuntime {
     }
   }
 
+  async inspectImage(ref: string): Promise<{ labels: Record<string, string> } | null> {
+    try {
+      const image = this.docker.getImage(ref);
+      const info = await image.inspect();
+      return { labels: (info.Config?.Labels ?? {}) as Record<string, string> };
+    } catch {
+      return null;
+    }
+  }
+
   async exec(
     containerId: string,
     cmd: string[],
     opts?: ExecOpts
   ): Promise<ExecResult> {
+    const hasInput = opts?.input != null;
     const container = this.docker.getContainer(containerId);
     const exec = await container.exec({
       Cmd: cmd,
       AttachStdout: true,
       AttachStderr: true,
+      AttachStdin: hasInput,
       WorkingDir: opts?.workdir,
       Env: opts?.env,
       User: opts?.user,
     });
 
-    const stream = await exec.start({ hijack: true, stdin: false });
+    const stream = await exec.start({ hijack: true, stdin: hasInput });
+    if (hasInput) {
+      stream.write(opts!.input!);
+      stream.end();
+    }
     let stdout = '';
     let stderr = '';
     let remainder: Buffer = Buffer.alloc(0);

--- a/src/main/runtime/local.ts
+++ b/src/main/runtime/local.ts
@@ -1,0 +1,223 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  ContainerRuntime,
+  ComposeOpts,
+  ContainerFilter,
+  Container,
+  ContainerInfo,
+  ContainerStats,
+  ContainerStatus,
+  LogOpts,
+  ExecOpts,
+  ExecResult,
+} from './types';
+
+interface LocalContainer {
+  id: string;
+  name: string;
+  image: string;
+  tmpdir: string;
+  status: ContainerStatus;
+  created: string;
+  labels: Record<string, string>;
+}
+
+/**
+ * ContainerRuntime that runs commands as local subprocesses inside per-container
+ * tmpdirs. Requires no Docker or Podman daemon — intended for unit testing and
+ * local development workflows where container isolation is not needed.
+ *
+ * Containers are registered programmatically via `registerContainer()`.
+ * Images are registered via `registerImage()`.
+ */
+export class LocalRuntime implements ContainerRuntime {
+  readonly name = 'local';
+
+  private containers = new Map<string, LocalContainer>();
+  private imageLabels = new Map<string, Record<string, string>>();
+  private ownedTmpdirs: string[] = [];
+  private composeContainers = new Map<string, string>();
+
+  /**
+   * Register a fake container. Returns the tmpdir path created for it.
+   * If `tmpdir` is not provided, a new one is created and will be cleaned
+   * up when `destroy()` is called.
+   */
+  registerContainer(
+    id: string,
+    opts: { name: string; image: string; tmpdir?: string; status?: ContainerStatus; labels?: Record<string, string> }
+  ): string {
+    let tmpdir = opts.tmpdir;
+    if (!tmpdir) {
+      tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'localrt-'));
+      this.ownedTmpdirs.push(tmpdir);
+    }
+    this.containers.set(id, {
+      id,
+      name: opts.name,
+      image: opts.image,
+      tmpdir,
+      status: opts.status ?? 'running',
+      created: new Date().toISOString(),
+      labels: opts.labels ?? {},
+    });
+    return tmpdir;
+  }
+
+  /**
+   * Register fake image metadata (labels). Returns null from `inspectImage`
+   * for any ref not registered here.
+   */
+  registerImage(ref: string, labels: Record<string, string>): void {
+    this.imageLabels.set(ref, labels);
+  }
+
+  /** Remove all registered containers and clean up owned tmpdirs. */
+  destroy(): void {
+    this.containers.clear();
+    this.imageLabels.clear();
+    this.composeContainers.clear();
+    for (const dir of this.ownedTmpdirs) {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    this.ownedTmpdirs = [];
+  }
+
+  async composeUp(_projectDir: string, opts: ComposeOpts): Promise<void> {
+    const id = opts.projectName;
+    this.registerContainer(id, {
+      name: opts.projectName,
+      image: 'local',
+      status: 'running',
+      labels: { 'com.docker.compose.project': opts.projectName },
+    });
+    this.composeContainers.set(opts.projectName, id);
+  }
+
+  async composeDown(_projectDir: string, opts: ComposeOpts): Promise<void> {
+    const id = this.composeContainers.get(opts.projectName);
+    if (id) {
+      const c = this.containers.get(id);
+      if (c && this.ownedTmpdirs.includes(c.tmpdir)) {
+        try { fs.rmSync(c.tmpdir, { recursive: true, force: true }); } catch { /* ignore */ }
+        this.ownedTmpdirs = this.ownedTmpdirs.filter((d) => d !== c.tmpdir);
+      }
+      this.containers.delete(id);
+      this.composeContainers.delete(opts.projectName);
+    }
+  }
+
+  async listContainers(filter?: ContainerFilter): Promise<Container[]> {
+    let result = Array.from(this.containers.values());
+    if (filter?.name) {
+      result = result.filter((c) => c.name.includes(filter.name!));
+    }
+    if (filter?.status) {
+      result = result.filter((c) => c.status === filter.status);
+    }
+    if (filter?.label) {
+      const eq = filter.label.indexOf('=');
+      if (eq !== -1) {
+        const key = filter.label.slice(0, eq);
+        const val = filter.label.slice(eq + 1);
+        result = result.filter((c) => c.labels[key] === val);
+      } else {
+        result = result.filter((c) => Object.prototype.hasOwnProperty.call(c.labels, filter.label!));
+      }
+    }
+    return result.map((c) => ({
+      id: c.id,
+      name: c.name,
+      image: c.image,
+      status: c.status,
+      state: c.status,
+      ports: [],
+      labels: c.labels,
+      created: c.created,
+    }));
+  }
+
+  async inspect(containerId: string): Promise<ContainerInfo> {
+    const c = this.containers.get(containerId);
+    if (!c) throw new Error(`LocalRuntime: container ${containerId} not found`);
+    return {
+      id: c.id,
+      name: c.name,
+      state: {
+        status: c.status,
+        running: c.status === 'running',
+        exitCode: 0,
+        startedAt: c.created,
+        finishedAt: '',
+      },
+      config: { image: c.image, env: [] },
+    };
+  }
+
+  async *logs(_containerId: string, _opts?: LogOpts): AsyncIterable<string> {
+    // No logs in local mode
+  }
+
+  async containerStats(_containerId: string): Promise<ContainerStats> {
+    return { memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 };
+  }
+
+  async exec(
+    containerId: string,
+    cmd: string[],
+    opts?: ExecOpts
+  ): Promise<ExecResult> {
+    const c = this.containers.get(containerId);
+    if (!c) {
+      return { exitCode: 1, stdout: '', stderr: `container not found: ${containerId}` };
+    }
+    const cwd = opts?.workdir
+      ? path.resolve(c.tmpdir, opts.workdir)
+      : c.tmpdir;
+
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (opts?.env) {
+      for (const entry of opts.env) {
+        const eq = entry.indexOf('=');
+        if (eq !== -1) env[entry.slice(0, eq)] = entry.slice(eq + 1);
+      }
+    }
+
+    const hasInput = opts?.input != null;
+    const [bin, ...args] = cmd;
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(bin, args, {
+        cwd,
+        env,
+        stdio: [hasInput ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      });
+      if (hasInput && child.stdin) {
+        child.stdin.write(opts!.input!);
+        child.stdin.end();
+      }
+      let stdout = '';
+      let stderr = '';
+      child.stdout?.on('data', (d: Buffer) => (stdout += d.toString()));
+      child.stderr?.on('data', (d: Buffer) => (stderr += d.toString()));
+      child.on('close', (code) => resolve({ exitCode: code ?? 0, stdout, stderr }));
+      child.on('error', reject);
+    });
+  }
+
+  async inspectImage(ref: string): Promise<{ labels: Record<string, string> } | null> {
+    const labels = this.imageLabels.get(ref);
+    return labels != null ? { labels } : null;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async version(): Promise<string> {
+    return 'local';
+  }
+}

--- a/src/main/runtime/podman.ts
+++ b/src/main/runtime/podman.ts
@@ -103,12 +103,25 @@ export class PodmanRuntime implements ContainerRuntime {
     }
   }
 
+  async inspectImage(ref: string): Promise<{ labels: Record<string, string> } | null> {
+    try {
+      const result = await this.runCapture('podman', ['image', 'inspect', ref, '--format', 'json']);
+      const data = JSON.parse(result);
+      const info = Array.isArray(data) ? data[0] : data;
+      return { labels: (info.Labels ?? info.Config?.Labels ?? {}) as Record<string, string> };
+    } catch {
+      return null;
+    }
+  }
+
   async exec(
     containerId: string,
     cmd: string[],
     opts?: ExecOpts
   ): Promise<ExecResult> {
+    const hasInput = opts?.input != null;
     const args = ['exec'];
+    if (hasInput) args.push('-i');
     if (opts?.workdir) args.push('-w', opts.workdir);
     if (opts?.user) args.push('-u', opts.user);
     if (opts?.env) {
@@ -118,8 +131,12 @@ export class PodmanRuntime implements ContainerRuntime {
 
     return new Promise((resolve, reject) => {
       const child = spawn('podman', args, {
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: [hasInput ? 'pipe' : 'ignore', 'pipe', 'pipe'],
       });
+      if (hasInput && child.stdin) {
+        child.stdin.write(opts!.input!);
+        child.stdin.end();
+      }
       let stdout = '';
       let stderr = '';
       child.stdout?.on('data', (d: Buffer) => (stdout += d.toString()));

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -57,6 +57,7 @@ export interface ExecOpts {
   env?: string[];
   interactive?: boolean;
   user?: string;
+  input?: string;
 }
 
 export interface ExecResult {
@@ -88,6 +89,9 @@ export interface ContainerRuntime {
     cmd: string[],
     opts?: ExecOpts
   ): Promise<ExecResult>;
+
+  // Image inspection (returns null if image not found)
+  inspectImage(ref: string): Promise<{ labels: Record<string, string> } | null>;
 
   // Health
   isAvailable(): Promise<boolean>;

--- a/tests/helpers/fake-container-runtime.ts
+++ b/tests/helpers/fake-container-runtime.ts
@@ -1,0 +1,38 @@
+import { vi } from 'vitest';
+import type { ContainerRuntime } from '../../src/main/runtime/types';
+
+/**
+ * Factory for ContainerRuntime test doubles.
+ *
+ * Returns a fully-typed mock with sensible no-op defaults for every interface
+ * method. Pass `overrides` to replace any subset of methods with custom
+ * implementations — useful for exec-behavior tests without repeating all the
+ * other stubs.
+ *
+ * Using a single factory means adding a new method to ContainerRuntime only
+ * requires updating this file rather than every test file.
+ */
+export function makeFakeContainerRuntime(
+  overrides?: Partial<ContainerRuntime>
+): ContainerRuntime {
+  const base: ContainerRuntime = {
+    name: 'mock',
+    composeUp: vi.fn().mockResolvedValue(undefined),
+    composeDown: vi.fn().mockResolvedValue(undefined),
+    listContainers: vi.fn().mockResolvedValue([]),
+    inspect: vi.fn().mockResolvedValue({
+      id: 'mock-id',
+      name: 'mock-container',
+      state: { status: 'running', running: true, exitCode: 0, startedAt: '', finishedAt: '' },
+      config: { image: 'mock-image', env: [] },
+    }),
+    logs: vi.fn().mockReturnValue((async function* () {})()),
+    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
+    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    inspectImage: vi.fn().mockResolvedValue(null),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    version: vi.fn().mockResolvedValue('Mock 1.0'),
+  };
+
+  return { ...base, ...overrides };
+}

--- a/tests/helpers/runtime-conformance-helpers.ts
+++ b/tests/helpers/runtime-conformance-helpers.ts
@@ -1,0 +1,80 @@
+import { expect } from 'vitest';
+import type { ContainerRuntime } from '../../src/main/runtime/types';
+
+/** Assert that a runtime instance exposes every required interface method. */
+export function assertInterfaceComplete(runtime: ContainerRuntime): void {
+  const required = [
+    'composeUp',
+    'composeDown',
+    'listContainers',
+    'inspect',
+    'logs',
+    'containerStats',
+    'exec',
+    'inspectImage',
+    'isAvailable',
+    'version',
+  ];
+  const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(runtime));
+  for (const method of required) {
+    expect(methods, `Missing method: ${method}`).toContain(method);
+  }
+}
+
+/** Assert that inspectImage returns null for an image that does not exist. */
+export async function assertInspectImageUnknown(runtime: ContainerRuntime): Promise<void> {
+  const result = await runtime.inspectImage('sandstorm-parity-test-nonexistent-image:9999');
+  expect(result).toBeNull();
+}
+
+/** Assert that listContainers returns an array with the expected shape. */
+export async function assertListContainersShape(runtime: ContainerRuntime): Promise<void> {
+  const containers = await runtime.listContainers();
+  expect(Array.isArray(containers)).toBe(true);
+
+  if (containers.length > 0) {
+    const c = containers[0];
+    expect(typeof c.id).toBe('string');
+    expect(typeof c.name).toBe('string');
+    expect(typeof c.status).toBe('string');
+    expect(Array.isArray(c.ports)).toBe(true);
+  }
+}
+
+/**
+ * Assert that filtering by a label that no container has returns an empty array.
+ * Safe to call without any running containers.
+ */
+export async function assertListContainersLabelFilterEmpty(runtime: ContainerRuntime): Promise<void> {
+  const results = await runtime.listContainers({ label: 'sandstorm-parity-test-nonexistent=xyz9999' });
+  expect(Array.isArray(results)).toBe(true);
+  expect(results).toHaveLength(0);
+}
+
+/** Assert that exec runs a command and returns its stdout. */
+export async function assertExecReturnsStdout(runtime: ContainerRuntime, containerId: string): Promise<void> {
+  const result = await runtime.exec(containerId, ['echo', 'hello']);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout.trim()).toBe('hello');
+}
+
+/** Assert that exec captures stdout and stderr separately. */
+export async function assertExecCapturesStderr(runtime: ContainerRuntime, containerId: string): Promise<void> {
+  const result = await runtime.exec(containerId, ['sh', '-c', 'echo err >&2; echo out']);
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout.trim()).toBe('out');
+  expect(result.stderr.trim()).toBe('err');
+}
+
+/** Assert that exec returns non-zero exit codes. */
+export async function assertExecNonZeroExit(runtime: ContainerRuntime, containerId: string): Promise<void> {
+  const result = await runtime.exec(containerId, ['sh', '-c', 'exit 42']);
+  expect(result.exitCode).toBe(42);
+}
+
+/** Assert that exec pipes opts.input to stdin (cat-style roundtrip). */
+export async function assertExecInputRoundtrip(runtime: ContainerRuntime, containerId: string): Promise<void> {
+  const result = await runtime.exec(containerId, ['cat'], { input: 'hello stdin\n' });
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toBe('hello stdin\n');
+}

--- a/tests/integration/runtime-parity.test.ts
+++ b/tests/integration/runtime-parity.test.ts
@@ -1,79 +1,126 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { DockerRuntime } from '../../src/main/runtime/docker';
 import { PodmanRuntime } from '../../src/main/runtime/podman';
+import { LocalRuntime } from '../../src/main/runtime/local';
+import {
+  assertInterfaceComplete,
+  assertInspectImageUnknown,
+  assertListContainersShape,
+  assertListContainersLabelFilterEmpty,
+  assertExecReturnsStdout,
+  assertExecCapturesStderr,
+  assertExecNonZeroExit,
+  assertExecInputRoundtrip,
+} from '../helpers/runtime-conformance-helpers';
 
 describe('Runtime Parity (Integration)', () => {
   let dockerRuntime: DockerRuntime;
   let podmanRuntime: PodmanRuntime;
+  let localRuntime: LocalRuntime;
   let dockerAvailable: boolean;
   let podmanAvailable: boolean;
+  let localContainerId: string;
 
   beforeAll(async () => {
     dockerRuntime = new DockerRuntime();
     podmanRuntime = new PodmanRuntime();
+    localRuntime = new LocalRuntime();
     dockerAvailable = await dockerRuntime.isAvailable();
     podmanAvailable = await podmanRuntime.isAvailable();
+
+    localContainerId = 'parity-exec-test';
+    localRuntime.registerContainer(localContainerId, { name: localContainerId, image: 'local-parity' });
   });
 
-  it('both runtimes implement the same interface', () => {
-    // Verify both have the same methods
-    const dockerMethods = Object.getOwnPropertyNames(
-      Object.getPrototypeOf(dockerRuntime)
-    ).sort();
-    const podmanMethods = Object.getOwnPropertyNames(
-      Object.getPrototypeOf(podmanRuntime)
-    ).sort();
-
-    // Both should have core interface methods
-    const required = [
-      'composeUp',
-      'composeDown',
-      'listContainers',
-      'inspect',
-      'logs',
-      'exec',
-      'isAvailable',
-      'version',
-    ];
-
-    for (const method of required) {
-      expect(dockerMethods).toContain(method);
-      expect(podmanMethods).toContain(method);
-    }
+  afterAll(() => {
+    localRuntime.destroy();
   });
 
-  it('both have a name property', () => {
+  it('all runtimes implement the full ContainerRuntime interface', () => {
+    assertInterfaceComplete(dockerRuntime);
+    assertInterfaceComplete(podmanRuntime);
+    assertInterfaceComplete(localRuntime);
+  });
+
+  it('all runtimes have a name property', () => {
     expect(dockerRuntime.name).toBe('docker');
     expect(podmanRuntime.name).toBe('podman');
+    expect(localRuntime.name).toBe('local');
   });
 
   it('Docker listContainers returns consistent format', async () => {
     if (!dockerAvailable) return;
-
-    const containers = await dockerRuntime.listContainers();
-    expect(Array.isArray(containers)).toBe(true);
-
-    if (containers.length > 0) {
-      const c = containers[0];
-      expect(typeof c.id).toBe('string');
-      expect(typeof c.name).toBe('string');
-      expect(typeof c.status).toBe('string');
-      expect(Array.isArray(c.ports)).toBe(true);
-    }
+    await assertListContainersShape(dockerRuntime);
   });
 
   it('Podman listContainers returns consistent format', async () => {
     if (!podmanAvailable) return;
+    await assertListContainersShape(podmanRuntime);
+  });
 
-    const containers = await podmanRuntime.listContainers();
-    expect(Array.isArray(containers)).toBe(true);
+  it('LocalRuntime listContainers returns consistent format', async () => {
+    await assertListContainersShape(localRuntime);
+  });
 
-    if (containers.length > 0) {
-      const c = containers[0];
-      expect(typeof c.id).toBe('string');
-      expect(typeof c.name).toBe('string');
-      expect(typeof c.status).toBe('string');
-      expect(Array.isArray(c.ports)).toBe(true);
-    }
+  it('Docker inspectImage returns null for unknown image', async () => {
+    if (!dockerAvailable) return;
+    await assertInspectImageUnknown(dockerRuntime);
+  });
+
+  it('Podman inspectImage returns null for unknown image', async () => {
+    if (!podmanAvailable) return;
+    await assertInspectImageUnknown(podmanRuntime);
+  });
+
+  it('LocalRuntime inspectImage returns null for unknown image', async () => {
+    await assertInspectImageUnknown(localRuntime);
+  });
+
+  // --- exec behavioral assertions ---
+
+  it('LocalRuntime exec returns stdout', async () => {
+    await assertExecReturnsStdout(localRuntime, localContainerId);
+  });
+
+  it('LocalRuntime exec captures stderr separately', async () => {
+    await assertExecCapturesStderr(localRuntime, localContainerId);
+  });
+
+  it('LocalRuntime exec reports non-zero exit codes', async () => {
+    await assertExecNonZeroExit(localRuntime, localContainerId);
+  });
+
+  it('LocalRuntime exec input roundtrip via stdin', async () => {
+    await assertExecInputRoundtrip(localRuntime, localContainerId);
+  });
+
+  it('Docker exec returns stdout (skipped when unavailable or no running containers)', async () => {
+    if (!dockerAvailable) return;
+    const containers = await dockerRuntime.listContainers({ status: 'running' });
+    if (containers.length === 0) return;
+    await assertExecReturnsStdout(dockerRuntime, containers[0].id);
+  });
+
+  it('Podman exec returns stdout (skipped when unavailable or no running containers)', async () => {
+    if (!podmanAvailable) return;
+    const containers = await podmanRuntime.listContainers({ status: 'running' });
+    if (containers.length === 0) return;
+    await assertExecReturnsStdout(podmanRuntime, containers[0].id);
+  });
+
+  // --- label filter behavioral assertions ---
+
+  it('LocalRuntime listContainers label filter returns empty for non-matching label', async () => {
+    await assertListContainersLabelFilterEmpty(localRuntime);
+  });
+
+  it('Docker listContainers label filter returns empty for non-matching label', async () => {
+    if (!dockerAvailable) return;
+    await assertListContainersLabelFilterEmpty(dockerRuntime);
+  });
+
+  it('Podman listContainers label filter returns empty for non-matching label', async () => {
+    if (!podmanAvailable) return;
+    await assertListContainersLabelFilterEmpty(podmanRuntime);
   });
 });

--- a/tests/integration/startup-reconciler-nonblocking.test.ts
+++ b/tests/integration/startup-reconciler-nonblocking.test.ts
@@ -6,6 +6,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { StackManager } from '../../src/main/control-plane/stack-manager';
 import { ContainerRuntime, Container } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import { runStartupReconciliation } from '../../src/main/control-plane/startup-reconciler';
 
 function makeTempDb(): string {
@@ -82,16 +83,11 @@ describe('DR-F: non-blocking startup reconciliation (integration)', () => {
       created: '2026-01-01T00:00:00.000Z',
     };
 
-    const slowRuntime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
+    const slowRuntime = makeFakeContainerRuntime({
       listContainers: vi.fn().mockImplementation(async () => {
         await barrier; // Blocked until we call releaseBarrier()
         return [mockContainer];
       }),
-      inspect: vi.fn(),
-      logs: vi.fn().mockReturnValue((async function* () {})()),
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           return { exitCode: 0, stdout: 'completed', stderr: '' };
@@ -101,10 +97,7 @@ describe('DR-F: non-blocking startup reconciliation (integration)', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-      containerStats: vi.fn(),
-    };
+    });
 
     const stackManagerMock = {
       resumeStackWithContinuation: vi.fn(),
@@ -180,18 +173,9 @@ describe('DR-F: non-blocking startup reconciliation (integration)', () => {
     const updatesEmitted: string[] = [];
     const notifyUpdate = vi.fn(() => updatesEmitted.push('stacks:updated'));
 
-    const noContainerRuntime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn().mockReturnValue((async function* () {})()),
+    const noContainerRuntime = makeFakeContainerRuntime({
       exec: vi.fn(),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-      containerStats: vi.fn(),
-    };
+    });
 
     const stackManagerMock = {
       resumeStackWithContinuation: vi.fn(),

--- a/tests/integration/task-completion.test.ts
+++ b/tests/integration/task-completion.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { Registry } from '../../src/main/control-plane/registry';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -39,13 +40,7 @@ describe('Task Completion (Integration)', () => {
 
   it('watcher correctly transitions task through running → completed', async () => {
     let callCount = 0;
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           callCount++;
@@ -60,9 +55,7 @@ describe('Task Completion (Integration)', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('int-task-stack', 'integration task');

--- a/tests/unit/auto-rebuild.test.ts
+++ b/tests/unit/auto-rebuild.test.ts
@@ -4,6 +4,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { PortAllocator } from '../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -19,18 +20,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
-  };
+  return makeFakeContainerRuntime();
 }
 
 describe('Auto-rebuild mechanism', () => {
@@ -87,13 +77,13 @@ describe('Auto-rebuild mechanism', () => {
       // Override private field for testing
       (unknownManager as unknown as { appVersion: string }).appVersion = 'unknown';
 
-      const result = await unknownManager.checkImageNeedsRebuild('/some/project');
+      const result = await unknownManager.checkImageNeedsRebuild('/some/project', runtime);
       expect(result).toBe(false);
     });
 
     it('returns false when docker inspect fails (image does not exist)', async () => {
       // spawn will fail since Docker is not available in test env
-      const result = await manager.checkImageNeedsRebuild('/nonexistent/project');
+      const result = await manager.checkImageNeedsRebuild('/nonexistent/project', runtime);
       expect(result).toBe(false);
     });
   });

--- a/tests/unit/claude-backend.test.ts
+++ b/tests/unit/claude-backend.test.ts
@@ -61,7 +61,12 @@ vi.mock('child_process', async (importOriginal) => {
 // Mock fs to avoid real file operations
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal() as typeof import('fs');
-  return {
+  // Build mock object first so we can assign it as `default` too.
+  // claude-backend uses `import fs from 'fs'` (default import), which resolves
+  // to `actual.default` (the original module) when we spread `...actual`.
+  // Setting `default: mockFs` ensures both named imports and default imports
+  // reference the same vi.fn() instances.
+  const mockFs = {
     ...actual,
     existsSync: vi.fn().mockReturnValue(false),
     mkdirSync: vi.fn(),
@@ -77,6 +82,7 @@ vi.mock('fs', async (importOriginal) => {
     })),
     rmSync: vi.fn(),
   };
+  return { ...mockFs, default: mockFs };
 });
 
 // Mock http server
@@ -465,6 +471,37 @@ describe('ClaudeBackend (AgentBackend implementation)', () => {
       await expect(
         backend.syncCredentials([{ status: 'stopped', services: [] }])
       ).resolves.toBeUndefined();
+    });
+
+    it('calls runtime.exec with credentials for a running stack with a claude container', async () => {
+      const fakeCreds = JSON.stringify({ token: 'test-token' });
+      const { readFileSync } = await import('fs');
+      (readFileSync as ReturnType<typeof vi.fn>).mockImplementationOnce(() => fakeCreds);
+
+      const execMock = vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+      const mockRuntime = { exec: execMock };
+      const resolveRuntime = vi.fn().mockReturnValue(mockRuntime);
+
+      const backendWithRuntime = new ClaudeBackend(1000, undefined, resolveRuntime as never);
+      backendWithRuntime.setMainWindow(mockWindow as never);
+      await backendWithRuntime.initialize();
+
+      const stack = {
+        status: 'running',
+        services: [{ name: 'claude', status: 'running', containerId: 'abc123' }],
+        runtime: 'docker' as const,
+      };
+
+      await backendWithRuntime.syncCredentials([stack]);
+
+      expect(resolveRuntime).toHaveBeenCalledWith(stack);
+      expect(execMock).toHaveBeenCalledWith(
+        'abc123',
+        ['bash', '-c', 'mkdir -p ~/.claude && cat > ~/.claude/.credentials.json'],
+        expect.objectContaining({ user: 'claude', input: fakeCreds })
+      );
+
+      backendWithRuntime.destroy();
     });
   });
 

--- a/tests/unit/execute-outputs-watcher.test.ts
+++ b/tests/unit/execute-outputs-watcher.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Registry } from '../../src/main/control-plane/registry';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -29,13 +30,7 @@ function makeStack(id: string = 'test-stack') {
 }
 
 function createMetadataRuntime(files: Record<string, string>): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn(),
-    composeDown: vi.fn(),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
-    logs: vi.fn(),
+  return makeFakeContainerRuntime({
     exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
       if (cmd.includes('/tmp/claude-task.status')) {
         return { exitCode: 0, stdout: 'running', stderr: '' };
@@ -68,10 +63,7 @@ function createMetadataRuntime(files: Record<string, string>): ContainerRuntime 
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-    containerStats: vi.fn(),
-  };
+  });
 }
 
 describe('TaskWatcher execute_outputs reading', () => {

--- a/tests/unit/main/control-plane/stack-manager-ask-clarifying.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-ask-clarifying.test.ts
@@ -14,6 +14,7 @@ import { Registry } from '../../../../src/main/control-plane/registry';
 import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
 import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../../../helpers/fake-container-runtime';
 
 function makeTempDb(): string {
   return path.join(
@@ -29,10 +30,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
+  return makeFakeContainerRuntime({
     listContainers: vi.fn().mockResolvedValue([
       {
         id: 'cid-claude',
@@ -45,13 +43,7 @@ function createMockRuntime(): ContainerRuntime {
         created: new Date().toISOString(),
       },
     ]),
-    inspect: vi.fn().mockResolvedValue({}),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 describe('ASK_CLARIFYING_QUESTIONS_PROMPT', () => {

--- a/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
@@ -13,6 +13,7 @@ import { Registry } from '../../../../src/main/control-plane/registry';
 import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
 import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../../../helpers/fake-container-runtime';
 
 // ---------------------------------------------------------------------------
 // Mock ticket-references so we don't hit the network or gh CLI.
@@ -50,10 +51,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
+  return makeFakeContainerRuntime({
     listContainers: vi.fn().mockResolvedValue([
       {
         id: 'claude-cid',
@@ -66,12 +64,7 @@ function createMockRuntime(): ContainerRuntime {
         created: new Date().toISOString(),
       },
     ]),
-    inspect: vi.fn().mockResolvedValue({}),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 function makeStack(id: string) {

--- a/tests/unit/main/control-plane/stack-manager-recheck-completed.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-recheck-completed.test.ts
@@ -11,6 +11,7 @@ import { Registry } from '../../../../src/main/control-plane/registry';
 import { PortAllocator } from '../../../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
 import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../../../helpers/fake-container-runtime';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -29,18 +30,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn().mockResolvedValue({}),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  return makeFakeContainerRuntime();
 }
 
 const RUNNING_CONTAINER = { id: 'cid-abc', name: 'sandstorm-proj-s1-claude-1', status: 'running' };

--- a/tests/unit/main/control-plane/startup-reconciler-completed.test.ts
+++ b/tests/unit/main/control-plane/startup-reconciler-completed.test.ts
@@ -12,6 +12,7 @@ import { PortAllocator } from '../../../../src/main/control-plane/port-allocator
 import { TaskWatcher } from '../../../../src/main/control-plane/task-watcher';
 import { StackManager } from '../../../../src/main/control-plane/stack-manager';
 import type { ContainerRuntime } from '../../../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../../../helpers/fake-container-runtime';
 
 function makeTempDb(): string {
   return path.join(
@@ -27,18 +28,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn().mockResolvedValue({}),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  return makeFakeContainerRuntime();
 }
 
 describe('runStartupReconciliation — completed stacks pass', () => {

--- a/tests/unit/main/control-plane/task-watcher-liveness.test.ts
+++ b/tests/unit/main/control-plane/task-watcher-liveness.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TaskWatcher, LIVENESS_CHECK_INTERVAL_MS, LIVENESS_STALL_THRESHOLD_MS } from '../../../../src/main/control-plane/task-watcher';
 import { Registry, Task } from '../../../../src/main/control-plane/registry';
 import { ContainerRuntime } from '../../../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../../../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -24,48 +25,32 @@ function createLivenessMockRuntime(opts: {
   pgrepShouldThrow?: boolean;
 } = {}): ContainerRuntime {
   let statusCallIdx = 0;
-  return {
-    name: 'mock',
-    composeUp: vi.fn(),
-    composeDown: vi.fn(),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
+  return makeFakeContainerRuntime({
     logs: vi.fn().mockReturnValue({
       [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true, value: '' }) }),
     }),
     exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
-      // /tmp/claude-task.status read (main poll + idempotency re-read)
       if (cmd.includes('/tmp/claude-task.status')) {
         const seq = opts.statusSequence ?? ['running'];
         const idx = Math.min(statusCallIdx++, seq.length - 1);
         return { exitCode: 0, stdout: seq[idx], stderr: '' };
       }
-
-      // stat for liveness log size
       if (cmd[0] === 'stat' && cmd.includes('/tmp/claude-raw.log')) {
         if (opts.statShouldThrow) throw new Error('stat exec error');
         const size = typeof opts.logSize === 'function' ? opts.logSize() : (opts.logSize ?? 0);
         return { exitCode: 0, stdout: String(size), stderr: '' };
       }
-
-      // pgrep for process liveness
       if (cmd[0] === 'pgrep') {
         if (opts.pgrepShouldThrow) throw new Error('pgrep exec error');
         const out = opts.pgrepOut ?? '';
         return { exitCode: out ? 0 : 1, stdout: out, stderr: '' };
       }
-
-      // /tmp/claude-task.exit
       if (cmd.includes('/tmp/claude-task.exit')) {
         return { exitCode: 0, stdout: '0', stderr: '' };
       }
-
-      // Everything else (token files, iteration files, metadata)
       return { exitCode: 0, stdout: '', stderr: '' };
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 describe('TaskWatcher — liveness check', () => {

--- a/tests/unit/main/opencode-syncCredentials.test.ts
+++ b/tests/unit/main/opencode-syncCredentials.test.ts
@@ -1,24 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OpenCodeBackend } from '../../../src/main/agent/opencode-backend';
 import type { StackInfo } from '../../../src/main/agent/types';
-
-// Mock child_process.spawn so we don't need Docker
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
-  return {
-    ...actual,
-    spawn: vi.fn().mockImplementation(() => {
-      const proc = {
-        stdin: { write: vi.fn(), end: vi.fn() },
-        on: vi.fn().mockImplementation((event: string, cb: () => void) => {
-          if (event === 'close' || event === 'error') cb();
-          return proc;
-        }),
-      };
-      return proc;
-    }),
-  };
-});
+import type { ContainerRuntime } from '../../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../../helpers/fake-container-runtime';
 
 // Mock the '../index' import to return a fake registry
 vi.mock('../../../src/main/index', () => ({
@@ -46,10 +30,14 @@ vi.mock('../../../src/main/opencode-config', () => ({
 }));
 
 describe('OpenCodeBackend.syncCredentials', () => {
+  let runtime: ContainerRuntime;
+  let execMock: ReturnType<typeof vi.fn>;
   let backend: OpenCodeBackend;
 
   beforeEach(() => {
-    backend = new OpenCodeBackend();
+    runtime = makeFakeContainerRuntime();
+    execMock = runtime.exec as ReturnType<typeof vi.fn>;
+    backend = new OpenCodeBackend(() => runtime);
   });
 
   afterEach(() => {
@@ -57,72 +45,64 @@ describe('OpenCodeBackend.syncCredentials', () => {
   });
 
   it('skips stacks that are not running or up', async () => {
-    const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
       { status: 'building', services: [{ name: 'claude', status: 'starting', containerId: 'cid1' }] },
       { status: 'stopped', services: [{ name: 'claude', status: 'exited', containerId: 'cid2' }] },
     ];
     await backend.syncCredentials(stacks);
-    expect(spawn).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('skips stacks with no claude service', async () => {
-    const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
       { status: 'running', project_dir: '/proj', services: [{ name: 'app', status: 'running', containerId: 'cid1' }] },
     ];
     await backend.syncCredentials(stacks);
-    expect(spawn).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
   });
 
-  it('calls docker exec to clean auth.json for running stacks', async () => {
-    const { spawn } = await import('child_process');
+  it('calls runtime.exec to clean auth.json for running stacks', async () => {
     const stacks: StackInfo[] = [
       { status: 'running', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'abc123' }] },
     ];
     await backend.syncCredentials(stacks);
 
-    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = execMock.mock.calls;
     expect(calls.length).toBeGreaterThanOrEqual(1);
 
     // First call should be the auth.json cleanup
-    const [cmd, args] = calls[0];
-    expect(cmd).toBe('docker');
-    expect(args).toContain('exec');
-    expect(args).toContain('abc123');
-    const scriptArg = args.find((a: string) => a.includes('auth.json'));
+    const [containerId, cmd] = calls[0];
+    expect(containerId).toBe('abc123');
+    const scriptArg = cmd.find((a: string) => a.includes('auth.json'));
     expect(scriptArg).toBeDefined();
     expect(scriptArg).toContain('rm -f');
   });
 
   it('writes generated config to /tmp/sandstorm-opencode-<provider>.json', async () => {
-    const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
       { status: 'up', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'def456' }] },
     ];
     await backend.syncCredentials(stacks);
 
-    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
-    // A docker exec should write the provider-specific config file
-    const configWriteCall = calls.find(([, args]: [string, string[]]) =>
-      args.some((a: string) => a.includes('sandstorm-opencode-anthropic.json')),
+    const calls = execMock.mock.calls;
+    // A runtime.exec call should write the provider-specific config file
+    const configWriteCall = calls.find(([, cmd]: [string, string[]]) =>
+      cmd.some((a: string) => a.includes('sandstorm-opencode-anthropic.json')),
     );
     expect(configWriteCall).toBeDefined();
-    const [, args] = configWriteCall;
-    expect(args).toContain('exec');
-    expect(args).toContain('def456');
+    const [containerId] = configWriteCall;
+    expect(containerId).toBe('def456');
   });
 
   it('skips writing config when stack has no project_dir', async () => {
-    const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
       { status: 'running', services: [{ name: 'claude', status: 'running', containerId: 'ghi789' }] },
     ];
     // Should not throw, and no provider config should be written (no project_dir to look up routing)
     await expect(backend.syncCredentials(stacks)).resolves.toBeUndefined();
-    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
-    const configWriteCall = calls.find(([, args]: [string, string[]]) =>
-      args.some((a: string) => a.includes('sandstorm-opencode-')),
+    const calls = execMock.mock.calls;
+    const configWriteCall = calls.find(([, cmd]: [string, string[]]) =>
+      cmd.some((a: string) => a.includes('sandstorm-opencode-')),
     );
     expect(configWriteCall).toBeUndefined();
   });
@@ -154,18 +134,17 @@ describe('OpenCodeBackend.syncCredentials', () => {
       return { backend: 'opencode', provider: 'amazon-bedrock', model: 'claude-sonnet', credentials: { region: 'us-east-1' } };
     });
 
-    const { spawn } = await import('child_process');
     const stacks: StackInfo[] = [
       { status: 'running', project_dir: '/proj', services: [{ name: 'claude', status: 'running', containerId: 'mno345' }] },
     ];
     await backend.syncCredentials(stacks);
 
-    const calls = (spawn as ReturnType<typeof vi.fn>).mock.calls;
-    const bedrockCall = calls.find(([, args]: [string, string[]]) =>
-      args.some((a: string) => a.includes('sandstorm-opencode-amazon-bedrock.json')),
+    const calls = execMock.mock.calls;
+    const bedrockCall = calls.find(([, cmd]: [string, string[]]) =>
+      cmd.some((a: string) => a.includes('sandstorm-opencode-amazon-bedrock.json')),
     );
-    const orCall = calls.find(([, args]: [string, string[]]) =>
-      args.some((a: string) => a.includes('sandstorm-opencode-openrouter.json')),
+    const orCall = calls.find(([, cmd]: [string, string[]]) =>
+      cmd.some((a: string) => a.includes('sandstorm-opencode-openrouter.json')),
     );
     expect(bedrockCall).toBeDefined();
     expect(orCall).toBeDefined();

--- a/tests/unit/reconcile-status.test.ts
+++ b/tests/unit/reconcile-status.test.ts
@@ -6,6 +6,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { PortAllocator } from '../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -24,10 +25,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(containerStatus = 'running'): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
+  return makeFakeContainerRuntime({
     listContainers: vi.fn().mockResolvedValue([
       {
         id: 'claude-container-1',
@@ -40,8 +38,6 @@ function createMockRuntime(containerStatus = 'running'): ContainerRuntime {
         created: new Date().toISOString(),
       },
     ]),
-    inspect: vi.fn(),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
     exec: vi.fn().mockImplementation((_id: string, cmd: string[]) => {
       const file = cmd[cmd.length - 1];
       if (file === '/tmp/claude-task.status') {
@@ -49,9 +45,7 @@ function createMockRuntime(containerStatus = 'running'): ContainerRuntime {
       }
       return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 describe('StackManager.reconcileStatus', () => {

--- a/tests/unit/runtime/runtime-conformance.test.ts
+++ b/tests/unit/runtime/runtime-conformance.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { LocalRuntime } from '../../../src/main/runtime/local';
+import {
+  assertExecReturnsStdout,
+  assertExecCapturesStderr,
+  assertExecNonZeroExit,
+  assertExecInputRoundtrip,
+  assertInspectImageUnknown,
+} from '../../helpers/runtime-conformance-helpers';
+
+describe('LocalRuntime — conformance', () => {
+  let runtime: LocalRuntime;
+  const CONTAINER_ID = 'test-container';
+
+  beforeEach(() => {
+    runtime = new LocalRuntime();
+    runtime.registerContainer(CONTAINER_ID, { name: 'test-container', image: 'test-image' });
+  });
+
+  afterEach(() => {
+    runtime.destroy();
+  });
+
+  it('has name "local"', () => {
+    expect(runtime.name).toBe('local');
+  });
+
+  it('isAvailable always returns true', async () => {
+    expect(await runtime.isAvailable()).toBe(true);
+  });
+
+  it('version returns "local"', async () => {
+    expect(await runtime.version()).toBe('local');
+  });
+
+  it('exec runs a command and returns stdout', async () => {
+    await assertExecReturnsStdout(runtime, CONTAINER_ID);
+  });
+
+  it('exec captures non-zero exit codes', async () => {
+    await assertExecNonZeroExit(runtime, CONTAINER_ID);
+  });
+
+  it('exec captures stderr separately', async () => {
+    await assertExecCapturesStderr(runtime, CONTAINER_ID);
+  });
+
+  it('exec pipes opts.input to stdin', async () => {
+    await assertExecInputRoundtrip(runtime, CONTAINER_ID);
+  });
+
+  it('exec without input does not pipe stdin', async () => {
+    const result = await runtime.exec(CONTAINER_ID, ['echo', 'no-stdin']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('no-stdin');
+  });
+
+  it('exec honors opts.workdir', async () => {
+    const result = await runtime.exec(CONTAINER_ID, ['pwd'], { workdir: '/tmp' });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('/tmp');
+  });
+
+  it('exec honors opts.env', async () => {
+    const result = await runtime.exec(CONTAINER_ID, ['sh', '-c', 'echo $MY_VAR'], {
+      env: ['MY_VAR=sandstorm-test'],
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('sandstorm-test');
+  });
+
+  it('listContainers returns registered containers', async () => {
+    const containers = await runtime.listContainers();
+    expect(containers).toHaveLength(1);
+    expect(containers[0].id).toBe(CONTAINER_ID);
+    expect(containers[0].name).toBe('test-container');
+    expect(containers[0].status).toBe('running');
+  });
+
+  it('listContainers filters by name', async () => {
+    runtime.registerContainer('other-id', { name: 'other-name', image: 'img' });
+    const results = await runtime.listContainers({ name: 'test' });
+    expect(results.every((c) => c.name.includes('test'))).toBe(true);
+  });
+
+  it('inspect returns container info', async () => {
+    const info = await runtime.inspect(CONTAINER_ID);
+    expect(info.id).toBe(CONTAINER_ID);
+    expect(info.state.running).toBe(true);
+    expect(info.state.status).toBe('running');
+  });
+
+  it('inspect throws for unknown container', async () => {
+    await expect(runtime.inspect('nonexistent')).rejects.toThrow();
+  });
+
+  it('containerStats returns zeros', async () => {
+    const stats = await runtime.containerStats(CONTAINER_ID);
+    expect(stats.memoryUsage).toBe(0);
+    expect(stats.memoryLimit).toBe(0);
+    expect(stats.cpuPercent).toBe(0);
+  });
+
+  it('logs yields nothing', async () => {
+    const chunks: string[] = [];
+    for await (const chunk of runtime.logs(CONTAINER_ID)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('inspectImage returns null for unregistered image', async () => {
+    await assertInspectImageUnknown(runtime);
+  });
+
+  it('inspectImage returns labels for registered image', async () => {
+    runtime.registerImage('my-image:latest', { 'sandstorm.app-version': '1.2.3' });
+    const result = await runtime.inspectImage('my-image:latest');
+    expect(result).not.toBeNull();
+    expect(result!.labels['sandstorm.app-version']).toBe('1.2.3');
+  });
+
+  it('inspectImage returns empty labels when image registered with no labels', async () => {
+    runtime.registerImage('bare-image', {});
+    const result = await runtime.inspectImage('bare-image');
+    expect(result).not.toBeNull();
+    expect(result!.labels).toEqual({});
+  });
+
+  it('exec rejects or returns non-zero for nonexistent container id', async () => {
+    const result = await runtime.exec('no-such-id', ['echo', 'x']);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('two registered containers use isolated tmpdirs', async () => {
+    const CONTAINER_B = 'test-container-b';
+    runtime.registerContainer(CONTAINER_B, { name: 'test-container-b', image: 'test-image' });
+
+    const resultA = await runtime.exec(CONTAINER_ID, ['pwd']);
+    const resultB = await runtime.exec(CONTAINER_B, ['pwd']);
+
+    expect(resultA.exitCode).toBe(0);
+    expect(resultB.exitCode).toBe(0);
+    expect(resultA.stdout.trim()).not.toBe(resultB.stdout.trim());
+  });
+
+  it('composeUp registers a container visible via listContainers', async () => {
+    await runtime.composeUp('/tmp', { projectName: 'my-project', composeFiles: [] });
+    const containers = await runtime.listContainers({ name: 'my-project' });
+    expect(containers).toHaveLength(1);
+    expect(containers[0].name).toBe('my-project');
+    expect(containers[0].status).toBe('running');
+  });
+
+  it('composeDown removes the container registered by composeUp', async () => {
+    await runtime.composeUp('/tmp', { projectName: 'rm-project', composeFiles: [] });
+    const before = await runtime.listContainers({ name: 'rm-project' });
+    expect(before).toHaveLength(1);
+    await runtime.composeDown('/tmp', { projectName: 'rm-project', composeFiles: [] });
+    const after = await runtime.listContainers({ name: 'rm-project' });
+    expect(after).toHaveLength(0);
+  });
+
+  it('listContainers filters by label key=value', async () => {
+    runtime.registerContainer('labeled-a', { name: 'container-a', image: 'img', labels: { env: 'prod' } });
+    runtime.registerContainer('labeled-b', { name: 'container-b', image: 'img', labels: { env: 'staging' } });
+    const results = await runtime.listContainers({ label: 'env=prod' });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('labeled-a');
+  });
+
+  it('destroy cleans up owned tmpdirs', () => {
+    const fs = require('fs');
+    const newRuntime = new LocalRuntime();
+    const tmpdir = newRuntime.registerContainer('c1', { name: 'c1', image: 'img' });
+    expect(fs.existsSync(tmpdir)).toBe(true);
+    newRuntime.destroy();
+    expect(fs.existsSync(tmpdir)).toBe(false);
+  });
+});

--- a/tests/unit/stack-lifecycle.test.ts
+++ b/tests/unit/stack-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { PortAllocator } from '../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import { StackStatus } from '../../src/main/control-plane/registry';
 import { SandstormError, ErrorCode } from '../../src/main/errors';
 import fs from 'fs';
@@ -23,10 +24,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
+  return makeFakeContainerRuntime({
     listContainers: vi.fn().mockResolvedValue([
       {
         id: 'claude-container-1',
@@ -39,13 +37,7 @@ function createMockRuntime(): ContainerRuntime {
         created: new Date().toISOString(),
       },
     ]),
-    inspect: vi.fn(),
-    containerStats: vi.fn().mockResolvedValue({ cpuPercent: 0, memoryUsage: 0, memoryLimit: 0 }),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 function makeStack(id: string, status: StackStatus = 'up') {

--- a/tests/unit/stack-manager-auto-resolve.test.ts
+++ b/tests/unit/stack-manager-auto-resolve.test.ts
@@ -45,6 +45,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { PortAllocator } from '../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import type { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -63,18 +64,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn().mockResolvedValue({}),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  return makeFakeContainerRuntime();
 }
 
 const TICKET = 'T-1';

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -15,6 +15,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { PortAllocator } from '../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -30,10 +31,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
+  return makeFakeContainerRuntime({
     listContainers: vi.fn().mockResolvedValue([
       {
         id: 'claude-container-1',
@@ -46,12 +44,7 @@ function createMockRuntime(): ContainerRuntime {
         created: new Date().toISOString(),
       },
     ]),
-    inspect: vi.fn(),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 function makeStack(id: string = 'test-stack') {

--- a/tests/unit/stale-workspaces.test.ts
+++ b/tests/unit/stale-workspaces.test.ts
@@ -4,6 +4,7 @@ import { Registry } from '../../src/main/control-plane/registry';
 import { PortAllocator } from '../../src/main/control-plane/port-allocator';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -19,18 +20,7 @@ function cleanupDb(dbPath: string): void {
 }
 
 function createMockRuntime(): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn().mockResolvedValue(undefined),
-    composeDown: vi.fn().mockResolvedValue(undefined),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
-    exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-    containerStats: vi.fn().mockResolvedValue({ memoryUsage: 0, memoryLimit: 0, cpuPercent: 0 }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  return makeFakeContainerRuntime();
 }
 
 describe('Stale Workspace Detection', () => {

--- a/tests/unit/startup-reconciler.test.ts
+++ b/tests/unit/startup-reconciler.test.ts
@@ -6,6 +6,7 @@ import { Registry, Stack } from '../../src/main/control-plane/registry';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { StackManager } from '../../src/main/control-plane/stack-manager';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import {
   runStartupReconciliation,
   type ReconcilerDeps,
@@ -63,10 +64,7 @@ function makeRuntime(opts: {
 
   let callIdx = 0;
 
-  return {
-    name: 'mock',
-    composeUp: vi.fn(),
-    composeDown: vi.fn(),
+  return makeFakeContainerRuntime({
     listContainers: vi.fn().mockImplementation(async () => {
       if (listThrows) throw new Error('Docker daemon unavailable');
       if (!containerFound) return [];
@@ -81,8 +79,6 @@ function makeRuntime(opts: {
         created: new Date().toISOString(),
       }];
     }),
-    inspect: vi.fn(),
-    logs: vi.fn().mockReturnValue((async function* () {})()),
     exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
       if (execThrows) throw new Error('container exec failed');
       if (cmd.includes('/tmp/claude-task.status')) {
@@ -95,10 +91,7 @@ function makeRuntime(opts: {
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-    containerStats: vi.fn(),
-  };
+  });
 }
 
 function makeStackManagerMock(): Partial<StackManager> & {

--- a/tests/unit/task-metadata-persistence.test.ts
+++ b/tests/unit/task-metadata-persistence.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Registry } from '../../src/main/control-plane/registry';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -291,23 +292,14 @@ describe('TaskWatcher metadata reading', () => {
   });
 
   function createMetadataRuntime(files: Record<string, string>): ContainerRuntime {
-    return {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    return makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
-        // Handle status file
         if (cmd.includes('/tmp/claude-task.status')) {
           return { exitCode: 0, stdout: 'running', stderr: '' };
         }
         if (cmd.includes('/tmp/claude-task.exit')) {
           return { exitCode: 0, stdout: '0', stderr: '' };
         }
-
-        // Handle 'sh -c' commands (ls for listing files)
         if (cmd[0] === 'sh' && cmd[1] === '-c') {
           const shellCmd = cmd[2];
           if (shellCmd.includes('claude-review-verdict')) {
@@ -320,8 +312,6 @@ describe('TaskWatcher metadata reading', () => {
           }
           return { exitCode: 0, stdout: '', stderr: '' };
         }
-
-        // Handle cat commands
         if (cmd[0] === 'cat' && cmd[1]) {
           const content = files[cmd[1]];
           if (content !== undefined) {
@@ -329,13 +319,9 @@ describe('TaskWatcher metadata reading', () => {
           }
           throw new Error(`File not found: ${cmd[1]}`);
         }
-
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-      containerStats: vi.fn(),
-    };
+    });
   }
 
   it('reads numbered review verdict files and stores JSON array', async () => {
@@ -424,18 +410,9 @@ describe('TaskWatcher metadata reading', () => {
 
   it('handles missing metadata files gracefully', async () => {
     // Runtime where all file reads throw (simulating no metadata files)
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockRejectedValue(new Error('file not found')),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-      containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50000 });
     const task = registry.createTask('test-stack', 'test prompt');

--- a/tests/unit/task-watcher.test.ts
+++ b/tests/unit/task-watcher.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TaskWatcher } from '../../src/main/control-plane/task-watcher';
 import { Registry } from '../../src/main/control-plane/registry';
 import { ContainerRuntime } from '../../src/main/runtime/types';
+import { makeFakeContainerRuntime } from '../helpers/fake-container-runtime';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -10,13 +11,7 @@ function createMockRuntime(
   taskStatus: string = 'running',
   exitCode: string = '0'
 ): ContainerRuntime {
-  return {
-    name: 'mock',
-    composeUp: vi.fn(),
-    composeDown: vi.fn(),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
-    logs: vi.fn(),
+  return makeFakeContainerRuntime({
     exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
       if (cmd.includes('/tmp/claude-task.status')) {
         return { exitCode: 0, stdout: taskStatus, stderr: '' };
@@ -26,9 +21,7 @@ function createMockRuntime(
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 /**
@@ -41,13 +34,7 @@ function createSequencedRuntime(
   exitCode: string = '0'
 ): ContainerRuntime {
   let callIndex = 0;
-  return {
-    name: 'mock',
-    composeUp: vi.fn(),
-    composeDown: vi.fn(),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
-    logs: vi.fn(),
+  return makeFakeContainerRuntime({
     exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
       if (cmd.includes('/tmp/claude-task.status')) {
         const idx = Math.min(callIndex, statuses.length - 1);
@@ -59,9 +46,7 @@ function createSequencedRuntime(
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 /**
@@ -70,13 +55,7 @@ function createSequencedRuntime(
  */
 function createFailingRuntime(failCount: number): ContainerRuntime {
   let callIndex = 0;
-  return {
-    name: 'mock',
-    composeUp: vi.fn(),
-    composeDown: vi.fn(),
-    listContainers: vi.fn().mockResolvedValue([]),
-    inspect: vi.fn(),
-    logs: vi.fn(),
+  return makeFakeContainerRuntime({
     exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
       callIndex++;
       if (callIndex <= failCount) {
@@ -87,9 +66,7 @@ function createFailingRuntime(failCount: number): ContainerRuntime {
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     }),
-    isAvailable: vi.fn().mockResolvedValue(true),
-    version: vi.fn().mockResolvedValue('Mock 1.0'),
-  };
+  });
 }
 
 describe('TaskWatcher', () => {
@@ -464,13 +441,7 @@ describe('TaskWatcher', () => {
 
     // Stay running for many polls, then complete
     let statusPollCount = 0;
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           statusPollCount++;
@@ -492,10 +463,8 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     // Use very short poll interval and token poll interval to trigger real-time polling
     const watcher = new TaskWatcher(registry, runtime, runtime, {
@@ -532,13 +501,7 @@ describe('TaskWatcher', () => {
 
   it('throttles token polling based on tokenPollInterval', async () => {
     let statusPollCount = 0;
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           statusPollCount++;
@@ -554,10 +517,8 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     // Token poll interval much longer than status poll interval
     // means tokens won't be polled every status check
@@ -614,18 +575,11 @@ describe('TaskWatcher', () => {
     vi.useFakeTimers();
 
     // Always fail
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockRejectedValue(new Error('Docker unavailable')),
       isAvailable: vi.fn().mockResolvedValue(false),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, {
       pollInterval: 10,
@@ -666,12 +620,7 @@ describe('TaskWatcher', () => {
 
   it('cleans up output stream on unwatch', async () => {
     let streamConsumed = false;
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       logs: vi.fn().mockImplementation(async function* () {
         yield 'line 1\n';
         // Simulate a long-running stream
@@ -680,10 +629,8 @@ describe('TaskWatcher', () => {
         yield 'line 2\n';
       }),
       exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'running', stderr: '' }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('watch-stack', 'test task');
@@ -704,21 +651,14 @@ describe('TaskWatcher', () => {
   });
 
   it('replaces existing output stream when streamOutput called again', async () => {
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       logs: vi.fn().mockImplementation(async function* () {
         yield 'data\n';
         await new Promise((r) => setTimeout(r, 10000));
       }),
       exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'running', stderr: '' }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('watch-stack', 'test task');
@@ -741,22 +681,15 @@ describe('TaskWatcher', () => {
   // --- streamOutput data flow ---
 
   it('streamOutput emits task:output events for each chunk', async () => {
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       logs: vi.fn().mockImplementation(async function* () {
         yield 'chunk 1\n';
         yield 'chunk 2\n';
         yield 'chunk 3\n';
       }),
       exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'running', stderr: '' }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('watch-stack', 'test task');
@@ -785,18 +718,11 @@ describe('TaskWatcher', () => {
       yield 'data\n';
     });
 
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       logs: logsSpy,
       exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     await watcher.streamOutput('watch-stack', 'container-abc', vi.fn());
@@ -861,13 +787,7 @@ describe('TaskWatcher', () => {
     let stack1Calls = 0;
     let stack2Calls = 0;
 
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           if (_id === 'container-1') {
@@ -892,10 +812,8 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
 
@@ -993,13 +911,7 @@ describe('TaskWatcher', () => {
     const sessionId = 'sess-token-limit-123';
     const rawJsonOutput = `{"type":"result","usage":{"input_tokens":1000,"output_tokens":500},"session_id":"${sessionId}"}`;
 
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         const cmdStr = cmd.join(' ');
         if (cmdStr.includes('/tmp/claude-task.status')) {
@@ -1014,9 +926,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     const task = registry.createTask('watch-stack', 'token limit task');
@@ -1183,13 +1093,7 @@ describe('TaskWatcher', () => {
   it('accepts stale status after MAX_STALE_POLLS without seeing running', async () => {
     // Simulate a scenario where the task runner crashes before writing "running"
     // The status file has "completed" from a prior task and never changes
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           return { exitCode: 0, stdout: 'completed', stderr: '' };
@@ -1199,10 +1103,8 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
       containerStats: vi.fn(),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 10 });
     registry.createTask('watch-stack', 'stale safety net task');
@@ -1225,13 +1127,7 @@ describe('TaskWatcher', () => {
   });
 
   it('getWorkflowProgress returns progress data for running task', async () => {
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           return { exitCode: 0, stdout: 'running', stderr: '' };
@@ -1253,9 +1149,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
 
@@ -1304,13 +1198,7 @@ describe('TaskWatcher', () => {
 
   it('emits workflow progress during token poll', async () => {
     let pollCount = 0;
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           pollCount++;
@@ -1321,9 +1209,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, {
       pollInterval: 20,
@@ -1347,13 +1233,7 @@ describe('TaskWatcher', () => {
   });
 
   it('emits workflow progress immediately on first running poll even with long token interval', async () => {
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         if (cmd.includes('/tmp/claude-task.status')) {
           return { exitCode: 0, stdout: 'running', stderr: '' };
@@ -1369,9 +1249,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     // Long token poll interval — but first poll should still emit immediately
     const watcher = new TaskWatcher(registry, runtime, runtime, {
@@ -1400,13 +1278,7 @@ describe('TaskWatcher', () => {
 
   it('emits task:failed and records needs_human status when STOP_AND_ASK detected', async () => {
     const stopReason = 'tests/integration/fixtures.ts is out of scope for this ticket';
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         const cmdStr = cmd.join(' ');
         if (cmdStr.includes('/tmp/claude-task.status')) {
@@ -1419,9 +1291,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('watch-stack', 'test task');
@@ -1451,13 +1321,7 @@ describe('TaskWatcher', () => {
 
   it('emits task:failed with needs_human and sets verify_blocked_environmental stack status when status file reads verify_blocked_environmental', async () => {
     const envFingerprint = 'jq: command not found';
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         const cmdStr = cmd.join(' ');
         if (cmdStr.includes('/tmp/claude-task.status')) {
@@ -1469,9 +1333,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('watch-stack', 'test task');
@@ -1501,13 +1363,7 @@ describe('TaskWatcher', () => {
 
   it('emits task:failed and records needs_key status when phase has no credentials', async () => {
     const keyReason = "Phase 'execution' requires provider 'openrouter' but no credentials are configured.";
-    const runtime: ContainerRuntime = {
-      name: 'mock',
-      composeUp: vi.fn(),
-      composeDown: vi.fn(),
-      listContainers: vi.fn().mockResolvedValue([]),
-      inspect: vi.fn(),
-      logs: vi.fn(),
+    const runtime = makeFakeContainerRuntime({
       exec: vi.fn().mockImplementation(async (_id: string, cmd: string[]) => {
         const cmdStr = cmd.join(' ');
         if (cmdStr.includes('/tmp/claude-task.status')) {
@@ -1520,9 +1376,7 @@ describe('TaskWatcher', () => {
         }
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
-      isAvailable: vi.fn().mockResolvedValue(true),
-      version: vi.fn().mockResolvedValue('Mock 1.0'),
-    };
+    });
 
     const watcher = new TaskWatcher(registry, runtime, runtime, { pollInterval: 50 });
     registry.createTask('watch-stack', 'test task');


### PR DESCRIPTION
## Summary

The stack rebuild check (`checkImageNeedsRebuild`) hardcoded the `docker` CLI to inspect image labels, so podman-backed stacks always inspected the wrong (or a nonexistent) daemon and silently skipped version-stamp rebuilds. This adds an `inspectImage` method to the `ContainerRuntime` interface, implemented for both Docker and Podman, and threads the resolved runtime through `checkImageNeedsRebuild` and `buildStackInBackground` so the rebuild decision always targets the runtime the stack actually runs on.

Supporting changes:

- `ExecOpts` gains an `input` field; Docker and Podman `exec` now attach stdin and write the payload when input is provided. Credential sync (`claude-backend`, `opencode-backend`) writes credential JSON through `runtime.exec` stdin instead of shelling out, keeping it runtime-agnostic.
- `StackInfo` carries an optional `runtime` (`docker | podman`) so the correct runtime can be resolved for rebuilds.
- Adds a daemonless `LocalRuntime` plus shared test helpers, letting the unit/integration suites construct backends and the stack manager against a real `ContainerRuntime` rather than ad-hoc CLI mocks. The affected test files were migrated to this helper.

## QA plan

1. Create a podman-backed stack, then bump the app version and create/refresh a stack from the same project dir. Confirm the stack enters `rebuilding` and the rebuilt image carries the current `sandstorm.app-version` label (`podman image inspect`), rather than skipping the rebuild.
2. Repeat with a docker-backed stack and confirm the rebuild path still triggers correctly on a version bump and is skipped when the label already matches.
3. Dispatch a task to a Claude stack and confirm credentials sync successfully (agent authenticates) on both docker and podman runtimes, verifying the stdin-based credential write works.
4. With a stack whose image is missing entirely, confirm stack creation builds from scratch without reporting a spurious rebuild.

Closes #682