### PR TITLE
[703] fix: warn when spec tools run on a stale main branch

### DIFF
--- a/src/main/claude/tools.ts
+++ b/src/main/claude/tools.ts
@@ -19,6 +19,7 @@ import type { ProjectTicketConfig } from '../control-plane/registry';
 import { getDefaultSpecQualityGate } from '../spec-quality-gate';
 import { showNotification } from '../tray';
 import { resolveTicketReferences, renderResolvedReferences } from '../control-plane/ticket-references';
+import { ensureFreshAgainstMain } from '../control-plane/git-freshness';
 import {
   createSchedule,
   listSchedules,
@@ -419,13 +420,16 @@ async function handleSpecCheck(
     return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
   }
 
+  const freshness = await ensureFreshAgainstMain(projectDir);
+
   const references = await resolveTicketReferences(ctx.ticketBody);
   const referencesSection = renderResolvedReferences(references);
   const prompt = buildSpecCheckPrompt(ctx.gate, ctx.ticketBody, referencesSection || undefined, ctx.epicContext);
   const resolvedSpecCheckModel = descriptor.backend === 'opencode'
     ? `${descriptor.provider}/${descriptor.model}`
     : descriptor.model;
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolvedSpecCheckModel, 'refine');
+  const rawResult = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'spec' }, resolvedSpecCheckModel, 'refine');
+  const result = freshness.warning ? `${freshness.warning}\n\n${rawResult}` : rawResult;
   const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
 
   return {
@@ -677,15 +681,19 @@ async function handleSpecRefine(
     return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
   }
 
+  const freshness = await ensureFreshAgainstMain(projectDir);
+
   if (!userAnswers) {
     const prompt = buildSpecRefineInitialPrompt(ctx.gate, ctx.ticketBody, ctx.epicContext);
-    const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
+    const rawResult = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
+    const result = freshness.warning ? `${freshness.warning}\n\n${rawResult}` : rawResult;
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   }
 
   const prompt = buildSpecRefineAnswerPrompt(ctx.gate, ctx.ticketBody, userAnswers, ctx.epicContext);
-  const result = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
+  const rawResult = await agentBackend.runEphemeralAgent(prompt, projectDir, SCHEDULED_REFINE_TIMEOUT_MS, { ticketId, stage: 'refine' }, undefined, 'refine');
+  const result = freshness.warning ? `${freshness.warning}\n\n${rawResult}` : rawResult;
   return applySpecRefineResult(ticketId, projectDir, result, true);
 }
 
@@ -716,6 +724,9 @@ export function spawnSpecCheck(
       return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
     }
 
+    const freshness = await ensureFreshAgainstMain(projectDir);
+    if (cancelled) throw new Error('Cancelled');
+
     const references = await resolveTicketReferences(res.ctx.ticketBody);
     const referencesSection = renderResolvedReferences(references);
     const prompt = buildSpecCheckPrompt(res.ctx.gate, res.ctx.ticketBody, referencesSection || undefined, res.ctx.epicContext);
@@ -726,7 +737,8 @@ export function spawnSpecCheck(
     innerCancel = epCancel;
     if (cancelled) { epCancel(); throw new Error('Cancelled'); }
 
-    const result = await ep;
+    const rawResult = await ep;
+    const result = freshness.warning ? `${freshness.warning}\n\n${rawResult}` : rawResult;
     const passed = /## Spec Quality Gate:\s*PASS/i.test(result);
     return { passed, report: result };
   })();
@@ -800,6 +812,9 @@ export function spawnSpecRefine(
       return { status: 'needs_key', backend: descriptor.backend, provider: descriptor.provider };
     }
 
