### PR TITLE
Generate execution contract on spec-gate pass (#689)

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -8,7 +8,13 @@
  */
 
 import { stackManager, agentBackend, registry } from '../index';
-import { fetchTicketWithConfig, updateTicketWithConfig } from '../control-plane/ticket-config';
+import {
+  fetchTicketWithConfig,
+  updateTicketWithConfig,
+  upsertContractCommentWithConfig,
+} from '../control-plane/ticket-config';
+import { generateContract, buildContractComment } from '../control-plane/contract-generator';
+import { markContractReady } from '../control-plane/ticket-spec';
 import type { ProjectTicketConfig } from '../control-plane/registry';
 import { getDefaultSpecQualityGate } from '../spec-quality-gate';
 import { showNotification } from '../tray';
@@ -425,6 +431,40 @@ async function handleSpecCheck(
   return {
     passed,
     report: result,
+  };
+}
+
+/**
+ * Wire the contract-generation + storage deps consumed by the spec gate's
+ * atomic post-pass step. Resolves the `contract_generator` touchpoint for model
+ * routing, delegates the bounded ephemeral call to the agent backend, and
+ * stores the result as a marked ticket comment + `contract:sha` label.
+ */
+export function makeContractGateDeps(): {
+  generateContract: (ticketId: string, projectDir: string, specBody: string) => Promise<string>;
+  storeContract: (ticketId: string, projectDir: string, json: string, hash: string) => Promise<void>;
+} {
+  return {
+    generateContract: async (ticketId, projectDir, specBody) => {
+      const desc = registry.getEffectiveTouchpointDescriptor(projectDir, 'contract_generator');
+      if (desc.backend === 'opencode' && desc.credentials === null) {
+        throw new Error(`Contract generation blocked: provider ${desc.provider} needs an API key`);
+      }
+      const model = desc.backend === 'opencode' ? `${desc.provider}/${desc.model}` : desc.model;
+      const { json } = await generateContract(
+        { ticketId, projectDir, specBody },
+        {
+          runEphemeral: (prompt, dir, timeoutMs) =>
+            agentBackend.runEphemeralAgent(prompt, dir, timeoutMs, { ticketId, stage: 'contract' }, model, 'contract_generator'),
+        },
+      );
+      return json;
+    },
+    storeContract: async (ticketId, projectDir, json, hash) => {
+      const config = registry.getProjectTicketConfig(projectDir);
+      await upsertContractCommentWithConfig(ticketId, buildContractComment(json, hash), config, projectDir);
+      await markContractReady(ticketId, hash);
+    },
   };
 }
 

--- a/src/main/contract-generator-prompt.ts
+++ b/src/main/contract-generator-prompt.ts
@@ -1,0 +1,237 @@
+/**
+ * Contract Generator prompt.
+ *
+ * Mirrors `getDefaultSpecQualityGate()` in `spec-quality-gate.ts`: a single
+ * source-of-truth string returned by a function, plus a `buildContractPrompt`
+ * helper that appends the approved ticket (mirrors `buildSpecCheckPrompt` in
+ * claude/tools.ts). The output is consumed by `generateContract` in
+ * control-plane/contract-generator.ts, which parses + validates the JSON.
+ */
+
+export function getContractGeneratorPrompt(): string {
+  return `You are the Sandstorm Contract Generator.
+
+The input ticket has already passed all ticket quality gates.
+
+You MUST NOT:
+
+* Review ticket quality
+* Suggest ticket changes
+* Expand scope
+* Add speculative requirements
+* Invent features
+* Perform architecture review
+
+Your sole responsibility is to transform the approved ticket into a machine-verifiable execution contract.
+
+The contract will be consumed by:
+
+1. Executor
+2. Mechanical Validator
+3. Semantic Reviewer
+
+The contract must be:
+
+* Explicit
+* Concrete
+* Testable
+* Verifiable
+
+Avoid vague language such as:
+
+* improve
+* optimize
+* clean up
+* handle appropriately
+* best practice
+* consider
+* refactor if needed
+
+Every requirement must be observable.
+
+Every acceptance criterion must be verifiable.
+
+Every required test must represent a concrete scenario.
+
+Output ONLY valid JSON.
+
+Required Schema:
+
+{
+"contract_version": 1,
+"change_type": "",
+"requirements": [],
+"acceptance_criteria": [],
+"required_tests": [],
+"implementation_obligations": [],
+"forbidden_changes": {
+"files": [],
+"modules": [],
+"behaviors": []
+},
+"risk_areas": [],
+"success_conditions": [],
+"review_focus": [],
+"mechanical_checks": {
+"require_tests": true,
+"allow_dependency_changes": false,
+"allow_schema_changes": false,
+"max_files_changed": null,
+"max_lines_changed": null
+}
+}
+
+Rules:
+
+CHANGE TYPE
+
+Must be one of:
+
+* feature
+* bugfix
+* refactor
+* migration
+* docs
+* test_only
+
+REQUIREMENTS
+
+Requirements represent behaviors that must exist after implementation.
+
+Format:
+
+{
+"id": "R1",
+"description": ""
+}
+
+ACCEPTANCE CRITERIA
+
+Acceptance criteria must be observable outcomes.
+
+Format:
+
+{
+"id": "AC1",
+"description": ""
+}
+
+REQUIRED TESTS
+
+Every meaningful behavior should have explicit testing obligations.
+
+Format:
+
+{
+"id": "T1",
+"scenario": "",
+"type": "unit|integration|regression|e2e"
+}
+
+IMPLEMENTATION OBLIGATIONS
+
+Implementation obligations describe work the executor must perform.
+
+Examples:
+
+* Add regression test
+* Update query logic
+* Add validation
+* Update endpoint handler
+
+Format:
+
+{
+"id": "IO1",
+"description": ""
+}
+
+FORBIDDEN CHANGES
+
+Capture systems, files, modules, or behaviors that must not be modified.
+
+Only include restrictions explicitly supported by the ticket.
+
+Never invent restrictions.
+
+RISK AREAS
+
+Capture affected domains.
+
+Examples:
+
+* authentication
+* authorization
+* payments
+* persistence
+* caching
+* notifications
+* ui
+* api
+
+Format:
+
+{
+"name": "",
+"reason": ""
+}
+
+SUCCESS CONDITIONS
+
+Concrete completion conditions.
+
+Examples:
+
+* All required tests pass
+* Endpoint returns expected response
+* Feature behaves as specified
+
+REVIEW FOCUS
+
+Only include categories requiring semantic review.
+
+Allowed values:
+
+* requirements
+* correctness
+* security
+
+Do NOT include:
+
+* optimization
+* best_practice
+* scalability
+* style
+* refactor_opportunities
+
+MECHANICAL CHECKS
+
+Set defaults conservatively.
+
+If the ticket explicitly requires dependency or schema changes, update the relevant flags.
+
+Otherwise:
+
+{
+"require_tests": true,
+"allow_dependency_changes": false,
+"allow_schema_changes": false
+}
+
+Return ONLY valid JSON.
+
+No markdown.
+
+No explanations.
+
+No prose outside JSON.`;
+}
+
+/**
+ * Compose the full ephemeral prompt: the generator instruction followed by the
+ * approved ticket. `runEphemeralAgent` takes a single prompt string, so we
+ * concatenate (same shape as `buildSpecCheckPrompt`).
+ */
+export function buildContractPrompt(specBody: string): string {
+  return `${getContractGeneratorPrompt()}\n\n---\n\n## Approved Ticket\n\n${specBody}`;
+}

--- a/src/main/control-plane/contract-dispatch.ts
+++ b/src/main/control-plane/contract-dispatch.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure helper for embedding the execution contract into the dispatch prompt
+ * handed to the inner execution agent. Kept electron-free and isolated so it
+ * can be unit-tested without the stack-manager's heavy dependencies.
+ */
+
+/**
+ * Append a clearly-labeled `## Execution Contract` section carrying the
+ * contract JSON. Returns the prompt unchanged when there is no contract, so
+ * the re-dispatch path (which already carries the contract in the stored
+ * prompt) and non-GitHub providers degrade gracefully.
+ */
+export function appendContractSection(prompt: string, contractJson: string | null | undefined): string {
+  if (!contractJson || !contractJson.trim()) return prompt;
+  return (
+    `${prompt}\n\n---\n\n## Execution Contract\n\n` +
+    'The following machine-generated contract is authoritative for this task. ' +
+    'Satisfy every requirement, acceptance criterion, and required test; do not modify anything listed under forbidden_changes.\n\n' +
+    '```json\n' +
+    `${contractJson.trim()}\n` +
+    '```'
+  );
+}

--- a/src/main/control-plane/contract-generator.ts
+++ b/src/main/control-plane/contract-generator.ts
@@ -1,0 +1,213 @@
+/**
+ * Contract Generator — pure, dependency-injected module.
+ *
+ * Transforms an approved (gate-passed) ticket into a machine-verifiable
+ * execution contract via a bounded ephemeral LLM call, then parses and
+ * validates the result against the contract schema. Also owns the on-ticket
+ * storage format: a single marked GitHub issue comment that carries the
+ * contract JSON plus the spec-body sha it was generated from.
+ *
+ * This module is electron-free and registry-free so it can be unit-tested in
+ * isolation. The LLM call and provider I/O are injected by the caller
+ * (claude/tools.ts wires `runEphemeral`; ticket-config.ts owns the comment I/O).
+ *
+ * Mirrors the shape of pr-creator.ts (pure-ish, deps-injected, structured
+ * result, fence-tolerant JSON parsing).
+ */
+
+import { buildContractPrompt } from '../contract-generator-prompt';
+
+/** Hard timeout for a single contract-generation call. */
+export const CONTRACT_TIMEOUT_MS = 180_000;
+
+/** Marker that identifies the contract comment on a ticket. */
+export const CONTRACT_MARKER = '<!-- sandstorm:contract';
+/** Current on-ticket contract envelope version. */
+export const CONTRACT_COMMENT_VERSION = 1;
+
+const VALID_CHANGE_TYPES = [
+  'feature',
+  'bugfix',
+  'refactor',
+  'migration',
+  'docs',
+  'test_only',
+] as const;
+
+const VALID_REVIEW_FOCUS = ['requirements', 'correctness', 'security'] as const;
+
+export type ChangeType = (typeof VALID_CHANGE_TYPES)[number];
+export type ReviewFocus = (typeof VALID_REVIEW_FOCUS)[number];
+
+export interface Contract {
+  contract_version: number;
+  change_type: ChangeType;
+  requirements: unknown[];
+  acceptance_criteria: unknown[];
+  required_tests: unknown[];
+  implementation_obligations: unknown[];
+  forbidden_changes: {
+    files: unknown[];
+    modules: unknown[];
+    behaviors: unknown[];
+  };
+  risk_areas: unknown[];
+  success_conditions: unknown[];
+  review_focus: ReviewFocus[];
+  mechanical_checks: {
+    require_tests: boolean;
+    allow_dependency_changes: boolean;
+    allow_schema_changes: boolean;
+    max_files_changed: number | null;
+    max_lines_changed: number | null;
+  };
+}
+
+export interface ContractGenDeps {
+  /** One-shot ephemeral LLM call. Returns the agent's full text response. */
+  runEphemeral: (prompt: string, projectDir: string, timeoutMs?: number) => Promise<string>;
+}
+
+export interface GenerateContractArgs {
+  ticketId: string;
+  projectDir: string;
+  /** The approved ticket body (same text hashed for the spec-ready sha). */
+  specBody: string;
+}
+
+/**
+ * Parse + validate a contract JSON string. Tolerates a single leading code
+ * fence (```json ... ```) like `parseDraftResponse`. Throws a descriptive
+ * error on any schema violation so the atomic gate step fails closed.
+ */
+export function parseContract(raw: string): { json: string; contract: Contract } {
+  let text = raw.trim();
+  text = text.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`Contract response did not contain JSON: ${text.slice(0, 200)}`);
+  }
+  const slice = text.slice(start, end + 1);
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(slice) as Record<string, unknown>;
+  } catch (e) {
+    throw new Error(`Contract JSON did not parse: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const requiredKeys = [
+    'contract_version',
+    'change_type',
+    'requirements',
+    'acceptance_criteria',
+    'required_tests',
+    'implementation_obligations',
+    'forbidden_changes',
+    'risk_areas',
+    'success_conditions',
+    'review_focus',
+    'mechanical_checks',
+  ];
+  for (const key of requiredKeys) {
+    if (!(key in parsed)) throw new Error(`Contract missing required key: ${key}`);
+  }
+
+  if (!VALID_CHANGE_TYPES.includes(parsed.change_type as ChangeType)) {
+    throw new Error(
+      `Contract change_type must be one of ${VALID_CHANGE_TYPES.join(', ')} (got ${JSON.stringify(parsed.change_type)})`,
+    );
+  }
+
+  if (!Array.isArray(parsed.review_focus)) {
+    throw new Error('Contract review_focus must be an array');
+  }
+  for (const f of parsed.review_focus as unknown[]) {
+    if (!VALID_REVIEW_FOCUS.includes(f as ReviewFocus)) {
+      throw new Error(
+        `Contract review_focus contains a disallowed value: ${JSON.stringify(f)} (allowed: ${VALID_REVIEW_FOCUS.join(', ')})`,
+      );
+    }
+  }
+
+  const arrayKeys = [
+    'requirements',
+    'acceptance_criteria',
+    'required_tests',
+    'implementation_obligations',
+    'risk_areas',
+    'success_conditions',
+  ];
+  for (const key of arrayKeys) {
+    if (!Array.isArray(parsed[key])) throw new Error(`Contract ${key} must be an array`);
+  }
+
+  const fc = parsed.forbidden_changes as Record<string, unknown> | null;
+  if (!fc || typeof fc !== 'object' || Array.isArray(fc)) {
+    throw new Error('Contract forbidden_changes must be an object');
+  }
+  for (const key of ['files', 'modules', 'behaviors']) {
+    if (!Array.isArray(fc[key])) throw new Error(`Contract forbidden_changes.${key} must be an array`);
+  }
+
+  const mc = parsed.mechanical_checks as Record<string, unknown> | null;
+  if (!mc || typeof mc !== 'object' || Array.isArray(mc)) {
+    throw new Error('Contract mechanical_checks must be an object');
+  }
+  for (const key of ['require_tests', 'allow_dependency_changes', 'allow_schema_changes']) {
+    if (typeof mc[key] !== 'boolean') {
+      throw new Error(`Contract mechanical_checks.${key} must be a boolean`);
+    }
+  }
+
+  // Re-serialize the validated object so storage is canonical (pretty-printed,
+  // no surrounding prose) regardless of how the model formatted its output.
+  const contract = parsed as unknown as Contract;
+  return { json: JSON.stringify(contract, null, 2), contract };
+}
+
+/**
+ * Generate and validate an execution contract for an approved ticket. The only
+ * side effect is the bounded ephemeral call delegated through `deps.runEphemeral`.
+ */
+export async function generateContract(
+  args: GenerateContractArgs,
+  deps: ContractGenDeps,
+): Promise<{ json: string; contract: Contract }> {
+  if (!args.specBody.trim()) {
+    throw new Error('Cannot generate a contract from an empty ticket body');
+  }
+  const prompt = buildContractPrompt(args.specBody);
+  const raw = await deps.runEphemeral(prompt, args.projectDir, CONTRACT_TIMEOUT_MS);
+  return parseContract(raw);
+}
+
+/**
+ * Render the on-ticket contract comment: a marker line carrying the version and
+ * the spec-body sha, followed by the contract JSON in a fenced block.
+ */
+export function buildContractComment(json: string, sha: string): string {
+  return [
+    `${CONTRACT_MARKER} v=${CONTRACT_COMMENT_VERSION} sha=${sha} -->`,
+    '',
+    '**Sandstorm execution contract** — machine-generated from the approved spec. Do not edit by hand.',
+    '',
+    '```json',
+    json,
+    '```',
+  ].join('\n');
+}
+
+/**
+ * Extract the contract from a comment body. Returns null for any comment that
+ * is not a contract comment (no marker), so callers can scan all comments.
+ */
+export function parseContractComment(commentBody: string): { sha: string; json: string } | null {
+  if (!commentBody || !commentBody.includes(CONTRACT_MARKER)) return null;
+  const shaMatch = commentBody.match(/sandstorm:contract\s+v=\d+\s+sha=([^\s]+)\s*-->/);
+  const sha = shaMatch ? shaMatch[1] : '';
+  const fence = commentBody.match(/```json\s*\n([\s\S]*?)\n```/);
+  if (!fence) return null;
+  return { sha, json: fence[1].trim() };
+}

