### PR TITLE
[693] fix: route lifecycle writes through TaskLifecycleManager

### DIFF
--- a/src/main/control-plane/stack-manager.ts
+++ b/src/main/control-plane/stack-manager.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import { Registry, Stack, StackHistoryRecord, StackStatus, Task, TokenUsage } from './registry';
+import { TaskLifecycleManager } from './task-lifecycle-manager';
 import { PortAllocator, ServicePort } from './port-allocator';
 import { PortProxy } from './port-proxy';
 import { TaskWatcher, WorkflowProgressData } from './task-watcher';
@@ -216,6 +217,7 @@ export class StackManager {
   private appVersion: string;
   private portProxy?: PortProxy;
   private askClarifyingInFlight = new Set<string>();
+  private tlm: TaskLifecycleManager;
 
   constructor(
     private registry: Registry,
@@ -225,6 +227,7 @@ export class StackManager {
     private podmanRuntime: ContainerRuntime,
     private cliDir: string = ''
   ) {
+    this.tlm = new TaskLifecycleManager(registry);
     // When the task watcher detects a status change, push a UI update
     this.taskWatcher.setOnStatusChange(() => this.notifyUpdate());
     this.appVersion = StackManager.resolveAppVersion();
@@ -484,7 +487,7 @@ export class StackManager {
       const buildRuntime = opts.runtime === 'podman' ? this.podmanRuntime : this.dockerRuntime;
       const needsRebuild = await this.checkImageNeedsRebuild(opts.projectDir, buildRuntime);
       if (needsRebuild) {
-        this.registry.updateStackStatus(opts.name, 'rebuilding');
+        this.tlm.updateStackStatus(opts.name, 'rebuilding');
         this.notifyUpdate();
       }
 
@@ -507,7 +510,7 @@ export class StackManager {
         build: needsRebuild,
       });
 
-      this.registry.updateStackStatus(opts.name, 'up');
+      this.tlm.updateStackStatus(opts.name, 'up');
       this.notifyUpdate();
 
       // If a task was provided, dispatch it (with one retry on failure).
@@ -524,7 +527,7 @@ export class StackManager {
             await this.dispatchTask(opts.name, opts.task, opts.model, gateOpts);
           } catch (retryErr) {
             const msg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-            this.registry.updateStackStatus(opts.name, 'failed', `Task dispatch failed after retry: ${msg}`);
+            this.tlm.updateStackStatus(opts.name, 'failed', `Task dispatch failed after retry: ${msg}`);
             this.notifyUpdate();
             return;
           }
@@ -532,7 +535,7 @@ export class StackManager {
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
-      this.registry.updateStackStatus(opts.name, 'failed', errorMessage);
+      this.tlm.updateStackStatus(opts.name, 'failed', errorMessage);
       this.notifyUpdate();
     }
   }
@@ -542,7 +545,7 @@ export class StackManager {
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
     this.taskWatcher.unwatch(stackId);
-    this.registry.updateStackStatus(stackId, 'stopped');
+    this.tlm.updateStackStatus(stackId, 'stopped');
     this.notifyUpdate();
 
     // Stop containers in background (keeps containers/volumes/images intact)
@@ -561,7 +564,7 @@ export class StackManager {
     const stack = this.registry.getStack(stackId);
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
 
-    this.registry.updateStackStatus(stackId, 'building');
+    this.tlm.updateStackStatus(stackId, 'building');
     this.notifyUpdate();
 
     // Start containers in background
@@ -582,7 +585,7 @@ export class StackManager {
         result.stderr.trim() || result.stdout.trim() || 'Failed to start stack containers before dispatch'
       );
     }
-    this.registry.updateStackStatus(stackId, 'up');
+    this.tlm.updateStackStatus(stackId, 'up');
     this.notifyUpdate();
   }
 
@@ -592,11 +595,11 @@ export class StackManager {
       if (result.exitCode !== 0) {
         throw new SandstormError(ErrorCode.COMPOSE_FAILED, result.stderr.trim() || result.stdout.trim() || 'Stack start failed');
       }
-      this.registry.updateStackStatus(stackId, 'up');
+      this.tlm.updateStackStatus(stackId, 'up');
       this.notifyUpdate();
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
-      this.registry.updateStackStatus(stackId, 'failed', errorMessage);
+      this.tlm.updateStackStatus(stackId, 'failed', errorMessage);
       this.notifyUpdate();
     }
   }
@@ -614,7 +617,7 @@ export class StackManager {
     for (const stack of stacks) {
       if (runningStatuses.has(stack.status)) {
         this.taskWatcher.unwatch(stack.id);
-        this.registry.updateStackStatus(stack.id, 'session_paused');
+        this.tlm.updateStackStatus(stack.id, 'session_paused');
         paused.push(stack.id);
         // Stop containers in background
         this.stopInBackground(stack, stack.id).catch(() => {});
@@ -635,7 +638,7 @@ export class StackManager {
     if (!stack) throw new SandstormError(ErrorCode.STACK_NOT_FOUND, `Stack "${stackId}" not found`);
     if (stack.status !== 'session_paused') return;
 
-    this.registry.updateStackStatus(stackId, 'building');
+    this.tlm.updateStackStatus(stackId, 'building');
     this.notifyUpdate();
     this.startInBackground(stack, stackId).catch(() => {});
   }
@@ -649,7 +652,7 @@ export class StackManager {
 
     for (const stack of stacks) {
       if (stack.status === 'session_paused') {
-        this.registry.updateStackStatus(stack.id, 'building');
+        this.tlm.updateStackStatus(stack.id, 'building');
         resumed.push(stack.id);
         this.startInBackground(stack, stack.id).catch(() => {});
       }
@@ -693,13 +696,13 @@ export class StackManager {
     }
 
     // Bring containers up synchronously
-    this.registry.updateStackStatus(stackId, 'building');
+    this.tlm.updateStackStatus(stackId, 'building');
     this.notifyUpdate();
     try {
       await this.ensureStackContainersRunning(stack, stackId);
     } catch (err) {
       // Revert to session_paused on container failure so the user can retry
-      this.registry.updateStackStatus(stackId, 'session_paused');
+      this.tlm.updateStackStatus(stackId, 'session_paused');
       this.notifyUpdate();
       throw err;
     }
@@ -713,11 +716,11 @@ export class StackManager {
       const mostRecentTask = this.registry.getMostRecentTask(stackId);
       if (!mostRecentTask) {
         // Case C: no task at all — leave stack idle
-        this.registry.updateStackStatus(stackId, 'idle');
+        this.tlm.updateStackStatus(stackId, 'idle');
         this.notifyUpdate();
         return { outcome: 'idle' };
       }
-      this.registry.reopenTaskForResume(mostRecentTask.id);
+      this.tlm.markReopened(mostRecentTask.id);
       runningTask = { ...mostRecentTask, status: 'running' as const };
     }
 
@@ -726,20 +729,20 @@ export class StackManager {
       try {
         await this.dispatchContinuation(stack, stackId, runningTask);
       } catch (err) {
-        this.registry.updateStackStatus(stackId, 'session_paused');
+        this.tlm.updateStackStatus(stackId, 'session_paused');
         this.notifyUpdate();
         throw err;
       }
       return { outcome: 'resuming_with_session' };
     } else {
       // Case B: session not yet logged — interrupt and redispatch fresh
-      this.registry.interruptTask(runningTask.id);
+      this.tlm.markInterrupted(runningTask.id);
       try {
         await this.dispatchTask(stackId, runningTask.prompt, runningTask.model ?? undefined, {
           skipTicketFetch: true,
         });
       } catch (err) {
-        this.registry.updateStackStatus(stackId, 'session_paused');
+        this.tlm.updateStackStatus(stackId, 'session_paused');
         this.notifyUpdate();
         throw err;
       }
@@ -768,8 +771,8 @@ export class StackManager {
 
     await this.waitForClaudeReady(claudeContainer.id, runtime);
 
-    this.registry.setTaskResumedAt(task.id, new Date().toISOString());
-    this.registry.updateStackStatus(stackId, 'running');
+    this.tlm.markResumedAt(task.id, new Date().toISOString());
+    this.tlm.updateStackStatus(stackId, 'running');
     this.notifyUpdate();
 
     try {
@@ -779,7 +782,7 @@ export class StackManager {
         resume: task.session_id!,
       });
     } catch (err) {
-      this.registry.updateStackStatus(stackId, 'session_paused');
+      this.tlm.updateStackStatus(stackId, 'session_paused');
       this.notifyUpdate();
       const msg = err instanceof Error ? err.message : String(err);
       throw new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, msg || 'Resume dispatch failed');
@@ -811,8 +814,8 @@ export class StackManager {
 
     await this.waitForClaudeReady(claudeContainer.id, runtime);
 
-    this.registry.setTaskResumedAt(task.id, new Date().toISOString());
-    this.registry.updateStackStatus(stackId, 'running');
+    this.tlm.markResumedAt(task.id, new Date().toISOString());
+    this.tlm.updateStackStatus(stackId, 'running');
     this.notifyUpdate();
 
     try {
@@ -822,7 +825,7 @@ export class StackManager {
         resume: task.session_id!,
       });
     } catch (err) {
-      this.registry.updateStackStatus(stackId, 'needs_human');
+      this.tlm.updateStackStatus(stackId, 'needs_human');
       this.notifyUpdate();
       const msg = err instanceof Error ? err.message : String(err);
       throw new SandstormError(ErrorCode.TASK_DISPATCH_FAILED, msg || 'Investigation dispatch failed');
@@ -916,7 +919,7 @@ export class StackManager {
     // Transition to session_paused so resumeStackWithContinuation can proceed.
     // The task is still 'completed'; the Q-A fallback in resumeStackWithContinuation
     // will call getMostRecentTask + reopenTaskForResume before Case A/B.
-    this.registry.updateStackStatus(stackId, 'session_paused');
+    this.tlm.updateStackStatus(stackId, 'session_paused');
     this.notifyUpdate();
 
     try {
@@ -928,9 +931,9 @@ export class StackManager {
       // if dispatchTask throws, the task is 'interrupted', not 'running'.
       const reopenedTask = this.registry.getMostRecentTask(stackId);
       if (reopenedTask && (reopenedTask.status === 'running' || reopenedTask.status === 'interrupted')) {
-        this.registry.completeTask(reopenedTask.id, 0); // also sets stack to 'completed'
+        this.tlm.markCompleted(reopenedTask.id, 0); // also sets stack to 'completed'
       } else {
-        this.registry.updateStackStatus(stackId, 'completed');
+        this.tlm.updateStackStatus(stackId, 'completed');
       }
       this.notifyUpdate();
       throw err;
@@ -982,15 +985,15 @@ export class StackManager {
     const task = this.registry.getMostRecentTask(stackId);
 
     if (containerStatus === 'running') {
-      this.registry.updateStackStatus(stackId, 'running');
-      if (task) this.registry.reopenTaskForResume(task.id);
+      this.tlm.updateStackStatus(stackId, 'running');
+      if (task) this.tlm.markReopened(task.id);
       this.taskWatcher.watch(stackId, container.id);
       this.notifyUpdate();
       return { outcome: 'reconciled', status: 'running' };
     }
 
     if (containerStatus === 'token_limited') {
-      this.registry.updateStackStatus(stackId, 'session_paused');
+      this.tlm.updateStackStatus(stackId, 'session_paused');
       this.notifyUpdate();
       return { outcome: 'reconciled', status: 'session_paused' };
     }
@@ -1022,9 +1025,9 @@ export class StackManager {
       }
 
       if (task) {
-        this.registry.completeTaskNeedsHuman(task.id, stopReason, questionsJson);
+        this.tlm.markNeedsHuman(task.id, stopReason, questionsJson);
       } else {
-        this.registry.updateStackStatus(stackId, 'needs_human');
+        this.tlm.updateStackStatus(stackId, 'needs_human');
       }
       this.notifyUpdate();
       return { outcome: 'reconciled', status: 'needs_human' };
@@ -1038,9 +1041,9 @@ export class StackManager {
       } catch { /* best effort */ }
 
       if (task) {
-        this.registry.completeTaskNeedsKey(task.id, keyReason);
+        this.tlm.markNeedsKey(task.id, keyReason);
       } else {
-        this.registry.updateStackStatus(stackId, 'needs_key');
+        this.tlm.updateStackStatus(stackId, 'needs_key');
       }
       this.notifyUpdate();
       return { outcome: 'reconciled', status: 'needs_key' };
@@ -1054,9 +1057,9 @@ export class StackManager {
       } catch { /* best effort */ }
 
       if (task) {
-        this.registry.completeTaskVerifyBlockedEnvironmental(task.id, envReason);
+        this.tlm.markVerifyBlockedEnvironmental(task.id, envReason);
       } else {
-        this.registry.updateStackStatus(stackId, 'verify_blocked_environmental');
+        this.tlm.updateStackStatus(stackId, 'verify_blocked_environmental');
       }
       this.notifyUpdate();
       return { outcome: 'reconciled', status: 'verify_blocked_environmental' };
@@ -1071,9 +1074,9 @@ export class StackManager {
       } catch { /* best effort */ }
 
       if (task) {
-        this.registry.completeTask(task.id, exitCode);
+        this.tlm.markCompleted(task.id, exitCode);
       } else {
-        this.registry.updateStackStatus(stackId, containerStatus as 'completed' | 'failed');
+        this.tlm.updateStackStatus(stackId, containerStatus as 'completed' | 'failed');
       }
       this.notifyUpdate();
       return { outcome: 'reconciled', status: containerStatus as 'completed' | 'failed' };
@@ -1081,9 +1084,9 @@ export class StackManager {
 
     // Unrecognized status — surface to user as needs_human
     if (task) {
-      this.registry.completeTaskNeedsHuman(task.id, `Unrecognized container status: ${containerStatus}`);
+      this.tlm.markNeedsHuman(task.id, `Unrecognized container status: ${containerStatus}`);
     } else {
-      this.registry.updateStackStatus(stackId, 'needs_human');
+      this.tlm.updateStackStatus(stackId, 'needs_human');
     }
     this.notifyUpdate();
     return { outcome: 'reconciled', status: 'needs_human' };
@@ -1107,12 +1110,12 @@ export class StackManager {
     const originalStatus = stack.status;
 
     // Bring containers up
-    this.registry.updateStackStatus(stackId, 'building');
+    this.tlm.updateStackStatus(stackId, 'building');
     this.notifyUpdate();
     try {
       await this.ensureStackContainersRunning(stack, stackId);
     } catch (err) {
-      this.registry.updateStackStatus(stackId, originalStatus);
+      this.tlm.updateStackStatus(stackId, originalStatus);
       this.notifyUpdate();
       throw err;
     }
@@ -1123,11 +1126,11 @@ export class StackManager {
     try {
       if (task.session_id) {
         // Case A: resume with existing Claude session — reopen task then dispatch continuation
-        this.registry.reopenTaskForResume(task.id);
+        this.tlm.markReopened(task.id);
         await this.dispatchContinuation(stack, stackId, { ...task, status: 'running' }, continuationPrompt);
       } else {
         // Case B: no session_id — close the original task and redispatch fresh with original prompt + answers
-        this.registry.interruptTask(task.id);
+        this.tlm.markInterrupted(task.id);
         const freshPrompt = `${task.prompt}\n\n---\nAdditional context from human:\n${answers}`;
         try {
           await this.dispatchTask(stackId, freshPrompt, task.model ?? undefined, {
@@ -1135,8 +1138,8 @@ export class StackManager {
           });
         } catch (err) {
           // Revert task to terminal state so it doesn't strand in interrupted
-          this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
-          this.registry.updateStackStatus(stackId, originalStatus);
+          this.tlm.markNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+          this.tlm.updateStackStatus(stackId, originalStatus);
           this.notifyUpdate();
           throw err;
         }
@@ -1144,8 +1147,8 @@ export class StackManager {
     } catch (err) {
       if (task.session_id) {
         // Revert task to terminal state so it doesn't strand in running
-        this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
-        this.registry.updateStackStatus(stackId, originalStatus);
+        this.tlm.markNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+        this.tlm.updateStackStatus(stackId, originalStatus);
         this.notifyUpdate();
       }
       throw err;
@@ -1180,13 +1183,13 @@ export class StackManager {
       throw new SandstormError(ErrorCode.INTERNAL_ERROR, `No task found for stack "${stackId}"`);
     }
 
-    this.registry.updateStackStatus(stackId, 'building');
+    this.tlm.updateStackStatus(stackId, 'building');
     this.notifyUpdate();
     try {
       await this.ensureStackContainersRunning(stack, stackId);
     } catch (err) {
       this.askClarifyingInFlight.delete(stackId);
-      this.registry.updateStackStatus(stackId, 'needs_human');
+      this.tlm.updateStackStatus(stackId, 'needs_human');
       this.notifyUpdate();
       throw err;
     }
@@ -1194,27 +1197,27 @@ export class StackManager {
     try {
       if (task.session_id) {
         // Case A: resume in-container session with fixed prompt to trigger STOP_AND_ASK
-        this.registry.reopenTaskForResume(task.id);
+        this.tlm.markReopened(task.id);
         await this.dispatchContinuation(stack, stackId, { ...task, status: 'running' }, ASK_CLARIFYING_QUESTIONS_PROMPT);
       } else {
         // Case B: no session_id — re-dispatch fresh with original prompt
         // The fixed clarifying-questions prompt does not apply; the original prompt is re-run.
-        this.registry.interruptTask(task.id);
+        this.tlm.markInterrupted(task.id);
         try {
           await this.dispatchTask(stackId, task.prompt, task.model ?? undefined, {
             skipTicketFetch: true,
           });
         } catch (err) {
-          this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
-          this.registry.updateStackStatus(stackId, 'needs_human');
+          this.tlm.markNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+          this.tlm.updateStackStatus(stackId, 'needs_human');
           this.notifyUpdate();
           throw err;
         }
       }
     } catch (err) {
       if (task.session_id) {
-        this.registry.completeTaskNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
-        this.registry.updateStackStatus(stackId, 'needs_human');
+        this.tlm.markNeedsHuman(task.id, 'Resume dispatch failed', task.needs_human_questions);
+        this.tlm.updateStackStatus(stackId, 'needs_human');
         this.notifyUpdate();
       }
       throw err;
@@ -1244,7 +1247,7 @@ export class StackManager {
       } catch {
         // Best effort — container may already be gone
       }
-      this.registry.interruptTask(runningTask.id);
+      this.tlm.markInterrupted(runningTask.id);
     }
 
     // Archive to history before deleting
@@ -1426,7 +1429,7 @@ export class StackManager {
       }
     }
 
-    const task = this.registry.createTask(stackId, prompt, model);
+    const task = this.tlm.createTask(stackId, prompt, model);
 
     const runtime = this.getRuntimeForStack(stack);
 
@@ -1479,7 +1482,7 @@ export class StackManager {
     } catch (err) {
       // Task was created but dispatch failed — mark it as failed so the
       // stack doesn't stay stuck in 'running' status forever.
-      this.registry.completeTask(task.id, 1);
+      this.tlm.markCompleted(task.id, 1);
       this.notifyUpdate();
       throw err;
     }
@@ -1532,21 +1535,13 @@ export class StackManager {
       throw new SandstormError(ErrorCode.COMPOSE_FAILED, result.stderr.trim() || result.stdout.trim() || 'Push failed');
     }
 
-    this.registry.updateStackStatus(stackId, 'pushed');
+    this.tlm.updateStackStatus(stackId, 'pushed');
     this.notifyUpdate();
     return { stdout: result.stdout, stderr: result.stderr };
   }
 
   setPullRequest(stackId: string, prUrl: string, prNumber: number): void {
-    const stack = this.registry.getStack(stackId);
-    if (!stack) throw new Error(`Stack "${stackId}" not found`);
-
-    this.registry.setPullRequest(stackId, prUrl, prNumber);
-
-    if (stack.ticket) {
-      this.registry.advanceTicketToPrOpenIfInStack(stack.ticket, stack.project_dir);
-    }
-
+    this.tlm.markPrCreated(stackId, prUrl, prNumber);
     this.notifyUpdate();
   }
 
@@ -2502,13 +2497,13 @@ export class StackManager {
     // Set guard as within-call race lock before dispatch
     this.registry.setSelfhealContinueUsed(stackId, 1);
 
-    this.registry.updateStackStatus(stackId, 'building');
+    this.tlm.updateStackStatus(stackId, 'building');
     this.notifyUpdate();
     try {
       await this.ensureStackContainersRunning(stack, stackId);
     } catch (err) {
       this.registry.setSelfhealContinueUsed(stackId, 0);
-      this.registry.updateStackStatus(stackId, 'failed');
+      this.tlm.updateStackStatus(stackId, 'failed');
       this.notifyUpdate();
       throw err;
     }
@@ -2516,7 +2511,7 @@ export class StackManager {
     try {
       if (task.session_id) {
         // Case A: resume with existing Claude session — reopen task, reset iterations, dispatch continuation
-        this.registry.reopenTaskForResume(task.id);
+        this.tlm.markReopened(task.id);
         this.registry.setTaskIterations(task.id, 0, task.verify_retries);
         const continuationPrompt =
           'Continue the prior work on this task. The review loop count has been reset — you have fresh review iterations to work with. Resume from where you left off.';
@@ -2533,11 +2528,11 @@ export class StackManager {
     } catch (err) {
       if (task.session_id) {
         // Revert reopened task to terminal state so it doesn't strand in running
-        this.registry.completeTask(task.id, 1);
+        this.tlm.markCompleted(task.id, 1);
       }
       // Reset guard so the stack is not permanently blocked
       this.registry.setSelfhealContinueUsed(stackId, 0);
-      this.registry.updateStackStatus(stackId, 'failed');
+      this.tlm.updateStackStatus(stackId, 'failed');
       this.notifyUpdate();
       throw err;
     }

--- a/src/main/control-plane/startup-reconciler.ts
+++ b/src/main/control-plane/startup-reconciler.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { execFile } from 'child_process';
 import { Registry, Stack } from './registry';
+import { TaskLifecycleManager } from './task-lifecycle-manager';
 import { TaskWatcher } from './task-watcher';
 import { StackManager, sanitizeComposeName } from './stack-manager';
 import { ContainerRuntime } from '../runtime/types';
@@ -107,6 +108,8 @@ export async function runStartupReconciliation(
     workspaceExistsFn = defaultWorkspaceExists,
   } = deps;
 
+  const tlm = new TaskLifecycleManager(registry);
+
   // Repair cards stuck in pr_open after a failed PR creation (runs before stack reconciliation
   // so the board is consistent when the renderer loads).
   registry.reconcilePrOpenStuckTickets();
@@ -127,6 +130,7 @@ export async function runStartupReconciliation(
       await reconcileStack(
         stack,
         registry,
+        tlm,
         stackManager,
         taskWatcher,
         dockerRuntime,
@@ -158,6 +162,7 @@ export async function runStartupReconciliation(
 async function reconcileStack(
   stack: Stack,
   registry: Registry,
+  tlm: TaskLifecycleManager,
   stackManager: StackManager,
   taskWatcher: TaskWatcher,
   dockerRuntime: ContainerRuntime,
@@ -181,7 +186,7 @@ async function reconcileStack(
 
   if (!container) {
     if (workspaceExistsFn(stack)) {
-      await handleBranch3(stack, registry, stackManager, notifyUpdate);
+      await handleBranch3(stack, registry, tlm, stackManager, notifyUpdate);
     } else {
       await handleBranch5(stack, registry, fetchTicketStateFn, notifyUpdate);
     }
@@ -198,11 +203,11 @@ async function reconcileStack(
   }
 
   if (statusContent !== null && TERMINAL_FILE_STATUSES.has(statusContent)) {
-    await handleBranch1(stack, statusContent, container.id, runtime, registry, notifyUpdate);
+    await handleBranch1(stack, statusContent, container.id, runtime, registry, tlm, notifyUpdate);
   } else if (statusContent === 'running') {
     handleBranch2(stack.id, container.id, taskWatcher, notifyUpdate);
   } else {
-    await handleBranch4(stack, registry, stackManager, notifyUpdate);
+    await handleBranch4(stack, registry, tlm, stackManager, notifyUpdate);
   }
 }
 
@@ -212,6 +217,7 @@ async function handleBranch1(
   containerId: string,
   runtime: ContainerRuntime,
   registry: Registry,
+  tlm: TaskLifecycleManager,
   notifyUpdate: () => void
 ): Promise<void> {
   const task = registry.getRunningTask(stack.id);
@@ -223,14 +229,14 @@ async function handleBranch1(
       const r = await runtime.exec(containerId, ['cat', '/tmp/claude-stop-reason.txt']);
       if (r.stdout.trim()) stopReason = r.stdout.trim();
     } catch { /* best effort */ }
-    registry.completeTaskNeedsHuman(task.id, stopReason);
+    tlm.markNeedsHuman(task.id, stopReason);
   } else if (statusContent === 'verify_blocked_environmental') {
     let envReason = 'Verify failed repeatedly — likely an environmental issue';
     try {
       const r = await runtime.exec(containerId, ['cat', '/tmp/claude-verify-environmental.txt']);
       if (r.stdout.trim()) envReason = `Verify blocked (environmental): ${r.stdout.trim()}`;
     } catch { /* best effort */ }
-    registry.completeTaskVerifyBlockedEnvironmental(task.id, envReason);
+    tlm.markVerifyBlockedEnvironmental(task.id, envReason);
   } else {
     let exitCode: number;
     try {
@@ -240,7 +246,7 @@ async function handleBranch1(
     } catch {
       exitCode = statusContent === 'completed' ? 0 : 1;
     }
-    registry.completeTask(task.id, exitCode);
+    tlm.markCompleted(task.id, exitCode);
   }
   notifyUpdate();
 }
@@ -258,12 +264,13 @@ function handleBranch2(
 async function handleBranch3(
   stack: Stack,
   registry: Registry,
+  tlm: TaskLifecycleManager,
   stackManager: StackManager,
   notifyUpdate: () => void
 ): Promise<void> {
   // Temporarily mark as session_paused so resumeStackWithContinuation applies its
   // recreate-and-resume logic (Case A for session resume, Case B for fresh dispatch).
-  registry.updateStackStatus(stack.id, 'session_paused');
+  tlm.updateStackStatus(stack.id, 'session_paused');
   notifyUpdate();
 
   try {
@@ -272,7 +279,7 @@ async function handleBranch3(
     console.warn(`[StartupReconciler] Branch 3 resume failed for stack ${stack.id}:`, err);
     const task = registry.getRunningTask(stack.id);
     if (task) {
-      registry.completeTaskNeedsHuman(
+      tlm.markNeedsHuman(
         task.id,
         `Startup recovery failed: ${err instanceof Error ? err.message : String(err)}`
       );
@@ -284,13 +291,14 @@ async function handleBranch3(
 async function handleBranch4(
   stack: Stack,
   registry: Registry,
+  tlm: TaskLifecycleManager,
   stackManager: StackManager,
   notifyUpdate: () => void
 ): Promise<void> {
   // Interrupt the stale running task so dispatchTask creates a clean new one
   const task = registry.getRunningTask(stack.id);
   if (task) {
-    registry.interruptTask(task.id);
+    tlm.markInterrupted(task.id);
   }
 
   try {
@@ -301,12 +309,12 @@ async function handleBranch4(
     console.warn(`[StartupReconciler] Branch 4 dispatch failed for stack ${stack.id}:`, err);
     const newTask = registry.getRunningTask(stack.id);
     if (newTask) {
-      registry.completeTaskNeedsHuman(
+      tlm.markNeedsHuman(
         newTask.id,
         `Investigation dispatch failed: ${err instanceof Error ? err.message : String(err)}`
       );
     } else {
-      registry.updateStackStatus(stack.id, 'needs_human');
+      tlm.updateStackStatus(stack.id, 'needs_human');
     }
     notifyUpdate();
   }

--- a/src/main/control-plane/task-lifecycle-manager.ts
+++ b/src/main/control-plane/task-lifecycle-manager.ts
@@ -1,0 +1,75 @@
+import { Registry, Task, StackStatus } from './registry';
+
+/**
+ * TaskLifecycleManager (TLM) — the single owner of all task/stack lifecycle
+ * state writes. All transitions that mutate task status or stack status flow
+ * through this class; no other module may call the raw registry write methods
+ * directly (enforced by tests/unit/architecture-registry-boundary.test.ts).
+ *
+ * TLM owns the WRITE, not the emit. Callers retain their existing
+ * notifyUpdate() calls verbatim — emission is not 1:1 with writes.
+ */
+export class TaskLifecycleManager {
+  constructor(private registry: Registry) {}
+
+  /** Create a new task for a stack; auto-transitions stack → 'running'. */
+  createTask(stackId: string, prompt: string, model?: string): Task {
+    return this.registry.createTask(stackId, prompt, model);
+  }
+
+  /** Set the stack status (for build/deploy and other stack-only transitions). */
+  updateStackStatus(stackId: string, status: StackStatus, error?: string): void {
+    this.registry.updateStackStatus(stackId, status, error);
+  }
+
+  /** Complete a task with an exit code; auto-transitions stack → 'completed'|'failed'. */
+  markCompleted(taskId: number, exitCode: number): void {
+    this.registry.completeTask(taskId, exitCode);
+  }
+
+  /** Transition task → 'needs_human'; auto-transitions stack → 'needs_human'. */
+  markNeedsHuman(taskId: number, reason: string, questionsJson?: string | null): void {
+    this.registry.completeTaskNeedsHuman(taskId, reason, questionsJson);
+  }
+
+  /** Transition task → 'needs_key'; auto-transitions stack → 'needs_key'. */
+  markNeedsKey(taskId: number, reason: string): void {
+    this.registry.completeTaskNeedsKey(taskId, reason);
+  }
+
+  /**
+   * Transition task → 'needs_human' (environmental block);
+   * auto-transitions stack → 'verify_blocked_environmental'.
+   */
+  markVerifyBlockedEnvironmental(taskId: number, reason: string): void {
+    this.registry.completeTaskVerifyBlockedEnvironmental(taskId, reason);
+  }
+
+  /**
+   * Record a created PR on the stack and advance the linked ticket to pr_open
+   * if one exists. Auto-transitions stack → 'pr_created'.
+   */
+  markPrCreated(stackId: string, prUrl: string, prNumber: number): void {
+    const stack = this.registry.getStack(stackId);
+    if (!stack) throw new Error(`Stack "${stackId}" not found`);
+    this.registry.setPullRequest(stackId, prUrl, prNumber);
+    if (stack.ticket) {
+      this.registry.advanceTicketToPrOpenIfInStack(stack.ticket, stack.project_dir);
+    }
+  }
+
+  /** Transition a running task → 'interrupted'. No-op if task is not 'running'. */
+  markInterrupted(taskId: number): void {
+    this.registry.interruptTask(taskId);
+  }
+
+  /** Reopen a completed/interrupted task for resume (status → 'running'). */
+  markReopened(taskId: number): void {
+    this.registry.reopenTaskForResume(taskId);
+  }
+
+  /** Stamp the resumed_at timestamp on a task. */
+  markResumedAt(taskId: number, ts: string): void {
+    this.registry.setTaskResumedAt(taskId, ts);
+  }
+}

--- a/src/main/control-plane/task-watcher.ts
+++ b/src/main/control-plane/task-watcher.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { Registry, Task } from './registry';
+import { TaskLifecycleManager } from './task-lifecycle-manager';
 import { ContainerRuntime } from '../runtime/types';
 import { parseTokenUsage, parsePhaseTokenTotals, parsePhaseTokenSteps } from './token-parser';
 
@@ -84,6 +85,8 @@ export class TaskWatcher extends EventEmitter {
   /** Callback invoked when a stall is confirmed and investigation should be dispatched */
   private onDispatchInvestigation?: (stackId: string, task: Task) => Promise<void>;
 
+  private tlm: TaskLifecycleManager;
+
   constructor(
     private registry: Registry,
     private dockerRuntime: ContainerRuntime,
@@ -93,9 +96,11 @@ export class TaskWatcher extends EventEmitter {
       tokenPollInterval?: number;
       livenessCheckInterval?: number;
       livenessStallThreshold?: number;
+      lifecycleManager?: TaskLifecycleManager;
     }
   ) {
     super();
+    this.tlm = options?.lifecycleManager ?? new TaskLifecycleManager(registry);
     this.pollInterval = options?.pollInterval ?? 2000;
     this.tokenPollInterval = options?.tokenPollInterval ?? 5_000;
     this.livenessCheckIntervalMs = options?.livenessCheckInterval ?? LIVENESS_CHECK_INTERVAL_MS;
@@ -192,9 +197,9 @@ export class TaskWatcher extends EventEmitter {
     questionsJson?: string | null
   ): void {
     if (status === 'needs_human') {
-      this.registry.completeTaskNeedsHuman(task.id, stopReason ?? 'Agent signaled STOP_AND_ASK — needs human intervention', questionsJson);
+      this.tlm.markNeedsHuman(task.id, stopReason ?? 'Agent signaled STOP_AND_ASK — needs human intervention', questionsJson);
     } else {
-      this.registry.completeTask(task.id, exitCode);
+      this.tlm.markCompleted(task.id, exitCode);
     }
 
     // Check for suspicious completion: fast exit with no changes
@@ -664,7 +669,7 @@ export class TaskWatcher extends EventEmitter {
 
     if (!task.session_id) {
       // No session_id — cannot resume; mark needs_human (edge case 2)
-      this.registry.completeTaskNeedsHuman(
+      this.tlm.markNeedsHuman(
         task.id,
         'Task stalled with no resumable session — needs human review'
       );
@@ -763,7 +768,7 @@ export class TaskWatcher extends EventEmitter {
         // Transition to session_paused WITHOUT completing the task — the
         // running task and its session_id remain intact so resumeStackWithContinuation
         // enters Case A rather than Case C.
-        this.registry.updateStackStatus(stackId, 'session_paused');
+        this.tlm.updateStackStatus(stackId, 'session_paused');
         this.onStatusChange?.();
         this.unwatch(stackId);
         return;
@@ -804,7 +809,7 @@ export class TaskWatcher extends EventEmitter {
           const reasonResult = await runtime.exec(containerId, ['cat', '/tmp/claude-task-needs-key.txt']);
           if (reasonResult.stdout.trim()) keyReason = reasonResult.stdout.trim();
         } catch { /* best effort */ }
-        this.registry.completeTaskNeedsKey(task.id, keyReason);
+        this.tlm.markNeedsKey(task.id, keyReason);
         const needsKeyTask = {
           ...task,
           status: 'needs_key' as const,
@@ -866,7 +871,7 @@ export class TaskWatcher extends EventEmitter {
               envReason = `Verify blocked (environmental): ${envResult.stdout.trim()}`;
             }
           } catch { /* best effort */ }
-          this.registry.completeTaskVerifyBlockedEnvironmental(task.id, envReason);
+          this.tlm.markVerifyBlockedEnvironmental(task.id, envReason);
           const updatedTask = {
             ...task,
             status: 'needs_human' as const,

--- a/tests/unit/architecture-registry-boundary.test.ts
+++ b/tests/unit/architecture-registry-boundary.test.ts
@@ -1,0 +1,90 @@
+/**
+ * T8 — Architecture test: TaskLifecycleManager is the sole caller of raw
+ * registry lifecycle transition methods.
+ *
+ * Scans every TypeScript source file under src/ and asserts that only
+ * task-lifecycle-manager.ts (and registry.ts itself) contain direct calls to
+ * the following raw Registry lifecycle methods:
+ *
+ *   registry.updateStackStatus(
+ *   registry.completeTask(
+ *   registry.completeTaskNeedsHuman(
+ *   registry.completeTaskNeedsKey(
+ *   registry.completeTaskVerifyBlockedEnvironmental(
+ *   registry.setPullRequest(
+ *   registry.interruptTask(
+ *   registry.reopenTaskForResume(
+ *   registry.setTaskResumedAt(
+ *   registry.createTask(
+ *
+ * The patterns deliberately include the `registry.` prefix so that allowed
+ * calls like `this.tlm.updateStackStatus(` are not flagged.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const SRC_ROOT = path.resolve(__dirname, '../../src');
+
+const LIFECYCLE_PATTERNS = [
+  'registry.updateStackStatus(',
+  'registry.completeTask(',
+  'registry.completeTaskNeedsHuman(',
+  'registry.completeTaskNeedsKey(',
+  'registry.completeTaskVerifyBlockedEnvironmental(',
+  'registry.setPullRequest(',
+  'registry.interruptTask(',
+  'registry.reopenTaskForResume(',
+  'registry.setTaskResumedAt(',
+  'registry.createTask(',
+];
+
+const ALLOW_LIST = new Set([
+  'task-lifecycle-manager.ts',
+  'registry.ts',
+]);
+
+function collectTsFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectTsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+describe('architecture: registry lifecycle boundary', () => {
+  it('no src file other than task-lifecycle-manager.ts and registry.ts calls raw registry lifecycle methods', () => {
+    const files = collectTsFiles(SRC_ROOT);
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const base = path.basename(file);
+      if (ALLOW_LIST.has(base)) continue;
+
+      const content = fs.readFileSync(file, 'utf8');
+      const lines = content.split('\n');
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        for (const pattern of LIFECYCLE_PATTERNS) {
+          if (line.includes(pattern)) {
+            const rel = path.relative(SRC_ROOT, file);
+            violations.push(`${rel}:${i + 1}: found '${pattern}' — must go through TaskLifecycleManager`);
+          }
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      expect.fail(
+        `Registry lifecycle boundary violations (${violations.length}):\n` +
+        violations.map((v) => `  ${v}`).join('\n')
+      );
+    }
+  });
+});

--- a/tests/unit/task-lifecycle-manager.test.ts
+++ b/tests/unit/task-lifecycle-manager.test.ts
@@ -1,0 +1,212 @@
+/**
+ * T8 — Unit tests for TaskLifecycleManager.
+ *
+ * Each test exercises one TLM method against a real in-memory Registry and
+ * asserts the resulting task + stack status in the DB (the same observable
+ * contract the golden-path test relies on).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { Registry } from '../../src/main/control-plane/registry';
+import { TaskLifecycleManager } from '../../src/main/control-plane/task-lifecycle-manager';
+
+function makeTempDb(): string {
+  return path.join(os.tmpdir(), `tlm-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { fs.unlinkSync(dbPath + suffix); } catch { /* ignore */ }
+  }
+}
+
+function makeStackOpts(id: string, projectDir = '/proj') {
+  return {
+    id,
+    project: 'proj',
+    project_dir: projectDir,
+    ticket: null as string | null,
+    branch: null as string | null,
+    description: null as string | null,
+    status: 'up' as const,
+    runtime: 'docker' as const,
+  };
+}
+
+describe('TaskLifecycleManager', () => {
+  let dbPath: string;
+  let registry: Registry;
+  let tlm: TaskLifecycleManager;
+  let stackId: string;
+
+  beforeEach(async () => {
+    dbPath = makeTempDb();
+    registry = await Registry.create(dbPath);
+    tlm = new TaskLifecycleManager(registry);
+    stackId = `test-stack-${Date.now()}`;
+    registry.createStack(makeStackOpts(stackId));
+  });
+
+  afterEach(() => {
+    registry.close();
+    cleanupDb(dbPath);
+  });
+
+  // ---------------------------------------------------------------------------
+  // createTask
+  // ---------------------------------------------------------------------------
+
+  it('createTask creates a running task and transitions stack to running', () => {
+    const task = tlm.createTask(stackId, 'do the thing');
+    expect(task.status).toBe('running');
+    expect(task.stack_id).toBe(stackId);
+    expect(task.prompt).toBe('do the thing');
+    expect(registry.getStack(stackId)?.status).toBe('running');
+  });
+
+  it('createTask passes model through', () => {
+    const task = tlm.createTask(stackId, 'do the thing', 'claude-opus-4-8');
+    expect(task.model).toBe('claude-opus-4-8');
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateStackStatus
+  // ---------------------------------------------------------------------------
+
+  it('updateStackStatus writes the given status', () => {
+    tlm.updateStackStatus(stackId, 'building');
+    expect(registry.getStack(stackId)?.status).toBe('building');
+  });
+
+  it('updateStackStatus writes an error message when provided', () => {
+    tlm.updateStackStatus(stackId, 'failed', 'disk full');
+    const stack = registry.getStack(stackId);
+    expect(stack?.status).toBe('failed');
+    expect(stack?.error).toBe('disk full');
+  });
+
+  // ---------------------------------------------------------------------------
+  // markCompleted
+  // ---------------------------------------------------------------------------
+
+  it('markCompleted with exit 0 sets task=completed, stack=completed', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markCompleted(task.id, 0);
+    expect(registry.getMostRecentTask(stackId)?.status).toBe('completed');
+    expect(registry.getMostRecentTask(stackId)?.exit_code).toBe(0);
+    expect(registry.getStack(stackId)?.status).toBe('completed');
+  });
+
+  it('markCompleted with exit 1 sets task=failed, stack=failed', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markCompleted(task.id, 1);
+    expect(registry.getMostRecentTask(stackId)?.status).toBe('failed');
+    expect(registry.getStack(stackId)?.status).toBe('failed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // markNeedsHuman
+  // ---------------------------------------------------------------------------
+
+  it('markNeedsHuman sets task=needs_human, stack=needs_human', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markNeedsHuman(task.id, 'agent asked a question');
+    const t = registry.getMostRecentTask(stackId);
+    expect(t?.status).toBe('needs_human');
+    expect(t?.warnings).toBe('agent asked a question');
+    expect(registry.getStack(stackId)?.status).toBe('needs_human');
+  });
+
+  it('markNeedsHuman stores questionsJson', () => {
+    const task = tlm.createTask(stackId, 'work');
+    const q = JSON.stringify([{ id: 'q1', question: 'Which approach?' }]);
+    tlm.markNeedsHuman(task.id, 'reason', q);
+    expect(registry.getMostRecentTask(stackId)?.needs_human_questions).toBe(q);
+  });
+
+  // ---------------------------------------------------------------------------
+  // markNeedsKey
+  // ---------------------------------------------------------------------------
+
+  it('markNeedsKey sets task=needs_key, stack=needs_key', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markNeedsKey(task.id, 'missing anthropic key');
+    const t = registry.getMostRecentTask(stackId);
+    expect(t?.status).toBe('needs_key');
+    expect(t?.warnings).toBe('missing anthropic key');
+    expect(registry.getStack(stackId)?.status).toBe('needs_key');
+  });
+
+  // ---------------------------------------------------------------------------
+  // markVerifyBlockedEnvironmental
+  // ---------------------------------------------------------------------------
+
+  it('markVerifyBlockedEnvironmental sets task=needs_human, stack=verify_blocked_environmental', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markVerifyBlockedEnvironmental(task.id, 'permission denied');
+    const t = registry.getMostRecentTask(stackId);
+    expect(t?.status).toBe('needs_human');
+    expect(t?.warnings).toBe('permission denied');
+    expect(registry.getStack(stackId)?.status).toBe('verify_blocked_environmental');
+  });
+
+  // ---------------------------------------------------------------------------
+  // markPrCreated
+  // ---------------------------------------------------------------------------
+
+  it('markPrCreated sets pr_url, pr_number, and transitions stack to pr_created', () => {
+    tlm.updateStackStatus(stackId, 'completed');
+    tlm.markPrCreated(stackId, 'https://github.com/acme/repo/pull/7', 7);
+    const stack = registry.getStack(stackId);
+    expect(stack?.status).toBe('pr_created');
+    expect(stack?.pr_url).toBe('https://github.com/acme/repo/pull/7');
+    expect(stack?.pr_number).toBe(7);
+  });
+
+  it('markPrCreated throws if stack not found', () => {
+    expect(() => tlm.markPrCreated('nonexistent', 'url', 1)).toThrow(/not found/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // markInterrupted
+  // ---------------------------------------------------------------------------
+
+  it('markInterrupted transitions a running task to interrupted', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markInterrupted(task.id);
+    expect(registry.getMostRecentTask(stackId)?.status).toBe('interrupted');
+  });
+
+  it('markInterrupted is a no-op if task is not running', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markCompleted(task.id, 0);
+    // Should not throw; task stays completed
+    tlm.markInterrupted(task.id);
+    expect(registry.getMostRecentTask(stackId)?.status).toBe('completed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // markReopened
+  // ---------------------------------------------------------------------------
+
+  it('markReopened transitions a completed task back to running', () => {
+    const task = tlm.createTask(stackId, 'work');
+    tlm.markCompleted(task.id, 0);
+    tlm.markReopened(task.id);
+    expect(registry.getMostRecentTask(stackId)?.status).toBe('running');
+    expect(registry.getMostRecentTask(stackId)?.exit_code).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // markResumedAt
+  // ---------------------------------------------------------------------------
+
+  it('markResumedAt stamps resumed_at on the task', () => {
+    const task = tlm.createTask(stackId, 'work');
+    const ts = '2026-06-23T12:00:00.000Z';
+    tlm.markResumedAt(task.id, ts);
+    expect(registry.getMostRecentTask(stackId)?.resumed_at).toBe(ts);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `TaskLifecycleManager` (TLM) as the single owner of all task and stack lifecycle state writes. Previously, lifecycle mutations were scattered across the control plane as direct `Registry` calls, making the state machine hard to reason about and easy to violate.

The TLM wraps `Registry` and exposes semantic methods for each lifecycle transition (`createTask`, `updateStackStatus`, `markCompleted`, `markNeedsHuman`, `markNeedsKey`, `markVerifyBlockedEnvironmental`, `markPrCreated`, `markInterrupted`, `markReopened`, `markResumedAt`). All control-plane modules now go through it:

- `stack-manager.ts` constructs a TLM from its registry and routes every lifecycle write through it; `setPullRequest` now delegates to `tlm.markPrCreated`, which carries the ticket-advance logic.
- `task-watcher.ts` accepts an optional `lifecycleManager` and otherwise builds its own from the registry.
- `startup-reconciler.ts` creates a TLM at entry and threads it through its helpers so reconciliation writes go through the same path.

An architecture-boundary test scans `src/` and fails if any module other than `task-lifecycle-manager.ts` and `registry.ts` calls the raw registry lifecycle methods, locking in the boundary going forward.

## QA plan

1. Start a stack and dispatch a task; confirm it progresses through the normal lifecycle (created → running → completed) and the registry reflects each state.
2. Trigger a needs-human / needs-key path and confirm the task lands in the correct blocked state.
3. Let a task create a PR and confirm `setPullRequest` records the PR and advances the ticket as before.
4. Restart the app with an in-flight task and confirm startup reconciliation restores the correct state.

Closes #693