+    const freshness = await ensureFreshAgainstMain(projectDir);
+    if (cancelled) throw new Error('Cancelled');
+
     const key = refineSessionKey(projectDir, ticketId);
 
     if (userAnswers) {
@@ -813,7 +828,8 @@ export function spawnSpecRefine(
         activeDispose = () => disposeRefineSession(key);
         if (cancelled) { disposeRefineSession(key); throw new Error('Cancelled'); }
         try {
-          const result = await pooled.handle.sendFollowUp(answerPrompt);
+          const rawResult = await pooled.handle.sendFollowUp(answerPrompt);
+          const result = freshness.warning ? `${freshness.warning}\n\n${rawResult}` : rawResult;
           return applySpecRefineResult(ticketId, projectDir, result, true);
         } finally {
           disposeRefineSession(key);
@@ -827,7 +843,8 @@ export function spawnSpecRefine(
       );
       activeDispose = epCancel;
       if (cancelled) { epCancel(); throw new Error('Cancelled'); }
-      const result = await ep;
+      const rawResult = await ep;
+      const result = freshness.warning ? `${freshness.warning}\n\n${rawResult}` : rawResult;
       return applySpecRefineResult(ticketId, projectDir, result, true);
     }
 
@@ -843,9 +860,9 @@ export function spawnSpecRefine(
     };
     if (cancelled) { handle.dispose(); throw new Error('Cancelled'); }
 
-    let result: string;
+    let rawInitialResult: string;
     try {
-      result = await handle.initialResult;
+      rawInitialResult = await handle.initialResult;
     } catch (err) {
       // Initial pass failed — make sure nothing is held.
       try { handle.dispose(); } catch { /* noop */ }
@@ -853,6 +870,8 @@ export function spawnSpecRefine(
     }
 
     if (cancelled) { handle.dispose(); throw new Error('Cancelled'); }
+
+    const result = freshness.warning ? `${freshness.warning}\n\n${rawInitialResult}` : rawInitialResult;
 
     // Pool the session so the after-answers pass can reuse it. If the gate
     // already passed without questions, dispose immediately — no follow-up.

--- a/src/main/control-plane/git-freshness.ts
+++ b/src/main/control-plane/git-freshness.ts
@@ -1,0 +1,96 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface GitFreshnessResult {
+  mutated: boolean;
+  warning?: string;
+}
+
+async function git(args: string[], cwd: string): Promise<{ stdout: string; code: number }> {
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd, timeout: 30_000 });
+    return { stdout: stdout.trim(), code: 0 };
+  } catch (err: unknown) {
+    const e = err as { code?: number; stdout?: string };
+    return { stdout: (e.stdout ?? '').trim(), code: e.code ?? 1 };
+  }
+}
+
+/**
+ * Ensures the project directory is fresh against origin/main before spec-check/refine
+ * evaluates file:line citations.
+ *
+ * Strategy:
+ *  1. git fetch origin (read-only; safe)
+ *  2. If fetch fails → warn "offline", proceed without mutation
+ *  3. If HEAD == origin/main → up-to-date, no-op
+ *  4. If on main branch + clean tree + HEAD is ancestor of origin/main → fast-forward
+ *  5. All other cases (dirty, feature branch, detached HEAD, diverged) → warn-only, no mutation
+ */
+export async function ensureFreshAgainstMain(projectDir: string): Promise<GitFreshnessResult> {
+  // Step 1: git fetch origin
+  const fetch = await git(['fetch', 'origin'], projectDir);
+  if (fetch.code !== 0) {
+    return {
+      mutated: false,
+      warning:
+        '[Staleness warning] Could not verify against `origin/main` (fetch failed/offline). ' +
+        'Citations evaluated against the local tree as-is — results may be stale.',
+    };
+  }
+
+  // Step 2: Determine current branch
+  const branchRes = await git(['rev-parse', '--abbrev-ref', 'HEAD'], projectDir);
+  const branch = branchRes.stdout;
+  const isOnMain = branch === 'main';
+  const isDetached = branch === 'HEAD';
+
+  // Step 3: Get SHAs
+  const headShaRes = await git(['rev-parse', 'HEAD'], projectDir);
+  const originShaRes = await git(['rev-parse', 'origin/main'], projectDir);
+  const headSha = headShaRes.stdout;
+  const originSha = originShaRes.stdout;
+
+  // Up-to-date: no-op, no warning
+  if (headSha === originSha) {
+    return { mutated: false };
+  }
+
+  // Step 4: Check if HEAD is ancestor of origin/main (FF-eligible)
+  const ancestorRes = await git(['merge-base', '--is-ancestor', 'HEAD', 'origin/main'], projectDir);
+  const isAncestor = ancestorRes.code === 0;
+
+  if (isOnMain && isAncestor) {
+    // Check working tree cleanliness
+    const statusRes = await git(['status', '--porcelain'], projectDir);
+    const isDirty = statusRes.stdout.length > 0;
+
+    if (!isDirty) {
+      // Safe to fast-forward
+      const ffRes = await git(['merge', '--ff-only', 'origin/main'], projectDir);
+      if (ffRes.code === 0) {
+        return { mutated: true };
+      }
+      // FF unexpectedly failed — fall through to warn
+    } else {
+      // Dirty tree on main, behind — warn only
+      return {
+        mutated: false,
+        warning:
+          `[Staleness warning] Project dir is on \`main@${headSha.slice(0, 8)}\` with uncommitted changes, ` +
+          `behind \`origin/main\` — citations may be stale; refresh before trusting a FAIL.`,
+      };
+    }
+  }
+
+  // All warn-only cases: diverged, feature branch, detached HEAD, non-FF
+  const displayBranch = isDetached ? `detached@${headSha.slice(0, 8)}` : `${branch}@${headSha.slice(0, 8)}`;
+  return {
+    mutated: false,
+    warning:
+      `[Staleness warning] Project dir is on \`${displayBranch}\`, ` +
+      `behind \`origin/main\` — citations may be stale; refresh before trusting a FAIL.`,
+  };
+}

