### PR TITLE
[692] fix: centralize IPC channel names in shared constants module

### DIFF
--- a/src/main/agent/claude-backend.ts
+++ b/src/main/agent/claude-backend.ts
@@ -13,6 +13,7 @@ import { app } from 'electron';
 import { handleToolCall } from '../claude/tools';
 import { acquireBridge, type BridgeHandle } from './bridge-server';
 import { cliDir } from '../index';
+import { AGENT_DONE, AGENT_ERROR, AGENT_OUTPUT, AGENT_QUEUED, AGENT_TOKEN_USAGE_EVENT, AGENT_USER_MESSAGE, EVENT_CHANNELS } from '../ipc-channels';
 import {
   AgentBackend,
   ChatMessage,
@@ -166,7 +167,7 @@ export class ClaudeBackend implements AgentBackend {
   /** Push the current session token totals to the renderer for the given tab. */
   private emitSessionTokens(tabId: string): void {
     const tokens = this.getSessionTokens(tabId);
-    this.mainWindow?.webContents.send(`agent:token-usage:${tabId}`, tokens);
+    this.mainWindow?.webContents.send(AGENT_TOKEN_USAGE_EVENT(tabId), tokens);
   }
 
   private initLogger(): void {
@@ -235,14 +236,14 @@ export class ClaudeBackend implements AgentBackend {
 
     session.messages.push({ role: 'user', content: message });
     session.processing = true;
-    this.mainWindow?.webContents.send(`agent:user-message:${tabId}`, message);
+    this.mainWindow?.webContents.send(AGENT_USER_MESSAGE(tabId), message);
     this.log(`Message received for tab=${tabId}`);
 
     // If process is alive and currently processing a response (or finishing a cancelled turn), queue the message
     if (session.process && (session.fullResponse !== '' || session.cancelledTurn)) {
       session.pendingMessages.push(message);
       this.log(`Message queued for tab=${tabId} (queue size: ${session.pendingMessages.length})`);
-      this.mainWindow?.webContents.send(`agent:queued:${tabId}`);
+      this.mainWindow?.webContents.send(AGENT_QUEUED(tabId));
       return;
     }
 
@@ -301,7 +302,7 @@ export class ClaudeBackend implements AgentBackend {
       session.cancelledTurn = true;
       session.processing = false;
       session.pendingMessages = [];
-      this.mainWindow?.webContents.send(`agent:done:${tabId}`);
+      this.mainWindow?.webContents.send(AGENT_DONE(tabId));
       this.log(`Turn cancelled for tab=${tabId} (process kept alive, pid=${session.process.pid})`);
 
       // Fallback: if the process produces no result within 30s, kill it
@@ -777,7 +778,7 @@ export class ClaudeBackend implements AgentBackend {
         if (urlMatch && !urlOpened) {
           urlOpened = true;
           shell.openExternal(urlMatch[1]);
-          win?.webContents.send('auth:url-opened', urlMatch[1]);
+          win?.webContents.send(EVENT_CHANNELS.AUTH_URL_OPENED, urlMatch[1]);
         }
       });
 
@@ -791,10 +792,10 @@ export class ClaudeBackend implements AgentBackend {
 
       child.on('close', async (code) => {
         if (code === 0) {
-          win?.webContents.send('auth:completed', true);
+          win?.webContents.send(EVENT_CHANNELS.AUTH_COMPLETED, true);
           resolve({ success: true });
         } else {
-          win?.webContents.send('auth:completed', false);
+          win?.webContents.send(EVENT_CHANNELS.AUTH_COMPLETED, false);
           resolve({ success: false, error: stderr.trim() || 'Auth login failed' });
         }
       });
@@ -1019,7 +1020,7 @@ export class ClaudeBackend implements AgentBackend {
 
     this.log(`Persistent Claude process spawned for tab=${tabId} pid=${child.pid}`);
 
-    const send = (channel: string, ...data: unknown[]): void => {
+    const send = (channel: `agent:${string}:${string}`, ...data: unknown[]): void => {
       this.mainWindow?.webContents.send(channel, ...data);
     };
 
@@ -1098,7 +1099,7 @@ export class ClaudeBackend implements AgentBackend {
             if (session.fullResponse) {
               session.messages.push({ role: 'assistant', content: session.fullResponse });
             }
-            send(`agent:done:${tabId}`);
+            send(AGENT_DONE(tabId));
 
             // Dequeue next pending message
             if (session.pendingMessages.length > 0) {
@@ -1140,7 +1141,7 @@ export class ClaudeBackend implements AgentBackend {
               session.fullResponse += extracted;
             } else {
               session.fullResponse += extracted;
-              send(`agent:output:${tabId}`, extracted);
+              send(AGENT_OUTPUT(tabId), extracted);
             }
             // Reset watchdog on any streaming output — only fire during TRUE silence
             this.resetWatchdog(tabId);
@@ -1171,7 +1172,7 @@ export class ClaudeBackend implements AgentBackend {
         // Process died while we were expecting a response
         const errorMsg = session.stderrBuffer.trim()
           || `Claude process exited unexpectedly (code ${code})`;
-        send(`agent:error:${tabId}`, errorMsg);
+        send(AGENT_ERROR(tabId), errorMsg);
         session.processing = false;
         session.pendingMessages = [];
       }
@@ -1192,7 +1193,7 @@ export class ClaudeBackend implements AgentBackend {
       session.cancelledTurn = false;
       session.pendingMessages = [];
       this.log(`Spawn error for tab=${tabId}: ${err.message}`);
-      send(`agent:error:${tabId}`, err.message);
+      send(AGENT_ERROR(tabId), err.message);
     });
   }
 

--- a/src/main/agent/opencode-backend.ts
+++ b/src/main/agent/opencode-backend.ts
@@ -36,6 +36,7 @@ import type {
   Config as OpenCodeConfig,
 } from '@opencode-ai/sdk';
 import { handleToolCall } from '../claude/tools';
+import { AGENT_DONE, AGENT_ERROR, AGENT_OUTPUT, AGENT_QUEUED, AGENT_TOKEN_USAGE_EVENT, AGENT_USER_MESSAGE } from '../ipc-channels';
 import { acquireBridge, type BridgeHandle } from './bridge-server';
 import { generateOuterOpencodeConfig } from '../opencode-config';
 import { buildProviderEntry } from '../../shared/opencode-providers';
@@ -338,12 +339,12 @@ export class OpenCodeBackend implements AgentBackend {
 
     if (part.type === 'text' && delta) {
       tabSession.fullResponse += delta;
-      this.mainWindow?.webContents.send(`agent:output:${tabId}`, delta);
+      this.mainWindow?.webContents.send(AGENT_OUTPUT(tabId), delta);
     } else if (part.type === 'tool') {
       const toolPart = part as ToolPart;
       const summary = `\n[tool: ${toolPart.tool}]\n`;
       tabSession.fullResponse += summary;
-      this.mainWindow?.webContents.send(`agent:output:${tabId}`, summary);
+      this.mainWindow?.webContents.send(AGENT_OUTPUT(tabId), summary);
     } else if (part.type === 'step-finish') {
       this.accumulateTokens(tabId, part as StepFinishPart);
     }
@@ -362,7 +363,7 @@ export class OpenCodeBackend implements AgentBackend {
     }
     tabSession.fullResponse = '';
     tabSession.processing = false;
-    this.mainWindow?.webContents.send(`agent:done:${tabId}`);
+    this.mainWindow?.webContents.send(AGENT_DONE(tabId));
   }
 
   private handleSessionError(event: EventSessionError): void {
@@ -376,7 +377,7 @@ export class OpenCodeBackend implements AgentBackend {
     if (tabSession) tabSession.processing = false;
 
     const errorMsg = this.formatSessionError(event);
-    this.mainWindow?.webContents.send(`agent:error:${tabId}`, errorMsg);
+    this.mainWindow?.webContents.send(AGENT_ERROR(tabId), errorMsg);
   }
 
   private formatSessionError(event: EventSessionError): string {
@@ -398,7 +399,7 @@ export class OpenCodeBackend implements AgentBackend {
       cache_read_input_tokens: prev.cache_read_input_tokens + tokens.cache.read,
     };
     this.sessionTokens.set(tabId, next);
-    this.mainWindow?.webContents.send(`agent:token-usage:${tabId}`, next);
+    this.mainWindow?.webContents.send(AGENT_TOKEN_USAGE_EVENT(tabId), next);
   }
 
   // --- Session management ---
@@ -422,15 +423,15 @@ export class OpenCodeBackend implements AgentBackend {
     tabSession.messages.push({ role: 'user', content: message });
 
     if (tabSession.processing) {
-      this.mainWindow?.webContents.send(`agent:queued:${tabId}`);
+      this.mainWindow?.webContents.send(AGENT_QUEUED(tabId));
     }
 
     tabSession.processing = true;
-    this.mainWindow?.webContents.send(`agent:user-message:${tabId}`, message);
+    this.mainWindow?.webContents.send(AGENT_USER_MESSAGE(tabId), message);
 
     if (!this.client) {
       tabSession.processing = false;
-      this.mainWindow?.webContents.send(`agent:error:${tabId}`, 'Backend not initialized');
+      this.mainWindow?.webContents.send(AGENT_ERROR(tabId), 'Backend not initialized');
       return;
     }
     void this.sendMessageAsync(tabSession, message);
@@ -480,7 +481,7 @@ export class OpenCodeBackend implements AgentBackend {
     } catch (err) {
       tabSession.processing = false;
       const msg = err instanceof Error ? err.message : String(err);
-      this.mainWindow?.webContents.send(`agent:error:${tabId}`, msg);
+      this.mainWindow?.webContents.send(AGENT_ERROR(tabId), msg);
     }
   }
 
@@ -495,7 +496,7 @@ export class OpenCodeBackend implements AgentBackend {
     if (!tabSession || !this.client) return;
     if (tabSession.openCodeSessionId && tabSession.processing) {
       tabSession.processing = false;
-      this.mainWindow?.webContents.send(`agent:done:${tabId}`);
+      this.mainWindow?.webContents.send(AGENT_DONE(tabId));
       void this.client.session
         .abort({ path: { id: tabSession.openCodeSessionId } })
         .catch(() => {});
@@ -511,7 +512,7 @@ export class OpenCodeBackend implements AgentBackend {
     this.tabSessions.delete(tabId);
     this.sessionTokens.delete(tabId);
     // Push zero tokens so the UI counter resets immediately
-    this.mainWindow?.webContents.send(`agent:token-usage:${tabId}`, zeroSessionTokens());
+    this.mainWindow?.webContents.send(AGENT_TOKEN_USAGE_EVENT(tabId), zeroSessionTokens());
   }
 
   getSessionTokens(tabId: string): OuterClaudeSessionTokens {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import { PortAllocator } from './control-plane/port-allocator';
 import { PortProxy } from './control-plane/port-proxy';
 import { TaskWatcher } from './control-plane/task-watcher';
 import { StackManager } from './control-plane/stack-manager';
+import { EVENT_CHANNELS } from './ipc-channels';
 import { DockerRuntime } from './runtime/docker';
 import { PodmanRuntime } from './runtime/podman';
 import { ContainerRuntime } from './runtime/types';
@@ -190,30 +191,30 @@ async function initializeApp(): Promise<void> {
 
   // Wire session monitor events
   sessionMonitor.on('threshold:warning', (usage) => {
-    mainWindow?.webContents.send('session:threshold', { level: 'warning', usage });
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_THRESHOLD, { level: 'warning', usage });
   });
   sessionMonitor.on('threshold:critical', (usage) => {
-    mainWindow?.webContents.send('session:threshold', { level: 'critical', usage });
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_THRESHOLD, { level: 'critical', usage });
   });
   sessionMonitor.on('threshold:limit', (usage) => {
-    mainWindow?.webContents.send('session:threshold', { level: 'limit', usage });
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_THRESHOLD, { level: 'limit', usage });
   });
   sessionMonitor.on('threshold:cleared', () => {
-    mainWindow?.webContents.send('session:threshold', { level: 'normal', usage: null });
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_THRESHOLD, { level: 'normal', usage: null });
   });
   sessionMonitor.on('halt:triggered', () => {
     const paused = stackManager.sessionPauseAllStacks();
-    mainWindow?.webContents.send('session:halted', { pausedStacks: paused });
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_HALTED, { pausedStacks: paused });
   });
-  sessionMonitor.on('session:reset', () => {
+  sessionMonitor.on(EVENT_CHANNELS.SESSION_RESET, () => {
     const currentSettings = registry.getSessionMonitorSettings();
     if (currentSettings.autoResumeAfterReset) {
       stackManager.sessionResumeAllStacks();
     }
-    mainWindow?.webContents.send('session:reset');
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_RESET);
   });
   sessionMonitor.on('state:changed', (state) => {
-    mainWindow?.webContents.send('session:state', state);
+    mainWindow?.webContents.send(EVENT_CHANNELS.SESSION_STATE, state);
   });
 
   sessionMonitor.start();
@@ -280,7 +281,7 @@ async function initializeApp(): Promise<void> {
       // Notify the renderer so the UI can show an "action running" badge
       // on the schedule in the panel. No chat turn — this is just a UI
       // hint, keyed by scheduleId, not a message in the agent session.
-      mainWindow?.webContents.send('schedule:dispatched', {
+      mainWindow?.webContents.send(EVENT_CHANNELS.SCHEDULE_DISPATCHED, {
         projectDir: request.projectDir,
         scheduleId: request.scheduleId,
         scheduleLabel: schedule.label || schedule.id,
@@ -363,37 +364,37 @@ async function initializeApp(): Promise<void> {
     registry,
     stackManager,
     agentBackend,
-    () => mainWindow?.webContents.send('stacks:updated'),
+    () => mainWindow?.webContents.send(EVENT_CHANNELS.STACKS_UPDATED),
   );
   darkFactoryOrchestrator.startPeriodicWatcher();
 
   // Listen for task events to send to renderer
-  taskWatcher.on('task:completed', ({ stackId, task }) => {
-    mainWindow?.webContents.send('task:completed', { stackId, task });
-    mainWindow?.webContents.send('stacks:updated');
+  taskWatcher.on(EVENT_CHANNELS.TASK_COMPLETED, ({ stackId, task }) => {
+    mainWindow?.webContents.send(EVENT_CHANNELS.TASK_COMPLETED, { stackId, task });
+    mainWindow?.webContents.send(EVENT_CHANNELS.STACKS_UPDATED);
     darkFactoryOrchestrator.handleTaskCompleted(stackId, task);
   });
 
-  taskWatcher.on('task:failed', ({ stackId, task }) => {
-    mainWindow?.webContents.send('task:failed', { stackId, task });
-    mainWindow?.webContents.send('stacks:updated');
+  taskWatcher.on(EVENT_CHANNELS.TASK_FAILED, ({ stackId, task }) => {
+    mainWindow?.webContents.send(EVENT_CHANNELS.TASK_FAILED, { stackId, task });
+    mainWindow?.webContents.send(EVENT_CHANNELS.STACKS_UPDATED);
   });
 
-  taskWatcher.on('task:output', ({ stackId, data }) => {
-    mainWindow?.webContents.send('task:output', { stackId, data });
+  taskWatcher.on(EVENT_CHANNELS.TASK_OUTPUT, ({ stackId, data }) => {
+    mainWindow?.webContents.send(EVENT_CHANNELS.TASK_OUTPUT, { stackId, data });
   });
 
-  taskWatcher.on('task:workflow-progress', (progress) => {
-    mainWindow?.webContents.send('task:workflow-progress', progress);
+  taskWatcher.on(EVENT_CHANNELS.TASK_WORKFLOW_PROGRESS, (progress) => {
+    mainWindow?.webContents.send(EVENT_CHANNELS.TASK_WORKFLOW_PROGRESS, progress);
   });
 
   // Forward Docker connection status to renderer
   if (dockerConnectionManager) {
     dockerConnectionManager.on('connected', () => {
-      mainWindow?.webContents.send('docker:connected');
+      mainWindow?.webContents.send(EVENT_CHANNELS.DOCKER_CONNECTED);
     });
     dockerConnectionManager.on('disconnected', () => {
-      mainWindow?.webContents.send('docker:disconnected');
+      mainWindow?.webContents.send(EVENT_CHANNELS.DOCKER_DISCONNECTED);
     });
   }
 }
@@ -410,7 +411,7 @@ app.whenReady().then(async () => {
   try {
     const cronRunning = isCronRunning();
     mainWindow.webContents.once('did-finish-load', () => {
-      mainWindow?.webContents.send('scheduler:cronHealth', { running: cronRunning });
+      mainWindow?.webContents.send(EVENT_CHANNELS.SCHEDULER_CRON_HEALTH, { running: cronRunning });
     });
   } catch {
     // Non-fatal — renderer will check lazily when panel mounts
@@ -419,7 +420,7 @@ app.whenReady().then(async () => {
   // Background startup reconciliation — runs after the window is shown so it
   // never delays window readiness. Drives stale 'running' stacks to terminal
   // states or re-attaches watchers. Fire-and-forget; cards update live via
-  // per-stack 'stacks:updated' emissions.
+  // per-stack EVENT_CHANNELS.STACKS_UPDATED emissions.
   mainWindow.webContents.once('did-finish-load', () => {
     runStartupReconciliation(
       registry,
@@ -427,7 +428,7 @@ app.whenReady().then(async () => {
       taskWatcher,
       dockerRuntime,
       podmanRuntime,
-      () => mainWindow?.webContents.send('stacks:updated')
+      () => mainWindow?.webContents.send(EVENT_CHANNELS.STACKS_UPDATED)
     ).catch((err) => {
       console.warn('[StartupReconciler] Background reconciliation error:', err);
     });

--- a/src/main/ipc-channels.ts
+++ b/src/main/ipc-channels.ts
@@ -1,0 +1,261 @@
+// Single source of truth for all IPC channel names.
+// Import INVOKE_CHANNELS for ipcMain.handle / ipcRenderer.invoke channels,
+// EVENT_CHANNELS for static push events (webContents.send / sandstorm.on),
+// and the AGENT_* builders for per-tab dynamic agent event channels.
+
+export const INVOKE_CHANNELS = {
+  // --- Agent (request/response) ---
+  AGENT_SEND: 'agent:send',
+  AGENT_CANCEL: 'agent:cancel',
+  AGENT_RESET: 'agent:reset',
+  AGENT_HISTORY: 'agent:history',
+  AGENT_TOKEN_USAGE: 'agent:tokenUsage',
+  SESSION_ACTIVITY: 'session:activity',
+
+  // --- Projects ---
+  PROJECTS_LIST: 'projects:list',
+  PROJECTS_ADD: 'projects:add',
+  PROJECTS_REMOVE: 'projects:remove',
+  PROJECTS_BROWSE: 'projects:browse',
+  PROJECTS_CHECK_INIT: 'projects:checkInit',
+  PROJECTS_INITIALIZE: 'projects:initialize',
+  PROJECTS_CHECK_MIGRATION: 'projects:checkMigration',
+  PROJECTS_AUTO_DETECT_VERIFY: 'projects:autoDetectVerify',
+  PROJECTS_SAVE_MIGRATION: 'projects:saveMigration',
+  PROJECTS_GENERATE_COMPOSE: 'projects:generateCompose',
+  PROJECTS_SAVE_COMPOSE_SETUP: 'projects:saveComposeSetup',
+  PROJECT_TICKET_CONFIG_GET: 'projectTicketConfig:get',
+  PROJECT_TICKET_CONFIG_SET: 'projectTicketConfig:set',
+
+  // --- Stacks ---
+  STACKS_LIST: 'stacks:list',
+  STACKS_GET: 'stacks:get',
+  STACKS_CREATE: 'stacks:create',
+  STACKS_TEARDOWN: 'stacks:teardown',
+  STACKS_STOP: 'stacks:stop',
+  STACKS_START: 'stacks:start',
+  STACKS_HISTORY: 'stacks:history',
+  STACKS_SET_PR: 'stacks:setPr',
+  STACKS_DETECT_STALE: 'stacks:detectStale',
+  STACKS_CLEANUP_STALE: 'stacks:cleanupStale',
+  STACKS_GET_NEEDS_HUMAN_QUESTIONS: 'stacks:getNeedsHumanQuestions',
+  STACKS_RESUME_NEEDS_HUMAN: 'stacks:resumeNeedsHuman',
+  STACKS_ASK_CLARIFYING_QUESTIONS: 'stacks:askClarifyingQuestions',
+  STACKS_SELF_HEAL_CONTINUE: 'stacks:selfHealContinue',
+  STACKS_RESTART_WITH_FINDINGS: 'stacks:restartWithFindings',
+  STACKS_RECHECK_COMPLETED: 'stacks:recheckCompleted',
+  STACKS_RECONCILE_STATUS: 'stacks:reconcileStatus',
+
+  // --- Tasks ---
+  TASKS_DISPATCH: 'tasks:dispatch',
+  TASKS_LIST: 'tasks:list',
+  TASKS_TOKEN_STEPS: 'tasks:tokenSteps',
+  TASKS_WORKFLOW_PROGRESS: 'tasks:workflowProgress',
+
+  // --- Diff ---
+  DIFF_GET: 'diff:get',
+
+  // --- Push ---
+  PUSH_EXECUTE: 'push:execute',
+
+  // --- Ports ---
+  PORTS_GET: 'ports:get',
+  STACK_EXPOSE_PORT: 'stack:expose-port',
+  STACK_UNEXPOSE_PORT: 'stack:unexpose-port',
+  PORTS_CLEANUP_LEGACY: 'ports:cleanupLegacy',
+
+  // --- Logs ---
+  LOGS_STREAM: 'logs:stream',
+
+  // --- Stats ---
+  STATS_STACK_MEMORY: 'stats:stack-memory',
+  STATS_STACK_DETAILED: 'stats:stack-detailed',
+  STATS_TASK_METRICS: 'stats:task-metrics',
+  STATS_TOKEN_USAGE: 'stats:token-usage',
+  STATS_GLOBAL_TOKEN_USAGE: 'stats:global-token-usage',
+  STATS_RATE_LIMIT: 'stats:rate-limit',
+  STATS_ACCOUNT_USAGE: 'stats:account-usage',
+  STATS_TELEMETRY_SUMMARY: 'stats:telemetry:summary',
+  STATS_TELEMETRY_DAILY: 'stats:telemetry:daily',
+  STATS_TELEMETRY_BY_MODEL: 'stats:telemetry:byModel',
+  STATS_TELEMETRY_SESSION: 'stats:telemetry:session',
+  STATS_TELEMETRY_BY_TICKET: 'stats:telemetry:byTicket',
+  STATS_TELEMETRY_BY_EPIC: 'stats:telemetry:byEpic',
+  STATS_TELEMETRY_REFRESH: 'stats:telemetry:refresh',
+
+  // --- Context ---
+  CONTEXT_GET: 'context:get',
+  CONTEXT_SAVE_INSTRUCTIONS: 'context:saveInstructions',
+  CONTEXT_LIST_SKILLS: 'context:listSkills',
+  CONTEXT_GET_SKILL: 'context:getSkill',
+  CONTEXT_SAVE_SKILL: 'context:saveSkill',
+  CONTEXT_DELETE_SKILL: 'context:deleteSkill',
+  CONTEXT_GET_SETTINGS: 'context:getSettings',
+  CONTEXT_SAVE_SETTINGS: 'context:saveSettings',
+
+  // --- Review Prompt ---
+  REVIEW_PROMPT_GET_DEFAULT: 'reviewPrompt:getDefault',
+
+  // --- Runtime ---
+  RUNTIME_AVAILABLE: 'runtime:available',
+
+  // --- Model Settings ---
+  MODEL_SETTINGS_GET_GLOBAL: 'modelSettings:getGlobal',
+  MODEL_SETTINGS_SET_GLOBAL: 'modelSettings:setGlobal',
+  MODEL_SETTINGS_GET_PROJECT: 'modelSettings:getProject',
+  MODEL_SETTINGS_SET_PROJECT: 'modelSettings:setProject',
+  MODEL_SETTINGS_REMOVE_PROJECT: 'modelSettings:removeProject',
+  MODEL_SETTINGS_GET_EFFECTIVE: 'modelSettings:getEffective',
+
+  // --- Backend Settings ---
+  BACKEND_SETTINGS_GET_GLOBAL: 'backendSettings:getGlobal',
+  BACKEND_SETTINGS_SET_GLOBAL: 'backendSettings:setGlobal',
+  BACKEND_SETTINGS_GET_PROJECT: 'backendSettings:getProject',
+  BACKEND_SETTINGS_SET_PROJECT: 'backendSettings:setProject',
+  BACKEND_SETTINGS_GET_EFFECTIVE: 'backendSettings:getEffective',
+  BACKEND_SETTINGS_SET_SECRET: 'backendSettings:setSecret',
+  BACKEND_SETTINGS_SECRET_STATUS: 'backendSettings:secretStatus',
+  BACKEND_SETTINGS_SET_SECRET_BUNDLE: 'backendSettings:setSecretBundle',
+  BACKEND_SETTINGS_GET_SECRET_BUNDLE: 'backendSettings:getSecretBundle',
+
+  // --- Model Routing ---
+  MODEL_ROUTING_GET_EFFECTIVE: 'modelRouting:getEffective',
+  MODEL_ROUTING_GET_PROJECT: 'modelRouting:getProject',
+  MODEL_ROUTING_SET_PROJECT: 'modelRouting:setProject',
+  MODEL_ROUTING_REMOVE_PROJECT: 'modelRouting:removeProject',
+  MODEL_ROUTING_GET_GLOBAL: 'modelRouting:getGlobal',
+  MODEL_ROUTING_SET_GLOBAL: 'modelRouting:setGlobal',
+  MODEL_ROUTING_APPLY_PRESET: 'modelRouting:applyPreset',
+  MODEL_ROUTING_GET_AVAILABLE_MODELS: 'modelRouting:getAvailableModels',
+  MODEL_ROUTING_GET_AVAILABLE_MODELS_WITH_CATALOG: 'modelRouting:getAvailableModelsWithCatalog',
+
+  // --- Provider Secrets ---
+  PROVIDER_SECRETS_STATUS: 'providerSecrets:status',
+  PROVIDER_SECRETS_GET: 'providerSecrets:get',
+  PROVIDER_SECRETS_GET_BUNDLE: 'providerSecrets:getBundle',
+  PROVIDER_SECRETS_SET: 'providerSecrets:set',
+  PROVIDER_SECRETS_SET_BUNDLE: 'providerSecrets:setBundle',
+  PROVIDER_SECRETS_REMOVE: 'providerSecrets:remove',
+
+  // --- Providers ---
+  PROVIDERS_CATALOG: 'providers:catalog',
+  PROVIDERS_CONFIGURED: 'providers:configured',
+
+  // --- Session ---
+  SESSION_GET_STATE: 'session:getState',
+  SESSION_GET_SETTINGS: 'session:getSettings',
+  SESSION_UPDATE_SETTINGS: 'session:updateSettings',
+  SESSION_ACKNOWLEDGE_CRITICAL: 'session:acknowledgeCritical',
+  SESSION_HALT_ALL: 'session:haltAll',
+  SESSION_RESUME_ALL: 'session:resumeAll',
+  SESSION_RESUME_STACK: 'session:resumeStack',
+  SESSION_RESUME_STACK_WITH_CONTINUATION: 'session:resumeStackWithContinuation',
+  SESSION_FORCE_POLL: 'session:forcePoll',
+
+  // --- Docker ---
+  DOCKER_STATUS: 'docker:status',
+
+  // --- Auth ---
+  AUTH_STATUS: 'auth:status',
+  AUTH_LOGIN: 'auth:login',
+
+  // --- Schedules ---
+  SCHEDULES_LIST: 'schedules:list',
+  SCHEDULES_CREATE: 'schedules:create',
+  SCHEDULES_UPDATE: 'schedules:update',
+  SCHEDULES_DELETE: 'schedules:delete',
+  SCHEDULES_CRON_HEALTH: 'schedules:cronHealth',
+  SCHEDULER_LIST_BUILT_IN_ACTIONS: 'scheduler:listBuiltInActions',
+  SCHEDULES_LIST_SCRIPTS: 'schedules:listScripts',
+
+  // --- Tickets ---
+  TICKETS_FETCH: 'tickets:fetch',
+  TICKETS_SPEC_CHECK: 'tickets:specCheck',
+  TICKETS_SPEC_REFINE: 'tickets:specRefine',
+  TICKETS_SPEC_CHECK_ASYNC: 'tickets:specCheckAsync',
+  TICKETS_SPEC_REFINE_ASYNC: 'tickets:specRefineAsync',
+  TICKETS_RETRY_REFINEMENT_ASYNC: 'tickets:retryRefinementAsync',
+  TICKETS_POST_ANSWERS: 'tickets:postAnswers',
+  TICKETS_CANCEL_REFINEMENT: 'tickets:cancelRefinement',
+  TICKETS_LIST_REFINEMENTS: 'tickets:listRefinements',
+  TICKETS_CREATE: 'tickets:create',
+  TICKETS_FETCH_RAW: 'tickets:fetchRaw',
+  TICKETS_UPDATE: 'tickets:update',
+  TICKETS_LIST: 'tickets:list',
+  TICKETS_TEST_JIRA_CONNECTION: 'tickets:testJiraConnection',
+  TICKET_BOARD_SET_COLUMN: 'ticket-board:set-column',
+  TICKET_CLOSE: 'ticket:close',
+  TICKET_MARK_DONE: 'ticket:mark-done',
+  TICKET_BOARD_DELETE: 'ticket-board:delete',
+
+  // --- Pull Requests ---
+  PR_DRAFT_BODY: 'pr:draftBody',
+  PR_CREATE: 'pr:create',
+  PR_MERGE: 'pr:merge',
+  PR_CREATE_AUTO: 'pr:createAuto',
+  PR_AUTO_RESOLVE: 'pr:autoResolve',
+
+  // --- Dark Factory ---
+  DARK_FACTORY_GET_ENABLED: 'darkFactory:getEnabled',
+  DARK_FACTORY_SET_ENABLED: 'darkFactory:setEnabled',
+  DARK_FACTORY_GET_CONFIG: 'darkFactory:getConfig',
+  DARK_FACTORY_SET_CONFIG: 'darkFactory:setConfig',
+
+  // --- Epic ---
+  EPIC_START: 'epic:start',
+  EPIC_GET_RUN_PLAN: 'epic:getRunPlan',
+} as const;
+
+// Static push-event channels (webContents.send → window.sandstorm.on)
+export const EVENT_CHANNELS = {
+  EPIC_STATUS: 'epic:status',
+  STACKS_UPDATED: 'stacks:updated',
+  REFINEMENT_UPDATE: 'refinement:update',
+  REFINEMENT_PROGRESS: 'refinement:progress',
+  SESSION_THRESHOLD: 'session:threshold',
+  SESSION_HALTED: 'session:halted',
+  SESSION_RESET: 'session:reset',
+  SESSION_STATE: 'session:state',
+  SCHEDULE_DISPATCHED: 'schedule:dispatched',
+  TASK_COMPLETED: 'task:completed',
+  TASK_FAILED: 'task:failed',
+  TASK_OUTPUT: 'task:output',
+  TASK_WORKFLOW_PROGRESS: 'task:workflow-progress',
+  DOCKER_CONNECTED: 'docker:connected',
+  DOCKER_DISCONNECTED: 'docker:disconnected',
+  SCHEDULER_CRON_HEALTH: 'scheduler:cronHealth',
+  NAVIGATE_STACK: 'navigate:stack',
+  AUTH_URL_OPENED: 'auth:url-opened',
+  AUTH_COMPLETED: 'auth:completed',
+} as const;
+
+// Typed builders for per-tab dynamic agent event channels.
+// Each builder returns a template-literal type so callers are compile-checked.
+export const AGENT_OUTPUT = (tabId: string): `agent:output:${string}` =>
+  `agent:output:${tabId}`;
+
+export const AGENT_DONE = (tabId: string): `agent:done:${string}` =>
+  `agent:done:${tabId}`;
+
+export const AGENT_ERROR = (tabId: string): `agent:error:${string}` =>
+  `agent:error:${tabId}`;
+
+export const AGENT_QUEUED = (tabId: string): `agent:queued:${string}` =>
+  `agent:queued:${tabId}`;
+
+export const AGENT_TOKEN_USAGE_EVENT = (tabId: string): `agent:token-usage:${string}` =>
+  `agent:token-usage:${tabId}`;
+
+export const AGENT_USER_MESSAGE = (tabId: string): `agent:user-message:${string}` =>
+  `agent:user-message:${tabId}`;
+
+type StaticEventChannel = typeof EVENT_CHANNELS[keyof typeof EVENT_CHANNELS];
+type AgentEventChannel =
+  | `agent:output:${string}`
+  | `agent:done:${string}`
+  | `agent:error:${string}`
+  | `agent:queued:${string}`
+  | `agent:token-usage:${string}`
+  | `agent:user-message:${string}`;
+
+export type EventChannel = StaticEventChannel | AgentEventChannel;

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -95,6 +95,7 @@ import { listTicketsWithConfig } from './control-plane/ticket-lister';
 import { listTicketComments, postComment } from './control-plane/ticket-comments';
 import { getLatestUserAnswers, ANSWER_COMMENT_MARKER, GATE_FAIL_REPORT_MARKER } from './scheduler/refine-to-comments';
 import { KANBAN_COLUMNS } from '../shared/kanban';
+import { INVOKE_CHANNELS, EVENT_CHANNELS } from './ipc-channels';
 import os from 'os';
 import { createUsageEngine, clearUsageCache } from './telemetry/usage-engine';
 import type { DateRange, ByTicketEntry, ByEpicEntry } from './telemetry/usage-engine';
@@ -235,12 +236,12 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   epicRunner.setOnStatusUpdate((_epicId, snapshot) => {
-    mainWindow?.webContents.send('epic:status', snapshot);
+    mainWindow?.webContents.send(EVENT_CHANNELS.EPIC_STATUS, snapshot);
   });
 
   // Wire up stack update notifications to the renderer and advance any running epics
   stackManager.setOnStackUpdate(() => {
-    mainWindow?.webContents.send('stacks:updated');
+    mainWindow?.webContents.send(EVENT_CHANNELS.STACKS_UPDATED);
     getEpicRunner().onAnyStackUpdated().catch((err) => {
       console.warn('[EpicRunner] onAnyStackUpdated error:', err);
     });
@@ -249,38 +250,38 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   // --- Agent Sessions (backend-agnostic) ---
 
   ipcMain.handle(
-    'agent:send',
+    INVOKE_CHANNELS.AGENT_SEND,
     (_event, tabId: string, message: string, projectDir?: string) => {
       agentBackend.sendMessage(tabId, message, projectDir);
     }
   );
 
-  ipcMain.handle('agent:cancel', (_event, tabId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.AGENT_CANCEL, (_event, tabId: string) => {
     agentBackend.cancelSession(tabId);
   });
 
-  ipcMain.handle('agent:reset', (_event, tabId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.AGENT_RESET, (_event, tabId: string) => {
     agentBackend.resetSession(tabId);
   });
 
-  ipcMain.handle('agent:history', (_event, tabId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.AGENT_HISTORY, (_event, tabId: string) => {
     return agentBackend.getHistory(tabId);
   });
 
-  ipcMain.handle('agent:tokenUsage', (_event, tabId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.AGENT_TOKEN_USAGE, (_event, tabId: string) => {
     return agentBackend.getSessionTokens(tabId);
   });
   // --- Projects ---
 
-  ipcMain.handle('projects:list', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_LIST, async () => {
     return registry.listProjects();
   });
 
-  ipcMain.handle('projects:add', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_ADD, async (_event, directory: string) => {
     return registry.addProject(directory);
   });
 
-  ipcMain.handle('projects:remove', async (_event, id: number) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_REMOVE, async (_event, id: number) => {
     // Look up project directory before removal so we can clean up crontab entries
     const project = registry.getProject(id);
     registry.removeProject(id);
@@ -293,7 +294,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle('projects:browse', async (event) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_BROWSE, async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     const result = await dialog.showOpenDialog(win!, {
       properties: ['openDirectory'],
@@ -304,7 +305,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return result.filePaths[0];
   });
 
-  ipcMain.handle('projects:checkInit', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_CHECK_INIT, async (_event, directory: string) => {
     try {
       const state = checkInitState(directory);
 
@@ -320,7 +321,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle('projects:initialize', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_INITIALIZE, async (_event, directory: string) => {
     // Try CLI init first (full scaffolding with compose parsing)
     const cliBin = path.join(cliDir, 'bin', 'sandstorm');
     let cliError = '';
@@ -468,7 +469,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Migration Detection ---
 
-  ipcMain.handle('projects:checkMigration', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_CHECK_MIGRATION, async (_event, directory: string) => {
     try {
       const sandstormDir = path.join(directory, '.sandstorm');
       if (!fs.existsSync(path.join(sandstormDir, 'config'))) {
@@ -529,15 +530,15 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Project Ticket Config ---
 
-  ipcMain.handle('projectTicketConfig:get', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECT_TICKET_CONFIG_GET, (_event, projectDir: string) => {
     return registry.getProjectTicketConfig(projectDir);
   });
 
-  ipcMain.handle('projectTicketConfig:set', (_event, projectDir: string, config: ProjectTicketConfig) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECT_TICKET_CONFIG_SET, (_event, projectDir: string, config: ProjectTicketConfig) => {
     registry.setProjectTicketConfig(projectDir, config);
   });
 
-  ipcMain.handle('projects:autoDetectVerify', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_AUTO_DETECT_VERIFY, async (_event, directory: string) => {
     try {
       const lines = autoDetectVerifyLines(directory);
 
@@ -567,7 +568,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle(
-    'projects:saveMigration',
+    INVOKE_CHANNELS.PROJECTS_SAVE_MIGRATION,
     async (
       _event,
       directory: string,
@@ -617,7 +618,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Compose Setup ---
 
-  ipcMain.handle('projects:generateCompose', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROJECTS_GENERATE_COMPOSE, async (_event, directory: string) => {
     try {
       const configComposeFile = readComposeFileFromConfig(directory);
       const composeFile = findProjectComposeFile(directory, configComposeFile);
@@ -655,7 +656,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle(
-    'projects:saveComposeSetup',
+    INVOKE_CHANNELS.PROJECTS_SAVE_COMPOSE_SETUP,
     async (_event, directory: string, composeYaml: string, composeFile: string) => {
       const validation = validateComposeYaml(composeYaml);
       if (!validation.valid) {
@@ -667,38 +668,38 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Stacks ---
 
-  ipcMain.handle('stacks:list', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_LIST, async () => {
     return stackManager.listStacksWithServices();
   });
 
-  ipcMain.handle('stacks:get', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_GET, async (_event, stackId: string) => {
     return stackManager.getStackWithServices(stackId);
   });
 
-  ipcMain.handle('stacks:create', (_event, opts: CreateStackOpts) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_CREATE, (_event, opts: CreateStackOpts) => {
     return stackManager.createStack(opts);
   });
 
-  ipcMain.handle('stacks:teardown', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_TEARDOWN, async (_event, stackId: string) => {
     await stackManager.teardownStack(stackId);
   });
 
-  ipcMain.handle('stacks:stop', (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_STOP, (_event, stackId: string) => {
     stackManager.stopStack(stackId);
   });
 
-  ipcMain.handle('stacks:start', (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_START, (_event, stackId: string) => {
     stackManager.startStack(stackId);
   });
 
-  ipcMain.handle('stacks:history', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_HISTORY, async () => {
     return stackManager.listStackHistory();
   });
 
   // --- Tasks ---
 
   ipcMain.handle(
-    'tasks:dispatch',
+    INVOKE_CHANNELS.TASKS_DISPATCH,
     async (
       _event,
       stackId: string,
@@ -710,35 +711,35 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   );
 
-  ipcMain.handle('tasks:list', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TASKS_LIST, async (_event, stackId: string) => {
     return stackManager.getTasksForStack(stackId);
   });
 
-  ipcMain.handle('tasks:tokenSteps', async (_event, taskId: number) => {
+  ipcMain.handle(INVOKE_CHANNELS.TASKS_TOKEN_STEPS, async (_event, taskId: number) => {
     return registry.getTaskTokenSteps(taskId);
   });
 
-  ipcMain.handle('tasks:workflowProgress', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TASKS_WORKFLOW_PROGRESS, async (_event, stackId: string) => {
     return stackManager.getWorkflowProgress(stackId);
   });
 
   // --- Diff ---
 
-  ipcMain.handle('diff:get', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.DIFF_GET, async (_event, stackId: string) => {
     return stackManager.getDiff(stackId);
   });
 
   // --- Push ---
 
   ipcMain.handle(
-    'push:execute',
+    INVOKE_CHANNELS.PUSH_EXECUTE,
     async (_event, stackId: string, message?: string) => {
       await stackManager.push(stackId, message);
     }
   );
 
   ipcMain.handle(
-    'stacks:setPr',
+    INVOKE_CHANNELS.STACKS_SET_PR,
     (_event, stackId: string, prUrl: string, prNumber: number) => {
       stackManager.setPullRequest(stackId, prUrl, prNumber);
     }
@@ -746,32 +747,32 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Ports ---
 
-  ipcMain.handle('ports:get', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PORTS_GET, async (_event, stackId: string) => {
     return registry.getPorts(stackId);
   });
 
   ipcMain.handle(
-    'stack:expose-port',
+    INVOKE_CHANNELS.STACK_EXPOSE_PORT,
     async (_event, stackId: string, service: string, containerPort: number) => {
       return stackManager.exposePort(stackId, service, containerPort);
     }
   );
 
   ipcMain.handle(
-    'stack:unexpose-port',
+    INVOKE_CHANNELS.STACK_UNEXPOSE_PORT,
     async (_event, stackId: string, service: string, containerPort: number) => {
       await stackManager.unexposePort(stackId, service, containerPort);
     }
   );
 
-  ipcMain.handle('ports:cleanupLegacy', async (_event, directory: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PORTS_CLEANUP_LEGACY, async (_event, directory: string) => {
     return cleanupLegacyPorts(directory);
   });
 
   // --- Logs ---
 
   ipcMain.handle(
-    'logs:stream',
+    INVOKE_CHANNELS.LOGS_STREAM,
     async (_event, containerId: string, runtime: 'docker' | 'podman') => {
       const rt = runtime === 'podman' ? podmanRuntime : dockerRuntime;
       const lines: string[] = [];
@@ -784,31 +785,31 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Stats ---
 
-  ipcMain.handle('stats:stack-memory', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_STACK_MEMORY, async (_event, stackId: string) => {
     return stackManager.getStackMemoryUsage(stackId);
   });
 
-  ipcMain.handle('stats:stack-detailed', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_STACK_DETAILED, async (_event, stackId: string) => {
     return stackManager.getStackDetailedStats(stackId);
   });
 
-  ipcMain.handle('stats:task-metrics', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TASK_METRICS, async (_event, stackId: string) => {
     return stackManager.getStackTaskMetrics(stackId);
   });
 
-  ipcMain.handle('stats:token-usage', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TOKEN_USAGE, async (_event, stackId: string) => {
     return stackManager.getStackTokenUsage(stackId);
   });
 
-  ipcMain.handle('stats:global-token-usage', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_GLOBAL_TOKEN_USAGE, async () => {
     return stackManager.getGlobalTokenUsage();
   });
 
-  ipcMain.handle('stats:rate-limit', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_RATE_LIMIT, async () => {
     return stackManager.getRateLimitState();
   });
 
-  ipcMain.handle('stats:account-usage', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_ACCOUNT_USAGE, async () => {
     return fetchAccountUsage();
   });
 
@@ -836,7 +837,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return [hostRoot, ...stackRoots];
   }
 
-  ipcMain.handle('stats:telemetry:summary', async (_event, range: DateRange) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_SUMMARY, async (_event, range: DateRange) => {
     const engine = createUsageEngine(buildTelemetryRoots());
     const summary = engine.getSummary(range);
     const shipped = rollupStore.ticketsShipped();
@@ -852,19 +853,19 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     };
   });
 
-  ipcMain.handle('stats:telemetry:daily', async (_event, range: DateRange) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_DAILY, async (_event, range: DateRange) => {
     return createUsageEngine(buildTelemetryRoots()).getDaily(range);
   });
 
-  ipcMain.handle('stats:telemetry:byModel', async (_event, range: DateRange) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_BY_MODEL, async (_event, range: DateRange) => {
     return createUsageEngine(buildTelemetryRoots()).getByModel(range);
   });
 
-  ipcMain.handle('stats:telemetry:session', async (_event, range: DateRange) => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_SESSION, async (_event, range: DateRange) => {
     return createUsageEngine(buildTelemetryRoots()).getSessions(range);
   });
 
-  ipcMain.handle('stats:telemetry:byTicket', async (_event, range?: DateRange): Promise<ByTicketEntry[]> => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_BY_TICKET, async (_event, range?: DateRange): Promise<ByTicketEntry[]> => {
     const stepWeights = registry.getStepWeightsByTicket();
     const taskPhaseWeights = registry.getTaskPhaseTokensByTicket();
     const allEphemeral = readEphemeralTimingRecords(agentBackend.getEphemeralTimingPath());
@@ -874,7 +875,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords, taskPhaseWeights).getByTicket(range);
   });
 
-  ipcMain.handle('stats:telemetry:byEpic', async (_event, range?: DateRange): Promise<ByEpicEntry[]> => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_BY_EPIC, async (_event, range?: DateRange): Promise<ByEpicEntry[]> => {
     const stepWeights = registry.getStepWeightsByTicket();
     const taskPhaseWeights = registry.getTaskPhaseTokensByTicket();
     const allEphemeral = readEphemeralTimingRecords(agentBackend.getEphemeralTimingPath());
@@ -885,55 +886,55 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return createUsageEngine(buildTelemetryRoots(), stepWeights, ephemeralRecords, taskPhaseWeights).getByEpic(epicTasks, range);
   });
 
-  ipcMain.handle('stats:telemetry:refresh', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STATS_TELEMETRY_REFRESH, async () => {
     clearUsageCache();
     return { ok: true };
   });
 
   // --- Custom Context ---
 
-  ipcMain.handle('context:get', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.CONTEXT_GET, async (_event, projectDir: string) => {
     return getCustomContext(projectDir);
   });
 
   ipcMain.handle(
-    'context:saveInstructions',
+    INVOKE_CHANNELS.CONTEXT_SAVE_INSTRUCTIONS,
     async (_event, projectDir: string, content: string) => {
       saveCustomInstructions(projectDir, content);
     }
   );
 
-  ipcMain.handle('context:listSkills', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.CONTEXT_LIST_SKILLS, async (_event, projectDir: string) => {
     return listCustomSkills(projectDir);
   });
 
   ipcMain.handle(
-    'context:getSkill',
+    INVOKE_CHANNELS.CONTEXT_GET_SKILL,
     async (_event, projectDir: string, name: string) => {
       return getCustomSkill(projectDir, name);
     }
   );
 
   ipcMain.handle(
-    'context:saveSkill',
+    INVOKE_CHANNELS.CONTEXT_SAVE_SKILL,
     async (_event, projectDir: string, name: string, content: string) => {
       saveCustomSkill(projectDir, name, content);
     }
   );
 
   ipcMain.handle(
-    'context:deleteSkill',
+    INVOKE_CHANNELS.CONTEXT_DELETE_SKILL,
     async (_event, projectDir: string, name: string) => {
       deleteCustomSkill(projectDir, name);
     }
   );
 
-  ipcMain.handle('context:getSettings', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.CONTEXT_GET_SETTINGS, async (_event, projectDir: string) => {
     return getCustomSettings(projectDir);
   });
 
   ipcMain.handle(
-    'context:saveSettings',
+    INVOKE_CHANNELS.CONTEXT_SAVE_SETTINGS,
     async (_event, projectDir: string, content: string) => {
       saveCustomSettings(projectDir, content);
     }
@@ -941,23 +942,23 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Review Prompt ---
 
-  ipcMain.handle('reviewPrompt:getDefault', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.REVIEW_PROMPT_GET_DEFAULT, async () => {
     return getDefaultReviewPrompt();
   });
 
   // --- Stale Workspace Detection & Cleanup ---
 
-  ipcMain.handle('stacks:detectStale', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_DETECT_STALE, async () => {
     return stackManager.detectStaleWorkspaces();
   });
 
-  ipcMain.handle('stacks:cleanupStale', async (_event, workspacePaths: string[]) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_CLEANUP_STALE, async (_event, workspacePaths: string[]) => {
     return stackManager.cleanupStaleWorkspaces(workspacePaths);
   });
 
   // --- Runtime ---
 
-  ipcMain.handle('runtime:available', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.RUNTIME_AVAILABLE, async () => {
     const [dockerAvail, podmanAvail] = await Promise.all([
       dockerRuntime.isAvailable(),
       podmanRuntime.isAvailable(),
@@ -967,107 +968,107 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Model Settings ---
 
-  ipcMain.handle('modelSettings:getGlobal', () => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_SETTINGS_GET_GLOBAL, () => {
     return registry.getGlobalModelSettings();
   });
 
-  ipcMain.handle('modelSettings:setGlobal', (_event, settings: { inner_model?: string; outer_model?: string }) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_SETTINGS_SET_GLOBAL, (_event, settings: { inner_model?: string; outer_model?: string }) => {
     registry.setGlobalModelSettings(settings);
   });
 
-  ipcMain.handle('modelSettings:getProject', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_SETTINGS_GET_PROJECT, (_event, projectDir: string) => {
     return registry.getProjectModelSettings(projectDir);
   });
 
-  ipcMain.handle('modelSettings:setProject', (_event, projectDir: string, settings: { inner_model?: string; outer_model?: string }) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_SETTINGS_SET_PROJECT, (_event, projectDir: string, settings: { inner_model?: string; outer_model?: string }) => {
     registry.setProjectModelSettings(projectDir, settings);
   });
 
-  ipcMain.handle('modelSettings:removeProject', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_SETTINGS_REMOVE_PROJECT, (_event, projectDir: string) => {
     registry.removeProjectModelSettings(projectDir);
   });
 
-  ipcMain.handle('modelSettings:getEffective', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_SETTINGS_GET_EFFECTIVE, (_event, projectDir: string) => {
     return registry.getEffectiveModels(projectDir);
   });
 
   // --- Backend Settings ---
 
-  ipcMain.handle('backendSettings:getGlobal', () => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_GLOBAL, () => {
     return registry.getGlobalBackendSettings();
   });
 
-  ipcMain.handle('backendSettings:setGlobal', (_event, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_GLOBAL, (_event, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => {
     registry.setGlobalBackendSettings(settings);
   });
 
-  ipcMain.handle('backendSettings:getProject', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_PROJECT, (_event, projectDir: string) => {
     return registry.getProjectBackendSettings(projectDir);
   });
 
-  ipcMain.handle('backendSettings:setProject', (_event, projectDir: string, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_PROJECT, (_event, projectDir: string, settings: { inner_backend?: string; outer_backend?: string; inner_provider?: string | null; inner_model?: string | null; outer_provider?: string | null; outer_model?: string | null }) => {
     registry.setProjectBackendSettings(projectDir, settings);
   });
 
-  ipcMain.handle('backendSettings:getEffective', (_event, projectDir: string, surface: 'inner' | 'outer') => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_EFFECTIVE, (_event, projectDir: string, surface: 'inner' | 'outer') => {
     return registry.getEffectiveBackend(projectDir, surface);
   });
 
-  ipcMain.handle('backendSettings:setSecret', (_event, scope: string, surface: 'inner' | 'outer', name: string, value: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_SECRET, (_event, scope: string, surface: 'inner' | 'outer', name: string, value: string) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     registry.setBackendSecret(key, surface, name, value);
   });
 
-  ipcMain.handle('backendSettings:secretStatus', (_event, scope: string, surface: 'inner' | 'outer') => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_SECRET_STATUS, (_event, scope: string, surface: 'inner' | 'outer') => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return { set: registry.hasBackendSecret(key, surface) };
   });
 
-  ipcMain.handle('backendSettings:setSecretBundle', (_event, scope: string, surface: 'inner' | 'outer', bundle: Record<string, string>) => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_SECRET_BUNDLE, (_event, scope: string, surface: 'inner' | 'outer', bundle: Record<string, string>) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     registry.setBackendSecretBundle(key, surface, bundle);
   });
 
-  ipcMain.handle('backendSettings:getSecretBundle', (_event, scope: string, surface: 'inner' | 'outer') => {
+  ipcMain.handle(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_SECRET_BUNDLE, (_event, scope: string, surface: 'inner' | 'outer') => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return registry.getBackendSecretBundle(key, surface);
   });
 
   // --- Model Routing ---
 
-  ipcMain.handle('modelRouting:getEffective', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_GET_EFFECTIVE, (_event, projectDir: string) => {
     return registry.getEffectiveRouting(projectDir);
   });
 
-  ipcMain.handle('modelRouting:getProject', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_GET_PROJECT, (_event, projectDir: string) => {
     return registry.getProjectRouting(projectDir);
   });
 
-  ipcMain.handle('modelRouting:setProject', (_event, projectDir: string, config: { assignments?: Partial<Record<string, RoutingAssignment>>; preset?: PresetId | null }) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_SET_PROJECT, (_event, projectDir: string, config: { assignments?: Partial<Record<string, RoutingAssignment>>; preset?: PresetId | null }) => {
     registry.setProjectRouting(projectDir, config);
   });
 
-  ipcMain.handle('modelRouting:removeProject', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_REMOVE_PROJECT, (_event, projectDir: string) => {
     registry.removeProjectRouting(projectDir);
   });
 
-  ipcMain.handle('modelRouting:getGlobal', () => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_GET_GLOBAL, () => {
     return registry.getGlobalRouting();
   });
 
-  ipcMain.handle('modelRouting:setGlobal', (_event, config: { assignments?: Partial<Record<string, RoutingAssignment>>; preset?: PresetId | null }) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_SET_GLOBAL, (_event, config: { assignments?: Partial<Record<string, RoutingAssignment>>; preset?: PresetId | null }) => {
     registry.setGlobalRouting(config);
   });
 
-  ipcMain.handle('modelRouting:applyPreset', (_event, projectDir: string, presetId: PresetId) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_APPLY_PRESET, (_event, projectDir: string, presetId: PresetId) => {
     registry.applyPreset(projectDir, presetId);
   });
 
-  ipcMain.handle('modelRouting:getAvailableModels', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_GET_AVAILABLE_MODELS, (_event, projectDir: string) => {
     return getAvailableModels(projectDir, (key, provider) => registry.hasProviderSecret(key, provider));
   });
 
-  ipcMain.handle('modelRouting:getAvailableModelsWithCatalog', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.MODEL_ROUTING_GET_AVAILABLE_MODELS_WITH_CATALOG, async (_event, projectDir: string) => {
     const catalog = await fetchProviderCatalog(getBackendServerUrl());
     return getAvailableModels(
       projectDir,
@@ -1078,58 +1079,58 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Provider Secrets ---
 
-  ipcMain.handle('providerSecrets:status', (_event, scope: string, provider: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDER_SECRETS_STATUS, (_event, scope: string, provider: string) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return { set: registry.hasProviderSecret(key, provider) };
   });
 
-  ipcMain.handle('providerSecrets:get', (_event, scope: string, provider: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDER_SECRETS_GET, (_event, scope: string, provider: string) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return registry.getProviderSecretBundle(key, provider);
   });
 
-  ipcMain.handle('providerSecrets:getBundle', (_event, scope: string, provider: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDER_SECRETS_GET_BUNDLE, (_event, scope: string, provider: string) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return registry.getProviderSecretBundle(key, provider);
   });
 
-  ipcMain.handle('providerSecrets:set', (_event, scope: string, provider: string, bundle: Record<string, string>) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDER_SECRETS_SET, (_event, scope: string, provider: string, bundle: Record<string, string>) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     registry.setProviderSecretBundle(key, provider, bundle);
   });
 
-  ipcMain.handle('providerSecrets:setBundle', (_event, scope: string, provider: string, bundle: Record<string, string>) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDER_SECRETS_SET_BUNDLE, (_event, scope: string, provider: string, bundle: Record<string, string>) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     registry.setProviderSecretBundle(key, provider, bundle);
   });
 
-  ipcMain.handle('providerSecrets:remove', (_event, scope: string, provider: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDER_SECRETS_REMOVE, (_event, scope: string, provider: string) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     registry.removeProviderSecret(key, provider);
   });
 
   // --- Provider Catalog ---
 
-  ipcMain.handle('providers:catalog', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDERS_CATALOG, async () => {
     return fetchProviderCatalog(getBackendServerUrl());
   });
 
-  ipcMain.handle('providers:configured', (_event, scope: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PROVIDERS_CONFIGURED, (_event, scope: string) => {
     const key = scope === 'global' ? 'global' : `project:${path.resolve(scope)}`;
     return registry.getStoredProviderKeys(key);
   });
 
   // --- Session Monitor ---
 
-  ipcMain.handle('session:getState', () => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_GET_STATE, () => {
     return sessionMonitor.getState();
   });
 
-  ipcMain.handle('session:getSettings', () => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_GET_SETTINGS, () => {
     return registry.getSessionMonitorSettings();
   });
 
-  ipcMain.handle('session:updateSettings', (_event, settings: Record<string, unknown>) => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_UPDATE_SETTINGS, (_event, settings: Record<string, unknown>) => {
     registry.setSessionMonitorSettings(settings as Partial<{
       warningThreshold: number;
       criticalThreshold: number;
@@ -1143,24 +1144,24 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     sessionMonitor.updateSettings(registry.getSessionMonitorSettings());
   });
 
-  ipcMain.handle('session:acknowledgeCritical', () => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_ACKNOWLEDGE_CRITICAL, () => {
     sessionMonitor.acknowledgeCritical();
   });
 
-  ipcMain.handle('session:haltAll', () => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_HALT_ALL, () => {
     return stackManager.sessionPauseAllStacks();
   });
 
-  ipcMain.handle('session:resumeAll', () => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_RESUME_ALL, () => {
     sessionMonitor.markResumed();
     return stackManager.sessionResumeAllStacks();
   });
 
-  ipcMain.handle('session:resumeStack', (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_RESUME_STACK, (_event, stackId: string) => {
     stackManager.sessionResumeStack(stackId);
   });
 
-  ipcMain.handle('session:resumeStackWithContinuation', async (_event, stackId: string, manual: boolean = false) => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_RESUME_STACK_WITH_CONTINUATION, async (_event, stackId: string, manual: boolean = false) => {
     try {
       const result = await stackManager.resumeStackWithContinuation(
         stackId,
@@ -1177,43 +1178,43 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle('session:forcePoll', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.SESSION_FORCE_POLL, async () => {
     return sessionMonitor.forcePoll();
   });
 
-  ipcMain.handle('stacks:getNeedsHumanQuestions', (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_GET_NEEDS_HUMAN_QUESTIONS, (_event, stackId: string) => {
     return registry.getNeedsHumanQuestions(stackId);
   });
 
-  ipcMain.handle('stacks:resumeNeedsHuman', async (_event, stackId: string, answers: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_RESUME_NEEDS_HUMAN, async (_event, stackId: string, answers: string) => {
     await stackManager.resumeNeedsHumanStack(stackId, answers);
   });
 
-  ipcMain.handle('stacks:askClarifyingQuestions', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_ASK_CLARIFYING_QUESTIONS, async (_event, stackId: string) => {
     await stackManager.askClarifyingQuestions(stackId);
   });
 
-  ipcMain.handle('stacks:recheckCompleted', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_RECHECK_COMPLETED, async (_event, stackId: string) => {
     return stackManager.recheckCompletedStack(stackId);
   });
 
-  ipcMain.handle('stacks:reconcileStatus', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_RECONCILE_STATUS, async (_event, stackId: string) => {
     return stackManager.reconcileStatus(stackId);
   });
 
-  ipcMain.handle('stacks:selfHealContinue', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_SELF_HEAL_CONTINUE, async (_event, stackId: string) => {
     await stackManager.selfHealContinue(stackId);
   });
 
-  ipcMain.handle('stacks:restartWithFindings', async (_event, stackId: string, findings: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.STACKS_RESTART_WITH_FINDINGS, async (_event, stackId: string, findings: string) => {
     return stackManager.restartWithFindings(stackId, findings);
   });
 
-  ipcMain.on('session:activity', () => {
+  ipcMain.on(INVOKE_CHANNELS.SESSION_ACTIVITY, () => {
     sessionMonitor.reportActivity();
   });
 
-  ipcMain.handle('docker:status', () => {
+  ipcMain.handle(INVOKE_CHANNELS.DOCKER_STATUS, () => {
     return {
       connected: dockerConnectionManager?.isConnected ?? false,
     };
@@ -1221,11 +1222,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Auth (delegated to agent backend) ---
 
-  ipcMain.handle('auth:status', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.AUTH_STATUS, async () => {
     return agentBackend.getAuthStatus();
   });
 
-  ipcMain.handle('auth:login', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.AUTH_LOGIN, async () => {
     const result = await agentBackend.login(mainWindow ?? undefined);
     if (result.success) {
       // Sync credentials to running stacks after successful login
@@ -1237,14 +1238,14 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Schedules ---
 
-  ipcMain.handle('schedules:list', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.SCHEDULES_LIST, async (_event, projectDir: string) => {
     const dirError = validateProjectDir(projectDir);
     if (dirError) throw new Error(dirError.error);
     return listSchedules(projectDir);
   });
 
   ipcMain.handle(
-    'schedules:create',
+    INVOKE_CHANNELS.SCHEDULES_CREATE,
     async (_event, projectDir: string, data: { label?: string; cronExpression: string; action: ScheduleAction; enabled?: boolean }) => {
       const dirError = validateProjectDir(projectDir);
       if (dirError) throw new Error(dirError.error);
@@ -1265,7 +1266,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'schedules:update',
+    INVOKE_CHANNELS.SCHEDULES_UPDATE,
     async (_event, projectDir: string, id: string, patch: { label?: string; cronExpression?: string; action?: ScheduleAction; enabled?: boolean }) => {
       const dirError = validateProjectDir(projectDir);
       if (dirError) throw new Error(dirError.error);
@@ -1280,7 +1281,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'schedules:delete',
+    INVOKE_CHANNELS.SCHEDULES_DELETE,
     async (_event, projectDir: string, id: string) => {
       const dirError = validateProjectDir(projectDir);
       if (dirError) throw new Error(dirError.error);
@@ -1293,15 +1294,15 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   );
 
-  ipcMain.handle('schedules:cronHealth', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.SCHEDULES_CRON_HEALTH, async () => {
     return { running: isCronRunning() };
   });
 
-  ipcMain.handle('scheduler:listBuiltInActions', async () => {
+  ipcMain.handle(INVOKE_CHANNELS.SCHEDULER_LIST_BUILT_IN_ACTIONS, async () => {
     return BUILT_IN_ACTIONS;
   });
 
-  ipcMain.handle('schedules:listScripts', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.SCHEDULES_LIST_SCRIPTS, async (_event, projectDir: string) => {
     const dirError = validateProjectDir(projectDir);
     if (dirError) throw new Error(dirError.error);
     const scriptsDir = path.join(projectDir, '.sandstorm', 'scripts', 'scheduled');
@@ -1334,7 +1335,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   /** Emit a refinement session update to the renderer. */
   function emitRefinementUpdate(session: RefinementSession): void {
-    mainWindow?.webContents.send('refinement:update', session);
+    mainWindow?.webContents.send(EVENT_CHANNELS.REFINEMENT_UPDATE, session);
   }
 
   /** Cancel a refinement session: abort in-flight agent, remove from map, delete from disk, broadcast cancelled. */
@@ -1345,7 +1346,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       activeRefinements.delete(id);
       deleteRefinement(id);
       if (broadcast) {
-        mainWindow?.webContents.send('refinement:update', { id, status: 'cancelled' });
+        mainWindow?.webContents.send(EVENT_CHANNELS.REFINEMENT_UPDATE, { id, status: 'cancelled' });
       }
     }
   }
@@ -1419,7 +1420,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       const delta = event.kind === 'tool_use'
         ? `→ ${event.summary}\n`
         : event.delta;
-      mainWindow?.webContents.send('refinement:progress', { sessionId: id, delta });
+      mainWindow?.webContents.send(EVENT_CHANNELS.REFINEMENT_PROGRESS, { sessionId: id, delta });
     };
 
     const { promise, cancel } = phase === 'check'
@@ -1504,26 +1505,26 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return id;
   }
 
-  ipcMain.handle('tickets:fetch', async (_event, ticketId: string, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKETS_FETCH, async (_event, ticketId: string, projectDir: string) => {
     const config = registry.getProjectTicketConfig(projectDir);
     return fetchTicketForRenderer(ticketId, config, projectDir);
   });
 
-  ipcMain.handle('tickets:specCheck', async (_event, ticketId: string, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKETS_SPEC_CHECK, async (_event, ticketId: string, projectDir: string) => {
     return runSpecCheck(ticketId, projectDir, specDeps);
   });
 
   ipcMain.handle(
-    'tickets:specRefine',
+    INVOKE_CHANNELS.TICKETS_SPEC_REFINE,
     async (_event, ticketId: string, projectDir: string, userAnswers: string) => {
       return runSpecRefine(ticketId, projectDir, userAnswers, specDeps);
     },
   );
 
   // Async (non-blocking) variants — return a session ID immediately and
-  // emit 'refinement:update' events as the operation progresses.
+  // emit EVENT_CHANNELS.REFINEMENT_UPDATE events as the operation progresses.
   ipcMain.handle(
-    'tickets:specCheckAsync',
+    INVOKE_CHANNELS.TICKETS_SPEC_CHECK_ASYNC,
     (_event, ticketId: string, projectDir: string) => {
       const sessionId = startRefinementAsync(ticketId, projectDir, null, 'check');
       return { sessionId };
@@ -1531,22 +1532,22 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'tickets:specRefineAsync',
+    INVOKE_CHANNELS.TICKETS_SPEC_REFINE_ASYNC,
     (_event, sessionId: string, ticketId: string, projectDir: string, userAnswers: string) => {
       startRefinementAsync(ticketId, projectDir, sessionId, 'refine', userAnswers);
     },
   );
 
-  ipcMain.handle('tickets:cancelRefinement', (_event, id: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKETS_CANCEL_REFINEMENT, (_event, id: string) => {
     cancelRefinementSession(id);
   });
 
-  ipcMain.handle('tickets:listRefinements', () => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKETS_LIST_REFINEMENTS, () => {
     return Array.from(activeRefinements.values()).map((e) => e.session);
   });
 
   ipcMain.handle(
-    'tickets:retryRefinementAsync',
+    INVOKE_CHANNELS.TICKETS_RETRY_REFINEMENT_ASYNC,
     async (_event, sessionId: string, ticketId: string, projectDir: string) => {
       // Read the existing session to determine phase before cancelling it.
       const existingEntry = sessionId ? activeRefinements.get(sessionId) : undefined;
@@ -1581,7 +1582,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'tickets:postAnswers',
+    INVOKE_CHANNELS.TICKETS_POST_ANSWERS,
     async (_event, ticketId: string, projectDir: string, answersBody: string) => {
       if (!answersBody.trim()) return;
       const body = `${ANSWER_COMMENT_MARKER}\n\n${answersBody}`;
@@ -1590,7 +1591,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'tickets:create',
+    INVOKE_CHANNELS.TICKETS_CREATE,
     async (_event, projectDir: string, title: string, body: string) => {
       const config = registry.getProjectTicketConfig(projectDir);
       if (!config) {
@@ -1603,7 +1604,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'tickets:fetchRaw',
+    INVOKE_CHANNELS.TICKETS_FETCH_RAW,
     async (_event, ticketId: string, projectDir: string) => {
       const config = registry.getProjectTicketConfig(projectDir);
       if (!config) {
@@ -1614,7 +1615,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   );
 
   ipcMain.handle(
-    'tickets:update',
+    INVOKE_CHANNELS.TICKETS_UPDATE,
     async (_event, projectDir: string, ticketId: string, body: string) => {
       const config = registry.getProjectTicketConfig(projectDir);
       if (!config) {
@@ -1628,7 +1629,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   const VALID_KANBAN_COLUMNS: readonly string[] = KANBAN_COLUMNS;
 
-  ipcMain.handle('tickets:list', async (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKETS_LIST, async (_event, projectDir: string) => {
     const dirError = validateProjectDir(projectDir);
     if (dirError) throw new Error(dirError.error);
     const normalizedDir = path.resolve(projectDir);
@@ -1665,7 +1666,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return { tickets, error: listError };
   });
 
-  ipcMain.handle('tickets:testJiraConnection', async (_event, params: {
+  ipcMain.handle(INVOKE_CHANNELS.TICKETS_TEST_JIRA_CONNECTION, async (_event, params: {
     jiraUrl: string;
     jiraUsername: string;
     jiraApiToken: string;
@@ -1679,7 +1680,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     return testJiraConnection(params);
   });
 
-  ipcMain.handle('ticket-board:set-column', async (_event, ticketId: string, projectDir: string, column: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKET_BOARD_SET_COLUMN, async (_event, ticketId: string, projectDir: string, column: string) => {
     if (!ticketId?.trim()) throw new Error('ticketId is required');
     const dirError = validateProjectDir(projectDir);
     if (dirError) throw new Error(dirError.error);
@@ -1688,7 +1689,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     darkFactoryOrchestrator?.handleTicketColumnChanged(ticketId, path.resolve(projectDir), column);
   });
 
-  ipcMain.handle('ticket:close', async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKET_CLOSE, async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
     if (!ticketId?.trim()) throw new Error('ticketId is required');
     const dirError = validateProjectDir(projectDir);
     if (dirError) throw new Error(dirError.error);
@@ -1697,7 +1698,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     await closeTicketWithConfig(ticketId, config, path.resolve(projectDir));
   });
 
-  ipcMain.handle('ticket:mark-done', async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKET_MARK_DONE, async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
     const resolvedDir = path.resolve(projectDir);
     const config = registry.getProjectTicketConfig(resolvedDir);
     if (!config) return { ok: true }; // no ticket provider configured — skip silently
@@ -1713,7 +1714,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle('ticket-board:delete', async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
+  ipcMain.handle(INVOKE_CHANNELS.TICKET_BOARD_DELETE, async (_event, { ticketId, projectDir }: { ticketId: string; projectDir: string }) => {
     if (!ticketId?.trim()) throw new Error('ticketId is required');
     const dirError = validateProjectDir(projectDir);
     if (dirError) throw new Error(dirError.error);
@@ -1722,7 +1723,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- PR creation (deterministic UI for make-PR workflow, #310) ---
 
-  ipcMain.handle('pr:draftBody', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PR_DRAFT_BODY, async (_event, stackId: string) => {
     const stack = await stackManager.getStackWithServices(stackId);
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
     const prDescriptor = registry.getEffectiveTouchpointDescriptor(stack.project_dir, 'pr_description');
@@ -1744,7 +1745,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   ipcMain.handle(
-    'pr:create',
+    INVOKE_CHANNELS.PR_CREATE,
     async (_event, stackId: string, title: string, body: string) => {
       const stack = await stackManager.getStackWithServices(stackId);
       if (!stack) throw new Error(`Stack "${stackId}" not found`);
@@ -1777,7 +1778,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     },
   );
 
-  ipcMain.handle('pr:merge', async (_event, stackId: string, prNumber: number) => {
+  ipcMain.handle(INVOKE_CHANNELS.PR_MERGE, async (_event, stackId: string, prNumber: number) => {
     const stack = await stackManager.getStackWithServices(stackId);
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
     const workspace = workspacePathFor(stack.project_dir, stackId);
@@ -1812,7 +1813,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle('pr:createAuto', async (_event, stackId: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PR_CREATE_AUTO, async (_event, stackId: string) => {
     const stack = await stackManager.getStackWithServices(stackId);
     if (!stack) throw new Error(`Stack "${stackId}" not found`);
 
@@ -1873,11 +1874,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
 
   // --- Dark Factory ---
 
-  ipcMain.handle('darkFactory:getEnabled', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.DARK_FACTORY_GET_ENABLED, (_event, projectDir: string) => {
     return registry.getDarkFactoryEnabled(projectDir);
   });
 
-  ipcMain.handle('darkFactory:setEnabled', (_event, projectDir: string, enabled: boolean) => {
+  ipcMain.handle(INVOKE_CHANNELS.DARK_FACTORY_SET_ENABLED, (_event, projectDir: string, enabled: boolean) => {
     const prior = registry.getDarkFactoryEnabled(projectDir);
     registry.setDarkFactoryEnabled(projectDir, enabled);
     if (!prior && enabled) {
@@ -1887,25 +1888,25 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
-  ipcMain.handle('darkFactory:getConfig', (_event, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.DARK_FACTORY_GET_CONFIG, (_event, projectDir: string) => {
     return registry.getDarkFactoryConfig(projectDir);
   });
 
-  ipcMain.handle('darkFactory:setConfig', (_event, projectDir: string, config: { level: string; merge_strategy: string }) => {
+  ipcMain.handle(INVOKE_CHANNELS.DARK_FACTORY_SET_CONFIG, (_event, projectDir: string, config: { level: string; merge_strategy: string }) => {
     registry.setDarkFactoryConfig(projectDir, config);
   });
 
-  ipcMain.handle('pr:autoResolve', async (_event, ticketId: string, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.PR_AUTO_RESOLVE, async (_event, ticketId: string, projectDir: string) => {
     return stackManager.autoResolveConflicts(ticketId, projectDir);
   });
 
   // --- Epic Runner ---
 
-  ipcMain.handle('epic:start', async (_event, epicId: string, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.EPIC_START, async (_event, epicId: string, projectDir: string) => {
     return getEpicRunner().startEpic(epicId, projectDir);
   });
 
-  ipcMain.handle('epic:getRunPlan', async (_event, epicId: string, projectDir: string) => {
+  ipcMain.handle(INVOKE_CHANNELS.EPIC_GET_RUN_PLAN, async (_event, epicId: string, projectDir: string) => {
     return getEpicRunner().getRunPlan(epicId, projectDir);
   });
 

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,6 +1,7 @@
 import { Tray, Menu, BrowserWindow, Notification, nativeImage, app } from 'electron';
 import path from 'path';
 import { registry } from './index';
+import { EVENT_CHANNELS } from './ipc-channels';
 
 let tray: Tray | null = null;
 
@@ -42,7 +43,7 @@ export function createTray(mainWindow: BrowserWindow): void {
         click: () => {
           mainWindow.show();
           mainWindow.focus();
-          mainWindow.webContents.send('navigate:stack', s.id);
+          mainWindow.webContents.send(EVENT_CHANNELS.NAVIGATE_STACK, s.id);
         },
       };
     });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import { INVOKE_CHANNELS, type EventChannel } from '../main/ipc-channels';
 import type { ByTicketEntry, ByEpicEntry } from '@main/telemetry/types';
 import type { CatalogProviderList } from '../shared/opencode-providers';
 
@@ -308,269 +309,269 @@ export interface SandstormAPI {
     start: (epicId: string, projectDir: string) => Promise<unknown>;
     getRunPlan: (epicId: string, projectDir: string) => Promise<unknown>;
   };
-  on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
+  on: (channel: EventChannel, callback: (...args: unknown[]) => void) => () => void;
 }
 
 const api: SandstormAPI = {
   projects: {
-    list: () => ipcRenderer.invoke('projects:list'),
-    add: (directory) => ipcRenderer.invoke('projects:add', directory),
-    remove: (id) => ipcRenderer.invoke('projects:remove', id),
-    browse: () => ipcRenderer.invoke('projects:browse'),
-    checkInit: (directory) => ipcRenderer.invoke('projects:checkInit', directory),
-    initialize: (directory) => ipcRenderer.invoke('projects:initialize', directory),
-    checkMigration: (directory) => ipcRenderer.invoke('projects:checkMigration', directory),
-    autoDetectVerify: (directory) => ipcRenderer.invoke('projects:autoDetectVerify', directory),
+    list: () => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_LIST),
+    add: (directory) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_ADD, directory),
+    remove: (id) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_REMOVE, id),
+    browse: () => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_BROWSE),
+    checkInit: (directory) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_CHECK_INIT, directory),
+    initialize: (directory) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_INITIALIZE, directory),
+    checkMigration: (directory) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_CHECK_MIGRATION, directory),
+    autoDetectVerify: (directory) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_AUTO_DETECT_VERIFY, directory),
     saveMigration: (directory: string, verifyScript: string, serviceDescriptions: Record<string, string>) =>
-      ipcRenderer.invoke('projects:saveMigration', directory, verifyScript, serviceDescriptions),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_SAVE_MIGRATION, directory, verifyScript, serviceDescriptions),
     generateCompose: (directory: string) =>
-      ipcRenderer.invoke('projects:generateCompose', directory),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_GENERATE_COMPOSE, directory),
     saveComposeSetup: (directory: string, composeYaml: string, composeFile: string) =>
-      ipcRenderer.invoke('projects:saveComposeSetup', directory, composeYaml, composeFile),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PROJECTS_SAVE_COMPOSE_SETUP, directory, composeYaml, composeFile),
   },
   stacks: {
-    list: () => ipcRenderer.invoke('stacks:list'),
-    get: (id) => ipcRenderer.invoke('stacks:get', id),
-    create: (opts) => ipcRenderer.invoke('stacks:create', opts),
-    teardown: (id) => ipcRenderer.invoke('stacks:teardown', id),
-    stop: (id) => ipcRenderer.invoke('stacks:stop', id),
-    start: (id) => ipcRenderer.invoke('stacks:start', id),
-    history: () => ipcRenderer.invoke('stacks:history'),
+    list: () => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_LIST),
+    get: (id) => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_GET, id),
+    create: (opts) => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_CREATE, opts),
+    teardown: (id) => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_TEARDOWN, id),
+    stop: (id) => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_STOP, id),
+    start: (id) => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_START, id),
+    history: () => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_HISTORY),
     setPr: (id: string, prUrl: string, prNumber: number) =>
-      ipcRenderer.invoke('stacks:setPr', id, prUrl, prNumber),
-    detectStale: () => ipcRenderer.invoke('stacks:detectStale'),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_SET_PR, id, prUrl, prNumber),
+    detectStale: () => ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_DETECT_STALE),
     cleanupStale: (workspacePaths: string[]) =>
-      ipcRenderer.invoke('stacks:cleanupStale', workspacePaths),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_CLEANUP_STALE, workspacePaths),
     getNeedsHumanQuestions: (stackId: string) =>
-      ipcRenderer.invoke('stacks:getNeedsHumanQuestions', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_GET_NEEDS_HUMAN_QUESTIONS, stackId),
     resumeNeedsHuman: (stackId: string, answers: string) =>
-      ipcRenderer.invoke('stacks:resumeNeedsHuman', stackId, answers),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_RESUME_NEEDS_HUMAN, stackId, answers),
     askClarifyingQuestions: (stackId: string) =>
-      ipcRenderer.invoke('stacks:askClarifyingQuestions', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_ASK_CLARIFYING_QUESTIONS, stackId),
     selfHealContinue: (stackId: string) =>
-      ipcRenderer.invoke('stacks:selfHealContinue', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_SELF_HEAL_CONTINUE, stackId),
     restartWithFindings: (stackId: string, updatedTicketBody: string) =>
-      ipcRenderer.invoke('stacks:restartWithFindings', stackId, updatedTicketBody),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_RESTART_WITH_FINDINGS, stackId, updatedTicketBody),
     recheckCompleted: (stackId: string) =>
-      ipcRenderer.invoke('stacks:recheckCompleted', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_RECHECK_COMPLETED, stackId),
     reconcileStatus: (stackId: string) =>
-      ipcRenderer.invoke('stacks:reconcileStatus', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACKS_RECONCILE_STATUS, stackId),
   },
   tasks: {
     dispatch: (stackId, prompt, model?) =>
-      ipcRenderer.invoke('tasks:dispatch', stackId, prompt, model),
-    list: (stackId) => ipcRenderer.invoke('tasks:list', stackId),
-    tokenSteps: (taskId) => ipcRenderer.invoke('tasks:tokenSteps', taskId),
-    workflowProgress: (stackId) => ipcRenderer.invoke('tasks:workflowProgress', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TASKS_DISPATCH, stackId, prompt, model),
+    list: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.TASKS_LIST, stackId),
+    tokenSteps: (taskId) => ipcRenderer.invoke(INVOKE_CHANNELS.TASKS_TOKEN_STEPS, taskId),
+    workflowProgress: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.TASKS_WORKFLOW_PROGRESS, stackId),
   },
   diff: {
-    get: (stackId) => ipcRenderer.invoke('diff:get', stackId),
+    get: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.DIFF_GET, stackId),
   },
   push: {
     execute: (stackId, message) =>
-      ipcRenderer.invoke('push:execute', stackId, message),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PUSH_EXECUTE, stackId, message),
   },
   ports: {
-    get: (stackId) => ipcRenderer.invoke('ports:get', stackId),
+    get: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.PORTS_GET, stackId),
     expose: (stackId, service, containerPort) =>
-      ipcRenderer.invoke('stack:expose-port', stackId, service, containerPort),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACK_EXPOSE_PORT, stackId, service, containerPort),
     unexpose: (stackId, service, containerPort) =>
-      ipcRenderer.invoke('stack:unexpose-port', stackId, service, containerPort),
+      ipcRenderer.invoke(INVOKE_CHANNELS.STACK_UNEXPOSE_PORT, stackId, service, containerPort),
     cleanupLegacy: (directory) =>
-      ipcRenderer.invoke('ports:cleanupLegacy', directory),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PORTS_CLEANUP_LEGACY, directory),
   },
   logs: {
     stream: (containerId, runtime) =>
-      ipcRenderer.invoke('logs:stream', containerId, runtime),
+      ipcRenderer.invoke(INVOKE_CHANNELS.LOGS_STREAM, containerId, runtime),
   },
   stats: {
-    stackMemory: (stackId) => ipcRenderer.invoke('stats:stack-memory', stackId),
-    stackDetailed: (stackId) => ipcRenderer.invoke('stats:stack-detailed', stackId),
-    taskMetrics: (stackId) => ipcRenderer.invoke('stats:task-metrics', stackId),
-    tokenUsage: (stackId) => ipcRenderer.invoke('stats:token-usage', stackId),
-    globalTokenUsage: () => ipcRenderer.invoke('stats:global-token-usage'),
-    rateLimit: () => ipcRenderer.invoke('stats:rate-limit'),
-    accountUsage: () => ipcRenderer.invoke('stats:account-usage'),
+    stackMemory: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_STACK_MEMORY, stackId),
+    stackDetailed: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_STACK_DETAILED, stackId),
+    taskMetrics: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TASK_METRICS, stackId),
+    tokenUsage: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TOKEN_USAGE, stackId),
+    globalTokenUsage: () => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_GLOBAL_TOKEN_USAGE),
+    rateLimit: () => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_RATE_LIMIT),
+    accountUsage: () => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_ACCOUNT_USAGE),
   },
   runtime: {
-    available: () => ipcRenderer.invoke('runtime:available'),
+    available: () => ipcRenderer.invoke(INVOKE_CHANNELS.RUNTIME_AVAILABLE),
   },
   agent: {
     send: (tabId, message, projectDir) =>
-      ipcRenderer.invoke('agent:send', tabId, message, projectDir),
-    cancel: (tabId) => ipcRenderer.invoke('agent:cancel', tabId),
-    reset: (tabId) => ipcRenderer.invoke('agent:reset', tabId),
-    history: (tabId) => ipcRenderer.invoke('agent:history', tabId),
-    tokenUsage: (tabId) => ipcRenderer.invoke('agent:tokenUsage', tabId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.AGENT_SEND, tabId, message, projectDir),
+    cancel: (tabId) => ipcRenderer.invoke(INVOKE_CHANNELS.AGENT_CANCEL, tabId),
+    reset: (tabId) => ipcRenderer.invoke(INVOKE_CHANNELS.AGENT_RESET, tabId),
+    history: (tabId) => ipcRenderer.invoke(INVOKE_CHANNELS.AGENT_HISTORY, tabId),
+    tokenUsage: (tabId) => ipcRenderer.invoke(INVOKE_CHANNELS.AGENT_TOKEN_USAGE, tabId),
   },
   context: {
-    get: (projectDir) => ipcRenderer.invoke('context:get', projectDir),
+    get: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_GET, projectDir),
     saveInstructions: (projectDir, content) =>
-      ipcRenderer.invoke('context:saveInstructions', projectDir, content),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_SAVE_INSTRUCTIONS, projectDir, content),
     listSkills: (projectDir) =>
-      ipcRenderer.invoke('context:listSkills', projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_LIST_SKILLS, projectDir),
     getSkill: (projectDir, name) =>
-      ipcRenderer.invoke('context:getSkill', projectDir, name),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_GET_SKILL, projectDir, name),
     saveSkill: (projectDir, name, content) =>
-      ipcRenderer.invoke('context:saveSkill', projectDir, name, content),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_SAVE_SKILL, projectDir, name, content),
     deleteSkill: (projectDir, name) =>
-      ipcRenderer.invoke('context:deleteSkill', projectDir, name),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_DELETE_SKILL, projectDir, name),
     getSettings: (projectDir) =>
-      ipcRenderer.invoke('context:getSettings', projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_GET_SETTINGS, projectDir),
     saveSettings: (projectDir, content) =>
-      ipcRenderer.invoke('context:saveSettings', projectDir, content),
+      ipcRenderer.invoke(INVOKE_CHANNELS.CONTEXT_SAVE_SETTINGS, projectDir, content),
   },
   reviewPrompt: {
-    getDefault: () => ipcRenderer.invoke('reviewPrompt:getDefault'),
+    getDefault: () => ipcRenderer.invoke(INVOKE_CHANNELS.REVIEW_PROMPT_GET_DEFAULT),
   },
   modelSettings: {
-    getGlobal: () => ipcRenderer.invoke('modelSettings:getGlobal'),
-    setGlobal: (settings) => ipcRenderer.invoke('modelSettings:setGlobal', settings),
-    getProject: (projectDir) => ipcRenderer.invoke('modelSettings:getProject', projectDir),
-    setProject: (projectDir, settings) => ipcRenderer.invoke('modelSettings:setProject', projectDir, settings),
-    removeProject: (projectDir) => ipcRenderer.invoke('modelSettings:removeProject', projectDir),
-    getEffective: (projectDir) => ipcRenderer.invoke('modelSettings:getEffective', projectDir),
+    getGlobal: () => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_SETTINGS_GET_GLOBAL),
+    setGlobal: (settings) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_SETTINGS_SET_GLOBAL, settings),
+    getProject: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_SETTINGS_GET_PROJECT, projectDir),
+    setProject: (projectDir, settings) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_SETTINGS_SET_PROJECT, projectDir, settings),
+    removeProject: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_SETTINGS_REMOVE_PROJECT, projectDir),
+    getEffective: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_SETTINGS_GET_EFFECTIVE, projectDir),
   },
   backendSettings: {
-    getGlobal: () => ipcRenderer.invoke('backendSettings:getGlobal'),
-    setGlobal: (settings) => ipcRenderer.invoke('backendSettings:setGlobal', settings),
-    getProject: (projectDir) => ipcRenderer.invoke('backendSettings:getProject', projectDir),
-    setProject: (projectDir, settings) => ipcRenderer.invoke('backendSettings:setProject', projectDir, settings),
-    getEffective: (projectDir, surface) => ipcRenderer.invoke('backendSettings:getEffective', projectDir, surface),
-    setSecret: (scope, surface, name, value) => ipcRenderer.invoke('backendSettings:setSecret', scope, surface, name, value),
-    secretStatus: (scope, surface) => ipcRenderer.invoke('backendSettings:secretStatus', scope, surface),
-    setSecretBundle: (scope, surface, bundle) => ipcRenderer.invoke('backendSettings:setSecretBundle', scope, surface, bundle),
-    getSecretBundle: (scope, surface) => ipcRenderer.invoke('backendSettings:getSecretBundle', scope, surface),
+    getGlobal: () => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_GLOBAL),
+    setGlobal: (settings) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_GLOBAL, settings),
+    getProject: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_PROJECT, projectDir),
+    setProject: (projectDir, settings) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_PROJECT, projectDir, settings),
+    getEffective: (projectDir, surface) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_EFFECTIVE, projectDir, surface),
+    setSecret: (scope, surface, name, value) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_SECRET, scope, surface, name, value),
+    secretStatus: (scope, surface) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_SECRET_STATUS, scope, surface),
+    setSecretBundle: (scope, surface, bundle) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_SET_SECRET_BUNDLE, scope, surface, bundle),
+    getSecretBundle: (scope, surface) => ipcRenderer.invoke(INVOKE_CHANNELS.BACKEND_SETTINGS_GET_SECRET_BUNDLE, scope, surface),
   },
   providerSecrets: {
-    get: (scope, provider) => ipcRenderer.invoke('providerSecrets:get', scope, provider),
-    set: (scope, provider, bundle) => ipcRenderer.invoke('providerSecrets:set', scope, provider, bundle),
-    remove: (scope, provider) => ipcRenderer.invoke('providerSecrets:remove', scope, provider),
-    status: (scope, provider) => ipcRenderer.invoke('providerSecrets:status', scope, provider),
-    getBundle: (scope, provider) => ipcRenderer.invoke('providerSecrets:getBundle', scope, provider),
-    setBundle: (scope, provider, bundle) => ipcRenderer.invoke('providerSecrets:setBundle', scope, provider, bundle),
+    get: (scope, provider) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDER_SECRETS_GET, scope, provider),
+    set: (scope, provider, bundle) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDER_SECRETS_SET, scope, provider, bundle),
+    remove: (scope, provider) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDER_SECRETS_REMOVE, scope, provider),
+    status: (scope, provider) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDER_SECRETS_STATUS, scope, provider),
+    getBundle: (scope, provider) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDER_SECRETS_GET_BUNDLE, scope, provider),
+    setBundle: (scope, provider, bundle) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDER_SECRETS_SET_BUNDLE, scope, provider, bundle),
   },
   providers: {
-    catalog: () => ipcRenderer.invoke('providers:catalog'),
-    configured: (scope) => ipcRenderer.invoke('providers:configured', scope),
+    catalog: () => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDERS_CATALOG),
+    configured: (scope) => ipcRenderer.invoke(INVOKE_CHANNELS.PROVIDERS_CONFIGURED, scope),
   },
   modelRouting: {
-    getEffective: (projectDir) => ipcRenderer.invoke('modelRouting:getEffective', projectDir),
-    getProject: (projectDir) => ipcRenderer.invoke('modelRouting:getProject', projectDir),
-    setProject: (projectDir, config) => ipcRenderer.invoke('modelRouting:setProject', projectDir, config),
-    removeProject: (projectDir) => ipcRenderer.invoke('modelRouting:removeProject', projectDir),
-    getGlobal: () => ipcRenderer.invoke('modelRouting:getGlobal'),
-    setGlobal: (config) => ipcRenderer.invoke('modelRouting:setGlobal', config),
-    applyPreset: (projectDir, presetId) => ipcRenderer.invoke('modelRouting:applyPreset', projectDir, presetId),
-    getAvailableModels: (projectDir) => ipcRenderer.invoke('modelRouting:getAvailableModels', projectDir),
-    getAvailableModelsWithCatalog: (projectDir) => ipcRenderer.invoke('modelRouting:getAvailableModelsWithCatalog', projectDir),
+    getEffective: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_GET_EFFECTIVE, projectDir),
+    getProject: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_GET_PROJECT, projectDir),
+    setProject: (projectDir, config) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_SET_PROJECT, projectDir, config),
+    removeProject: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_REMOVE_PROJECT, projectDir),
+    getGlobal: () => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_GET_GLOBAL),
+    setGlobal: (config) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_SET_GLOBAL, config),
+    applyPreset: (projectDir, presetId) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_APPLY_PRESET, projectDir, presetId),
+    getAvailableModels: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_GET_AVAILABLE_MODELS, projectDir),
+    getAvailableModelsWithCatalog: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.MODEL_ROUTING_GET_AVAILABLE_MODELS_WITH_CATALOG, projectDir),
   },
   projectTicketConfig: {
-    get: (projectDir) => ipcRenderer.invoke('projectTicketConfig:get', projectDir),
-    set: (projectDir, config) => ipcRenderer.invoke('projectTicketConfig:set', projectDir, config),
+    get: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECT_TICKET_CONFIG_GET, projectDir),
+    set: (projectDir, config) => ipcRenderer.invoke(INVOKE_CHANNELS.PROJECT_TICKET_CONFIG_SET, projectDir, config),
   },
   session: {
-    getState: () => ipcRenderer.invoke('session:getState'),
-    getSettings: () => ipcRenderer.invoke('session:getSettings'),
-    updateSettings: (settings) => ipcRenderer.invoke('session:updateSettings', settings),
-    acknowledgeCritical: () => ipcRenderer.invoke('session:acknowledgeCritical'),
-    haltAll: () => ipcRenderer.invoke('session:haltAll'),
-    resumeAll: () => ipcRenderer.invoke('session:resumeAll'),
-    resumeStack: (stackId) => ipcRenderer.invoke('session:resumeStack', stackId),
+    getState: () => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_GET_STATE),
+    getSettings: () => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_GET_SETTINGS),
+    updateSettings: (settings) => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_UPDATE_SETTINGS, settings),
+    acknowledgeCritical: () => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_ACKNOWLEDGE_CRITICAL),
+    haltAll: () => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_HALT_ALL),
+    resumeAll: () => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_RESUME_ALL),
+    resumeStack: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_RESUME_STACK, stackId),
     resumeStackWithContinuation: (stackId, manual) =>
-      ipcRenderer.invoke('session:resumeStackWithContinuation', stackId, manual),
-    forcePoll: () => ipcRenderer.invoke('session:forcePoll'),
-    reportActivity: () => { ipcRenderer.send('session:activity'); },
+      ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_RESUME_STACK_WITH_CONTINUATION, stackId, manual),
+    forcePoll: () => ipcRenderer.invoke(INVOKE_CHANNELS.SESSION_FORCE_POLL),
+    reportActivity: () => { ipcRenderer.send(INVOKE_CHANNELS.SESSION_ACTIVITY); },
   },
   schedules: {
-    list: (projectDir) => ipcRenderer.invoke('schedules:list', projectDir),
-    create: (projectDir, data) => ipcRenderer.invoke('schedules:create', projectDir, data),
-    update: (projectDir, id, patch) => ipcRenderer.invoke('schedules:update', projectDir, id, patch),
-    delete: (projectDir, id) => ipcRenderer.invoke('schedules:delete', projectDir, id),
-    cronHealth: () => ipcRenderer.invoke('schedules:cronHealth'),
-    listBuiltInActions: () => ipcRenderer.invoke('scheduler:listBuiltInActions'),
-    listScripts: (projectDir) => ipcRenderer.invoke('schedules:listScripts', projectDir),
+    list: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULES_LIST, projectDir),
+    create: (projectDir, data) => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULES_CREATE, projectDir, data),
+    update: (projectDir, id, patch) => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULES_UPDATE, projectDir, id, patch),
+    delete: (projectDir, id) => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULES_DELETE, projectDir, id),
+    cronHealth: () => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULES_CRON_HEALTH),
+    listBuiltInActions: () => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULER_LIST_BUILT_IN_ACTIONS),
+    listScripts: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.SCHEDULES_LIST_SCRIPTS, projectDir),
   },
   auth: {
-    status: () => ipcRenderer.invoke('auth:status'),
-    login: () => ipcRenderer.invoke('auth:login'),
+    status: () => ipcRenderer.invoke(INVOKE_CHANNELS.AUTH_STATUS),
+    login: () => ipcRenderer.invoke(INVOKE_CHANNELS.AUTH_LOGIN),
   },
   docker: {
-    status: () => ipcRenderer.invoke('docker:status'),
+    status: () => ipcRenderer.invoke(INVOKE_CHANNELS.DOCKER_STATUS),
   },
   tickets: {
     fetch: (ticketId, projectDir) =>
-      ipcRenderer.invoke('tickets:fetch', ticketId, projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_FETCH, ticketId, projectDir),
     specCheck: (ticketId, projectDir) =>
-      ipcRenderer.invoke('tickets:specCheck', ticketId, projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_SPEC_CHECK, ticketId, projectDir),
     specRefine: (ticketId, projectDir, userAnswers) =>
-      ipcRenderer.invoke('tickets:specRefine', ticketId, projectDir, userAnswers),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_SPEC_REFINE, ticketId, projectDir, userAnswers),
     specCheckAsync: (ticketId, projectDir) =>
-      ipcRenderer.invoke('tickets:specCheckAsync', ticketId, projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_SPEC_CHECK_ASYNC, ticketId, projectDir),
     specRefineAsync: (sessionId, ticketId, projectDir, userAnswers) =>
-      ipcRenderer.invoke('tickets:specRefineAsync', sessionId, ticketId, projectDir, userAnswers),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_SPEC_REFINE_ASYNC, sessionId, ticketId, projectDir, userAnswers),
     retryRefinementAsync: (sessionId, ticketId, projectDir) =>
-      ipcRenderer.invoke('tickets:retryRefinementAsync', sessionId, ticketId, projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_RETRY_REFINEMENT_ASYNC, sessionId, ticketId, projectDir),
     postAnswers: (ticketId, projectDir, answersBody) =>
-      ipcRenderer.invoke('tickets:postAnswers', ticketId, projectDir, answersBody),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_POST_ANSWERS, ticketId, projectDir, answersBody),
     cancelRefinement: (sessionId) =>
-      ipcRenderer.invoke('tickets:cancelRefinement', sessionId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_CANCEL_REFINEMENT, sessionId),
     listRefinements: () =>
-      ipcRenderer.invoke('tickets:listRefinements'),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_LIST_REFINEMENTS),
     create: (projectDir, title, body) =>
-      ipcRenderer.invoke('tickets:create', projectDir, title, body),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_CREATE, projectDir, title, body),
     list: async (projectDir) => {
-      const raw = await ipcRenderer.invoke('tickets:list', projectDir);
+      const raw = await ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_LIST, projectDir);
       if (Array.isArray(raw)) return { tickets: raw, error: null };
       return raw;
     },
     fetchRaw: (ticketId, projectDir) =>
-      ipcRenderer.invoke('tickets:fetchRaw', ticketId, projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_FETCH_RAW, ticketId, projectDir),
     update: (projectDir, ticketId, body) =>
-      ipcRenderer.invoke('tickets:update', projectDir, ticketId, body),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_UPDATE, projectDir, ticketId, body),
     testJiraConnection: (params) =>
-      ipcRenderer.invoke('tickets:testJiraConnection', params),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKETS_TEST_JIRA_CONNECTION, params),
     close: (ticketId, projectDir) =>
-      ipcRenderer.invoke('ticket:close', { ticketId, projectDir }),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKET_CLOSE, { ticketId, projectDir }),
     markDone: (ticketId, projectDir) =>
-      ipcRenderer.invoke('ticket:mark-done', { ticketId, projectDir }),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKET_MARK_DONE, { ticketId, projectDir }),
   },
   ticketBoard: {
     setColumn: (ticketId, projectDir, column) =>
-      ipcRenderer.invoke('ticket-board:set-column', ticketId, projectDir, column),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKET_BOARD_SET_COLUMN, ticketId, projectDir, column),
     delete: (ticketId, projectDir) =>
-      ipcRenderer.invoke('ticket-board:delete', { ticketId, projectDir }),
+      ipcRenderer.invoke(INVOKE_CHANNELS.TICKET_BOARD_DELETE, { ticketId, projectDir }),
   },
   pr: {
-    draftBody: (stackId) => ipcRenderer.invoke('pr:draftBody', stackId),
+    draftBody: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.PR_DRAFT_BODY, stackId),
     create: (stackId, title, body) =>
-      ipcRenderer.invoke('pr:create', stackId, title, body),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PR_CREATE, stackId, title, body),
     merge: (stackId, prNumber) =>
-      ipcRenderer.invoke('pr:merge', stackId, prNumber),
-    createAuto: (stackId) => ipcRenderer.invoke('pr:createAuto', stackId),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PR_MERGE, stackId, prNumber),
+    createAuto: (stackId) => ipcRenderer.invoke(INVOKE_CHANNELS.PR_CREATE_AUTO, stackId),
     autoResolve: (ticketId, projectDir) =>
-      ipcRenderer.invoke('pr:autoResolve', ticketId, projectDir),
+      ipcRenderer.invoke(INVOKE_CHANNELS.PR_AUTO_RESOLVE, ticketId, projectDir),
   },
   darkFactory: {
-    getEnabled: (projectDir) => ipcRenderer.invoke('darkFactory:getEnabled', projectDir),
-    setEnabled: (projectDir, enabled) => ipcRenderer.invoke('darkFactory:setEnabled', projectDir, enabled),
-    getConfig: (projectDir) => ipcRenderer.invoke('darkFactory:getConfig', projectDir),
-    setConfig: (projectDir, config) => ipcRenderer.invoke('darkFactory:setConfig', projectDir, config),
+    getEnabled: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.DARK_FACTORY_GET_ENABLED, projectDir),
+    setEnabled: (projectDir, enabled) => ipcRenderer.invoke(INVOKE_CHANNELS.DARK_FACTORY_SET_ENABLED, projectDir, enabled),
+    getConfig: (projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.DARK_FACTORY_GET_CONFIG, projectDir),
+    setConfig: (projectDir, config) => ipcRenderer.invoke(INVOKE_CHANNELS.DARK_FACTORY_SET_CONFIG, projectDir, config),
   },
   telemetry: {
-    summary: (range) => ipcRenderer.invoke('stats:telemetry:summary', range),
-    daily: (range) => ipcRenderer.invoke('stats:telemetry:daily', range),
-    byModel: (range) => ipcRenderer.invoke('stats:telemetry:byModel', range),
-    session: (range) => ipcRenderer.invoke('stats:telemetry:session', range),
-    byTicket: (range) => ipcRenderer.invoke('stats:telemetry:byTicket', range),
-    byEpic: (range) => ipcRenderer.invoke('stats:telemetry:byEpic', range),
-    refresh: () => ipcRenderer.invoke('stats:telemetry:refresh'),
+    summary: (range) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_SUMMARY, range),
+    daily: (range) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_DAILY, range),
+    byModel: (range) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_BY_MODEL, range),
+    session: (range) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_SESSION, range),
+    byTicket: (range) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_BY_TICKET, range),
+    byEpic: (range) => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_BY_EPIC, range),
+    refresh: () => ipcRenderer.invoke(INVOKE_CHANNELS.STATS_TELEMETRY_REFRESH),
   },
   epic: {
-    start: (epicId, projectDir) => ipcRenderer.invoke('epic:start', epicId, projectDir),
-    getRunPlan: (epicId, projectDir) => ipcRenderer.invoke('epic:getRunPlan', epicId, projectDir),
+    start: (epicId, projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.EPIC_START, epicId, projectDir),
+    getRunPlan: (epicId, projectDir) => ipcRenderer.invoke(INVOKE_CHANNELS.EPIC_GET_RUN_PLAN, epicId, projectDir),
   },
-  on: (channel, callback) => {
+  on: (channel: EventChannel, callback: (...args: unknown[]) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, ...args: unknown[]) =>
       callback(...args);
     ipcRenderer.on(channel, handler);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useAppStore, ThresholdLevel } from './store';
+import { EVENT_CHANNELS } from '../main/ipc-channels';
 import { StackDetail } from './components/StackDetail';
 import { RefineTicketDialog } from './components/RefineTicketDialog';
 import { CreateTicketDialog } from './components/CreateTicketDialog';
@@ -119,12 +120,12 @@ export default function App() {
       setDockerConnected(connected);
     }).catch(() => {});
 
-    const unsubConnected = window.sandstorm.on('docker:connected', () => {
+    const unsubConnected = window.sandstorm.on(EVENT_CHANNELS.DOCKER_CONNECTED, () => {
       setDockerConnected(true);
       refreshStacks();
       refreshMetrics();
     });
-    const unsubDisconnected = window.sandstorm.on('docker:disconnected', () => {
+    const unsubDisconnected = window.sandstorm.on(EVENT_CHANNELS.DOCKER_DISCONNECTED, () => {
       setDockerConnected(false);
     });
 
@@ -174,11 +175,11 @@ export default function App() {
       sessions.forEach((s) => upsertRefinementSession(s, { replay: true }));
     }).catch(() => {});
 
-    const unsubRefinement = window.sandstorm.on('refinement:update', (data: unknown) => {
+    const unsubRefinement = window.sandstorm.on(EVENT_CHANNELS.REFINEMENT_UPDATE, (data: unknown) => {
       upsertRefinementSession(data as Parameters<typeof upsertRefinementSession>[0]);
     });
 
-    const unsubProgress = window.sandstorm.on('refinement:progress', (data: unknown) => {
+    const unsubProgress = window.sandstorm.on(EVENT_CHANNELS.REFINEMENT_PROGRESS, (data: unknown) => {
       const { sessionId, delta } = data as { sessionId: string; delta: string };
       appendRefinementStreamChunk(sessionId, delta);
     });
@@ -194,7 +195,7 @@ export default function App() {
   useEffect(() => {
     refreshSessionState();
 
-    const unsubThreshold = window.sandstorm.on('session:threshold', (data: unknown) => {
+    const unsubThreshold = window.sandstorm.on(EVENT_CHANNELS.SESSION_THRESHOLD, (data: unknown) => {
       const { level } = data as { level: ThresholdLevel; usage: unknown };
       useAppStore.setState({ sessionWarningLevel: level });
       if (level === 'critical' || level === 'limit' || level === 'over_limit') {
@@ -203,22 +204,22 @@ export default function App() {
       refreshSessionState();
     });
 
-    const unsubHalted = window.sandstorm.on('session:halted', () => {
+    const unsubHalted = window.sandstorm.on(EVENT_CHANNELS.SESSION_HALTED, () => {
       refreshSessionState();
       refreshStacks();
     });
 
-    const unsubReset = window.sandstorm.on('session:reset', () => {
+    const unsubReset = window.sandstorm.on(EVENT_CHANNELS.SESSION_RESET, () => {
       useAppStore.setState({ sessionWarningLevel: null, showSessionWarningModal: false });
       refreshSessionState();
       refreshStacks();
     });
 
-    const unsubState = window.sandstorm.on('session:state', () => {
+    const unsubState = window.sandstorm.on(EVENT_CHANNELS.SESSION_STATE, () => {
       refreshSessionState();
     });
 
-    const unsubCronHealth = window.sandstorm.on('scheduler:cronHealth', (data: unknown) => {
+    const unsubCronHealth = window.sandstorm.on(EVENT_CHANNELS.SCHEDULER_CRON_HEALTH, (data: unknown) => {
       const { running } = data as { running: boolean };
       useAppStore.setState({ cronHealthy: running });
     });
@@ -246,19 +247,19 @@ export default function App() {
       ? setInterval(refreshMetrics, METRICS_POLL_INTERVAL)
       : null;
 
-    const unsubCompleted = window.sandstorm.on('task:completed', () => {
+    const unsubCompleted = window.sandstorm.on(EVENT_CHANNELS.TASK_COMPLETED, () => {
       refreshStacks();
     });
-    const unsubFailed = window.sandstorm.on('task:failed', () => {
+    const unsubFailed = window.sandstorm.on(EVENT_CHANNELS.TASK_FAILED, () => {
       refreshStacks();
     });
     const unsubNavigate = window.sandstorm.on(
-      'navigate:stack',
+      EVENT_CHANNELS.NAVIGATE_STACK,
       (stackId: unknown) => {
         selectStack(stackId as string);
       }
     );
-    const unsubStacksUpdated = window.sandstorm.on('stacks:updated', () => {
+    const unsubStacksUpdated = window.sandstorm.on(EVENT_CHANNELS.STACKS_UPDATED, () => {
       refreshStacks();
       const state = useAppStore.getState();
       const project = state.activeProject();

--- a/src/renderer/agentStreamService.ts
+++ b/src/renderer/agentStreamService.ts
@@ -12,6 +12,7 @@
  */
 
 import { useAppStore, OuterClaudeSessionTokens } from './store';
+import { AGENT_DONE, AGENT_ERROR, AGENT_OUTPUT, AGENT_QUEUED, AGENT_TOKEN_USAGE_EVENT, AGENT_USER_MESSAGE } from '../main/ipc-channels';
 
 const registeredTabs = new Set<string>();
 
@@ -19,11 +20,11 @@ export function registerAgentStreamListeners(tabId: string): void {
   if (registeredTabs.has(tabId)) return;
   registeredTabs.add(tabId);
 
-  window.sandstorm.on(`agent:queued:${tabId}`, () => {
+  window.sandstorm.on(AGENT_QUEUED(tabId), () => {
     useAppStore.getState().updateAgentSession(tabId, { isQueued: true });
   });
 
-  window.sandstorm.on(`agent:output:${tabId}`, (data: unknown) => {
+  window.sandstorm.on(AGENT_OUTPUT(tabId), (data: unknown) => {
     const current = useAppStore.getState().agentSessions[tabId];
     useAppStore.getState().updateAgentSession(tabId, {
       isQueued: false,
@@ -31,7 +32,7 @@ export function registerAgentStreamListeners(tabId: string): void {
     });
   });
 
-  window.sandstorm.on(`agent:done:${tabId}`, () => {
+  window.sandstorm.on(AGENT_DONE(tabId), () => {
     useAppStore.getState().updateAgentSession(tabId, {
       isQueued: false,
       isLoading: false,
@@ -50,7 +51,7 @@ export function registerAgentStreamListeners(tabId: string): void {
     });
   });
 
-  window.sandstorm.on(`agent:error:${tabId}`, (error: unknown) => {
+  window.sandstorm.on(AGENT_ERROR(tabId), (error: unknown) => {
     const current = useAppStore.getState().agentSessions[tabId];
     const partial = current?.streamingContent ?? '';
     const errorMsg = (partial ? partial + '\n\n' : '') + 'Error: ' + (error as string);
@@ -65,11 +66,11 @@ export function registerAgentStreamListeners(tabId: string): void {
     });
   });
 
-  window.sandstorm.on(`agent:token-usage:${tabId}`, (tokens: unknown) => {
+  window.sandstorm.on(AGENT_TOKEN_USAGE_EVENT(tabId), (tokens: unknown) => {
     useAppStore.getState().setOuterClaudeTokens(tabId, tokens as OuterClaudeSessionTokens);
   });
 
-  window.sandstorm.on(`agent:user-message:${tabId}`, (message: unknown) => {
+  window.sandstorm.on(AGENT_USER_MESSAGE(tabId), (message: unknown) => {
     const current = useAppStore.getState().agentSessions[tabId];
     const msgs = current?.messages ?? [];
     const last = msgs[msgs.length - 1];

--- a/src/renderer/components/AuthIndicator.tsx
+++ b/src/renderer/components/AuthIndicator.tsx
@@ -1,3 +1,4 @@
+import { EVENT_CHANNELS } from '../../main/ipc-channels';
 import React, { useEffect, useState, useCallback } from 'react';
 
 interface AuthStatus {
@@ -26,7 +27,7 @@ export function AuthIndicator() {
     const interval = setInterval(checkStatus, 60_000);
 
     // Listen for auth completion events
-    const unsub = window.sandstorm.on('auth:completed', () => {
+    const unsub = window.sandstorm.on(EVENT_CHANNELS.AUTH_COMPLETED, () => {
       setLoginInProgress(false);
       checkStatus();
     });

--- a/src/renderer/components/StackDetail.tsx
+++ b/src/renderer/components/StackDetail.tsx
@@ -1,3 +1,4 @@
+import { EVENT_CHANNELS } from '../../main/ipc-channels';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAppStore, Task, TaskTokenStep, StackMetrics, WorkflowProgress } from '../store';
 import { ServiceList } from './ServiceList';
@@ -78,7 +79,7 @@ export function StackDetail({
       .catch(() => {});
 
     // Listen for live updates (only relevant while running)
-    const unsubscribe = window.sandstorm.on('task:workflow-progress', (data: unknown) => {
+    const unsubscribe = window.sandstorm.on(EVENT_CHANNELS.TASK_WORKFLOW_PROGRESS, (data: unknown) => {
       const progress = data as WorkflowProgress;
       if (progress && progress.stackId === stackId) {
         setWorkflowProgress(progress);
@@ -103,8 +104,8 @@ export function StackDetail({
       }
     };
 
-    const unsubComplete = window.sandstorm.on('task:completed', refetchProgress);
-    const unsubFailed = window.sandstorm.on('task:failed', refetchProgress);
+    const unsubComplete = window.sandstorm.on(EVENT_CHANNELS.TASK_COMPLETED, refetchProgress);
+    const unsubFailed = window.sandstorm.on(EVENT_CHANNELS.TASK_FAILED, refetchProgress);
 
     return () => {
       unsubComplete();

--- a/src/renderer/components/TaskOutput.tsx
+++ b/src/renderer/components/TaskOutput.tsx
@@ -1,3 +1,4 @@
+import { EVENT_CHANNELS } from '../../main/ipc-channels';
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 
 export const TaskOutput = React.memo(function TaskOutput({
@@ -58,7 +59,7 @@ export const TaskOutput = React.memo(function TaskOutput({
 
   // Listen for live output updates, filtered by stackId
   useEffect(() => {
-    const unsub = window.sandstorm.on('task:output', (data: unknown) => {
+    const unsub = window.sandstorm.on(EVENT_CHANNELS.TASK_OUTPUT, (data: unknown) => {
       const { stackId: eventStackId, data: chunk } = data as {
         stackId: string;
         data: string;

--- a/src/renderer/hooks/useTaskOutput.ts
+++ b/src/renderer/hooks/useTaskOutput.ts
@@ -1,3 +1,4 @@
+import { EVENT_CHANNELS } from '../../main/ipc-channels';
 import { useState, useEffect, useCallback } from 'react';
 
 export function useTaskOutput(stackId: string) {
@@ -5,7 +6,7 @@ export function useTaskOutput(stackId: string) {
 
   useEffect(() => {
     const unsub = window.sandstorm.on(
-      'task:output',
+      EVENT_CHANNELS.TASK_OUTPUT,
       (data: unknown) => {
         const payload = data as { stackId: string; data: string };
         if (payload.stackId === stackId) {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -11,6 +11,7 @@ import type {
   SessionEntry,
   DateRange,
 } from '@main/telemetry/types';
+import type { EventChannel } from '../main/ipc-channels';
 
 export interface ChatMessage {
   role: 'user' | 'assistant';
@@ -910,7 +911,7 @@ declare global {
         byTicket: (range?: DateRange) => Promise<ByTicketEntry[]>;
         refresh: () => Promise<{ ok: true }>;
       };
-      on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
+      on: (channel: EventChannel, callback: (...args: unknown[]) => void) => () => void;
     };
   }
 }

--- a/tests/unit/ipc-channels.test.ts
+++ b/tests/unit/ipc-channels.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import {
+  INVOKE_CHANNELS,
+  EVENT_CHANNELS,
+  AGENT_OUTPUT,
+  AGENT_DONE,
+  AGENT_ERROR,
+  AGENT_QUEUED,
+  AGENT_TOKEN_USAGE_EVENT,
+  AGENT_USER_MESSAGE,
+} from '@main/ipc-channels';
+
+describe('ipc-channels registry', () => {
+  it('INVOKE_CHANNELS values are all non-empty strings', () => {
+    for (const [key, value] of Object.entries(INVOKE_CHANNELS)) {
+      expect(typeof value, `INVOKE_CHANNELS.${key}`).toBe('string');
+      expect(value.length, `INVOKE_CHANNELS.${key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('EVENT_CHANNELS values are all non-empty strings', () => {
+    for (const [key, value] of Object.entries(EVENT_CHANNELS)) {
+      expect(typeof value, `EVENT_CHANNELS.${key}`).toBe('string');
+      expect(value.length, `EVENT_CHANNELS.${key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('INVOKE_CHANNELS has no duplicate values', () => {
+    const values = Object.values(INVOKE_CHANNELS);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it('EVENT_CHANNELS has no duplicate values', () => {
+    const values = Object.values(EVENT_CHANNELS);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it('INVOKE_CHANNELS and EVENT_CHANNELS have no overlapping values', () => {
+    const invokeValues = new Set(Object.values(INVOKE_CHANNELS));
+    for (const val of Object.values(EVENT_CHANNELS)) {
+      expect(invokeValues.has(val), `'${val}' appears in both INVOKE_CHANNELS and EVENT_CHANNELS`).toBe(false);
+    }
+  });
+
+  it('agent event builders return correct template literal strings', () => {
+    expect(AGENT_OUTPUT('tab-1')).toBe('agent:output:tab-1');
+    expect(AGENT_DONE('tab-1')).toBe('agent:done:tab-1');
+    expect(AGENT_ERROR('tab-1')).toBe('agent:error:tab-1');
+    expect(AGENT_QUEUED('tab-1')).toBe('agent:queued:tab-1');
+    expect(AGENT_TOKEN_USAGE_EVENT('tab-1')).toBe('agent:token-usage:tab-1');
+    expect(AGENT_USER_MESSAGE('tab-1')).toBe('agent:user-message:tab-1');
+  });
+
+  it('all known channels are present in the registry', () => {
+    // Spot-check a representative sample from each namespace
+    expect(INVOKE_CHANNELS.AGENT_SEND).toBe('agent:send');
+    expect(INVOKE_CHANNELS.PROJECTS_LIST).toBe('projects:list');
+    expect(INVOKE_CHANNELS.STACKS_CREATE).toBe('stacks:create');
+    expect(INVOKE_CHANNELS.TASKS_DISPATCH).toBe('tasks:dispatch');
+    expect(INVOKE_CHANNELS.TICKETS_LIST).toBe('tickets:list');
+    expect(INVOKE_CHANNELS.PR_CREATE).toBe('pr:create');
+    expect(INVOKE_CHANNELS.EPIC_START).toBe('epic:start');
+    expect(INVOKE_CHANNELS.SCHEDULES_LIST).toBe('schedules:list');
+    expect(INVOKE_CHANNELS.SESSION_ACTIVITY).toBe('session:activity');
+    expect(INVOKE_CHANNELS.DARK_FACTORY_GET_ENABLED).toBe('darkFactory:getEnabled');
+
+    expect(EVENT_CHANNELS.STACKS_UPDATED).toBe('stacks:updated');
+    expect(EVENT_CHANNELS.TASK_COMPLETED).toBe('task:completed');
+    expect(EVENT_CHANNELS.TASK_FAILED).toBe('task:failed');
+    expect(EVENT_CHANNELS.DOCKER_CONNECTED).toBe('docker:connected');
+    expect(EVENT_CHANNELS.SESSION_THRESHOLD).toBe('session:threshold');
+    expect(EVENT_CHANNELS.NAVIGATE_STACK).toBe('navigate:stack');
+    expect(EVENT_CHANNELS.AUTH_COMPLETED).toBe('auth:completed');
+  });
+
+  it('no raw channel string literals remain in IPC handler and emitter files', () => {
+    const root = path.resolve(__dirname, '../..');
+    const allChannels = [
+      ...Object.values(INVOKE_CHANNELS),
+      ...Object.values(EVENT_CHANNELS),
+    ];
+
+    const filesToCheck = [
+      path.join(root, 'src/main/ipc.ts'),
+      path.join(root, 'src/preload/index.ts'),
+      path.join(root, 'src/main/index.ts'),
+      path.join(root, 'src/main/tray.ts'),
+      path.join(root, 'src/main/agent/claude-backend.ts'),
+      path.join(root, 'src/main/agent/opencode-backend.ts'),
+    ];
+
+    for (const file of filesToCheck) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const basename = path.basename(file);
+      for (const channel of allChannels) {
+        // Escape regex special chars in the channel string
+        const escaped = channel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // Match the channel as a quoted string literal only
+        const pattern = new RegExp(`['"]${escaped}['"]`);
+        expect(
+          pattern.test(content),
+          `${basename} still contains raw literal '${channel}'`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('no raw agent template-literal channels remain in renderer and backend files', () => {
+    const root = path.resolve(__dirname, '../..');
+    const filesToCheck = [
+      path.join(root, 'src/renderer/agentStreamService.ts'),
+      path.join(root, 'src/main/agent/claude-backend.ts'),
+      path.join(root, 'src/main/agent/opencode-backend.ts'),
+    ];
+    const agentTemplateLiterals = [
+      'agent:output:${tabId}',
+      'agent:done:${tabId}',
+      'agent:error:${tabId}',
+      'agent:queued:${tabId}',
+      'agent:token-usage:${tabId}',
+      'agent:user-message:${tabId}',
+    ];
+
+    for (const file of filesToCheck) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const basename = path.basename(file);
+      for (const literal of agentTemplateLiterals) {
+        // Escape for regex: ${tabId} → \$\{tabId\}
+        const escaped = literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const pattern = new RegExp(`\`${escaped}\``);
+        expect(
+          pattern.test(content),
+          `${basename} still contains raw template literal \`${literal}\``
+        ).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

IPC channel names were previously scattered as raw string literals across the main, preload, and renderer layers, making them easy to mistype and hard to keep in sync between the `ipcMain.handle`/`ipcRenderer.invoke` sides and the `webContents.send`/`sandstorm.on` sides.

This change introduces `src/main/ipc-channels.ts` as the single source of truth for every channel name:

- `INVOKE_CHANNELS` for request/response channels.
- `EVENT_CHANNELS` for static push events.
- Typed `AGENT_*` builders for per-tab dynamic agent event channels, returning template-literal types so callers are compile-checked.

All usages in `ipc.ts`, `preload/index.ts`, the agent backends, the tray, and the renderer (`App.tsx`, `agentStreamService.ts`, store, hooks, and components) now reference these constants instead of inline strings. Imports use relative paths rather than the `@main/ipc-channels` alias so the module resolves cleanly across the build boundaries. A unit test covers the channel constants and builders.

No channel string values changed, so this is a behavior-preserving refactor.

## QA plan

1. Launch the app and confirm it starts without IPC errors in the console.
2. Dispatch a task to a stack and verify agent output, completion, and error events still stream to the correct tab.
3. Exercise a few invoke flows (list stacks, view a diff, open settings) and confirm responses come back as before.
4. Trigger a push/PR action and a schedule action to confirm those channels still round-trip.

Closes #692