### PR TITLE
[685] fix: dispatch stacks via runtime primitives, not runCli

### DIFF
--- a/src/main/control-plane/dispatch.ts
+++ b/src/main/control-plane/dispatch.ts
@@ -1,0 +1,105 @@
+import { ContainerRuntime } from '../runtime/types';
+
+export interface BringUpOpts {
+  projectName: string;
+  composeFiles: string[];
+  env?: Record<string, string>;
+  build?: boolean;
+}
+
+export interface DeliverTaskInputs {
+  prompt: string;
+  model?: string;
+  modelsJson?: string;
+  resume?: string;
+  backend?: string;
+  backendModel?: string;
+  phaseRoutingJson?: string;
+}
+
+/**
+ * Bring a stack up by delegating to runtime.composeUp.
+ * For LocalRuntime this registers a fake container and starts the local loop.
+ * For DockerRuntime this runs `docker compose up -d` with the supplied files.
+ */
+export async function bringUp(
+  runtime: ContainerRuntime,
+  projectDir: string,
+  opts: BringUpOpts
+): Promise<void> {
+  await runtime.composeUp(projectDir, {
+    projectName: opts.projectName,
+    composeFiles: opts.composeFiles,
+    env: opts.env,
+    build: opts.build,
+  });
+}
+
+async function writeToContainer(
+  runtime: ContainerRuntime,
+  containerId: string,
+  filePath: string,
+  content: string
+): Promise<void> {
+  const result = await runtime.exec(
+    containerId,
+    ['bash', '-c', `cat > ${filePath}`],
+    { input: content, user: 'claude' }
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `deliverTask: failed to write ${filePath}: ${result.stderr || result.stdout}`
+    );
+  }
+}
+
+/**
+ * Deliver a task to a running container by writing state files via runtime.exec.
+ *
+ * Matches the file-write sequence performed by `sandstorm task` in stack.sh:
+ *   - prompt and label written first
+ *   - optional files written only when the input is present
+ *   - trigger touched last (B1: large prompts go via stdin, never argv)
+ */
+export async function deliverTask(
+  runtime: ContainerRuntime,
+  containerId: string,
+  inputs: DeliverTaskInputs
+): Promise<void> {
+  // Label = first line of prompt, max 80 chars (mirrors: head -1 | cut -c1-80)
+  const label = (inputs.prompt.split('\n')[0] ?? '').slice(0, 80);
+
+  await writeToContainer(runtime, containerId, '/tmp/claude-task-prompt.txt', inputs.prompt);
+  await writeToContainer(runtime, containerId, '/tmp/claude-task-label.txt', label);
+
+  if (inputs.model != null) {
+    await writeToContainer(runtime, containerId, '/tmp/claude-task-model.txt', inputs.model);
+  }
+  if (inputs.modelsJson != null) {
+    await writeToContainer(runtime, containerId, '/tmp/claude-task-models.json', inputs.modelsJson);
+  }
+  if (inputs.resume != null) {
+    await writeToContainer(runtime, containerId, '/tmp/claude-task-resume.txt', inputs.resume);
+  }
+  if (inputs.backend != null) {
+    await writeToContainer(runtime, containerId, '/tmp/claude-task-backend.txt', inputs.backend);
+  }
+  if (inputs.backendModel != null) {
+    await writeToContainer(runtime, containerId, '/tmp/claude-task-backend-model.txt', inputs.backendModel);
+  }
+  if (inputs.phaseRoutingJson != null) {
+    await writeToContainer(runtime, containerId, '/tmp/claude-task-phase-routing.json', inputs.phaseRoutingJson);
+  }
+
+  // Touch trigger LAST — inputs must all exist before the loop sees the trigger
+  const triggerResult = await runtime.exec(
+    containerId,
+    ['bash', '-c', 'touch /tmp/claude-task-trigger'],
+    { user: 'claude' }
+  );
+  if (triggerResult.exitCode !== 0) {
+    throw new Error(
+      `deliverTask: failed to set trigger: ${triggerResult.stderr || triggerResult.stdout}`
+    );
+  }
+}

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -15,6 +15,7 @@ import { resolveTicketReferences, renderResolvedReferences } from './ticket-refe
 import { workspacePathFor } from './pr-creator';
 import { parseTokenUsage } from './token-parser';
 import type { TouchpointId } from './routing';
+import { bringUp, deliverTask } from './dispatch';
 
 const execFileAsync = promisify(execFile);
 