--- a/tests/unit/control-plane/git-freshness.test.ts
+++ b/tests/unit/control-plane/git-freshness.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock child_process before importing the module under test
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from 'child_process';
+import { ensureFreshAgainstMain } from '../../../src/main/control-plane/git-freshness';
+
+const mockExecFile = vi.mocked(execFile);
+
+const PROJECT_DIR = '/some/project';
+
+/**
+ * Helper to set up execFile mock to resolve/reject for a sequence of git commands.
+ * Each call provides either { stdout } for success or an Error for failure.
+ */
+function mockGitSequence(
+  responses: Array<{ stdout: string } | Error>,
+): void {
+  let callIndex = 0;
+  mockExecFile.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      const cb = callback as (err: Error | null, stdout?: string, stderr?: string) => void;
+      const response = responses[callIndex++];
+      if (response instanceof Error) {
+        // Attach stdout so the catch block in git() can read it
+        const err = Object.assign(response, { code: 1, stdout: '' });
+        cb(err);
+      } else {
+        // Standard promisify resolves with the 2nd callback arg.
+        // vi.fn() doesn't carry the [util.promisify.custom] symbol that real execFile
+        // has, so we pass { stdout } directly as the resolved value.
+        cb(null, { stdout: response.stdout } as unknown as string, '');
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+describe('ensureFreshAgainstMain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('up-to-date (HEAD == origin/main): no mutation, no warning', async () => {
+    const SHA = 'abc1234def5678901234567890abcdef12345678';
+    mockGitSequence([
+      { stdout: '' },           // git fetch origin
+      { stdout: 'main' },       // git rev-parse --abbrev-ref HEAD
+      { stdout: SHA },          // git rev-parse HEAD
+      { stdout: SHA },          // git rev-parse origin/main
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeUndefined();
+    // merge --ff-only should NOT have been called
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('merge'))).toBe(false);
+  });
+
+  it('behind + clean + on main: fast-forwards and returns mutated:true', async () => {
+    const HEAD_SHA = 'aaa0000000000000000000000000000000000001';
+    const ORIGIN_SHA = 'bbb0000000000000000000000000000000000002';
+    mockGitSequence([
+      { stdout: '' },           // git fetch origin
+      { stdout: 'main' },       // git rev-parse --abbrev-ref HEAD
+      { stdout: HEAD_SHA },     // git rev-parse HEAD
+      { stdout: ORIGIN_SHA },   // git rev-parse origin/main
+      { stdout: '' },           // git merge-base --is-ancestor HEAD origin/main (exit 0 = is ancestor)
+      { stdout: '' },           // git status --porcelain (empty = clean)
+      { stdout: '' },           // git merge --ff-only origin/main
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(true);
+    expect(result.warning).toBeUndefined();
+
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    const ffCall = calls.find((c) => c.includes('--ff-only'));
+    expect(ffCall).toBeDefined();
+    expect(ffCall).toContain('origin/main');
+    // merge --ff-only should have been called exactly once
+    expect(calls.filter((c) => c.includes('--ff-only')).length).toBe(1);
+  });
+
+  it('dirty tree on main, behind origin/main: no merge, warning present', async () => {
+    const HEAD_SHA = 'aaa0000000000000000000000000000000000001';
+    const ORIGIN_SHA = 'bbb0000000000000000000000000000000000002';
+    mockGitSequence([
+      { stdout: '' },            // git fetch origin
+      { stdout: 'main' },        // git rev-parse --abbrev-ref HEAD
+      { stdout: HEAD_SHA },      // git rev-parse HEAD
+      { stdout: ORIGIN_SHA },    // git rev-parse origin/main
+      { stdout: '' },            // git merge-base --is-ancestor (exit 0)
+      { stdout: 'M  src/foo.ts' }, // git status --porcelain (dirty)
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('Staleness warning');
+
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('--ff-only'))).toBe(false);
+  });
+
+  it('feature branch, behind origin/main: no merge, warning present', async () => {
+    const HEAD_SHA = 'aaa0000000000000000000000000000000000001';
+    const ORIGIN_SHA = 'bbb0000000000000000000000000000000000002';
+    mockGitSequence([
+      { stdout: '' },            // git fetch origin
+      { stdout: 'feat/my-branch' }, // git rev-parse --abbrev-ref HEAD
+      { stdout: HEAD_SHA },      // git rev-parse HEAD
+      { stdout: ORIGIN_SHA },    // git rev-parse origin/main
+      { stdout: '' },            // git merge-base --is-ancestor (exit 0 — ancestor but not on main)
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('Staleness warning');
+    expect(result.warning).toContain('feat/my-branch');
+
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('--ff-only'))).toBe(false);
+  });
+
+  it('detached HEAD: no merge, warning present', async () => {
+    const HEAD_SHA = 'aaa0000000000000000000000000000000000001';
+    const ORIGIN_SHA = 'bbb0000000000000000000000000000000000002';
+    mockGitSequence([
+      { stdout: '' },            // git fetch origin
+      { stdout: 'HEAD' },        // git rev-parse --abbrev-ref HEAD (detached)
+      { stdout: HEAD_SHA },      // git rev-parse HEAD
+      { stdout: ORIGIN_SHA },    // git rev-parse origin/main
+      { stdout: '' },            // git merge-base --is-ancestor (exit 0)
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('Staleness warning');
+    expect(result.warning).toContain('detached');
+
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('--ff-only'))).toBe(false);
+  });
+
+  it('git fetch fails (offline): no merge, offline note present, does not throw', async () => {
+    mockGitSequence([
+      new Error('network unreachable'), // git fetch origin fails
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('fetch failed/offline');
+
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('merge'))).toBe(false);
+  });
+
+  it('diverged HEAD (not ancestor of origin/main): no merge, warning present', async () => {
+    const HEAD_SHA = 'aaa0000000000000000000000000000000000001';
+    const ORIGIN_SHA = 'bbb0000000000000000000000000000000000002';
+    mockGitSequence([
+      { stdout: '' },            // git fetch origin
+      { stdout: 'main' },        // git rev-parse --abbrev-ref HEAD
+      { stdout: HEAD_SHA },      // git rev-parse HEAD
+      { stdout: ORIGIN_SHA },    // git rev-parse origin/main
+      new Error('not ancestor'), // git merge-base --is-ancestor (exit 1 = not ancestor)
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('Staleness warning');
+
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('--ff-only'))).toBe(false);
+  });
+
+  it('idempotent: second run after fast-forward finds HEAD == origin/main and is a no-op', async () => {
+    const SHA = 'abc1234def5678901234567890abcdef12345678';
+    // Second run: HEAD and origin/main are identical
+    mockGitSequence([
+      { stdout: '' },    // git fetch origin
+      { stdout: 'main' }, // git rev-parse --abbrev-ref HEAD
+      { stdout: SHA },   // git rev-parse HEAD
+      { stdout: SHA },   // git rev-parse origin/main
+    ]);
+
+    const result = await ensureFreshAgainstMain(PROJECT_DIR);
+
+    expect(result.mutated).toBe(false);
+    expect(result.warning).toBeUndefined();
+    const calls = mockExecFile.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('merge'))).toBe(false);
+  });
+});

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -66,11 +66,16 @@ vi.mock('../../src/main/control-plane/ticket-references', () => ({
   renderResolvedReferences: vi.fn().mockReturnValue(''),
 }));
 
