### PR TITLE
[686] fix: simulate claude task loop in LocalRuntime

### DIFF
--- a/src/main/runtime/local.ts
+++ b/src/main/runtime/local.ts
@@ -25,6 +25,11 @@ interface LocalContainer {
   labels: Record<string, string>;
 }
 
+interface LocalLoop {
+  stopped: boolean;
+  timer: ReturnType<typeof setInterval> | null;
+}
+
 /**
  * ContainerRuntime that runs commands as local subprocesses inside per-container
  * tmpdirs. Requires no Docker or Podman daemon — intended for unit testing and
@@ -40,6 +45,7 @@ export class LocalRuntime implements ContainerRuntime {
   private imageLabels = new Map<string, Record<string, string>>();
   private ownedTmpdirs: string[] = [];
   private composeContainers = new Map<string, string>();
+  private loops = new Map<string, LocalLoop>();
 
   /**
    * Register a fake container. Returns the tmpdir path created for it.
@@ -77,6 +83,9 @@ export class LocalRuntime implements ContainerRuntime {
 
   /** Remove all registered containers and clean up owned tmpdirs. */
   destroy(): void {
+    for (const id of [...this.loops.keys()]) {
+      this.stopLocalLoop(id);
+    }
     this.containers.clear();
     this.imageLabels.clear();
     this.composeContainers.clear();
@@ -86,20 +95,70 @@ export class LocalRuntime implements ContainerRuntime {
     this.ownedTmpdirs = [];
   }
 
+  /** Return the container id registered for a compose project name. */
+  getProjectContainerId(projectName: string): string | undefined {
+    return this.composeContainers.get(projectName);
+  }
+
+  /** Return the per-container tmpdir path for the given container id. */
+  getContainerTmpdir(containerId: string): string | undefined {
+    return this.containers.get(containerId)?.tmpdir;
+  }
+
+  private startLocalLoop(id: string, tmpdir: string): void {
+    const loop: LocalLoop = { stopped: false, timer: null };
+    this.loops.set(id, loop);
+
+    try { fs.writeFileSync(path.join(tmpdir, 'claude-ready'), 'ready', 'utf8'); } catch { /* ignore */ }
+
+    loop.timer = setInterval(() => {
+      if (loop.stopped) return;
+      const triggerPath = path.join(tmpdir, 'claude-task-trigger');
+      if (!fs.existsSync(triggerPath)) return;
+
+      try { fs.unlinkSync(triggerPath); } catch { return; }
+
+      try {
+        try { fs.unlinkSync(path.join(tmpdir, 'claude-ready')); } catch { /* ignore */ }
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.status'), 'running', 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.pid'), String(process.pid), 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.review-iterations'), '0', 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.verify-retries'), '0', 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.log'), 'fake local loop: task simulated\n', 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.status'), 'completed', 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-task.exit'), '0', 'utf8');
+        fs.writeFileSync(path.join(tmpdir, 'claude-ready'), 'ready', 'utf8');
+      } catch { /* tmpdir removed during teardown */ }
+    }, 50);
+  }
+
+  private stopLocalLoop(id: string): void {
+    const loop = this.loops.get(id);
+    if (!loop) return;
+    loop.stopped = true;
+    if (loop.timer !== null) {
+      clearInterval(loop.timer);
+      loop.timer = null;
+    }
+    this.loops.delete(id);
+  }
+
   async composeUp(_projectDir: string, opts: ComposeOpts): Promise<void> {
     const id = opts.projectName;
-    this.registerContainer(id, {
+    const tmpdir = this.registerContainer(id, {
       name: opts.projectName,
       image: 'local',
       status: 'running',
       labels: { 'com.docker.compose.project': opts.projectName },
     });
     this.composeContainers.set(opts.projectName, id);
+    this.startLocalLoop(id, tmpdir);
   }
 
   async composeDown(_projectDir: string, opts: ComposeOpts): Promise<void> {
     const id = this.composeContainers.get(opts.projectName);
     if (id) {
+      this.stopLocalLoop(id);
       const c = this.containers.get(id);
       if (c && this.ownedTmpdirs.includes(c.tmpdir)) {
         try { fs.rmSync(c.tmpdir, { recursive: true, force: true }); } catch { /* ignore */ }
@@ -179,6 +238,8 @@ export class LocalRuntime implements ContainerRuntime {
       : c.tmpdir;
 
     const env: NodeJS.ProcessEnv = { ...process.env };
+    // Redirect $TMPDIR so shell scripts using it also resolve under the container tmpdir
+    env['TMPDIR'] = c.tmpdir;
     if (opts?.env) {
       for (const entry of opts.env) {
         const eq = entry.indexOf('=');
@@ -186,8 +247,10 @@ export class LocalRuntime implements ContainerRuntime {
       }
     }
 
+    // Rewrite absolute /tmp/ path references in command args to the per-container tmpdir
+    const rewrittenCmd = cmd.map((arg) => arg.split('/tmp/').join(c.tmpdir + '/'));
     const hasInput = opts?.input != null;
-    const [bin, ...args] = cmd;
+    const [bin, ...args] = rewrittenCmd;
 
     return new Promise((resolve, reject) => {
       const child = spawn(bin, args, {

--- a/tests/unit/runtime/local-runtime-loop.test.ts
+++ b/tests/unit/runtime/local-runtime-loop.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { LocalRuntime } from '../../../src/main/runtime/local';
+
+const PROJECT_DIR = '/tmp/sandstorm-test-project-dir';
+
+function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (predicate()) { resolve(); return; }
+      if (Date.now() - start > timeoutMs) { reject(new Error('waitFor timed out')); return; }
+      setTimeout(check, 20);
+    };
+    check();
+  });
+}
+
+describe('LocalRuntime — local loop', () => {
+  let runtime: LocalRuntime;
+
+  beforeEach(() => {
+    runtime = new LocalRuntime();
+  });
+
+  afterEach(() => {
+    runtime.destroy();
+  });
+
+  it('composeUp writes claude-ready=ready in the container tmpdir', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-ready', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-ready')!;
+    const tmpdir = runtime.getContainerTmpdir(id)!;
+
+    await waitFor(() => fs.existsSync(path.join(tmpdir, 'claude-ready')));
+    const content = fs.readFileSync(path.join(tmpdir, 'claude-ready'), 'utf8');
+    expect(content.trim()).toBe('ready');
+  });
+
+  it('exec rewrites /tmp/ paths to the per-container tmpdir', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-rewrite', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-rewrite')!;
+    const tmpdir = runtime.getContainerTmpdir(id)!;
+    const hostPath = '/tmp/claude-task-prompt.txt';
+
+    if (fs.existsSync(hostPath)) fs.unlinkSync(hostPath);
+
+    const result = await runtime.exec(id, ['sh', '-c', 'echo "fake prompt" > /tmp/claude-task-prompt.txt']);
+    expect(result.exitCode).toBe(0);
+
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-prompt.txt'))).toBe(true);
+    expect(fs.existsSync(hostPath)).toBe(false);
+  });
+
+  it('TMPDIR env var is set to the container tmpdir in exec', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-tmpdir-env', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-tmpdir-env')!;
+    const tmpdir = runtime.getContainerTmpdir(id)!;
+
+    const result = await runtime.exec(id, ['sh', '-c', 'echo $TMPDIR']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(tmpdir);
+  });
+
+  it('trigger causes loop to produce status=completed and exit=0', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-trigger', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-trigger')!;
+    const tmpdir = runtime.getContainerTmpdir(id)!;
+
+    await waitFor(() => fs.existsSync(path.join(tmpdir, 'claude-ready')));
+
+    // Write a prompt then drop the trigger
+    await runtime.exec(id, ['sh', '-c', 'echo "a prompt" > /tmp/claude-task-prompt.txt']);
+    await runtime.exec(id, ['touch', '/tmp/claude-task-trigger']);
+
+    await waitFor(() => {
+      try {
+        return fs.readFileSync(path.join(tmpdir, 'claude-task.status'), 'utf8').trim() === 'completed';
+      } catch { return false; }
+    });
+
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task.status'), 'utf8').trim()).toBe('completed');
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task.exit'), 'utf8').trim()).toBe('0');
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-ready'), 'utf8').trim()).toBe('ready');
+  });
+
+  it('exec writes never touch the host /tmp for claude-* files', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-no-host', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-no-host')!;
+    const hostLabel = '/tmp/claude-task-label.txt';
+
+    if (fs.existsSync(hostLabel)) fs.unlinkSync(hostLabel);
+
+    await runtime.exec(id, ['sh', '-c', 'echo "label" > /tmp/claude-task-label.txt']);
+    await runtime.exec(id, ['touch', '/tmp/claude-task-trigger']);
+
+    // Wait a beat to ensure any writes would have landed
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(fs.existsSync(hostLabel)).toBe(false);
+  });
+
+  it('two concurrent containers are fully isolated', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-iso-a', composeFiles: [] });
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-iso-b', composeFiles: [] });
+
+    const idA = runtime.getProjectContainerId('loop-iso-a')!;
+    const idB = runtime.getProjectContainerId('loop-iso-b')!;
+    const tmpdirA = runtime.getContainerTmpdir(idA)!;
+    const tmpdirB = runtime.getContainerTmpdir(idB)!;
+
+    expect(tmpdirA).not.toBe(tmpdirB);
+
+    await waitFor(() =>
+      fs.existsSync(path.join(tmpdirA, 'claude-ready')) &&
+      fs.existsSync(path.join(tmpdirB, 'claude-ready'))
+    );
+
+    // Write prompt only to A, trigger only A
+    await runtime.exec(idA, ['sh', '-c', 'echo "prompt-a" > /tmp/claude-task-prompt.txt']);
+    await runtime.exec(idA, ['touch', '/tmp/claude-task-trigger']);
+
+    await waitFor(() => {
+      try {
+        return fs.readFileSync(path.join(tmpdirA, 'claude-task.status'), 'utf8').trim() === 'completed';
+      } catch { return false; }
+    });
+
+    // A produced output
+    expect(fs.readFileSync(path.join(tmpdirA, 'claude-task.status'), 'utf8').trim()).toBe('completed');
+    expect(fs.readFileSync(path.join(tmpdirA, 'claude-task-prompt.txt'), 'utf8').trim()).toBe('prompt-a');
+
+    // B is untouched by A's writes
+    expect(fs.existsSync(path.join(tmpdirB, 'claude-task-prompt.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpdirB, 'claude-task.status'))).toBe(false);
+    expect(fs.readFileSync(path.join(tmpdirB, 'claude-ready'), 'utf8').trim()).toBe('ready');
+  });
+
+  it('composeDown stops the loop and removes the tmpdir', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-down', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-down')!;
+    const tmpdir = runtime.getContainerTmpdir(id)!;
+
+    await waitFor(() => fs.existsSync(path.join(tmpdir, 'claude-ready')));
+    expect(fs.existsSync(tmpdir)).toBe(true);
+
+    await runtime.composeDown(PROJECT_DIR, { projectName: 'loop-down', composeFiles: [] });
+
+    expect(fs.existsSync(tmpdir)).toBe(false);
+
+    const containers = await runtime.listContainers({ name: 'loop-down' });
+    expect(containers).toHaveLength(0);
+
+    // Let enough time pass to confirm no residual timer fires (would crash on missing tmpdir)
+    await new Promise((r) => setTimeout(r, 150));
+  });
+
+  it('loop handles a second trigger after the first completes', async () => {
+    await runtime.composeUp(PROJECT_DIR, { projectName: 'loop-multi', composeFiles: [] });
+    const id = runtime.getProjectContainerId('loop-multi')!;
+    const tmpdir = runtime.getContainerTmpdir(id)!;
+
+    await waitFor(() => fs.existsSync(path.join(tmpdir, 'claude-ready')));
+
+    // First trigger
+    await runtime.exec(id, ['touch', '/tmp/claude-task-trigger']);
+    await waitFor(() => {
+      try {
+        return fs.readFileSync(path.join(tmpdir, 'claude-task.status'), 'utf8').trim() === 'completed';
+      } catch { return false; }
+    });
+
+    // Loop should have restored ready
+    await waitFor(() => fs.existsSync(path.join(tmpdir, 'claude-ready')));
+
+    // Clear first-round status before dropping the trigger so the loop
+    // cannot process the trigger and write completed before we delete it
+    fs.unlinkSync(path.join(tmpdir, 'claude-task.status'));
+    // Second trigger
+    await runtime.exec(id, ['touch', '/tmp/claude-task-trigger']);
+
+    await waitFor(() => {
+      try {
+        return fs.readFileSync(path.join(tmpdir, 'claude-task.status'), 'utf8').trim() === 'completed';
+      } catch { return false; }
+    });
+
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task.status'), 'utf8').trim()).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Summary

The `LocalRuntime` fake container backend (used by unit tests with no Docker/Podman daemon) did not emulate the in-container claude task loop, so tests exercising the task lifecycle had nothing to drive against. This adds a tmpdir-scoped fake loop and tightens path isolation:

- `composeUp` now starts a per-container loop that writes `claude-ready`, watches for a `claude-task-trigger`, and on trigger simulates a task run by emitting the `claude-task.*` status/exit/log/pid files and restoring `claude-ready`. `composeDown` and `destroy` stop the loop and clear its interval so no timer fires after the tmpdir is removed.
- `exec` now redirects `$TMPDIR` to the container tmpdir and rewrites absolute `/tmp/` path references in command args to the per-container tmpdir, so shell scripts and label writes stay isolated and never touch the host `/tmp`.
- Adds `getProjectContainerId` and `getContainerTmpdir` accessors so tests can resolve a container's tmpdir from its compose project name.

These changes keep each fake container fully isolated and let the task loop be driven deterministically in unit tests.

## QA plan

1. Run a workflow that spins up a local stack and dispatches a task; confirm the task transitions to `completed` with exit `0` and that `claude-ready` is restored afterward.
2. Spin up two concurrent local containers, trigger only one, and confirm the other's tmpdir is untouched (no prompt/status files leak across containers).
3. Confirm no `claude-*` files appear under the host `/tmp` during a run.
4. Tear a stack down mid-loop and confirm the tmpdir is removed and no residual timer errors fire afterward.

Closes #686