--- a/src/main/control-plane/routing.ts
+++ b/src/main/control-plane/routing.ts
@@ -4,6 +4,7 @@ import type { CatalogProvider } from '../../shared/opencode-providers';
 export type TouchpointId =
   | 'outer'
   | 'refine'
+  | 'contract_generator'
   | 'execution'
   | 'review'
   | 'meta_review'
@@ -13,6 +14,7 @@ export type TouchpointId =
 export const TOUCHPOINTS: readonly TouchpointId[] = [
   'outer',
   'refine',
+  'contract_generator',
   'execution',
   'review',
   'meta_review',
@@ -34,6 +36,7 @@ export const PRESETS: Record<PresetId, Record<TouchpointId, RoutingAssignment>> 
   balanced: {
     outer:          { backend: 'claude', provider: 'anthropic', model: 'opus' },
     refine:         { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
+    contract_generator: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
     execution:      { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
     review:         { backend: 'claude', provider: 'anthropic', model: 'opus' },
     meta_review:    { backend: 'claude', provider: 'anthropic', model: 'opus' },
@@ -43,6 +46,7 @@ export const PRESETS: Record<PresetId, Record<TouchpointId, RoutingAssignment>> 
   max_quality: {
     outer:          { backend: 'claude', provider: 'anthropic', model: 'opus' },
     refine:         { backend: 'claude', provider: 'anthropic', model: 'opus' },
+    contract_generator: { backend: 'claude', provider: 'anthropic', model: 'opus' },
     execution:      { backend: 'claude', provider: 'anthropic', model: 'opus' },
     review:         { backend: 'claude', provider: 'anthropic', model: 'opus' },
     meta_review:    { backend: 'claude', provider: 'anthropic', model: 'opus' },
@@ -52,6 +56,7 @@ export const PRESETS: Record<PresetId, Record<TouchpointId, RoutingAssignment>> 
   budget: {
     outer:          { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
     refine:         { backend: 'claude', provider: 'anthropic', model: 'haiku' },
+    contract_generator: { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
     execution:      { backend: 'claude', provider: 'anthropic', model: 'haiku' },
     review:         { backend: 'claude', provider: 'anthropic', model: 'sonnet' },
     meta_review:    { backend: 'claude', provider: 'anthropic', model: 'sonnet' },

--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -9,7 +9,8 @@ import { PortProxy } from './port-proxy';
 import { TaskWatcher, WorkflowProgressData } from './task-watcher';
 import { ContainerRuntime, Container, ContainerStats } from '../runtime/types';
 import { SandstormError, ErrorCode } from '../errors';
-import { fetchRawBodyWithConfig, fetchTicketWithConfig, updateTicketWithConfig } from './ticket-config';
+import { fetchRawBodyWithConfig, fetchTicketWithConfig, updateTicketWithConfig, fetchContractCommentWithConfig } from './ticket-config';
+import { appendContractSection } from './contract-dispatch';
 import { referencesTicket } from './ticket-fetcher';
 import { resolveTicketReferences, renderResolvedReferences } from './ticket-references';
 import { workspacePathFor } from './pr-creator';
@@ -1411,6 +1412,18 @@ export class StackManager {
     const referencesSection = renderResolvedReferences(references);
     if (referencesSection) {
       prompt = `${prompt}\n\n---\n\n${referencesSection}`;
+    }
+
+    // Attach the machine-generated execution contract (stored as a ticket
+    // comment by the spec gate) so the inner executor has it alongside the spec.
+    // Guarded like the ticket fetch: skipped on re-dispatch, where the stored
+    // prompt already carries the contract.
+    if (stack.ticket && !opts?.skipTicketFetch) {
+      const ticketConfig = this.registry.getProjectTicketConfig(stack.project_dir);
+      if (ticketConfig) {
+        const contractJson = await fetchContractCommentWithConfig(stack.ticket, ticketConfig, stack.project_dir);
+        prompt = appendContractSection(prompt, contractJson);
+      }
     }
 
     const task = this.registry.createTask(stackId, prompt, model);

--- a/src/main/control-plane/ticket-config.ts
+++ b/src/main/control-plane/ticket-config.ts
@@ -3,6 +3,7 @@ import * as https from 'https';
 import * as http from 'http';
 import { URL } from 'url';
 import type { ProjectTicketConfig } from './registry';
+import { CONTRACT_MARKER, parseContractComment } from './contract-generator';
 
 export type { ProjectTicketConfig };
 
@@ -104,6 +105,76 @@ export async function githubUpdateTicket(ticketId: string, body: string, cwd: st
     const msg = err.stderr?.trim() || err.message;
     throw new Error(`gh issue edit failed: ${msg}`);
   });
+}
+
+/**
+ * Upsert the contract comment on a GitHub issue. Idempotent: any existing
+ * contract comment (identified by the marker) is deleted and replaced, so
+ * re-generation never piles up duplicate comments. `execFile` passes the body
+ * as a single argv entry with no shell, so arbitrary JSON content is safe.
+ * Throws on failure so the atomic gate step can fail closed.
+ */
+export async function githubUpsertContractComment(
+  ticketId: string,
+  commentBody: string,
+  cwd: string,
+): Promise<void> {
+  const { stdout: nwo } = await execFileAsync(
+    'gh',
+    ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
+    { cwd, timeout: 30000 },
+  );
+  const repo = nwo.trim();
+  if (!repo) throw new Error('Could not resolve repository for contract comment');
+
+  // Remove any pre-existing contract comments so we never accumulate duplicates.
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['api', '--paginate', `repos/${repo}/issues/${ticketId}/comments`],
+      { cwd, timeout: 30000, maxBuffer: 8 * 1024 * 1024 },
+    );
+    const comments = JSON.parse(stdout) as { id: number; body: string }[];
+    for (const c of comments) {
+      if ((c.body || '').includes(CONTRACT_MARKER)) {
+        await execFileAsync(
+          'gh',
+          ['api', `repos/${repo}/issues/comments/${c.id}`, '-X', 'DELETE'],
+          { cwd, timeout: 30000 },
+        ).catch(() => {});
+      }
+    }
+  } catch {
+    // Listing failed — fall through and post a fresh comment anyway.
+  }
+
+  await execFileAsync(
+    'gh',
+    ['issue', 'comment', ticketId, '--body', commentBody],
+    { cwd, timeout: 30000, maxBuffer: 2 * 1024 * 1024 },
+  ).catch((err: Error & { stderr?: string }) => {
+    const msg = err.stderr?.trim() || err.message;
+    throw new Error(`gh issue comment failed: ${msg}`);
+  });
+}
+
+/** Read the parsed contract JSON from a GitHub issue's contract comment, or null. */
+export async function githubFetchContractComment(ticketId: string, cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['issue', 'view', ticketId, '--json', 'comments'],
+      { cwd, timeout: 30000, maxBuffer: 8 * 1024 * 1024 },
+    );
+    const data = JSON.parse(stdout) as { comments: { body: string }[] };
+    for (const c of data.comments ?? []) {
+      const parsed = parseContractComment(c.body ?? '');
+      if (parsed) return parsed.json;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 type FilterConfig = Pick<
@@ -590,6 +661,35 @@ export async function closeTicketWithConfig(
     return githubCloseTicket(ticketId, cwd);
   }
   return jiraCloseTicket(ticketId, config);
+}
+
+/**
+ * Store the contract comment on a ticket. GitHub-only for now; other providers
+ * no-op gracefully (the contract still travels via the dispatch prompt path,
+ * which falls back to whatever storage the provider supports).
+ */
+export async function upsertContractCommentWithConfig(
+  ticketId: string,
+  commentBody: string,
+  config: ProjectTicketConfig | null,
+  cwd: string,
+): Promise<void> {
+  if (config?.provider === 'github') {
+    return githubUpsertContractComment(ticketId, commentBody, cwd);
+  }
+  // Non-GitHub providers: no contract-comment storage yet.
+}
+
+/** Read the stored contract JSON for a ticket, or null. GitHub-only for now. */
+export async function fetchContractCommentWithConfig(
+  ticketId: string,
+  config: ProjectTicketConfig | null,
+  cwd: string,
+): Promise<string | null> {
+  if (config?.provider === 'github') {
+    return githubFetchContractComment(ticketId, cwd);
+  }
+  return null;
 }
 
 /**

--- a/src/main/control-plane/ticket-spec.ts
+++ b/src/main/control-plane/ticket-spec.ts
@@ -33,6 +33,13 @@ export interface SpecGateResult {
   error?: string;
   /** Full evaluator report text, capped at 64KB. Present on FAIL; null/absent on PASS or error. */
   reportText?: string | null;
+  /**
+   * Set when the spec gate passed but contract generation/storage failed. The
+   * ticket is reported as NOT passed (stays in Refining) so the existing Retry
+   * action re-attempts. Distinct from `error` (which is a gate-evaluation
+   * failure) and from `reportText` (gate FAIL questions).
+   */
+  contractError?: string;
 }
 
 const MAX_REPORT_TEXT_LEN = 64 * 1024;
@@ -210,11 +217,11 @@ export function shortBodyHash(body: string): string {
 }
 
 /**
- * Replace existing `spec-ready:sha-*` labels with a fresh one tracking the
- * current body. Best-effort — failures (no gh, no perms, network) are swallowed.
- * GitHub-specific; no-op for Jira tickets.
+ * Replace existing `<prefix>:sha-*` labels with a fresh one tracking the
+ * current body hash. Best-effort — failures (no gh, no perms, network) are
+ * swallowed. GitHub-specific; no-op for Jira tickets.
  */
-async function markSpecReady(ticketId: string, hash: string): Promise<void> {
+async function replaceShaLabel(ticketId: string, prefix: string, hash: string): Promise<void> {
   if (!hash) return;
   try {
     const { stdout } = await execFileAsync(
@@ -225,7 +232,7 @@ async function markSpecReady(ticketId: string, hash: string): Promise<void> {
     const stale = stdout
       .split('\n')
       .map((l) => l.trim())
-      .filter((l) => l.startsWith('spec-ready:sha-'));
+      .filter((l) => l.startsWith(`${prefix}:sha-`));
     for (const lab of stale) {
       try {
         await execFileAsync('gh', ['issue', 'edit', ticketId, '--remove-label', lab], { timeout: 15000 });
@@ -233,10 +240,24 @@ async function markSpecReady(ticketId: string, hash: string): Promise<void> {
         // ignore
       }
     }
-    await execFileAsync('gh', ['issue', 'edit', ticketId, '--add-label', `spec-ready:sha-${hash}`], { timeout: 15000 });
+    await execFileAsync('gh', ['issue', 'edit', ticketId, '--add-label', `${prefix}:sha-${hash}`], { timeout: 15000 });
   } catch {
     // ignore
   }
+}
+
+/** Mark a ticket spec-ready by stamping the current body hash as a label. */
+async function markSpecReady(ticketId: string, hash: string): Promise<void> {
+  return replaceShaLabel(ticketId, 'spec-ready', hash);
+}
+
+/**
+ * Mark a ticket as having a current execution contract by stamping the spec
+ * body hash as a `contract:sha-<hash>` label. Lets the board/dispatch check
+ * contract presence + freshness without fetching comments.
+ */
+export async function markContractReady(ticketId: string, hash: string): Promise<void> {
+  return replaceShaLabel(ticketId, 'contract', hash);
 }
 
 export interface SpecGateDeps {
@@ -252,6 +273,42 @@ export interface SpecGateDeps {
   readSpecReadyHash: (ticketId: string) => Promise<string>;
   readTicketUrl: (ticketId: string) => Promise<string>;
   markSpecReady: (ticketId: string, hash: string) => Promise<void>;
+  /**
+   * Generate the execution contract JSON for an approved ticket. Throws on
+   * failure. Optional: when absent, the gate falls back to legacy
+   * mark-spec-ready-only behavior (e.g. scheduler paths / tests not exercising
+   * contracts).
+   */
+  generateContract?: (ticketId: string, projectDir: string, specBody: string) => Promise<string>;
+  /** Persist the contract JSON on the ticket (comment + label). Throws on failure. */
+  storeContract?: (ticketId: string, projectDir: string, json: string, hash: string) => Promise<void>;
+}
+
+/**
+ * Atomic post-gate-pass step: generate the contract, store it, then mark the
+ * ticket spec-ready. Spec-ready is set ONLY on full success, so a cached "pass"
+ * always implies a stored, current contract. When contract deps are not wired,
+ * preserves the legacy behavior (mark spec-ready immediately).
+ */
+export async function finalizeSpecGatePass(
+  ticketId: string,
+  projectDir: string,
+  body: string,
+  hash: string,
+  deps: Pick<SpecGateDeps, 'generateContract' | 'storeContract' | 'markSpecReady'>,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!deps.generateContract || !deps.storeContract) {
+    if (hash) await deps.markSpecReady(ticketId, hash);
+    return { ok: true };
+  }
+  try {
+    const json = await deps.generateContract(ticketId, projectDir, body);
+    await deps.storeContract(ticketId, projectDir, json, hash);
+    if (hash) await deps.markSpecReady(ticketId, hash);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 /**
@@ -330,7 +387,19 @@ export async function runSpecCheck(
   const passed = !!report.passed;
   const reportText = report.report || '';
   if (passed && curHash) {
-    await deps.markSpecReady(ticketId, curHash);
+    const fin = await finalizeSpecGatePass(ticketId, projectDir, body, curHash, deps);
+    if (!fin.ok) {
+      // Gate passed but the contract step failed: report NOT passed so the
+      // ticket stays in Refining and the existing Retry re-attempts.
+      return {
+        passed: false,
+        questions: [],
+        gateSummary: 'Spec passed; contract generation failed',
+        ticketUrl: url || null,
+        cached: false,
+        contractError: fin.error,
+      };
+    }
   }
 
   return {
@@ -422,6 +491,7 @@ export function defaultSpecGateDeps(
     userAnswers?: string
   ) => Promise<SpecGateReport>,
   getProviderConfig: (projectDir: string) => ProjectTicketConfig | null,
+  contractDeps?: Pick<SpecGateDeps, 'generateContract' | 'storeContract'>,
 ): SpecGateDeps {
   return {
     fetchTicket: async (ticketId, projectDir) => {
@@ -435,6 +505,8 @@ export function defaultSpecGateDeps(
     readSpecReadyHash,
     readTicketUrl,
     markSpecReady,
+    generateContract: contractDeps?.generateContract,
+    storeContract: contractDeps?.storeContract,
   };
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -299,7 +299,7 @@ async function initializeApp(): Promise<void> {
           }
           case 'refine-to-comments': {
             const { runRefineToComments, buildRefineToCommentsDeps } = await import('./scheduler/refine-to-comments');
-            const { handleToolCall } = await import('./claude/tools');
+            const { handleToolCall, makeContractGateDeps } = await import('./claude/tools');
             const { defaultSpecGateDeps, runSpecCheck, runSpecRefine } = await import('./control-plane/ticket-spec');
             const specDeps = defaultSpecGateDeps(
               (ticketId, projectDir) =>
@@ -307,6 +307,7 @@ async function initializeApp(): Promise<void> {
               (ticketId, projectDir, userAnswers) =>
                 handleToolCall('spec_refine', { ticketId, projectDir, userAnswers }) as Promise<import('./control-plane/ticket-spec').SpecGateReport>,
               (projectDir) => registry.getProjectTicketConfig(projectDir),
+              makeContractGateDeps(),
             );
             const deps = buildRefineToCommentsDeps(
               (ticketId, projectDir) => runSpecCheck(ticketId, projectDir, specDeps),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1485,7 +1485,9 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         emitRefinementUpdate(done);
 
         // Best-effort: post FAIL report as a ticket comment so it's visible on GitHub.
-        if (!passed && !rawError && cappedReport) {
+        // Skip when the gate itself passed but the contract step failed — that's
+        // not a spec FAIL and the report text is the PASS report, not gaps.
+        if (!passed && !rawError && !contractError && cappedReport) {
           postComment(ticketId, projectDir, `${GATE_FAIL_REPORT_MARKER}\n\n${cappedReport}`).catch(() => {});
         }
       })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -61,6 +61,7 @@ import {
   fetchTicketForRenderer,
   runSpecCheck,
   runSpecRefine,
+  finalizeSpecGatePass,
   extractQuestions,
   extractGateSummary,
   shortBodyHash,
@@ -89,7 +90,7 @@ import type { ProjectTicketConfig } from './control-plane/registry';
 import { getAvailableModels } from './control-plane/routing';
 import type { RoutingAssignment, PresetId } from './control-plane/routing';
 import type { EphemeralStreamEvent } from './agent/types';
-import { handleToolCall, spawnSpecCheck, spawnSpecRefine } from './claude/tools';
+import { handleToolCall, spawnSpecCheck, spawnSpecRefine, makeContractGateDeps } from './claude/tools';
 import { listTicketsWithConfig } from './control-plane/ticket-lister';
 import { listTicketComments, postComment } from './control-plane/ticket-comments';
 import { getLatestUserAnswers, ANSWER_COMMENT_MARKER, GATE_FAIL_REPORT_MARKER } from './scheduler/refine-to-comments';
@@ -1324,6 +1325,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     (ticketId, projectDir, userAnswers) =>
       handleToolCall('spec_refine', { ticketId, projectDir, userAnswers }) as Promise<SpecGateReport>,
     (projectDir) => registry.getProjectTicketConfig(projectDir),
+    makeContractGateDeps(),
   );
 
   // In-memory map of active refinement sessions (id → session + cancel handle).
@@ -1433,28 +1435,49 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
         // Convert the raw SpecGateReport to the renderer-facing SpecGateResult.
         const url = await specDeps.readTicketUrl(ticketId);
-        const passed = !!rawReport.passed;
+        let passed = !!rawReport.passed;
         const reportText = (rawReport as unknown as SpecGateReport).report || '';
         const rawError = (rawReport as unknown as SpecGateReport & { error?: string }).error;
 
+        // Atomic post-pass step: generate + store the contract, then mark
+        // spec-ready. If it fails, downgrade to NOT passed so the ticket stays
+        // in Refining and the existing Retry re-attempts (block-until-contract).
+        let contractError: string | undefined;
         if (passed && phase === 'check') {
-          // Mark spec-ready on GitHub (best-effort, same as the sync path).
           const body = await specDeps.fetchTicket(ticketId, projectDir);
-          if (body) await specDeps.markSpecReady(ticketId, shortBodyHash(body));
+          if (body) {
+            const fin = await finalizeSpecGatePass(ticketId, projectDir, body, shortBodyHash(body), specDeps);
+            if (!fin.ok) {
+              passed = false;
+              contractError = fin.error;
+            }
+          } else {
+            passed = false;
+            contractError = 'Could not fetch ticket body for contract generation';
+          }
         }
 
         const cappedReport = capReportText(reportText);
 
         const result: SpecGateResult = rawError
           ? { passed: false, questions: [], gateSummary: '', ticketUrl: url || null, cached: false, error: rawError }
-          : {
-              passed,
-              questions: passed ? [] : extractQuestions(reportText),
-              gateSummary: extractGateSummary(reportText),
-              ticketUrl: url || null,
-              cached: false,
-              reportText: passed ? null : (cappedReport || null),
-            };
+          : contractError
+            ? {
+                passed: false,
+                questions: [],
+                gateSummary: 'Spec passed; contract generation failed',
+                ticketUrl: url || null,
+                cached: false,
+                contractError,
+              }
+            : {
+                passed,
+                questions: passed ? [] : extractQuestions(reportText),
+                gateSummary: extractGateSummary(reportText),
+                ticketUrl: url || null,
+                cached: false,
+                reportText: passed ? null : (cappedReport || null),
+              };
 
         const done: RefinementSession = { ...session, status: 'ready', result };
         activeRefinements.set(id, { session: done, cancel: null });

--- a/src/renderer/components/RefineTicketDialog.tsx
+++ b/src/renderer/components/RefineTicketDialog.tsx
@@ -454,9 +454,18 @@ export function RefineTicketDialog() {
 
             {showFailState && gate && (
               <div className="space-y-3" data-testid="refine-fail">
-                <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
-                  Spec gate failed. {gate.gateSummary}
-                </div>
+                {gate.contractError ? (
+                  <div
+                    className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5"
+                    data-testid="refine-contract-error"
+                  >
+                    Spec passed, but contract generation failed: {gate.contractError} Use Retry to re-run.
+                  </div>
+                ) : (
+                  <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
+                    Spec gate failed. {gate.gateSummary}
+                  </div>
+                )}
                 {gate.questions.length > 0 ? (
                   <QuestionList
                     questions={gate.questions.map((q, i) => normalizeQuestion(q, i))}

--- a/src/renderer/components/config/ModelsPane.tsx
+++ b/src/renderer/components/config/ModelsPane.tsx
@@ -12,6 +12,7 @@ import { ConfigPane, ConfigPaneContext } from './types';
 const TOUCHPOINT_META: Record<TouchpointId, { label: string; description: string }> = {
   outer: { label: 'Outer orchestrator', description: 'Drives the chat session, plans & dispatches' },
   refine: { label: 'Refine', description: 'Turns a ticket into a detailed spec' },
+  contract_generator: { label: 'Contract generator', description: 'Turns the approved spec into a machine-verifiable contract' },
   execution: { label: 'Execution', description: 'Inner worker that writes the code' },
   review: { label: 'Review', description: 'Reviews the diff for bugs & quality' },
   meta_review: { label: 'Meta-review', description: 'Final gate; reviews the reviewer' },

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -937,6 +937,8 @@ export interface SpecGateResult {
   error?: string;
   /** Full evaluator report text, capped at 64KB. Present on FAIL; null/absent on PASS or error. */
   reportText?: string | null;
+  /** Set when the spec passed but contract generation/storage failed (ticket stays in Refining). */
+  contractError?: string;
 }
 
 export type RefinementStatus = 'running' | 'ready' | 'errored' | 'interrupted';

--- a/tests/unit/components/ModelsPane.test.tsx
+++ b/tests/unit/components/ModelsPane.test.tsx
@@ -169,7 +169,7 @@ describe('ModelsPane', () => {
       expect(toggle.getAttribute('aria-checked')).toBe('false');
     });
 
-    it('toggle reveals 7 touchpoint rows in TOUCHPOINTS order', async () => {
+    it('toggle reveals all touchpoint rows in TOUCHPOINTS order', async () => {
       const ctx = makeCtx(makeRouting());
       await renderPane(ctx);
 
@@ -178,7 +178,7 @@ describe('ModelsPane', () => {
       });
 
       const rows = screen.getAllByTestId(/^touchpoint-row-/);
-      expect(rows).toHaveLength(7);
+      expect(rows).toHaveLength(TOUCHPOINTS.length);
       expect(rows.map((r) => r.getAttribute('data-testid'))).toEqual(
         TOUCHPOINTS.map((t) => `touchpoint-row-${t}`)
       );

--- a/tests/unit/control-plane/contract-dispatch.test.ts
+++ b/tests/unit/control-plane/contract-dispatch.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { appendContractSection } from '../../../src/main/control-plane/contract-dispatch';
+
+describe('appendContractSection', () => {
+  const base = '# Issue\n\n## Task\n\nDo the thing';
+  const json = '{\n  "contract_version": 1\n}';
+
+  it('appends a labeled Execution Contract block when a contract is present', () => {
+    const out = appendContractSection(base, json);
+    expect(out.startsWith(base)).toBe(true);
+    expect(out).toContain('## Execution Contract');
+    expect(out).toContain('```json');
+    expect(out).toContain('"contract_version": 1');
+    expect(out).toContain('forbidden_changes');
+  });
+
+  it('returns the prompt unchanged when contract is null', () => {
+    expect(appendContractSection(base, null)).toBe(base);
+  });
+
+  it('returns the prompt unchanged when contract is undefined', () => {
+    expect(appendContractSection(base, undefined)).toBe(base);
+  });
+
+  it('returns the prompt unchanged when contract is blank', () => {
+    expect(appendContractSection(base, '   \n ')).toBe(base);
+  });
+});

--- a/tests/unit/control-plane/contract-generator.test.ts
+++ b/tests/unit/control-plane/contract-generator.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseContract,
+  generateContract,
+  buildContractComment,
+  parseContractComment,
+  CONTRACT_MARKER,
+} from '../../../src/main/control-plane/contract-generator';
+
+const VALID = {
+  contract_version: 1,
+  change_type: 'bugfix',
+  requirements: [{ id: 'R1', description: 'do x' }],
+  acceptance_criteria: [{ id: 'AC1', description: 'x happens' }],
+  required_tests: [{ id: 'T1', scenario: 'x path', type: 'unit' }],
+  implementation_obligations: [{ id: 'IO1', description: 'add regression test' }],
+  forbidden_changes: { files: [], modules: [], behaviors: [] },
+  risk_areas: [{ name: 'persistence', reason: 'touches db' }],
+  success_conditions: ['All required tests pass'],
+  review_focus: ['correctness'],
+  mechanical_checks: {
+    require_tests: true,
+    allow_dependency_changes: false,
+    allow_schema_changes: false,
+    max_files_changed: null,
+    max_lines_changed: null,
+  },
+};
+const validJson = JSON.stringify(VALID);
+
+describe('parseContract', () => {
+  it('parses a valid contract and re-serializes canonically', () => {
+    const { contract, json } = parseContract(validJson);
+    expect(contract.change_type).toBe('bugfix');
+    expect(contract.review_focus).toEqual(['correctness']);
+    // Re-serialized (pretty-printed) form parses back to the same object.
+    expect(JSON.parse(json)).toEqual(VALID);
+  });
+
+  it('tolerates a leading ```json code fence', () => {
+    const fenced = '```json\n' + validJson + '\n```';
+    expect(parseContract(fenced).contract.change_type).toBe('bugfix');
+  });
+
+  it('tolerates prose around the JSON object', () => {
+    const wrapped = 'Here is the contract:\n' + validJson + '\nDone.';
+    expect(parseContract(wrapped).contract.contract_version).toBe(1);
+  });
+
+  it('throws on an invalid change_type', () => {
+    const bad = JSON.stringify({ ...VALID, change_type: 'chore' });
+    expect(() => parseContract(bad)).toThrow(/change_type/);
+  });
+
+  it('throws on a disallowed review_focus value', () => {
+    const bad = JSON.stringify({ ...VALID, review_focus: ['optimization'] });
+    expect(() => parseContract(bad)).toThrow(/review_focus/);
+  });
+
+  it('throws when a required top-level key is missing', () => {
+    const { mechanical_checks, ...rest } = VALID;
+    void mechanical_checks;
+    expect(() => parseContract(JSON.stringify(rest))).toThrow(/missing required key: mechanical_checks/);
+  });
+
+  it('throws when forbidden_changes is not shaped correctly', () => {
+    const bad = JSON.stringify({ ...VALID, forbidden_changes: { files: [], modules: [] } });
+    expect(() => parseContract(bad)).toThrow(/forbidden_changes\.behaviors/);
+  });
+
+  it('throws when a mechanical_checks flag is not a boolean', () => {
+    const bad = JSON.stringify({
+      ...VALID,
+      mechanical_checks: { ...VALID.mechanical_checks, require_tests: 'yes' },
+    });
+    expect(() => parseContract(bad)).toThrow(/require_tests must be a boolean/);
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseContract('{ not json ')).toThrow();
+  });
+
+  it('throws when there is no JSON object at all', () => {
+    expect(() => parseContract('totally not json')).toThrow(/did not contain JSON/);
+  });
+});
+
+describe('generateContract', () => {
+  it('builds the prompt, calls runEphemeral, and returns the parsed contract', async () => {
+    const runEphemeral = vi.fn().mockResolvedValue(validJson);
+    const out = await generateContract(
+      { ticketId: '5', projectDir: '/p', specBody: '## Approved spec body' },
+      { runEphemeral },
+    );
+    expect(out.contract.change_type).toBe('bugfix');
+    const [prompt, dir] = runEphemeral.mock.calls[0];
+    expect(prompt).toContain('Sandstorm Contract Generator');
+    expect(prompt).toContain('## Approved spec body');
+    expect(dir).toBe('/p');
+  });
+
+  it('throws when the spec body is empty', async () => {
+    const runEphemeral = vi.fn();
+    await expect(
+      generateContract({ ticketId: '5', projectDir: '/p', specBody: '   ' }, { runEphemeral }),
+    ).rejects.toThrow(/empty ticket body/);
+    expect(runEphemeral).not.toHaveBeenCalled();
+  });
+
+  it('propagates parse failures from a bad LLM response', async () => {
+    const runEphemeral = vi.fn().mockResolvedValue('I cannot do that');
+    await expect(
+      generateContract({ ticketId: '5', projectDir: '/p', specBody: 'body' }, { runEphemeral }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('contract comment marshalling', () => {
+  it('round-trips json + sha through build/parse', () => {
+    const comment = buildContractComment(validJson, 'deadbeef1234');
+    expect(comment).toContain(CONTRACT_MARKER);
+    const parsed = parseContractComment(comment);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.sha).toBe('deadbeef1234');
+    expect(JSON.parse(parsed!.json)).toEqual(VALID);
+  });
+
+  it('returns null for a comment without the marker', () => {
+    expect(parseContractComment('just a normal human comment')).toBeNull();
+    expect(parseContractComment('```json\n{}\n```')).toBeNull();
+  });
+
+  it('returns null for an empty comment', () => {
+    expect(parseContractComment('')).toBeNull();
+  });
+});

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -353,6 +353,7 @@ vi.mock('../../src/main/control-plane/pr-creator', () => ({
 
 vi.mock('../../src/main/claude/tools', () => ({
   handleToolCall: vi.fn(),
+  makeContractGateDeps: vi.fn(() => ({ generateContract: vi.fn(), storeContract: vi.fn() })),
   spawnSpecCheck: (...args: unknown[]) => mockSpawnSpecCheck(...args),
   spawnSpecRefine: (...args: unknown[]) => mockSpawnSpecRefine(...args),
   validateProjectDir: vi.fn().mockReturnValue(null),

--- a/tests/unit/model-routing.test.ts
+++ b/tests/unit/model-routing.test.ts
@@ -35,8 +35,9 @@ describe('Model Routing', () => {
   // Contract: all touchpoints resolve for an unconfigured project
   // ==========================================================================
   describe('contract: unconfigured project resolves all touchpoints', () => {
-    it('resolves all 7 touchpoints to {backend, model} for a fresh database', () => {
-      expect(TOUCHPOINTS).toHaveLength(7);
+    it('resolves all 8 touchpoints to {backend, model} for a fresh database', () => {
+      expect(TOUCHPOINTS).toHaveLength(8);
+      expect(TOUCHPOINTS).toContain('contract_generator');
       for (const t of TOUCHPOINTS) {
         const result = registry.getEffectiveRoutingFor('/proj/unconfigured', t);
         expect(result).toHaveProperty('backend');
@@ -155,7 +156,7 @@ describe('Model Routing', () => {
     const presetIds: PresetId[] = ['max_quality', 'balanced', 'budget'];
 
     for (const presetId of presetIds) {
-      it(`PRESETS.${presetId} covers all 7 touchpoints with valid assignments`, () => {
+      it(`PRESETS.${presetId} covers all 8 touchpoints with valid assignments`, () => {
         const preset = PRESETS[presetId];
         for (const t of TOUCHPOINTS) {
           expect(preset[t]).toBeDefined();

--- a/tests/unit/refinement-streaming.test.ts
+++ b/tests/unit/refinement-streaming.test.ts
@@ -124,6 +124,7 @@ vi.mock('../../src/main/index', () => ({
 // Mock tools so spawnSpecCheck is controllable — the key seam under test.
 vi.mock('../../src/main/claude/tools', () => ({
   handleToolCall: vi.fn(),
+  makeContractGateDeps: vi.fn(() => ({ generateContract: vi.fn(), storeContract: vi.fn() })),
   spawnSpecCheck: mockSpawnSpecCheck,
   spawnSpecRefine: mockSpawnSpecRefine,
   validateProjectDir: vi.fn().mockReturnValue(null),

--- a/tests/unit/ticket-spec.test.ts
+++ b/tests/unit/ticket-spec.test.ts
@@ -5,6 +5,7 @@ import {
   shortBodyHash,
   runSpecCheck,
   runSpecRefine,
+  finalizeSpecGatePass,
   type SpecGateDeps,
 } from '../../src/main/control-plane/ticket-spec';
 import type { ProjectTicketConfig } from '../../src/main/control-plane/registry';
@@ -343,6 +344,39 @@ describe('runSpecCheck', () => {
     expect(deps.markSpecReady).not.toHaveBeenCalled();
   });
 
+  it('generates + stores the contract before marking spec-ready on PASS', async () => {
+    const body = '# Ticket body';
+    const generateContract = vi.fn().mockResolvedValue('{"contract_version":1}');
+    const storeContract = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      fetchTicket: vi.fn().mockResolvedValue(body),
+      generateContract,
+      storeContract,
+    });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(true);
+    expect(result.contractError).toBeUndefined();
+    expect(generateContract).toHaveBeenCalledWith('1', '/proj', body);
+    expect(storeContract).toHaveBeenCalledWith('1', '/proj', '{"contract_version":1}', shortBodyHash(body));
+    expect(deps.markSpecReady).toHaveBeenCalledWith('1', shortBodyHash(body));
+  });
+
+  it('reports NOT passed with a contractError when contract generation fails (block-until-contract)', async () => {
+    const body = '# Ticket body';
+    const generateContract = vi.fn().mockRejectedValue(new Error('model returned non-JSON'));
+    const storeContract = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      fetchTicket: vi.fn().mockResolvedValue(body),
+      generateContract,
+      storeContract,
+    });
+    const result = await runSpecCheck('1', '/proj', deps);
+    expect(result.passed).toBe(false);
+    expect(result.contractError).toContain('model returned non-JSON');
+    expect(storeContract).not.toHaveBeenCalled();
+    expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+
   it('includes reportText on FAIL and null on PASS', async () => {
     const failDeps = makeDeps({
       runCheck: vi.fn().mockResolvedValue({ passed: false, report: FAIL_REPORT }),
@@ -427,5 +461,45 @@ describe('runSpecRefine', () => {
     const passDeps = makeDeps();
     const passResult = await runSpecRefine('1', '/proj', 'answers', passDeps);
     expect(passResult.reportText).toBeNull();
+  });
+});
+
+describe('finalizeSpecGatePass', () => {
+  const mkDeps = (over: Partial<Pick<SpecGateDeps, 'generateContract' | 'storeContract' | 'markSpecReady'>> = {}) => ({
+    markSpecReady: vi.fn().mockResolvedValue(undefined),
+    generateContract: vi.fn().mockResolvedValue('{"contract_version":1}'),
+    storeContract: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  });
+
+  it('generates, stores, then marks spec-ready in order on success', async () => {
+    const deps = mkDeps();
+    const res = await finalizeSpecGatePass('7', '/p', 'body', 'abc123', deps);
+    expect(res).toEqual({ ok: true });
+    expect(deps.generateContract).toHaveBeenCalledWith('7', '/p', 'body');
+    expect(deps.storeContract).toHaveBeenCalledWith('7', '/p', '{"contract_version":1}', 'abc123');
+    expect(deps.markSpecReady).toHaveBeenCalledWith('7', 'abc123');
+  });
+
+  it('returns ok:false and does NOT mark spec-ready when generation throws', async () => {
+    const deps = mkDeps({ generateContract: vi.fn().mockRejectedValue(new Error('boom')) });
+    const res = await finalizeSpecGatePass('7', '/p', 'body', 'abc123', deps);
+    expect(res).toEqual({ ok: false, error: expect.stringContaining('boom') });
+    expect(deps.storeContract).not.toHaveBeenCalled();
+    expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:false and does NOT mark spec-ready when storage throws', async () => {
+    const deps = mkDeps({ storeContract: vi.fn().mockRejectedValue(new Error('gh down')) });
+    const res = await finalizeSpecGatePass('7', '/p', 'body', 'abc123', deps);
+    expect(res).toEqual({ ok: false, error: expect.stringContaining('gh down') });
+    expect(deps.markSpecReady).not.toHaveBeenCalled();
+  });
+
+  it('falls back to mark-spec-ready-only when contract deps are absent (legacy)', async () => {
+    const markSpecReady = vi.fn().mockResolvedValue(undefined);
+    const res = await finalizeSpecGatePass('7', '/p', 'body', 'abc123', { markSpecReady });
+    expect(res).toEqual({ ok: true });
+    expect(markSpecReady).toHaveBeenCalledWith('7', 'abc123');
   });
 });


### PR DESCRIPTION
Closes #689.

First piece of the contract-driven inner loop: auto-generate a machine-verifiable **execution contract** the moment a ticket passes the spec gate, store it on the ticket separately from the human spec, and inject it into the inner execution agent's prompt. The mechanical validator and semantic reviewer land in follow-ups.

## What it does

- **Contract generator** — verbatim generator prompt (`contract-generator-prompt.ts`) + a pure parse/validate module (`contract-generator.ts`). Fence-tolerant JSON parse; **fails closed** on invalid `change_type`, disallowed `review_focus`, missing keys, or non-boolean `mechanical_checks`.
- **Storage** — contract saved as a marked, sha-stamped **GitHub issue comment** (issue body untouched, so the `spec-ready:sha` idempotency hash is unaffected) plus a `contract:sha-<hash>` label mirroring `spec-ready`. Idempotent upsert — re-generation replaces, never piles up.
- **Atomic pass** — `finalizeSpecGatePass` generates + stores the contract *before* marking spec-ready. The renderer-facing `passed` now means **gate passed AND contract stored**, so a ticket reaches the Spec-ready column only with a current contract. On contract failure it stays in Refining with a `contractError` + the existing Retry. Invariant: **spec-ready ⇒ current contract exists.**
- **Routing** — new `contract_generator` touchpoint (sonnet on balanced/budget, opus on max_quality), configurable in the Models pane.
- **Dispatch** — `appendContractSection` embeds a `## Execution Contract` JSON block in the task prompt handed to the inner executor.

## Storage shape

The contract lives in an HTML-comment-marked issue comment, keyed to the spec-body hash:

```
<!-- sandstorm:contract v=1 sha=<bodyHash> -->
...fenced JSON contract...
```

A spec edit changes the body hash → `spec-ready` label invalidates → gate re-runs → contract regenerates. No stale contract can reach a stack.

## Tests

New: contract generate/parse/validate, comment marshalling round-trip, dispatch injection, `finalizeSpecGatePass` success/failure ordering. Updated: routing coverage, two `claude/tools` mocks, ModelsPane touchpoint count.

## Verification

- `npm run typecheck` clean; full `build` + `electron-rebuild` + `package` → AppImage (host).
- **Full unit suite run in a Sandstorm stack: 4590 passed / 4590 (187 files).** The sqlite-bound suites that can't run on the host (native-module ABI split) all pass in-stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