+vi.mock('../../src/main/control-plane/git-freshness', () => ({
+  ensureFreshAgainstMain: vi.fn().mockResolvedValue({ mutated: false }),
+}));
+
 import { stackManager, agentBackend, registry } from '../../src/main/index';
 import { fetchTicketWithConfig, updateTicketWithConfig } from '../../src/main/control-plane/ticket-config';
 import { resolveTicketReferences, renderResolvedReferences } from '../../src/main/control-plane/ticket-references';
 import { createSchedule, listSchedules, updateSchedule, deleteSchedule } from '../../src/main/scheduler';
 import { syncAllProjectsCrontab } from '../../src/main/scheduler/scheduler-manager';
+import { ensureFreshAgainstMain } from '../../src/main/control-plane/git-freshness';
 
 const mockGetProviderConfig = vi.mocked(registry.getProjectTicketConfig);
 
@@ -243,6 +248,59 @@ describe('MCP tools', () => {
       expect(prompt).toContain('Zero Unresolved');
       expect(prompt).toContain('Dependency Contracts');
       expect(prompt).toContain('Questions Requiring User Answers');
+    });
+
+    it('prepends staleness warning to report when ensureFreshAgainstMain returns a warning', async () => {
+      const WARNING = '[Staleness warning] Project dir is on `feat/some-branch@aaa0000`, behind `origin/main` — citations may be stale; refresh before trusting a FAIL.';
+      vi.mocked(ensureFreshAgainstMain).mockResolvedValue({ mutated: false, warning: WARNING });
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: Has citations\nBody');
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+      );
+
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/proj',
+      }) as { passed: boolean; report: string };
+
+      expect(result.passed).toBe(true);
+      expect(result.report).toMatch(/^\[Staleness warning\]/);
+      expect(result.report).toContain(WARNING);
+      expect(result.report).toContain('## Spec Quality Gate: PASS');
+    });
+
+    it('PASS/FAIL parse is unaffected by a prepended warning', async () => {
+      const WARNING = '[Staleness warning] fetch failed/offline — results may be stale.';
+      vi.mocked(ensureFreshAgainstMain).mockResolvedValue({ mutated: false, warning: WARNING });
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: Has citations\nBody');
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Spec Quality Gate: FAIL\n\n### Gaps\n- [ ] Missing detail',
+      );
+
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/proj',
+      }) as { passed: boolean; report: string };
+
+      expect(result.passed).toBe(false);
+      expect(result.report).toContain(WARNING);
+    });
+
+    it('no warning prepended when ensureFreshAgainstMain returns clean result', async () => {
+      vi.mocked(ensureFreshAgainstMain).mockResolvedValue({ mutated: true });
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: Up to date\nBody');
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+      );
+
+      const result = await handleToolCall('spec_check', {
+        ticketId: '42',
+        projectDir: '/proj',
+      }) as { passed: boolean; report: string };
+
+      expect(result.passed).toBe(true);
+      expect(result.report).not.toContain('Staleness warning');
+      expect(result.report).toMatch(/^## Spec Quality Gate/);
     });
   });
 