@@ -492,16 +493,18 @@ export class StackManager {
       // Pass the app version so the CLI can stamp the Docker image label
       portEnv['SANDSTORM_APP_VERSION'] = this.appVersion;
 
-      // Build CLI args
-      const args = ['up', opts.name];
-      if (opts.ticket) args.push('--ticket', opts.ticket);
-      if (opts.branch) args.push('--branch', opts.branch);
+      const projectBase = path.basename(opts.projectDir);
+      const composeProjectName = composeProjectNameFor(projectBase, opts.name);
+      const workspaceCompose = path.join(opts.projectDir, '.sandstorm', 'workspaces', opts.name, 'docker-compose.yml');
+      const sandstormCompose = path.join(opts.projectDir, '.sandstorm', 'docker-compose.yml');
+      const claudeOverlay = path.join(this.cliDir, 'compose', 'claude-overlay.yml');
 
-      const result = await this.runCli(opts.projectDir, args, portEnv);
-
-      if (result.exitCode !== 0) {
-        throw new SandstormError(ErrorCode.COMPOSE_FAILED, result.stderr.trim() || result.stdout.trim() || 'Stack creation failed');
-      }
+      await bringUp(buildRuntime, opts.projectDir, {
+        projectName: composeProjectName,
+        composeFiles: [workspaceCompose, sandstormCompose, claudeOverlay],
+        env: portEnv,
+        build: needsRebuild,
+      });
 
       this.registry.updateStackStatus(opts.name, 'up');
       this.notifyUpdate();
@@ -768,18 +771,17 @@ export class StackManager {
     this.registry.updateStackStatus(stackId, 'running');
     this.notifyUpdate();
 
-    const cliArgs = ['task', stackId, '--resume', task.session_id!];
-    if (task.model) cliArgs.push('--model', task.model);
-    cliArgs.push(continuationPrompt);
-
-    const result = await this.runCli(stack.project_dir, cliArgs);
-    if (result.exitCode !== 0) {
+    try {
+      await deliverTask(runtime, claudeContainer.id, {
+        prompt: continuationPrompt,
+        model: task.model ?? undefined,
+        resume: task.session_id!,
+      });
+    } catch (err) {
       this.registry.updateStackStatus(stackId, 'session_paused');
       this.notifyUpdate();
-      throw new SandstormError(
-        ErrorCode.TASK_DISPATCH_FAILED,
-        result.stderr.trim() || result.stdout.trim() || 'Resume dispatch failed'
-      );
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, msg || 'Resume dispatch failed');
     }
 
     this.taskWatcher.watch(stackId, claudeContainer.id);
@@ -812,18 +814,17 @@ export class StackManager {
     this.registry.updateStackStatus(stackId, 'running');
     this.notifyUpdate();
 
-    const cliArgs = ['task', stackId, '--resume', task.session_id!];
-    if (task.model) cliArgs.push('--model', task.model);
-    cliArgs.push(investigationPrompt);
-
-    const result = await this.runCli(stack.project_dir, cliArgs);
-    if (result.exitCode !== 0) {
+    try {
+      await deliverTask(runtime, claudeContainer.id, {
+        prompt: investigationPrompt,
+        model: task.model ?? undefined,
+        resume: task.session_id!,
+      });
+    } catch (err) {
       this.registry.updateStackStatus(stackId, 'needs_human');
       this.notifyUpdate();
-      throw new SandstormError(
-        ErrorCode.TASK_DISPATCH_FAILED,
-        result.stderr.trim() || result.stdout.trim() || 'Investigation dispatch failed'
-      );
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, msg || 'Investigation dispatch failed');
     }
 
     this.taskWatcher.watch(stackId, claudeContainer.id);
@@ -1415,7 +1416,6 @@ export class StackManager {
     const task = this.registry.createTask(stackId, prompt, model);
 
     const runtime = this.getRuntimeForStack(stack);
-    let promptTmpDir: string | undefined;
 
     try {
       let claudeContainer = await this.findClaudeContainer(stack, runtime);
@@ -1432,10 +1432,6 @@ export class StackManager {
       // Wait for the inner Claude agent to be ready before dispatching
       await this.waitForClaudeReady(claudeContainer.id, runtime);
 
-      // Use the sandstorm CLI to dispatch the task. The CLI's `task` command
-      // handles credential sync (OAuth), writes files as the correct user
-      // (`-u claude`), and creates the trigger file with proper ownership —
-      // preventing the infinite-loop and not-logged-in bugs.
       const execTouchpoint = opts?.executionTouchpoint ?? 'execution';
       const execDesc = this.registry.getEffectiveTouchpointDescriptor(stack.project_dir, execTouchpoint);
       const reviewDesc = this.registry.getEffectiveTouchpointDescriptor(stack.project_dir, 'review');
@@ -1453,25 +1449,12 @@ export class StackManager {
         review:      { backend: reviewDesc.backend, provider: reviewDesc.provider, model: reviewDesc.model || 'auto' },
         meta_review: { backend: metaDesc.backend,   provider: metaDesc.provider,   model: metaDesc.model   || 'auto' },
       });
-      const cliArgs = ['task', stackId];
-      if (model) cliArgs.push('--model', model);
-      cliArgs.push('--models-json', phaseModelsJson);
-      cliArgs.push('--phase-routing-json', phaseRoutingJson);
-      promptTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sandstorm-task-'));
-      const promptTmpFile = path.join(promptTmpDir, 'prompt.txt');
-      await fs.promises.writeFile(promptTmpFile, prompt, 'utf-8');
-      cliArgs.push('--file', promptTmpFile);
-
-      const result = await this.runCli(stack.project_dir, cliArgs).finally(() => {
-        if (promptTmpDir) fs.promises.rm(promptTmpDir, { recursive: true, force: true }).catch(() => {});
+      await deliverTask(runtime, claudeContainer.id, {
+        prompt,
+        model: model ?? undefined,
+        modelsJson: phaseModelsJson,
+        phaseRoutingJson,
       });
-
-      if (result.exitCode !== 0) {
-        throw new SandstormError(
-          ErrorCode.TASK_DISPATCH_FAILED,
-          result.stderr.trim() || result.stdout.trim() || 'Task dispatch failed'
-        );
-      }
 
       // Start watching for completion
       this.taskWatcher.watch(stackId, claudeContainer.id);
@@ -1481,9 +1464,6 @@ export class StackManager {
 
       return { id: task.id, stack_id: stackId, status: task.status };
     } catch (err) {
-      if (promptTmpDir) {
-        fs.promises.rm(promptTmpDir, { recursive: true, force: true }).catch(() => {});
-      }
       // Task was created but dispatch failed — mark it as failed so the
       // stack doesn't stay stuck in 'running' status forever.
       this.registry.completeTask(task.id, 1);

--- a/tests/contract/dispatch-cli-parity.test.ts
+++ b/tests/contract/dispatch-cli-parity.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Contract test: deliverTask must produce the same state files as the
+ * `sandstorm task` CLI command (stack.sh task subcommand).
+ *
+ * The single source of truth for which files are written is STATE_FILES in
+ * state-files.ts.  This test verifies that deliverTask writes exactly the set
+ * of non-conditional files always, and each conditional file iff the
+ * corresponding input is present — matching the CLI's behaviour.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { LocalRuntime } from '../../src/main/runtime/local';
+import { bringUp, deliverTask } from '../../src/main/control-plane/dispatch';
+import { STATE_FILES } from './state-files';
+
+const PROJECT_DIR = '/tmp/sandstorm-parity-test';
+
+// Only the pre-task input files produced by stack.sh
+const STACK_SH_INPUT_FILES = STATE_FILES.filter(
+  (f) => f.producer === 'stack.sh' && f.t0Reachable
+);
+const REQUIRED_FILES = STACK_SH_INPUT_FILES.filter((f) => !f.conditional);
+const CONDITIONAL_FILES = STACK_SH_INPUT_FILES.filter((f) => f.conditional);
+
+function fileBasename(pattern: string): string {
+  return path.basename(pattern);
+}
+
+describe('dispatch-cli-parity: deliverTask matches stack.sh task subcommand', () => {
+  let runtime: LocalRuntime;
+  let containerId: string;
+  let tmpdir: string;
+
+  beforeEach(async () => {
+    runtime = new LocalRuntime();
+    await bringUp(runtime, PROJECT_DIR, {
+      projectName: 'sandstorm-parity-test',
+      composeFiles: [],
+    });
+    containerId = runtime.getProjectContainerId('sandstorm-parity-test')!;
+    tmpdir = runtime.getContainerTmpdir(containerId)!;
+  });
+
+  afterEach(() => runtime?.destroy());
+
+  it('writes every non-conditional stack.sh input file', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test task' });
+    for (const file of REQUIRED_FILES) {
+      const name = fileBasename(file.pattern);
+      expect(fs.existsSync(path.join(tmpdir, name)), `${name} must exist`).toBe(true);
+    }
+  });
+
+  it('does not write conditional files when inputs are absent', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test task' });
+    for (const file of CONDITIONAL_FILES) {
+      const name = fileBasename(file.pattern);
+      expect(fs.existsSync(path.join(tmpdir, name)), `${name} must NOT exist`).toBe(false);
+    }
+  });
+
+  it('writes all conditional files when all optional inputs are supplied', async () => {
+    await deliverTask(runtime, containerId, {
+      prompt: 'full task',
+      model: 'claude-opus-4-8',
+      modelsJson: JSON.stringify({ execution: 'auto', review: 'auto', meta_review: 'auto' }),
+      resume: 'session-abc',
+      backend: 'claude',
+      backendModel: 'claude-sonnet-4-6',
+      phaseRoutingJson: JSON.stringify({
+        execution: { backend: 'claude', provider: 'anthropic', model: 'auto' },
+      }),
+    });
+    for (const file of CONDITIONAL_FILES) {
+      const name = fileBasename(file.pattern);
+      expect(fs.existsSync(path.join(tmpdir, name)), `${name} must exist`).toBe(true);
+    }
+  });
+
+  it('prompt file content matches exactly (B1: no argv truncation)', async () => {
+    // Prompt exceeds the Linux MAX_ARG_STRLEN limit (128 KB) — verifies that
+    // deliverTask delivers via stdin, never via argv.
+    const bigPrompt = 'x'.repeat(200 * 1024);
+    await deliverTask(runtime, containerId, { prompt: bigPrompt });
+    const written = fs.readFileSync(path.join(tmpdir, 'claude-task-prompt.txt'), 'utf-8');
+    expect(written).toBe(bigPrompt);
+  });
+
+  it('label matches first line of prompt, max 80 chars (mirrors head -1 | cut -c1-80)', async () => {
+    const prompt = 'Short first line\nExtra content that should be ignored';
+    await deliverTask(runtime, containerId, { prompt });
+    const label = fs.readFileSync(path.join(tmpdir, 'claude-task-label.txt'), 'utf-8');
+    expect(label).toBe('Short first line');
+  });
+
+  it('label is truncated to 80 chars for long first lines', async () => {
+    const longFirstLine = 'B'.repeat(200);
+    await deliverTask(runtime, containerId, { prompt: longFirstLine });
+    const label = fs.readFileSync(path.join(tmpdir, 'claude-task-label.txt'), 'utf-8');
+    expect(label).toHaveLength(80);
+    expect(label).toBe('B'.repeat(80));
+  });
+
+  it('trigger file is present after deliverTask completes (loop will fire)', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'trigger test' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-trigger'))).toBe(true);
+  });
+
+  it('prompt file exists when trigger is set (ordering invariant)', async () => {
+    // After deliverTask the prompt must be on disk — the loop reads it after trigger
+    await deliverTask(runtime, containerId, { prompt: 'ordering test' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-prompt.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-trigger'))).toBe(true);
+  });
+});

--- a/tests/unit/auto-rebuild.test.ts
+++ b/tests/unit/auto-rebuild.test.ts
@@ -90,13 +90,6 @@ describe('Auto-rebuild mechanism', () => {
 
   describe('createStack sets rebuilding status', () => {
     it('passes SANDSTORM_APP_VERSION to CLI via runCli', async () => {
-      // Spy on runCli to verify the env var is passed
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: '',
-        stderr: '',
-        exitCode: 0,
-      });
-
       // Mock checkImageNeedsRebuild to return false (no rebuild)
       vi.spyOn(manager, 'checkImageNeedsRebuild').mockResolvedValue(false);
 
@@ -113,13 +106,12 @@ describe('Auto-rebuild mechanism', () => {
           runtime: 'docker',
         });
 
-        // Wait for background build to reach runCli
+        // Wait for background build to reach composeUp
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        expect(runCliSpy).toHaveBeenCalled();
-        const envArg = runCliSpy.mock.calls[0][2];
-        expect(envArg).toBeDefined();
-        expect(envArg!['SANDSTORM_APP_VERSION']).toBe('test');
+        expect(runtime.composeUp).toHaveBeenCalled();
+        const composeOpts = (runtime.composeUp as ReturnType<typeof vi.fn>).mock.calls[0][1];
+        expect(composeOpts?.env?.['SANDSTORM_APP_VERSION']).toBe('test');
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/tests/unit/control-plane/dispatch.test.ts
+++ b/tests/unit/control-plane/dispatch.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { LocalRuntime } from '../../../src/main/runtime/local';
+import { bringUp, deliverTask } from '../../../src/main/control-plane/dispatch';
+
+const PROJECT_DIR = '/tmp/sandstorm-dispatch-test';
+
+describe('bringUp', () => {
+  let runtime: LocalRuntime;
+
+  afterEach(() => runtime?.destroy());
+
+  it('registers a container and starts the local loop', async () => {
+    runtime = new LocalRuntime();
+    await bringUp(runtime, PROJECT_DIR, {
+      projectName: 'sandstorm-test-42',
+      composeFiles: [],
+    });
+    const containerId = runtime.getProjectContainerId('sandstorm-test-42');
+    expect(containerId).toBeDefined();
+    const tmpdir = runtime.getContainerTmpdir(containerId!);
+    expect(tmpdir).toBeDefined();
+    expect(fs.existsSync(path.join(tmpdir!, 'claude-ready'))).toBe(true);
+  });
+
+  it('passes env and build options through to runtime.composeUp', async () => {
+    runtime = new LocalRuntime();
+    // LocalRuntime ignores env/build but must not throw
+    await expect(
+      bringUp(runtime, PROJECT_DIR, {
+        projectName: 'sandstorm-test-env',
+        composeFiles: [],
+        env: { SANDSTORM_APP_VERSION: '1.2.3' },
+        build: true,
+      })
+    ).resolves.toBeUndefined();
+    const containerId = runtime.getProjectContainerId('sandstorm-test-env');
+    expect(containerId).toBeDefined();
+  });
+
+  it('makes the container available via getProjectContainerId', async () => {
+    runtime = new LocalRuntime();
+    await bringUp(runtime, PROJECT_DIR, {
+      projectName: 'sandstorm-lookup-test',
+      composeFiles: [],
+    });
+    const id = runtime.getProjectContainerId('sandstorm-lookup-test');
+    const containers = await runtime.listContainers({ name: 'sandstorm-lookup-test' });
+    expect(containers.length).toBeGreaterThan(0);
+    expect(containers[0].id).toBe(id);
+  });
+});
+
+describe('deliverTask', () => {
+  let runtime: LocalRuntime;
+  let containerId: string;
+  let tmpdir: string;
+
+  beforeEach(async () => {
+    runtime = new LocalRuntime();
+    await bringUp(runtime, PROJECT_DIR, {
+      projectName: 'sandstorm-deliver-test',
+      composeFiles: [],
+    });
+    containerId = runtime.getProjectContainerId('sandstorm-deliver-test')!;
+    tmpdir = runtime.getContainerTmpdir(containerId)!;
+  });
+
+  afterEach(() => runtime?.destroy());
+
+  it('writes prompt to claude-task-prompt.txt', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'Hello world' });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-prompt.txt'), 'utf-8')).toBe('Hello world');
+  });
+
+  it('writes label as first line of prompt, max 80 chars', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'First line\nSecond line' });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-label.txt'), 'utf-8')).toBe('First line');
+  });
+
+  it('truncates label to 80 chars', async () => {
+    const longLine = 'A'.repeat(120);
+    await deliverTask(runtime, containerId, { prompt: longLine });
+    const label = fs.readFileSync(path.join(tmpdir, 'claude-task-label.txt'), 'utf-8');
+    expect(label).toHaveLength(80);
+    expect(label).toBe('A'.repeat(80));
+  });
+
+  it('writes trigger file last', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-trigger'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-prompt.txt'))).toBe(true);
+  });
+
+  it('writes optional model file when provided', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test', model: 'claude-opus-4-8' });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-model.txt'), 'utf-8')).toBe('claude-opus-4-8');
+  });
+
+  it('omits claude-task-model.txt when model is absent', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-model.txt'))).toBe(false);
+  });
+
+  it('writes modelsJson to claude-task-models.json', async () => {
+    const modelsJson = JSON.stringify({ execution: 'auto', review: 'auto', meta_review: 'auto' });
+    await deliverTask(runtime, containerId, { prompt: 'test', modelsJson });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-models.json'), 'utf-8')).toBe(modelsJson);
+  });
+
+  it('omits claude-task-models.json when modelsJson is absent', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-models.json'))).toBe(false);
+  });
+
+  it('writes resume to claude-task-resume.txt', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test', resume: 'session-abc-123' });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-resume.txt'), 'utf-8')).toBe('session-abc-123');
+  });
+
+  it('omits claude-task-resume.txt when resume is absent', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-resume.txt'))).toBe(false);
+  });
+
+  it('writes backend to claude-task-backend.txt', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test', backend: 'opencode' });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-backend.txt'), 'utf-8')).toBe('opencode');
+  });
+
+  it('writes backendModel to claude-task-backend-model.txt', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'test', backendModel: 'gpt-4o' });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-backend-model.txt'), 'utf-8')).toBe('gpt-4o');
+  });
+
+  it('writes phaseRoutingJson to claude-task-phase-routing.json', async () => {
+    const phaseRoutingJson = JSON.stringify({
+      execution: { backend: 'claude', provider: 'anthropic', model: 'auto' },
+      review: { backend: 'claude', provider: 'anthropic', model: 'auto' },
+      meta_review: { backend: 'claude', provider: 'anthropic', model: 'auto' },
+    });
+    await deliverTask(runtime, containerId, { prompt: 'test', phaseRoutingJson });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-phase-routing.json'), 'utf-8')).toBe(phaseRoutingJson);
+  });
+
+  it('omits all conditional files when only prompt is provided', async () => {
+    await deliverTask(runtime, containerId, { prompt: 'minimal' });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-model.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-models.json'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-resume.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-backend.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-backend-model.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-phase-routing.json'))).toBe(false);
+  });
+
+  it('writes all conditional files when all inputs are provided', async () => {
+    await deliverTask(runtime, containerId, {
+      prompt: 'full task',
+      model: 'claude-opus-4-8',
+      modelsJson: '{"execution":"auto"}',
+      resume: 'session-xyz',
+      backend: 'claude',
+      backendModel: 'claude-sonnet-4-6',
+      phaseRoutingJson: '{"execution":{"backend":"claude"}}',
+    });
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-model.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-models.json'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-resume.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-backend.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-backend-model.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpdir, 'claude-task-phase-routing.json'))).toBe(true);
+  });
+
+  it('preserves multi-line prompt content exactly', async () => {
+    const prompt = 'Line 1\nLine 2\nLine 3\n';
+    await deliverTask(runtime, containerId, { prompt });
+    expect(fs.readFileSync(path.join(tmpdir, 'claude-task-prompt.txt'), 'utf-8')).toBe(prompt);
+  });
+});