@@ -692,6 +750,42 @@ describe('MCP tools', () => {
       expect(prompt).toContain('Requires human input');
       expect(prompt).toContain('Zero Unresolved Assumptions');
       expect(prompt).toContain('Dependency Contracts');
+    });
+
+    it('spec_refine initial: prepends staleness warning to report when ensureFreshAgainstMain warns', async () => {
+      const WARNING = '[Staleness warning] Project dir is on `main@deadbeef`, behind `origin/main`.';
+      vi.mocked(ensureFreshAgainstMain).mockResolvedValue({ mutated: false, warning: WARNING });
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: Needs refine\nBody');
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Spec Quality Gate: FAIL\n\n### Questions Requiring User Answers\n1. What?',
+      );
+
+      const result = await handleToolCall('spec_refine', {
+        ticketId: 'T-42',
+        projectDir: '/proj',
+      }) as { passed: boolean; report: string };
+
+      expect(result.passed).toBe(false);
+      expect(result.report).toContain(WARNING);
+    });
+
+    it('spec_refine answer: prepends staleness warning to report when ensureFreshAgainstMain warns', async () => {
+      const WARNING = '[Staleness warning] fetch failed/offline — results may be stale.';
+      vi.mocked(ensureFreshAgainstMain).mockResolvedValue({ mutated: false, warning: WARNING });
+      vi.mocked(fetchTicketWithConfig).mockResolvedValue('# Issue: Needs refine\nBody');
+      vi.mocked(agentBackend.runEphemeralAgent).mockResolvedValue(
+        '## Updated Ticket Body\n\n# Issue: Updated\n\n## Spec Quality Gate: PASS\n\n### Results\n| C | R |\n|---|---|\n| X | PASS |',
+      );
+      vi.mocked(updateTicketWithConfig).mockResolvedValue(undefined);
+
+      const result = await handleToolCall('spec_refine', {
+        ticketId: 'T-42',
+        projectDir: '/proj',
+        userAnswers: 'some answers',
+      }) as { passed: boolean; report: string };
+
+      expect(result.passed).toBe(true);
+      expect(result.report).toContain(WARNING);
     });
 
     describe('ticket body cache (#370)', () => {


### PR DESCRIPTION
## Summary

The spec tools (`spec_check` and `spec_refine`) could run against a project tree that had fallen behind `main`, producing reports based on outdated code. This change adds a freshness guard that runs before each spec operation and surfaces a warning when the working tree is not current.

A new `ensureFreshAgainstMain(projectDir)` module inspects the project's git state and handles five cases: it stays silent when the tree is already up to date, fast-forwards a clean `main` automatically, and otherwise emits a warning when offline, when the tree is dirty, or when the checkout is a feature branch, detached HEAD, or diverged from `main`. All four spec code paths (`handleSpecCheck`, `handleSpecRefine`, `spawnSpecCheck`, `spawnSpecRefine`) invoke the guard and prepend any warning to the report so the user knows the result may be based on stale code rather than failing or silently proceeding.

## QA plan

1. In a project worktree that is even with `main`, run `spec_check` and confirm no freshness warning appears in the report.
2. Check out a feature branch (or leave uncommitted changes in the tree) and run `spec_check`; confirm a warning is prepended to the report explaining the tree is not current.
3. With a clean checkout of `main` that is behind origin, run `spec_refine` and confirm it fast-forwards automatically and produces no warning.
4. Simulate no network access and run `spec_refine`; confirm an offline warning is prepended rather than an error being thrown.

Closes #703