--- a/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
+++ b/tests/unit/main/control-plane/stack-manager-dispatch-references.test.ts
@@ -80,6 +80,17 @@ function makeStack(id: string) {
   };
 }
 
+/** Find the `input` content passed to runtime.exec for a specific tmpfile write. */
+function getExecInput(rt: ContainerRuntime, filename: string): string | undefined {
+  const calls = (rt.exec as ReturnType<typeof vi.fn>).mock.calls;
+  for (const [, cmd, opts] of calls) {
+    if (Array.isArray(cmd) && cmd[2]?.includes(filename)) {
+      return opts?.input as string | undefined;
+    }
+  }
+  return undefined;
+}
+
 const REFS_SECTION = '## Resolved References\n\n### https://gist.github.com/user/abc\n\n```\nmockup content\n```\n';
 
 /** Read the prompt delivered to runCli, handling the --file <path> dispatch pattern. */
@@ -123,9 +134,6 @@ describe('dispatchTask — reference resolution', () => {
 
   it('appends resolved references block to the prompt delivered to runCli', async () => {
     registry.createStack(makeStack('ref-stack'));
-    const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-      stdout: 'ok', stderr: '', exitCode: 0,
-    });
 
     // Simulate a gist reference being resolved
     mockResolveTicketReferences.mockResolvedValue([
@@ -136,9 +144,7 @@ describe('dispatchTask — reference resolution', () => {
     const prompt = 'Implement the mockup at https://gist.github.com/user/abc';
     await manager.dispatchTask('ref-stack', prompt, undefined, { forceBypass: true });
 
-    // Prompt is delivered via --file (temp file) to avoid argv E2BIG; read file for content verification.
-    const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
-    const deliveredPrompt = readDeliveredPrompt(cliArgs);
+    const deliveredPrompt = getExecInput(runtime, 'claude-task-prompt.txt')!;
 
     expect(deliveredPrompt).toContain('## Resolved References');
     expect(deliveredPrompt).toContain('mockup content');
@@ -147,9 +153,6 @@ describe('dispatchTask — reference resolution', () => {
 
   it('leaves prompt unchanged when the body has no external links (no-op)', async () => {
     registry.createStack(makeStack('noref-stack'));
-    const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-      stdout: 'ok', stderr: '', exitCode: 0,
-    });
 
     // No references
     mockResolveTicketReferences.mockResolvedValue([]);
@@ -158,9 +161,7 @@ describe('dispatchTask — reference resolution', () => {
     const prompt = 'Fix the bug in the auth module';
     await manager.dispatchTask('noref-stack', prompt, undefined, { forceBypass: true });
 
-    // Prompt is delivered via --file (temp file); read file for content verification.
-    const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
-    const deliveredPrompt = readDeliveredPrompt(cliArgs);
+    const deliveredPrompt = getExecInput(runtime, 'claude-task-prompt.txt')!;
 
     expect(deliveredPrompt).toBe(prompt);
     expect(deliveredPrompt).not.toContain('## Resolved References');
@@ -182,9 +183,6 @@ describe('dispatchTask — reference resolution', () => {
 
   it('appended section is separated by a horizontal rule', async () => {
     registry.createStack(makeStack('sep-stack'));
-    const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-      stdout: 'ok', stderr: '', exitCode: 0,
-    });
 
     mockResolveTicketReferences.mockResolvedValue([
       { url: 'https://example.com/doc', kind: 'other', content: 'design doc' },
@@ -193,9 +191,7 @@ describe('dispatchTask — reference resolution', () => {
 
     await manager.dispatchTask('sep-stack', 'Build per spec at https://example.com/doc', undefined, { forceBypass: true });
 
-    // Prompt is delivered via --file (temp file); read file for content verification.
-    const cliArgs: string[] = runCliSpy.mock.calls[0][1] as string[];
-    const deliveredPrompt = readDeliveredPrompt(cliArgs);
+    const deliveredPrompt = getExecInput(runtime, 'claude-task-prompt.txt')!;
 
     expect(deliveredPrompt).toContain('\n\n---\n\n');
     expect(deliveredPrompt).toContain('## Resolved References');

--- a/tests/unit/stack-lifecycle.test.ts
+++ b/tests/unit/stack-lifecycle.test.ts
@@ -299,11 +299,13 @@ describe('Stack Lifecycle Integration', () => {
     it('marks task as failed when dispatch CLI fails', async () => {
       registry.createStack(makeStack('dispatch-fail'));
 
-      // First call succeeds (waitForClaudeReady), second fails (runCli for task)
-      vi.spyOn(manager, 'runCli').mockResolvedValue({
+      // Mock waitForClaudeReady to succeed so exec failure is only seen by deliverTask
+      vi.spyOn(manager, 'waitForClaudeReady').mockResolvedValue(undefined);
+      // exec fails (deliverTask will throw)
+      (runtime.exec as ReturnType<typeof vi.fn>).mockResolvedValue({
+        exitCode: 1,
         stdout: '',
         stderr: 'dispatch error',
-        exitCode: 1,
       });
 
       await expect(

--- a/tests/unit/stack-manager.test.ts
+++ b/tests/unit/stack-manager.test.ts
@@ -60,6 +60,17 @@ function makeStack(id: string = 'test-stack') {
   };
 }
 
+/** Find the `input` content passed to runtime.exec for a specific tmpfile write. */
+function getExecInput(rt: ContainerRuntime, filename: string): string | undefined {
+  const calls = (rt.exec as ReturnType<typeof vi.fn>).mock.calls;
+  for (const [, cmd, opts] of calls) {
+    if (Array.isArray(cmd) && cmd[2]?.includes(filename)) {
+      return opts?.input as string | undefined;
+    }
+  }
+  return undefined;
+}
+
 describe('sanitizeComposeName', () => {
   it('passes through valid names unchanged', () => {
     expect(sanitizeComposeName('auth-refactor')).toBe('auth-refactor');
@@ -260,11 +271,7 @@ describe('StackManager', () => {
     });
 
     it('marks stack as failed with error message when CLI returns non-zero', async () => {
-      vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: '',
-        stderr: 'compose failed',
-        exitCode: 1,
-      });
+      (runtime.composeUp as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('compose failed'));
 
       fs.writeFileSync(path.join(tmpDir, '.sandstorm', 'config'), '# empty\n');
 
@@ -279,12 +286,6 @@ describe('StackManager', () => {
     });
 
     it('passes port env vars and stack args to CLI', async () => {
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: '',
-        stderr: '',
-        exitCode: 0,
-      });
-
       manager.createStack({
         name: 'env-test',
         projectDir: tmpDir,
@@ -299,18 +300,11 @@ describe('StackManager', () => {
         expect(stack!.status).toBe('up');
       }, { timeout: 5000 });
 
-      expect(runCliSpy).toHaveBeenCalled();
-      const [dir, args, env] = runCliSpy.mock.calls[0];
-      expect(dir).toBe(tmpDir);
-      expect(args).toContain('up');
-      expect(args).toContain('env-test');
-      expect(args).toContain('--ticket');
-      expect(args).toContain('PROJ-1');
-      expect(args).toContain('--branch');
-      expect(args).toContain('feature/test');
-      // Port env vars are no longer set at stack creation (on-demand proxy model)
-      expect(env).not.toHaveProperty('SANDSTORM_PORT_app_0');
-      expect(env).toHaveProperty('SANDSTORM_APP_VERSION');
+      expect(runtime.composeUp).toHaveBeenCalled();
+      const composeCall = (runtime.composeUp as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [, opts] = composeCall;
+      expect(opts.projectName).toContain('env-test');
+      expect(opts.env).toHaveProperty('SANDSTORM_APP_VERSION');
     });
 
     it('calls onStackUpdate callback when build completes', async () => {
@@ -395,11 +389,6 @@ describe('StackManager', () => {
   describe('dispatchTask', () => {
     it('dispatches a task via CLI to a stack', async () => {
       registry.createStack(makeStack('dispatch-test'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       const result = await manager.dispatchTask('dispatch-test', 'Fix the bug');
       expect(result.status).toBe('running');
@@ -407,44 +396,24 @@ describe('StackManager', () => {
       expect(typeof result.id).toBe('number');
       // Verify trimmed shape — prompt is NOT echoed in the MCP response (#255)
       expect(result).not.toHaveProperty('prompt');
-      // The prompt is still persisted in the registry
       const persisted = registry.getTasksForStack('dispatch-test');
       expect(persisted[0].prompt).toBe('Fix the bug');
-
-      // Should delegate to CLI `task` command (handles cred sync + user perms)
-      // When no model is specified, the effective default (sonnet) is used.
-      // --models-json carries the per-phase model map; --phase-routing-json carries full routing.
-      const [, callArgs] = runCliSpy.mock.calls[0];
-      expect(callArgs[0]).toBe('task');
-      expect(callArgs[1]).toBe('dispatch-test');
-      expect(callArgs).toContain('--model');
-      expect(callArgs).toContain('--models-json');
-      expect(callArgs).toContain('--phase-routing-json');
-      // dispatchTask always writes the prompt to a temp file and passes --file.
-      expect(callArgs).toContain('--file');
-      const fileIdx = callArgs.indexOf('--file');
-      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Fix the bug');
+      // Prompt delivered via runtime.exec stdin (B1: never via argv)
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBe('Fix the bug');
+      // Phase routing delivered
+      expect(getExecInput(runtime, 'claude-task-models.json')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-phase-routing.json')).toBeDefined();
     });
 
-    it('regression (E2BIG): a >128KB prompt is written to a temp file and passed via --file', async () => {
+    it('delivers large prompts via runtime.exec stdin, not argv (B1 invariant prevents E2BIG)', async () => {
       registry.createStack(makeStack('huge-prompt'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
-      // A prompt large enough that, as a single argv entry, it would overflow
-      // Linux's 128KB MAX_ARG_STRLEN and make spawn throw E2BIG on the host.
       const hugePrompt = 'x'.repeat(200 * 1024);
       await manager.dispatchTask('huge-prompt', hugePrompt);
 
-      const [, callArgs] = runCliSpy.mock.calls[0];
-      // dispatchTask always writes the prompt to a temp file and passes --file,
-      // so spawn never sees a large argv entry regardless of prompt size.
-      expect(callArgs).toContain('--file');
-      const fileIdx = callArgs.indexOf('--file');
-      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe(hugePrompt);
+      // Prompt delivered via runtime.exec stdin (B1: never via argv — prevents E2BIG)
+      const deliveredPrompt = getExecInput(runtime, 'claude-task-prompt.txt');
+      expect(deliveredPrompt).toBe(hugePrompt);
       // The full prompt is still persisted to the registry intact.
       const persisted = registry.getTasksForStack('huge-prompt');
       expect(persisted[0].prompt).toBe(hugePrompt);
@@ -458,10 +427,12 @@ describe('StackManager', () => {
 
     it('throws when CLI task dispatch fails', async () => {
       registry.createStack(makeStack('cli-fail'));
-      vi.spyOn(manager, 'runCli').mockResolvedValue({
+      // Mock waitForClaudeReady to succeed so exec failure is only seen by deliverTask
+      vi.spyOn(manager, 'waitForClaudeReady').mockResolvedValue(undefined);
+      (runtime.exec as ReturnType<typeof vi.fn>).mockResolvedValue({
+        exitCode: 1,
         stdout: '',
         stderr: 'credential sync failed',
-        exitCode: 1,
       });
 
       await expect(
@@ -480,59 +451,33 @@ describe('StackManager', () => {
 
     it('passes model to CLI args when provided', async () => {
       registry.createStack(makeStack('model-test'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       const result = await manager.dispatchTask('model-test', 'Complex task', 'opus');
       expect(result.status).toBe('running');
-      // The model is persisted on the Task in the registry even though the MCP
-      // response no longer echoes it.
       const persisted = registry.getTasksForStack('model-test');
       expect(persisted[0].model).toBe('opus');
-      // Single --model is for attribution; --models-json and --phase-routing-json carry per-phase routing.
-      const [, callArgs] = runCliSpy.mock.calls[0];
-      expect(callArgs).toContain('--model');
-      expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('opus');
-      expect(callArgs).toContain('--models-json');
-      expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).toContain('--file');
-      const fileIdx = callArgs.indexOf('--file');
-      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Complex task');
+      expect(getExecInput(runtime, 'claude-task-model.txt')).toBe('opus');
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBe('Complex task');
+      expect(getExecInput(runtime, 'claude-task-models.json')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-phase-routing.json')).toBeDefined();
     });
 
     it('resolves "auto" model to undefined and omits from CLI args', async () => {
       registry.createStack(makeStack('auto-model'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       const result = await manager.dispatchTask('auto-model', 'Simple task', 'auto');
       expect(result.status).toBe('running');
       // "auto" should resolve to null in the DB (undefined → null via registry)
       const persisted = registry.getTasksForStack('auto-model');
       expect(persisted[0].model).toBeNull();
-      // Single --model is omitted for 'auto'; --models-json and --phase-routing-json are still sent.
-      const [, callArgs] = runCliSpy.mock.calls[0];
-      expect(callArgs).not.toContain('--model');
-      expect(callArgs).toContain('--models-json');
-      expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).toContain('--file');
-      const fileIdx = callArgs.indexOf('--file');
-      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Simple task');
+      expect(getExecInput(runtime, 'claude-task-model.txt')).toBeUndefined();
+      expect(getExecInput(runtime, 'claude-task-models.json')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-phase-routing.json')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBe('Simple task');
     });
 
     it('uses effective default model when not provided', async () => {
       registry.createStack(makeStack('no-model'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       const result = await manager.dispatchTask('no-model', 'Simple task');
       expect(result.status).toBe('running');
@@ -540,31 +485,20 @@ describe('StackManager', () => {
       // on the registry Task, not echoed in the MCP response.
       const persisted = registry.getTasksForStack('no-model');
       expect(persisted[0].model).toBe('sonnet');
-      // Legacy/no-routing: --models-json and --phase-routing-json are sent alongside --model.
-      const [, callArgs] = runCliSpy.mock.calls[0];
-      expect(callArgs).toContain('--model');
-      expect(callArgs[callArgs.indexOf('--model') + 1]).toBe('sonnet');
-      expect(callArgs).toContain('--models-json');
-      expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).toContain('--file');
-      const fileIdx = callArgs.indexOf('--file');
-      expect(fs.readFileSync(callArgs[fileIdx + 1], 'utf-8')).toBe('Simple task');
+      expect(getExecInput(runtime, 'claude-task-model.txt')).toBe('sonnet');
+      expect(getExecInput(runtime, 'claude-task-models.json')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-phase-routing.json')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBe('Simple task');
     });
 
     it('includes per-phase model map in CLI args', async () => {
       registry.createStack(makeStack('phase-map-test'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       await manager.dispatchTask('phase-map-test', 'Fix the bug');
 
-      const [, args] = runCliSpy.mock.calls[0];
-      const jsonIdx = args.indexOf('--models-json');
-      expect(jsonIdx).toBeGreaterThan(-1);
-      const parsed = JSON.parse(args[jsonIdx + 1]);
+      const modelsJsonStr = getExecInput(runtime, 'claude-task-models.json');
+      expect(modelsJsonStr).toBeDefined();
+      const parsed = JSON.parse(modelsJsonStr!);
       expect(parsed).toHaveProperty('execution');
       expect(parsed).toHaveProperty('review');
       expect(parsed).toHaveProperty('meta_review');
@@ -579,18 +513,12 @@ describe('StackManager', () => {
           meta_review: { backend: 'claude', model: 'sonnet' },
         },
       });
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       await manager.dispatchTask('routing-config-test', 'Complex task');
 
-      const [, args] = runCliSpy.mock.calls[0];
-      const jsonIdx = args.indexOf('--models-json');
-      expect(jsonIdx).toBeGreaterThan(-1);
-      const parsed = JSON.parse(args[jsonIdx + 1]);
+      const modelsJsonStr = getExecInput(runtime, 'claude-task-models.json');
+      expect(modelsJsonStr).toBeDefined();
+      const parsed = JSON.parse(modelsJsonStr!);
       expect(parsed.execution).toBe('haiku');
       expect(parsed.review).toBe('opus');
       expect(parsed.meta_review).toBe('sonnet');
@@ -598,27 +526,18 @@ describe('StackManager', () => {
 
     it('all phases equal single model for legacy/no-routing dispatch', async () => {
       registry.createStack(makeStack('legacy-no-routing'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       // No routing configured — effective default for all phases is 'sonnet'
       await manager.dispatchTask('legacy-no-routing', 'Simple task');
 
-      const [, args] = runCliSpy.mock.calls[0];
-      const singleModel = args[args.indexOf('--model') + 1];
-      const jsonIdx = args.indexOf('--models-json');
-      const modelsJson = JSON.parse(args[jsonIdx + 1]);
+      const singleModel = getExecInput(runtime, 'claude-task-model.txt');
+      const modelsJson = JSON.parse(getExecInput(runtime, 'claude-task-models.json')!);
       expect(modelsJson.execution).toBe(singleModel);
       expect(modelsJson.review).toBe(singleModel);
       expect(modelsJson.meta_review).toBe(singleModel);
 
       // --phase-routing-json should carry backend+provider+model per phase
-      const routingIdx = args.indexOf('--phase-routing-json');
-      expect(routingIdx).toBeGreaterThan(-1);
-      const routing = JSON.parse(args[routingIdx + 1]);
+      const routing = JSON.parse(getExecInput(runtime, 'claude-task-phase-routing.json')!);
       expect(routing.execution.model).toBe(singleModel);
       expect(routing.review.model).toBe(singleModel);
       expect(routing.meta_review.model).toBe(singleModel);
@@ -634,24 +553,20 @@ describe('StackManager', () => {
           meta_review: { backend: 'opencode', provider: 'anthropic', model: 'claude-sonnet-4-6' },
         },
       });
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       await manager.dispatchTask('oc-backend', 'Do the work', 'sonnet');
 
-      const callArgs = runCliSpy.mock.calls[0][1] as string[];
-      expect(callArgs).toContain('--phase-routing-json');
-      const routingJson = callArgs[callArgs.indexOf('--phase-routing-json') + 1];
-      const routing = JSON.parse(routingJson);
+      const routingJson = getExecInput(runtime, 'claude-task-phase-routing.json');
+      expect(routingJson).toBeDefined();
+      const routing = JSON.parse(routingJson!);
       expect(routing.execution.backend).toBe('opencode');
       expect(routing.execution.provider).toBe('anthropic');
       expect(routing.execution.model).toBe('claude-sonnet-4-6');
-      // Old --backend/--backend-model flags are superseded by --phase-routing-json
-      expect(callArgs).not.toContain('--backend');
-      expect(callArgs).not.toContain('--backend-model');
+      // --backend/--backend-model flags are superseded by phase-routing-json; no separate exec calls for them
+      const backendInput = getExecInput(runtime, 'claude-task-backend.txt');
+      const backendModelInput = getExecInput(runtime, 'claude-task-backend-model.txt');
+      expect(backendInput).toBeUndefined();
+      expect(backendModelInput).toBeUndefined();
     });
 
     it('includes all phases in --phase-routing-json for mixed backend stacks', async () => {
@@ -663,17 +578,12 @@ describe('StackManager', () => {
           meta_review: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
         },
       });
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       await manager.dispatchTask('mixed-backend', 'Do work');
 
-      const callArgs = runCliSpy.mock.calls[0][1] as string[];
-      const routingJson = callArgs[callArgs.indexOf('--phase-routing-json') + 1];
-      const routing = JSON.parse(routingJson);
+      const routingJson = getExecInput(runtime, 'claude-task-phase-routing.json');
+      expect(routingJson).toBeDefined();
+      const routing = JSON.parse(routingJson!);
       expect(routing.execution.backend).toBe('opencode');
       expect(routing.execution.provider).toBe('openrouter');
       expect(routing.review.backend).toBe('claude');
@@ -682,18 +592,13 @@ describe('StackManager', () => {
 
     it('always includes --phase-routing-json (never falls back to --backend/--backend-model)', async () => {
       registry.createStack(makeStack('claude-backend'));
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'Task dispatched.',
-        stderr: '',
-        exitCode: 0,
-      });
 
       await manager.dispatchTask('claude-backend', 'Fix bug', 'sonnet');
 
-      const callArgs = runCliSpy.mock.calls[0][1] as string[];
-      expect(callArgs).toContain('--phase-routing-json');
-      expect(callArgs).not.toContain('--backend');
-      expect(callArgs).not.toContain('--backend-model');
+      const routingJson = getExecInput(runtime, 'claude-task-phase-routing.json');
+      expect(routingJson).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-backend.txt')).toBeUndefined();
+      expect(getExecInput(runtime, 'claude-task-backend-model.txt')).toBeUndefined();
     });
   });
 
@@ -719,22 +624,13 @@ describe('StackManager', () => {
       // Seed a prior task → stack has been dispatched to before.
       registry.createTask('gate-resume', 'initial prompt', 'sonnet');
 
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: 'ok',
-        stderr: '',
-        exitCode: 0,
-      });
-
       // No gateApproved, no forceBypass — but should succeed because it's a resume.
       await expect(
         manager.dispatchTask('gate-resume', 'Continue from where you left off')
       ).resolves.toEqual(expect.objectContaining({ stack_id: 'gate-resume' }));
 
-      // Verify we reached the CLI dispatch, i.e. we didn't bail early on the gate.
-      expect(runCliSpy).toHaveBeenCalledWith(
-        '/proj',
-        expect.arrayContaining(['task', 'gate-resume'])
-      );
+      // Verify dispatch reached runtime.exec (didn't bail early on the gate)
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBeDefined();
     });
 
     it('still honors forceBypass on the first dispatch when gate is not approved', async () => {
@@ -783,11 +679,8 @@ describe('StackManager', () => {
       expect(startCall).toBeDefined();
       expect(startCall![1]).toEqual(['up', 'autostart']);
 
-      // Dispatch itself still runs after the start.
-      const taskCall = runCliSpy.mock.calls.find(
-        ([, args]) => Array.isArray(args) && args[0] === 'task'
-      );
-      expect(taskCall).toBeDefined();
+      // Dispatch itself still runs after the start via runtime.exec.
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBeDefined();
     });
 
     it('does NOT run the start CLI when the claude container is already running', async () => {
@@ -2141,22 +2034,17 @@ describe('StackManager', () => {
       // Must set session_paused AFTER createTask — createTask calls updateStackStatus('running')
       registry.updateStackStatus('resume-a', 'session_paused');
 
+      // runCli still needed for ensureStackContainersRunning (up call)
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
       vi.spyOn(manager, 'waitForClaudeReady').mockResolvedValue(undefined);
       vi.spyOn(taskWatcher, 'watch').mockImplementation(() => {});
       vi.spyOn(taskWatcher, 'streamOutput').mockResolvedValue(undefined);
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: '', stderr: '', exitCode: 0,
-      });
 
       const result = await manager.resumeStackWithContinuation('resume-a');
       expect(result.outcome).toBe('resuming_with_session');
 
-      // CLI should include --resume and the session ID
-      const resumeCall = runCliSpy.mock.calls.find(
-        ([, args]) => Array.isArray(args) && args.includes('--resume')
-      );
-      expect(resumeCall).toBeDefined();
-      expect(resumeCall![1]).toContain('sess-abc123');
+      // Resume session ID delivered via runtime.exec stdin
+      expect(getExecInput(runtime, 'claude-task-resume.txt')).toBe('sess-abc123');
 
       // resumed_at should be stamped on the task
       const tasks = registry.getTasksForStack('resume-a');
@@ -2171,10 +2059,9 @@ describe('StackManager', () => {
       // session_id is null by default; set session_paused after createTask
       registry.updateStackStatus('resume-b', 'session_paused');
 
+      // runCli still needed for ensureStackContainersRunning (up call)
+      vi.spyOn(manager, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
       vi.spyOn(manager, 'waitForClaudeReady').mockResolvedValue(undefined);
-      const runCliSpy = vi.spyOn(manager, 'runCli').mockResolvedValue({
-        stdout: '', stderr: '', exitCode: 0,
-      });
 
       const result = await manager.resumeStackWithContinuation('resume-b');
       expect(result.outcome).toBe('resumed_fresh');
@@ -2187,12 +2074,9 @@ describe('StackManager', () => {
       // A new task was created for the fresh dispatch
       expect(allTasks.length).toBeGreaterThan(1);
 
-      // CLI task call must NOT carry --resume
-      const taskCall = runCliSpy.mock.calls.find(
-        ([, args]) => Array.isArray(args) && args[0] === 'task'
-      );
-      expect(taskCall).toBeDefined();
-      expect(taskCall![1]).not.toContain('--resume');
+      // Redispatch delivers prompt but not a resume session ID
+      expect(getExecInput(runtime, 'claude-task-prompt.txt')).toBeDefined();
+      expect(getExecInput(runtime, 'claude-task-resume.txt')).toBeUndefined();
     });
 
     it('Case C: marks stack idle when no running task exists', async () => {


### PR DESCRIPTION
## Summary

Replaces the `runCli` call sites in the control plane with two focused runtime primitives, so dispatch no longer shells out to the CLI and can run against `LocalRuntime` for no-Docker testing as well as `DockerRuntime` in production.

A new `src/main/control-plane/dispatch.ts` exposes:

- `bringUp(runtime, projectDir, opts)` — a thin wrapper over `runtime.composeUp()`.
- `deliverTask(runtime, containerId, inputs)` — writes the task state files via `runtime.exec` stdin and touches the trigger file last. Large prompts are always streamed through stdin rather than argv (the B1 invariant), so a 200KB prompt never hits the command line.

The four `runCli` sites in `stack-manager.ts` (`buildStackInBackground`, `dispatchTask`, `dispatchContinuation`, `dispatchInvestigation`) now call these primitives, dropping the temp-file dance previously needed for prompt delivery.

New coverage: unit tests for `bringUp`/`deliverTask` against `LocalRuntime`, and contract tests proving `deliverTask` produces the same state files as the CLI's `task` subcommand (including the B1 invariant). Existing tests were updated to assert on the new `runtime.exec`/`runtime.composeUp` behavior instead of `runCli` spies.

## QA plan

1. Spin up a stack and dispatch a normal task; confirm the inner Claude agent receives the work and the trigger fires.
2. Dispatch a task with a very large prompt (~200KB) and confirm it is delivered intact without command-line length errors.
3. Dispatch a continuation (resume) and an investigation; confirm both behave as before.
4. Verify the stack still builds and comes up via the normal flow.

Closes #685